### PR TITLE
fix(snapshot): stop the CI Test flake — never snapshot from a failed git add, verify revert deletions against a full tree listing

### DIFF
--- a/backend/cli/src/snapshot/index.ts
+++ b/backend/cli/src/snapshot/index.ts
@@ -158,6 +158,33 @@ export namespace Snapshot {
     const files = new Set<string>()
     const git = gitdir()
     for (const item of patches) {
+      // One full listing per snapshot instead of a per-file ls-tree pathspec:
+      // membership is checked in code on quotepath=false output, the same
+      // mechanism patch() uses, so unusual filenames behave identically on
+      // every platform. If the listing itself fails we know nothing about the
+      // snapshot, and deleting on an unverified miss would be destructive —
+      // keep files in that case.
+      const listing = await $`git -c core.quotepath=false --git-dir ${git} --work-tree ${Instance.worktree} ls-tree -r --name-only ${item.hash}`
+        .quiet()
+        .cwd(Instance.worktree)
+        .nothrow()
+      const snapshotFiles =
+        listing.exitCode === 0
+          ? new Set(
+              listing
+                .text()
+                .split("\n")
+                .map((x) => x.trim())
+                .filter(Boolean)
+                .map((x) => path.join(Instance.worktree, x)),
+            )
+          : undefined
+      if (!snapshotFiles)
+        log.warn("could not list snapshot tree", {
+          hash: item.hash,
+          exitCode: listing.exitCode,
+          stderr: listing.stderr.toString(),
+        })
       for (const file of item.files) {
         if (files.has(file)) continue
         log.info("reverting", { file, hash: item.hash })
@@ -166,21 +193,9 @@ export namespace Snapshot {
           .cwd(Instance.worktree)
           .nothrow()
         if (result.exitCode !== 0) {
-          const relativePath = path.relative(Instance.worktree, file)
-          const checkTree =
-            await $`git --git-dir ${git} --work-tree ${Instance.worktree} ls-tree ${item.hash} -- ${relativePath}`
-              .quiet()
-              .cwd(Instance.worktree)
-              .nothrow()
-          if (checkTree.exitCode !== 0) {
-            // Deleting on an unverified miss is destructive: if ls-tree itself
-            // failed we know nothing about the snapshot, so keep the file.
-            log.warn("could not verify file against snapshot, keeping", {
-              file,
-              exitCode: checkTree.exitCode,
-              stderr: checkTree.stderr.toString(),
-            })
-          } else if (checkTree.text().trim()) {
+          if (!snapshotFiles) {
+            log.warn("could not verify file against snapshot, keeping", { file })
+          } else if (snapshotFiles.has(file)) {
             log.info("file existed in snapshot but checkout failed, keeping", {
               file,
             })

--- a/backend/cli/src/snapshot/index.ts
+++ b/backend/cli/src/snapshot/index.ts
@@ -47,6 +47,29 @@ export namespace Snapshot {
     log.info("cleanup", { prune })
   }
 
+  // A failed `git add` must never be swallowed: write-tree would then snapshot a
+  // stale (or empty) index, and a later revert() against that tree deletes every
+  // file the tree is missing. Retry once for transient failures (index.lock
+  // contention), then report the failure to the caller.
+  async function stageAll(git: string) {
+    let result = await $`git --git-dir ${git} --work-tree ${Instance.worktree} add .`
+      .quiet()
+      .cwd(Instance.directory)
+      .nothrow()
+    if (result.exitCode !== 0) {
+      log.warn("add failed, retrying", { exitCode: result.exitCode, stderr: result.stderr.toString() })
+      result = await $`git --git-dir ${git} --work-tree ${Instance.worktree} add .`
+        .quiet()
+        .cwd(Instance.directory)
+        .nothrow()
+    }
+    if (result.exitCode !== 0) {
+      log.error("add failed", { exitCode: result.exitCode, stderr: result.stderr.toString() })
+      return false
+    }
+    return true
+  }
+
   export async function track() {
     if (Instance.project.vcs !== "git") return
     const cfg = await Config.get()
@@ -65,14 +88,18 @@ export namespace Snapshot {
       await $`git --git-dir ${git} config core.autocrlf false`.quiet().nothrow()
       log.info("initialized")
     }
-    await $`git --git-dir ${git} --work-tree ${Instance.worktree} add .`.quiet().cwd(Instance.directory).nothrow()
-    const hash = await $`git --git-dir ${git} --work-tree ${Instance.worktree} write-tree`
+    if (!(await stageAll(git))) return
+    const result = await $`git --git-dir ${git} --work-tree ${Instance.worktree} write-tree`
       .quiet()
       .cwd(Instance.directory)
       .nothrow()
-      .text()
+    if (result.exitCode !== 0) {
+      log.error("write-tree failed", { exitCode: result.exitCode, stderr: result.stderr.toString() })
+      return
+    }
+    const hash = result.text().trim()
     log.info("tracking", { hash, cwd: Instance.directory, git })
-    return hash.trim()
+    return hash
   }
 
   export const Patch = z.object({
@@ -83,7 +110,7 @@ export namespace Snapshot {
 
   export async function patch(hash: string): Promise<Patch> {
     const git = gitdir()
-    await $`git --git-dir ${git} --work-tree ${Instance.worktree} add .`.quiet().cwd(Instance.directory).nothrow()
+    await stageAll(git)
     const result =
       await $`git -c core.autocrlf=false -c core.quotepath=false --git-dir ${git} --work-tree ${Instance.worktree} diff --no-ext-diff --name-only ${hash} -- .`
         .quiet()
@@ -145,7 +172,15 @@ export namespace Snapshot {
               .quiet()
               .cwd(Instance.worktree)
               .nothrow()
-          if (checkTree.exitCode === 0 && checkTree.text().trim()) {
+          if (checkTree.exitCode !== 0) {
+            // Deleting on an unverified miss is destructive: if ls-tree itself
+            // failed we know nothing about the snapshot, so keep the file.
+            log.warn("could not verify file against snapshot, keeping", {
+              file,
+              exitCode: checkTree.exitCode,
+              stderr: checkTree.stderr.toString(),
+            })
+          } else if (checkTree.text().trim()) {
             log.info("file existed in snapshot but checkout failed, keeping", {
               file,
             })
@@ -161,7 +196,7 @@ export namespace Snapshot {
 
   export async function diff(hash: string) {
     const git = gitdir()
-    await $`git --git-dir ${git} --work-tree ${Instance.worktree} add .`.quiet().cwd(Instance.directory).nothrow()
+    await stageAll(git)
     const result =
       await $`git -c core.autocrlf=false -c core.quotepath=false --git-dir ${git} --work-tree ${Instance.worktree} diff --no-ext-diff ${hash} -- .`
         .quiet()


### PR DESCRIPTION
The required **Test** check has been failing on most Linux runs with `unicode filenames modification and restore` — ENOENT after revert, every sandbox file deleted. Two defects compound:

1. `track()` swallowed `git add` failures via `.nothrow()`. `write-tree` then snapshots a stale/empty index, and `revert()` against that tree deletes every file as 'not in snapshot'. Now staged via `stageAll()`, which retries once and reports failure — `track()` returns no snapshot instead of a wrong one. This was also a destructive-in-production bug: a transient git error could delete user files on revert.

2. `revert()` verified deletions with a per-file `ls-tree <hash> -- <pathspec>` whose behavior differs across platforms for unusual filenames. Replaced with one `ls-tree -r --name-only` listing per snapshot (quotepath=false, the same mechanism `patch()` uses), checked in code — deterministic on every platform, fewer git calls, and fail-safe: if the listing errors, files are kept rather than deleted.

Same change already passed the full Test suite on the #9 branch. Landing it on main separately so every open PR inherits a green base.