### PR TITLE
fix(managed): point the managed API base at the real backend; launcher install fallback

### DIFF
--- a/backend/cli/package.json
+++ b/backend/cli/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "name": "@synsci/openscience",
   "type": "module",
   "description": "AI-powered CLI for ML research and development workflows",

--- a/backend/cli/skills/ml-training/model-economics/SKILL.md
+++ b/backend/cli/skills/ml-training/model-economics/SKILL.md
@@ -13,7 +13,7 @@ dependencies: []
 
 ## When to Use This Skill
 
-Use this skill as the **first step** of any flywheel assessment to determine:
+Use this skill as the **first step** of any model-specialization assessment to determine:
 - Is it worth training a specialized model?
 - What will the total investment be?
 - When will the specialized model break even vs frontier APIs?

--- a/backend/cli/skills/research/initialize-atlas-graph/SKILL.md
+++ b/backend/cli/skills/research/initialize-atlas-graph/SKILL.md
@@ -18,7 +18,7 @@ clone at a different path resolves to the **same** graph.
 Run this skill when:
 - The canvas shows "no graph for this project" / the folder isn't linked yet.
 - The user asks to "initialize", "set up Atlas", or "start tracking" research.
-- You are about to begin research/flywheel work that should be recorded.
+- You are about to begin research work that should be recorded.
 
 ## Steps
 

--- a/backend/cli/src/agent/prompt/ml.txt
+++ b/backend/cli/src/agent/prompt/ml.txt
@@ -7,7 +7,7 @@ evidence: scope the problem, survey prior art, build the data pipeline, design a
 models, evaluate rigorously against real baselines, ablate what matters, and report honestly.
 You cover the full spectrum — classical ML, deep learning, LLMs, RL, and multimodal — and the
 complete experimental lifecycle. When the goal is to replace a frontier API dependency with a
-cheaper specialized model, you run the model flywheel (see the Model Specialization track).
+cheaper specialized model, you run the specialization loop (see the Model Specialization track).
 
 You are NOT a chatbot. You are an autonomous ML agent. Given a task, dataset, or research
 question, you independently produce a complete, reproducible analysis and result.
@@ -141,7 +141,7 @@ Before reporting, run the decoupled critique + reviewer gate. This is a blocking
 
 ---
 
-## Model Specialization Track (the flywheel)
+## Model Specialization Track
 When the goal is to REPLACE a frontier API dependency with a cheaper specialized model, run
 this loop instead of the generic pipeline: **production data → train specialized model →
 deploy → collect more data → retrain**. This is collaborative — present options with

--- a/backend/cli/src/cli/cmd/github.ts
+++ b/backend/cli/src/cli/cmd/github.ts
@@ -355,7 +355,7 @@ export const GithubInstallCommand = cmd({
 
             async function getInstallation() {
               return await fetch(
-                `https://api.syntheticsciences.ai/get_github_app_installation?owner=${app.owner}&repo=${app.repo}`,
+                `https://app.syntheticsciences.ai/get_github_app_installation?owner=${app.owner}&repo=${app.repo}`,
               )
                 .then((res) => res.json())
                 .then((data) => data.installation)
@@ -664,7 +664,7 @@ export const GithubRunCommand = cmd({
 
       function normalizeOidcBaseUrl(): string {
         const value = process.env["OIDC_BASE_URL"]
-        if (!value) return "https://api.syntheticsciences.ai"
+        if (!value) return "https://app.syntheticsciences.ai"
         return value.replace(/\/+$/, "")
       }
 

--- a/backend/cli/src/endpoints.ts
+++ b/backend/cli/src/endpoints.ts
@@ -17,7 +17,7 @@
  */
 
 /** Neutral public default. Contains no internal codename. */
-export const DEFAULT_MANAGED_API_BASE = "https://api.syntheticsciences.ai"
+export const DEFAULT_MANAGED_API_BASE = "https://app.syntheticsciences.ai"
 
 function stripTrailingSlashes(url: string): string {
   return url.replace(/\/+$/, "")

--- a/backend/cli/src/openscience/index.ts
+++ b/backend/cli/src/openscience/index.ts
@@ -185,8 +185,8 @@ export class InsufficientCreditsError extends Error {
 
 // ── Bundled atlas CLI resolution ─────────────────────────────────────────
 // The @synsci/atlas package ships as a dependency; its `atlas` binary lives in
-// node_modules. The agent shells out to native `atlas` commands (the research /
-// flywheel prompts drive the map + managed-compute path through it), so the
+// node_modules. The agent shells out to native `atlas` commands (the research
+// prompts drive the map + managed-compute path through it), so the
 // binary must be on the subprocess PATH without requiring a separate global
 // install. We resolve the package, prefer the npm-generated `.bin/atlas` shim,
 // and otherwise synthesize a tiny launcher in the openscience data dir that runs the

--- a/backend/cli/src/provider/provider.ts
+++ b/backend/cli/src/provider/provider.ts
@@ -109,7 +109,7 @@ export namespace Provider {
    * Blocker (c) — the inverse of requireAtlasProxyForManagedKey.
    *
    * A prior managed sync may have injected an Atlas proxy `*_BASE_URL` (e.g.
-   * ANTHROPIC_BASE_URL → api.syntheticsciences.ai). If the resolved key is the
+   * ANTHROPIC_BASE_URL → app.syntheticsciences.ai). If the resolved key is the
    * user's OWN key (BYOK), that key must NEVER be sent to the Atlas proxy — it
    * would leak the credential and mis-bill. Pin the base URL back to the
    * provider's public endpoint and drop the managed routing.

--- a/backend/cli/src/share/share.ts
+++ b/backend/cli/src/share/share.ts
@@ -68,7 +68,7 @@ export namespace Share {
 
   export const URL =
     process.env["OPENSCIENCE_API"] ??
-    (Installation.isPreview() || Installation.isLocal() ? "https://api.dev.syntheticsciences.ai" : "https://api.syntheticsciences.ai")
+    (Installation.isPreview() || Installation.isLocal() ? "https://app.dev.syntheticsciences.ai" : "https://app.syntheticsciences.ai")
 
   const disabled = true
 

--- a/tooling/launcher/bin/synsci.mjs
+++ b/tooling/launcher/bin/synsci.mjs
@@ -178,10 +178,22 @@ async function main() {
       cliPath = resolveCli()
       if (!cliPath) throw new Error("openscience not on PATH after install")
       s.ok("Installed OpenScience")
-    } catch (e) {
-      s.fail(`Install failed${e && e.message ? ": " + e.message : ""}`)
-      console.log(`\n  Try manually: ${CYAN}npm i -g @synsci/openscience${RESET}\n`)
-      process.exit(1)
+    } catch {
+      // Global npm installs commonly fail on permissions. Fall back to the
+      // standalone installer, which lands in ~/.openscience/bin without sudo
+      // (resolveCli already checks that location).
+      s.update("npm -g failed, trying the standalone installer...")
+      try {
+        execSync("curl -fsSL https://openscience.sh/install | bash", { stdio: "pipe" })
+        cliPath = resolveCli()
+        if (!cliPath) throw new Error("openscience not found after install")
+        s.ok("Installed OpenScience")
+      } catch (e2) {
+        s.fail(`Install failed${e2 && e2.message ? ": " + e2.message : ""}`)
+        console.log(`\n  Try manually: ${CYAN}npm i -g @synsci/openscience${RESET}`)
+        console.log(`  or:           ${CYAN}curl -fsSL https://openscience.sh/install | bash${RESET}\n`)
+        process.exit(1)
+      }
     }
   }
 

--- a/tooling/launcher/package.json
+++ b/tooling/launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synsci",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Install wizard for OpenScience, the open-source AI research workspace (optionally with Atlas)",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
**fix(managed): point default API base at app.syntheticsciences.ai**
The managed/Atlas base defaulted to `api.syntheticsciences.ai`, a host that never existed — managed mode failed with DNS/'fetch failed' errors (this is the root cause of the 'Could not initialize the graph. Check openscience connect login…' error users hit even when `openscience connect login` says Already authenticated). Repoints the default plus the hardcoded github/share/OIDC refs.

**chore: clean up agent prompt language, launcher install fallback, v1.2.3**
- ml agent 'flywheel' phrasing → 'model specialization' across the prompt and skills
- `npx synsci`: falls back to the standalone installer at openscience.sh/install when global npm install fails (common on permissions) instead of dead-ending
- Bump CLI + launcher to 1.2.3

Verified: turbo typecheck clean, provider tests 174/174.