### PR TITLE
fix(install): unblock upgrades from the deprecated @synsci/cli package

### DIFF
--- a/backend/cli/package.json
+++ b/backend/cli/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "name": "@synsci/openscience",
   "type": "module",
   "description": "AI-powered CLI for ML research and development workflows",

--- a/backend/cli/package.json
+++ b/backend/cli/package.json
@@ -7,6 +7,7 @@
   "license": "Apache-2.0",
   "private": true,
   "scripts": {
+    "preinstall": "node ./script/preinstall.mjs || exit 0",
     "typecheck": "tsgo --noEmit",
     "test": "bun test",
     "build": "bun run script/build.ts",

--- a/backend/cli/script/preinstall.mjs
+++ b/backend/cli/script/preinstall.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+// Best-effort guard for GLOBAL installs only: the deprecated @synsci/cli
+// package links the same `openscience` bin, and npm refuses to overwrite a
+// bin file owned by another package (EEXIST) — which dead-ends upgrades.
+// Remove the stale package before ours is linked.
+//
+// This must NEVER fail the install: npm policies that block nested npm calls
+// (or script execution entirely) make this best-effort. The `npx synsci`
+// launcher and the openscience.sh/install script handle the conflict
+// deterministically.
+
+import { execSync } from "child_process"
+
+try {
+  if (process.env.npm_config_global === "true" || process.env.npm_config_global === "1") {
+    execSync("npm rm -g @synsci/cli", { stdio: "ignore", timeout: 60000 })
+  }
+} catch {
+  // swallow everything — the install must proceed
+}
+process.exit(0)

--- a/backend/cli/script/publish.ts
+++ b/backend/cli/script/publish.ts
@@ -22,6 +22,7 @@ const version = Object.values(binaries)[0]
 
 await $`mkdir -p ./dist/${pkg.name}`
 await $`cp -r ./bin ./dist/${pkg.name}/bin`
+await $`cp ./script/preinstall.mjs ./dist/${pkg.name}/preinstall.mjs`
 await $`cp ./script/postinstall.mjs ./dist/${pkg.name}/postinstall.mjs`
 
 await Bun.file(`./dist/${pkg.name}/package.json`).write(
@@ -32,6 +33,9 @@ await Bun.file(`./dist/${pkg.name}/package.json`).write(
         openscience: `./bin/openscience`,
       },
       scripts: {
+        // best-effort: clears a stale global @synsci/cli whose `openscience`
+        // bin link would make npm refuse the install (EEXIST); never fails
+        preinstall: "node ./preinstall.mjs || exit 0",
         postinstall: "bun ./postinstall.mjs || node ./postinstall.mjs",
       },
       version: version,

--- a/backend/cli/skills/ml-training/model-economics/SKILL.md
+++ b/backend/cli/skills/ml-training/model-economics/SKILL.md
@@ -13,7 +13,7 @@ dependencies: []
 
 ## When to Use This Skill
 
-Use this skill as the **first step** of any flywheel assessment to determine:
+Use this skill as the **first step** of any model-specialization assessment to determine:
 - Is it worth training a specialized model?
 - What will the total investment be?
 - When will the specialized model break even vs frontier APIs?

--- a/backend/cli/skills/research/initialize-atlas-graph/SKILL.md
+++ b/backend/cli/skills/research/initialize-atlas-graph/SKILL.md
@@ -18,7 +18,7 @@ clone at a different path resolves to the **same** graph.
 Run this skill when:
 - The canvas shows "no graph for this project" / the folder isn't linked yet.
 - The user asks to "initialize", "set up Atlas", or "start tracking" research.
-- You are about to begin research/flywheel work that should be recorded.
+- You are about to begin research work that should be recorded.
 
 ## Steps
 

--- a/backend/cli/src/agent/prompt/ml.txt
+++ b/backend/cli/src/agent/prompt/ml.txt
@@ -7,7 +7,7 @@ evidence: scope the problem, survey prior art, build the data pipeline, design a
 models, evaluate rigorously against real baselines, ablate what matters, and report honestly.
 You cover the full spectrum — classical ML, deep learning, LLMs, RL, and multimodal — and the
 complete experimental lifecycle. When the goal is to replace a frontier API dependency with a
-cheaper specialized model, you run the model flywheel (see the Model Specialization track).
+cheaper specialized model, you run the specialization loop (see the Model Specialization track).
 
 You are NOT a chatbot. You are an autonomous ML agent. Given a task, dataset, or research
 question, you independently produce a complete, reproducible analysis and result.
@@ -141,7 +141,7 @@ Before reporting, run the decoupled critique + reviewer gate. This is a blocking
 
 ---
 
-## Model Specialization Track (the flywheel)
+## Model Specialization Track
 When the goal is to REPLACE a frontier API dependency with a cheaper specialized model, run
 this loop instead of the generic pipeline: **production data → train specialized model →
 deploy → collect more data → retrain**. This is collaborative — present options with

--- a/backend/cli/src/cli/cmd/github.ts
+++ b/backend/cli/src/cli/cmd/github.ts
@@ -355,7 +355,7 @@ export const GithubInstallCommand = cmd({
 
             async function getInstallation() {
               return await fetch(
-                `https://api.syntheticsciences.ai/get_github_app_installation?owner=${app.owner}&repo=${app.repo}`,
+                `https://app.syntheticsciences.ai/get_github_app_installation?owner=${app.owner}&repo=${app.repo}`,
               )
                 .then((res) => res.json())
                 .then((data) => data.installation)
@@ -664,7 +664,7 @@ export const GithubRunCommand = cmd({
 
       function normalizeOidcBaseUrl(): string {
         const value = process.env["OIDC_BASE_URL"]
-        if (!value) return "https://api.syntheticsciences.ai"
+        if (!value) return "https://app.syntheticsciences.ai"
         return value.replace(/\/+$/, "")
       }
 

--- a/backend/cli/src/endpoints.ts
+++ b/backend/cli/src/endpoints.ts
@@ -17,7 +17,7 @@
  */
 
 /** Neutral public default. Contains no internal codename. */
-export const DEFAULT_MANAGED_API_BASE = "https://api.syntheticsciences.ai"
+export const DEFAULT_MANAGED_API_BASE = "https://app.syntheticsciences.ai"
 
 function stripTrailingSlashes(url: string): string {
   return url.replace(/\/+$/, "")

--- a/backend/cli/src/openscience/index.ts
+++ b/backend/cli/src/openscience/index.ts
@@ -185,8 +185,8 @@ export class InsufficientCreditsError extends Error {
 
 // ── Bundled atlas CLI resolution ─────────────────────────────────────────
 // The @synsci/atlas package ships as a dependency; its `atlas` binary lives in
-// node_modules. The agent shells out to native `atlas` commands (the research /
-// flywheel prompts drive the map + managed-compute path through it), so the
+// node_modules. The agent shells out to native `atlas` commands (the research
+// prompts drive the map + managed-compute path through it), so the
 // binary must be on the subprocess PATH without requiring a separate global
 // install. We resolve the package, prefer the npm-generated `.bin/atlas` shim,
 // and otherwise synthesize a tiny launcher in the openscience data dir that runs the

--- a/backend/cli/src/provider/provider.ts
+++ b/backend/cli/src/provider/provider.ts
@@ -109,7 +109,7 @@ export namespace Provider {
    * Blocker (c) — the inverse of requireAtlasProxyForManagedKey.
    *
    * A prior managed sync may have injected an Atlas proxy `*_BASE_URL` (e.g.
-   * ANTHROPIC_BASE_URL → api.syntheticsciences.ai). If the resolved key is the
+   * ANTHROPIC_BASE_URL → app.syntheticsciences.ai). If the resolved key is the
    * user's OWN key (BYOK), that key must NEVER be sent to the Atlas proxy — it
    * would leak the credential and mis-bill. Pin the base URL back to the
    * provider's public endpoint and drop the managed routing.

--- a/backend/cli/src/share/share.ts
+++ b/backend/cli/src/share/share.ts
@@ -68,7 +68,7 @@ export namespace Share {
 
   export const URL =
     process.env["OPENSCIENCE_API"] ??
-    (Installation.isPreview() || Installation.isLocal() ? "https://api.dev.syntheticsciences.ai" : "https://api.syntheticsciences.ai")
+    (Installation.isPreview() || Installation.isLocal() ? "https://app.dev.syntheticsciences.ai" : "https://app.syntheticsciences.ai")
 
   const disabled = true
 

--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
     },
     "backend/cli": {
       "name": "@synsci/openscience",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "bin": {
         "openscience": "./bin/openscience",
       },
@@ -253,7 +253,7 @@
     },
     "tooling/launcher": {
       "name": "synsci",
-      "version": "1.2.2",
+      "version": "1.2.4",
       "bin": {
         "synsci": "bin/synsci.mjs",
       },

--- a/frontend/landing/public/install
+++ b/frontend/landing/public/install
@@ -429,6 +429,16 @@ if [ -n "${GITHUB_ACTIONS-}" ] && [ "${GITHUB_ACTIONS}" == "true" ]; then
     print_message info "Added $INSTALL_DIR to \$GITHUB_PATH"
 fi
 
+# An `openscience` from another package manager can sit earlier on PATH and
+# shadow this install — most commonly the deprecated @synsci/cli npm package,
+# whose stale bin link also blocks `npm i -g @synsci/openscience` with EEXIST.
+shadow=$(command -v openscience 2>/dev/null || true)
+if [[ -n "$shadow" && "$shadow" != "$INSTALL_DIR/openscience" ]]; then
+    print_message warning "Another openscience binary at ${shadow} may shadow this install."
+    print_message info "${MUTED}If it was installed by npm (the deprecated ${NC}@synsci/cli${MUTED} package), remove it with:${NC}"
+    print_message info "  npm rm -g @synsci/cli"
+fi
+
 echo -e ""
 echo -e "${MUTED}                    ${NC}OpenScience"
 echo -e "${MUTED}                    by Synthetic Sciences${NC}"

--- a/install
+++ b/install
@@ -429,6 +429,16 @@ if [ -n "${GITHUB_ACTIONS-}" ] && [ "${GITHUB_ACTIONS}" == "true" ]; then
     print_message info "Added $INSTALL_DIR to \$GITHUB_PATH"
 fi
 
+# An `openscience` from another package manager can sit earlier on PATH and
+# shadow this install — most commonly the deprecated @synsci/cli npm package,
+# whose stale bin link also blocks `npm i -g @synsci/openscience` with EEXIST.
+shadow=$(command -v openscience 2>/dev/null || true)
+if [[ -n "$shadow" && "$shadow" != "$INSTALL_DIR/openscience" ]]; then
+    print_message warning "Another openscience binary at ${shadow} may shadow this install."
+    print_message info "${MUTED}If it was installed by npm (the deprecated ${NC}@synsci/cli${MUTED} package), remove it with:${NC}"
+    print_message info "  npm rm -g @synsci/cli"
+fi
+
 echo -e ""
 echo -e "${MUTED}                    ${NC}OpenScience"
 echo -e "${MUTED}                    by Synthetic Sciences${NC}"

--- a/tooling/launcher/bin/synsci.mjs
+++ b/tooling/launcher/bin/synsci.mjs
@@ -115,6 +115,19 @@ function resolveCli() {
   return null
 }
 
+// The deprecated `@synsci/cli` package links the same `openscience` bin. npm
+// refuses to overwrite a bin file owned by another package (EEXIST), so a
+// stale global install dead-ends the upgrade — and its old binary shadows the
+// real one on PATH. `npm ls` exits nonzero when the package is absent but
+// still prints JSON, so read stdout either way.
+function hasDeprecatedCli() {
+  let out = ""
+  try { out = execSync("npm ls -g @synsci/cli --depth=0 --json", { encoding: "utf-8", stdio: "pipe" }) }
+  catch (e) { out = e && typeof e.stdout === "string" ? e.stdout : "" }
+  try { return Boolean(JSON.parse(out).dependencies["@synsci/cli"]) }
+  catch { return false }
+}
+
 function isConnected() {
   const xdgData = process.env.XDG_DATA_HOME || join(homedir(), ".local", "share")
   const sessionPath = join(xdgData, "openscience", "openscience-session.json")
@@ -149,6 +162,15 @@ async function main() {
   console.log()
 
   // --- Step 1: Install or upgrade the OpenScience CLI ---
+  if (hasDeprecatedCli()) {
+    const s = spinner("Removing the deprecated @synsci/cli so it can't shadow the openscience command...")
+    if (runQuiet("npm rm -g @synsci/cli") !== null) {
+      s.ok("Removed the deprecated @synsci/cli")
+    } else {
+      s.warn(`Couldn't remove the deprecated @synsci/cli — if install fails, run: ${CYAN}npm rm -g @synsci/cli${RESET}`)
+    }
+  }
+
   let cliPath = resolveCli()
   if (cliPath) {
     const raw = runFileQuiet(cliPath, ["--version"]) || "unknown"
@@ -174,7 +196,20 @@ async function main() {
   } else {
     const s = spinner("Installing OpenScience...")
     try {
-      execSync("npm i -g @synsci/openscience@latest", { stdio: "pipe" })
+      try {
+        execSync("npm i -g @synsci/openscience@latest", { stdio: "pipe" })
+      } catch (e) {
+        // npm refuses to overwrite a bin file owned by another package
+        // (EEXIST). If the conflict is the deprecated @synsci/cli, remove it
+        // and retry once before falling back to the standalone installer.
+        const stderr = e && e.stderr ? String(e.stderr) : ""
+        const conflict = stderr.includes("EEXIST") && (stderr.includes("@synsci/cli") || hasDeprecatedCli())
+        if (!conflict) throw e
+        s.update("Removing the deprecated @synsci/cli so it can't shadow the openscience command...")
+        runQuiet("npm rm -g @synsci/cli")
+        s.update("Retrying the OpenScience install...")
+        execSync("npm i -g @synsci/openscience@latest", { stdio: "pipe" })
+      }
       cliPath = resolveCli()
       if (!cliPath) throw new Error("openscience not on PATH after install")
       s.ok("Installed OpenScience")
@@ -238,7 +273,7 @@ async function main() {
   console.log(`  ${DIM}Opening the workspace in your browser…${RESET}`)
   console.log()
 
-  const child = spawn(cliPath, ["web"], { stdio: "inherit" })
+  const child = spawn(cliPath, ["web", ...process.argv.slice(2)], { stdio: "inherit" })
   child.on("close", (code) => process.exit(code ?? 0))
 }
 

--- a/tooling/launcher/bin/synsci.mjs
+++ b/tooling/launcher/bin/synsci.mjs
@@ -178,10 +178,22 @@ async function main() {
       cliPath = resolveCli()
       if (!cliPath) throw new Error("openscience not on PATH after install")
       s.ok("Installed OpenScience")
-    } catch (e) {
-      s.fail(`Install failed${e && e.message ? ": " + e.message : ""}`)
-      console.log(`\n  Try manually: ${CYAN}npm i -g @synsci/openscience${RESET}\n`)
-      process.exit(1)
+    } catch {
+      // Global npm installs commonly fail on permissions. Fall back to the
+      // standalone installer, which lands in ~/.openscience/bin without sudo
+      // (resolveCli already checks that location).
+      s.update("npm -g failed, trying the standalone installer...")
+      try {
+        execSync("curl -fsSL https://openscience.sh/install | bash", { stdio: "pipe" })
+        cliPath = resolveCli()
+        if (!cliPath) throw new Error("openscience not found after install")
+        s.ok("Installed OpenScience")
+      } catch (e2) {
+        s.fail(`Install failed${e2 && e2.message ? ": " + e2.message : ""}`)
+        console.log(`\n  Try manually: ${CYAN}npm i -g @synsci/openscience${RESET}`)
+        console.log(`  or:           ${CYAN}curl -fsSL https://openscience.sh/install | bash${RESET}\n`)
+        process.exit(1)
+      }
     }
   }
 

--- a/tooling/launcher/package.json
+++ b/tooling/launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synsci",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Install wizard for OpenScience, the open-source AI research workspace (optionally with Atlas)",
   "license": "Apache-2.0",
   "type": "module",

--- a/tooling/launcher/package.json
+++ b/tooling/launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synsci",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Install wizard for OpenScience, the open-source AI research workspace (optionally with Atlas)",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## The problem

The npm package was renamed from `@synsci/cli` (now deprecated with "Renamed to @synsci/openscience. Please install @synsci/openscience instead.") to `@synsci/openscience`. Both declare the same bin name, `openscience`, and npm's bin-links check refuses to overwrite a bin file owned by a different package. So everyone with the old package still installed globally dead-ends when upgrading:

```
npm error code EEXIST
npm error File exists: /opt/homebrew/bin/openscience
```

## The fix (three layers)

**1. `npx synsci` launcher (`tooling/launcher/bin/synsci.mjs`)** — the deterministic path.
- Before resolving/installing the CLI, detect a stale global `@synsci/cli` via `npm ls -g @synsci/cli --depth=0 --json` (reads stdout even on nonzero exit) and remove it, telling the user why: "Removing the deprecated @synsci/cli so it can't shadow the openscience command". This also stops the old package's binary from being picked up by `resolveCli()` at the global npm prefix and masquerading as an up-to-date install.
- If the global install still fails and stderr shows an `EEXIST` bin conflict attributable to `@synsci/cli`, remove the stale package and retry the install once before falling back to the standalone installer.
- Extra args passed to `npx synsci` are now forwarded to the final `openscience web` invocation.
- Launcher bumped to 1.2.4.

**2. `@synsci/openscience` preinstall guard (`backend/cli/script/preinstall.mjs`)** — best effort.
When `npm_config_global` is set, it tries `npm rm -g @synsci/cli` silently; it swallows every error and always exits 0, so it can never fail an install. Wired into both the source `package.json` and the published manifest generated by `script/publish.ts` (which now copies the script into the dist package, next to `postinstall.mjs`). Note: npm policies that block lifecycle scripts (or nested npm calls) make this layer advisory only — the launcher and the shell installer handle the conflict deterministically.

**3. Standalone installer (`frontend/landing/public/install`, served at openscience.sh/install)**.
It is a pure binary installer (no npm involved), so instead of remediation it now prints a hint after installing: if `command -v openscience` resolves to something other than `~/.openscience/bin/openscience`, it warns that the other binary may shadow the install and points at `npm rm -g @synsci/cli`. The root `install` copy is kept byte-identical.

## Also included (re-landed from #10)

The two commits approved in #10 whose squash was lost from `main`:

- `chore: clean up agent prompt language, launcher install fallback, v1.2.3` — reworded ml-agent prompt language, the `npx synsci` fallback to `curl -fsSL https://openscience.sh/install | bash` when the global npm install fails, and the 1.2.3 version bumps. The EEXIST handling above builds on that fallback.
- `fix(managed): point default API base at app.syntheticsciences.ai` — the managed/Atlas default pointed at `api.syntheticsciences.ai`, which never existed as a host, so managed mode failed with DNS/fetch errors; repointed to `app.syntheticsciences.ai` (plus the github/share/OIDC refs).

## Verification

- `node --check tooling/launcher/bin/synsci.mjs` — passes
- `node --check backend/cli/script/preinstall.mjs` — passes
- `sh -n install frontend/landing/public/install` (and `bash -n`) — passes
- `bun install` at repo root — clean (2032 packages)
- `bun run typecheck` — 6/6 tasks successful
- `bun run --cwd backend/cli test` — 820 pass, 0 fail (61 files)
- Preinstall guard exercised directly: exits 0 with `npm_config_global` unset, set, and with a broken PATH
- Stale-package detection exercised against a sandbox npm prefix containing a fake global `@synsci/cli`: detected, removed by `npm rm -g`, and reported absent afterwards
