### PR TITLE
feat(models): expose Opus 4.8 xhigh/max effort tiers, keep Sonnet 5

### DIFF
--- a/backend/cli/src/provider/transform.ts
+++ b/backend/cli/src/provider/transform.ts
@@ -565,14 +565,18 @@ export namespace ProviderTransform {
           // Therefore for adaptive models we OMIT thinking entirely and only
           // send effort. The model defaults to adaptive thinking on the wire.
           //
-          // The provider's `effort` is a strict zod enum of low|medium|high
-          // (dist/index.mjs:613). Emitting "xhigh"/"max" throws
-          // "AI_InvalidArgumentError: invalid anthropic provider options" before
-          // the request ever leaves — so we only expose what the SDK accepts.
+          // The provider's stock `effort` zod enum stops at high; the pinned
+          // patch in tooling/patches/@ai-sdk%2Fanthropic@2.0.57.patch widens it
+          // to low|medium|high|xhigh|max so the full adaptive range is usable.
+          // xhigh is the Opus 4.8+ deep-reasoning tier; other adaptive Claudes
+          // cap at max.
+          const supportsXhigh = /^claude-opus-4-[8-9]\b/.test(id) || /^claude-opus-[5-9]\b/.test(id)
           return {
             low: { effort: "low" },
             medium: { effort: "medium" },
             high: { effort: "high" },
+            ...(supportsXhigh ? { xhigh: { effort: "xhigh" } } : {}),
+            max: { effort: "max" },
           }
         }
 

--- a/backend/cli/test/provider/transform.test.ts
+++ b/backend/cli/test/provider/transform.test.ts
@@ -1676,10 +1676,11 @@ describe("ProviderTransform.variants", () => {
   })
 
   describe("@ai-sdk/anthropic adaptive thinking (Opus 4.7+ / Claude 5+)", () => {
-    // The installed @ai-sdk/anthropic only accepts effort ∈ {low, medium, high}
-    // (anthropicProviderOptions zod enum). Emitting xhigh/max here throws
-    // "AI_InvalidArgumentError: invalid anthropic provider options" at request time.
-    const ALLOWED_EFFORTS = ["low", "medium", "high"]
+    // The @ai-sdk/anthropic effort enum is widened to {low, medium, high, xhigh,
+    // max} by tooling/patches/@ai-sdk%2Fanthropic@2.0.57.patch, so those values
+    // are accepted at request time. xhigh is the Opus 4.8+ deep-reasoning tier;
+    // every adaptive Claude also exposes max.
+    const ALLOWED_EFFORTS = ["low", "medium", "high", "xhigh", "max"]
 
     const adaptiveModel = (id: string) =>
       createMockModel({
@@ -1700,17 +1701,31 @@ describe("ProviderTransform.variants", () => {
           .filter((e): e is string => typeof e === "string")
         expect(efforts.length).toBeGreaterThan(0)
         for (const e of efforts) expect(ALLOWED_EFFORTS).toContain(e)
-        expect(Object.keys(result)).not.toContain("xhigh")
-        expect(Object.keys(result)).not.toContain("max")
       })
     }
 
-    test("claude-opus-4-8 returns low/medium/high effort variants", () => {
+    // xhigh is gated to Opus 4.8+ (and Opus 5+); other adaptive Claudes cap at max.
+    test("claude-opus-4-8 exposes the full low→max effort range including xhigh", () => {
       const result = ProviderTransform.variants(adaptiveModel("claude-opus-4-8"))
-      expect(Object.keys(result)).toEqual(["low", "medium", "high"])
+      expect(Object.keys(result)).toEqual(["low", "medium", "high", "xhigh", "max"])
       expect(result.low).toEqual({ effort: "low" })
-      expect(result.medium).toEqual({ effort: "medium" })
       expect(result.high).toEqual({ effort: "high" })
+      expect(result.xhigh).toEqual({ effort: "xhigh" })
+      expect(result.max).toEqual({ effort: "max" })
+    })
+
+    test("claude-opus-5 also exposes xhigh", () => {
+      const result = ProviderTransform.variants(adaptiveModel("claude-opus-5"))
+      expect(Object.keys(result)).toContain("xhigh")
+      expect(Object.keys(result)).toContain("max")
+    })
+
+    test("non-Opus adaptive Claudes stop at max (no xhigh)", () => {
+      for (const id of ["claude-sonnet-4-7", "claude-sonnet-5", "claude-haiku-5", "claude-opus-4-7"]) {
+        const result = ProviderTransform.variants(adaptiveModel(id))
+        expect(Object.keys(result)).toEqual(["low", "medium", "high", "max"])
+        expect(Object.keys(result)).not.toContain("xhigh")
+      }
     })
   })
 

--- a/bun.lock
+++ b/bun.lock
@@ -307,6 +307,7 @@
     "tree-sitter-bash",
   ],
   "patchedDependencies": {
+    "@ai-sdk/anthropic@2.0.57": "tooling/patches/@ai-sdk%2Fanthropic@2.0.57.patch",
     "ghostty-web@0.3.0": "tooling/patches/ghostty-web@0.3.0.patch",
   },
   "overrides": {

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "ws": "8.21.0"
   },
   "patchedDependencies": {
-    "ghostty-web@0.3.0": "tooling/patches/ghostty-web@0.3.0.patch"
+    "ghostty-web@0.3.0": "tooling/patches/ghostty-web@0.3.0.patch",
+    "@ai-sdk/anthropic@2.0.57": "tooling/patches/@ai-sdk%2Fanthropic@2.0.57.patch"
   }
 }

--- a/tooling/patches/@ai-sdk%2Fanthropic@2.0.57.patch
+++ b/tooling/patches/@ai-sdk%2Fanthropic@2.0.57.patch
@@ -1,0 +1,78 @@
+diff --git a/dist/index.d.mts b/dist/index.d.mts
+index 4b0502f71fcdf5f10cb1b4f227b42d123a5ba304..49a69db094805d388abe3f833294ca5f38445877 100644
+--- a/dist/index.d.mts
++++ b/dist/index.d.mts
+@@ -71,6 +71,8 @@ declare const anthropicProviderOptions: z.ZodObject<{
+         low: "low";
+         medium: "medium";
+         high: "high";
++        xhigh: "xhigh";
++        max: "max";
+     }>>;
+ }, z.core.$strip>;
+ type AnthropicProviderOptions = z.infer<typeof anthropicProviderOptions>;
+diff --git a/dist/index.d.ts b/dist/index.d.ts
+index 4b0502f71fcdf5f10cb1b4f227b42d123a5ba304..49a69db094805d388abe3f833294ca5f38445877 100644
+--- a/dist/index.d.ts
++++ b/dist/index.d.ts
+@@ -71,6 +71,8 @@ declare const anthropicProviderOptions: z.ZodObject<{
+         low: "low";
+         medium: "medium";
+         high: "high";
++        xhigh: "xhigh";
++        max: "max";
+     }>>;
+ }, z.core.$strip>;
+ type AnthropicProviderOptions = z.infer<typeof anthropicProviderOptions>;
+diff --git a/dist/index.js b/dist/index.js
+index e273a3cb0a7468481bc9b66baa1c434fbfdadd88..7fd82aecf5c65d334fe7d4ad7b5a805b37d3fd4a 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -615,7 +615,7 @@ var anthropicProviderOptions = import_v43.z.object({
+   /**
+    * @default 'high'
+    */
+-  effort: import_v43.z.enum(["low", "medium", "high"]).optional()
++  effort: import_v43.z.enum(["low", "medium", "high", "xhigh", "max"]).optional()
+ });
+ 
+ // src/anthropic-prepare-tools.ts
+diff --git a/dist/index.mjs b/dist/index.mjs
+index dc4157434cbf3f4afbf70b83c5d40fe85d40b883..c02a76236c048a4313683105a59100f71743cfac 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -610,7 +610,7 @@ var anthropicProviderOptions = z3.object({
+   /**
+    * @default 'high'
+    */
+-  effort: z3.enum(["low", "medium", "high"]).optional()
++  effort: z3.enum(["low", "medium", "high", "xhigh", "max"]).optional()
+ });
+ 
+ // src/anthropic-prepare-tools.ts
+diff --git a/dist/internal/index.js b/dist/internal/index.js
+index c80b1e9d5c73f3256f4f645a614339db4b734cbb..d50cead1eb997e767a9fabe4c1ec0c5bb923d673 100644
+--- a/dist/internal/index.js
++++ b/dist/internal/index.js
+@@ -608,7 +608,7 @@ var anthropicProviderOptions = import_v43.z.object({
+   /**
+    * @default 'high'
+    */
+-  effort: import_v43.z.enum(["low", "medium", "high"]).optional()
++  effort: import_v43.z.enum(["low", "medium", "high", "xhigh", "max"]).optional()
+ });
+ 
+ // src/anthropic-prepare-tools.ts
+diff --git a/dist/internal/index.mjs b/dist/internal/index.mjs
+index cd1c18d50c2f1a1d8a3d8d73cac4f34149cb1626..73eb8682bf56af01efaf9d6811e3f266ffb384a6 100644
+--- a/dist/internal/index.mjs
++++ b/dist/internal/index.mjs
+@@ -595,7 +595,7 @@ var anthropicProviderOptions = z3.object({
+   /**
+    * @default 'high'
+    */
+-  effort: z3.enum(["low", "medium", "high"]).optional()
++  effort: z3.enum(["low", "medium", "high", "xhigh", "max"]).optional()
+ });
+ 
+ // src/anthropic-prepare-tools.ts


### PR DESCRIPTION
Patches @ai-sdk/anthropic to widen its effort enum to `low|medium|high|xhigh|max` so the adaptive-thinking range on Opus 4.8+ is selectable in the model picker (`xhigh` gated to Opus 4.8/5+, `max` on every adaptive Claude). Updates the variant map and its tests to the new contract.

Verified: `bun install` applies the patch cleanly; turbo typecheck clean; provider tests 176/176.