### PR TITLE
fix(provider): fall back gracefully when the configured model has no provider

### DIFF
--- a/backend/cli/src/provider/provider.ts
+++ b/backend/cli/src/provider/provider.ts
@@ -1404,6 +1404,9 @@ export namespace Provider {
     return undefined
   }
 
+  export const NO_PROVIDER_HINT =
+    "No model providers are available. Add an API key for a provider (`openscience auth login`) or connect a managed account (`openscience connect login`), then choose a model."
+
   const priority = ["claude-sonnet-4", "claude-opus-4", "gpt-5", "gemini-3-pro"]
   export function sort(models: Model[]) {
     return sortBy(
@@ -1420,10 +1423,18 @@ export namespace Provider {
 
   export async function defaultModel() {
     const cfg = await Config.get()
-    if (cfg.model) return parseModel(cfg.model)
+    const available = await list()
+    if (cfg.model) {
+      // Only honor the configured model when its provider is actually available
+      // (e.g. a saved `anthropic/...` model with no API key must not be returned)
+      // — otherwise fall through to the priority-based selection below.
+      const parsed = parseModel(cfg.model)
+      if (available[parsed.providerID]?.models[parsed.modelID]) return parsed
+      log.warn("configured model is not available, falling back to default selection", parsed)
+    }
 
     const managed = await hasManagedSession()
-    const providers = await list().then((val) => Object.values(val))
+    const providers = Object.values(available)
     const configured = (p: Info) => !cfg.provider || Object.keys(cfg.provider).includes(p.id)
     // Drop the hosted `openscience` provider from DEFAULT priority unless a managed
     // session is active, then pick the first provider that actually has models.
@@ -1434,9 +1445,9 @@ export namespace Provider {
       candidates.find((p) => Object.keys(p.models).length > 0) ??
       candidates[0] ??
       providers.find(configured)
-    if (!provider) throw new Error("no providers found")
+    if (!provider) throw new Error(NO_PROVIDER_HINT)
     const [model] = sort(Object.values(provider.models))
-    if (!model) throw new Error("no models found")
+    if (!model) throw new Error(NO_PROVIDER_HINT)
     return {
       providerID: provider.id,
       modelID: model.id,

--- a/backend/cli/src/server/routes/session.ts
+++ b/backend/cli/src/server/routes/session.ts
@@ -700,7 +700,11 @@ export const SessionRoutes = lazy(() =>
         return stream(c, async () => {
           const sessionID = c.req.valid("param").sessionID
           const body = c.req.valid("json")
-          SessionPrompt.prompt({ ...body, sessionID })
+          // fire-and-forget: session-level failures are published as session.error
+          // events inside prompt(); catch here so nothing becomes an unhandled rejection
+          SessionPrompt.prompt({ ...body, sessionID }).catch((error) => {
+            log.error("prompt_async failed", { sessionID, error })
+          })
         })
       },
     )

--- a/backend/cli/src/session/prompt.ts
+++ b/backend/cli/src/session/prompt.ts
@@ -170,7 +170,16 @@ export namespace SessionPrompt {
     const session = await Session.get(input.sessionID)
     await SessionRevert.cleanup(session)
 
-    const message = await createUserMessage(input)
+    const message = await createUserMessage(input).catch((e) => {
+      // e.g. no providers are available at all — surface the failure to the
+      // session (the web UI listens for session.error) instead of only throwing.
+      const message = e instanceof Error ? e.message : String(e)
+      Bus.publish(Session.Event.Error, {
+        sessionID: input.sessionID,
+        error: new NamedError.Unknown({ message }).toObject(),
+      })
+      throw e
+    })
     await Session.touch(input.sessionID)
 
     // this is backwards compatibility for allowing `tools` to be specified when
@@ -331,9 +340,47 @@ export namespace SessionPrompt {
           modelID: lastUser.model.modelID,
           providerID: lastUser.model.providerID,
           history: msgs,
-        })
+        }).catch((error) => log.error("failed to generate session title", { error }))
 
-      const model = await Provider.getModel(lastUser.model.providerID, lastUser.model.modelID)
+      const model = await Provider.getModel(lastUser.model.providerID, lastUser.model.modelID).catch((e) => {
+        if (Provider.ModelNotFoundError.isInstance(e)) return undefined
+        throw e
+      })
+      // The requested model has no available provider (e.g. the API key was
+      // removed) — surface a session error instead of crashing the loop.
+      if (!model) {
+        const error = new NamedError.Unknown({
+          message: `Model ${lastUser.model.providerID}/${lastUser.model.modelID} is not available. Add an API key for a provider (\`openscience auth login\`) or connect a managed account (\`openscience connect login\`), then choose a model.`,
+        }).toObject()
+        Bus.publish(Session.Event.Error, { sessionID, error })
+        await Session.updateMessage({
+          id: await MessageV2.nextMessageID(sessionID),
+          role: "assistant",
+          parentID: lastUser.id,
+          sessionID,
+          mode: lastUser.agent,
+          agent: lastUser.agent,
+          path: {
+            cwd: Instance.directory,
+            root: Instance.worktree,
+          },
+          cost: 0,
+          tokens: {
+            input: 0,
+            output: 0,
+            reasoning: 0,
+            cache: { read: 0, write: 0 },
+          },
+          modelID: lastUser.model.modelID,
+          providerID: lastUser.model.providerID,
+          error,
+          time: {
+            created: Date.now(),
+            completed: Date.now(),
+          },
+        })
+        break
+      }
       const task = tasks.pop()
 
       // pending subtask
@@ -686,7 +733,14 @@ export namespace SessionPrompt {
 
   async function lastModel(sessionID: string) {
     for await (const item of MessageV2.stream(sessionID)) {
-      if (item.info.role === "user" && item.info.model) return item.info.model
+      if (item.info.role !== "user" || !item.info.model) continue
+      // A historical model can reference a provider that is no longer available
+      // (e.g. its API key was removed) — validate before reusing it.
+      const model = item.info.model
+      const provider = await Provider.getProvider(model.providerID)
+      if (provider?.models[model.modelID]) return model
+      log.warn("last used model is no longer available, falling back to default", model)
+      break
     }
     return Provider.defaultModel()
   }


### PR DESCRIPTION
## Symptom

On a machine with a saved config model (`~/.config/openscience/openscience.json` → `{"model": "anthropic/claude-sonnet-4-6"}`) but no API keys and no managed session, sending a prompt from the web workspace crashes the server loop with a raw unhandled stack in the terminal:

```
ProviderModelNotFoundError ... data: { providerID: "anthropic", modelID: "claude-sonnet-4-6", suggestions: [] }
    at getModel (src/provider/provider.ts:1294)
```

and the web UI shows nothing — the session silently never answers.

## Root causes

1. `src/provider/provider.ts` — `defaultModel()` returned `parseModel(cfg.model)` without checking the provider/model is actually available; `lastModel()` in `src/session/prompt.ts` likewise reused the model of an old user message even if its provider is gone.
2. `src/server/routes/session.ts` — the `/:sessionID/prompt_async` route fire-and-forgets `SessionPrompt.prompt(...)` with no `.catch`, so any throw became an unhandled rejection: raw stack to the terminal, nothing to the UI.
3. `src/session/prompt.ts` — in `loop()`, `Provider.getModel(lastUser.model...)` threw without publishing a session error event (unlike the command path, which catches `ModelNotFoundError` and publishes `Session.Event.Error` before rethrowing).

## Fix

- **`backend/cli/src/provider/provider.ts`** — `defaultModel()` only honors `cfg.model` when its provider and model exist in the available providers; otherwise it logs a warning and falls through to the existing priority-based selection. The zero-providers throw now carries an actionable message (`NO_PROVIDER_HINT`). Behavior is unchanged when the configured model is available.
- **`backend/cli/src/session/prompt.ts`**
  - `lastModel()` validates that the historical model's provider+model are still available before reusing them, falling back to `Provider.defaultModel()`.
  - `loop()` catches `Provider.ModelNotFoundError` from `getModel`, publishes `Session.Event.Error` with an actionable message ("Model anthropic/claude-sonnet-4-6 is not available. Add an API key for a provider (`openscience auth login`) or connect a managed account (`openscience connect login`), then choose a model."), finalizes an assistant message carrying the error (same shape as the processor error path), and exits the loop cleanly. The fire-and-forget `ensureTitle` call now has a `.catch` — it was a second source of unhandled `ProviderModelNotFoundError` rejections.
  - `prompt()` publishes `Session.Event.Error` when user-message creation fails (e.g. truly zero providers), so the UI is never silent.
- **`backend/cli/src/server/routes/session.ts`** — the `prompt_async` fire-and-forget now has a `.catch` that logs and swallows; session-level error publishing happens inside prompt/loop.

## Verification

- `bun run typecheck` — 6/6 packages pass.
- `bun run --cwd backend/cli test` — 820 pass, 0 fail.
- End-to-end repro in an isolated env (`HOME`/`XDG_*` pointed at a temp dir containing only the config model, `ANTHROPIC_API_KEY=`/`OPENAI_API_KEY=` empty, `serve --port 412x`, `POST /session` + `POST /session/{id}/prompt_async {"parts":[{"type":"text","text":"hi"}]}`):

**Before** (dev.log):

```
INFO  ... service=session.prompt step=0 sessionID=ses_0d18df634ffe... loop
ERROR ... service=default e=ProviderModelNotFoundError rejection
ERROR ... service=default e=ProviderModelNotFoundError rejection
```

No `session.error` event, `GET /session/{id}/message` returned only the user message — the UI had nothing to show.

**After** (same env, same requests): zero `rejection` lines, no raw stack, and the session receives the error:

```
WARN  ... service=provider providerID=anthropic modelID=claude-sonnet-4-6 configured model is not available, falling back to default selection
ERROR ... service=server sessionID=ses_0d1894987ffe... error=No model providers are available. Add an API key for a provider (`openscience auth login`) or connect a managed account (`openscience connect login`), then choose a model. prompt_async failed
```

`/event` stream:

```
data: {"type":"session.error","properties":{"sessionID":"ses_0d1894987ffe...","error":{"name":"UnknownError","data":{"message":"No model providers are available. Add an API key for a provider (`openscience auth login`) or connect a managed account (`openscience connect login`), then choose a model."}}}}
```

- Loop path (explicit unavailable model in the request body, which bypasses the `lastModel` fallback): `GET /session/{id}/message` now shows a finalized assistant message with `error.data.message = "Model anthropic/claude-sonnet-4-6 is not available. Add an API key for a provider (`openscience auth login`) or connect a managed account (`openscience connect login`), then choose a model."` plus the matching `session.error` event — and zero unhandled rejections.
- Stale-session path (session created before the fix with a stored `anthropic/...` user message): `WARN ... last used model is no longer available, falling back to default`, graceful error, no crash.
