### PR TITLE
fix(release): satisfy npm provenance so packages actually publish

### DIFF
--- a/backend/cli/script/build.ts
+++ b/backend/cli/script/build.ts
@@ -189,6 +189,12 @@ for (const item of targets) {
         version: Script.version,
         os: [item.os],
         cpu: [item.arch],
+        // npm provenance refuses packages whose repository.url doesn't match
+        // the repo the workflow ran from (case-sensitive)
+        repository: {
+          type: "git",
+          url: "git+https://github.com/synthetic-sciences/openscience.git",
+        },
       },
       null,
       2,

--- a/backend/cli/script/publish.ts
+++ b/backend/cli/script/publish.ts
@@ -39,6 +39,12 @@ await Bun.file(`./dist/${pkg.name}/package.json`).write(
         postinstall: "bun ./postinstall.mjs || node ./postinstall.mjs",
       },
       version: version,
+      // npm provenance refuses packages whose repository.url doesn't match
+      // the repo the workflow ran from (case-sensitive)
+      repository: {
+        type: "git",
+        url: "git+https://github.com/synthetic-sciences/openscience.git",
+      },
       optionalDependencies: binaries,
     },
     null,

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/synthetic-sciences/OpenScience"
+    "url": "https://github.com/synthetic-sciences/openscience"
   },
   "license": "Apache-2.0",
   "prettier": {

--- a/tooling/launcher/package.json
+++ b/tooling/launcher/package.json
@@ -22,7 +22,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/synthetic-sciences/OpenScience.git"
+    "url": "git+https://github.com/synthetic-sciences/openscience.git"
   },
   "homepage": "https://syntheticsciences.ai"
 }

--- a/tooling/plugin/package.json
+++ b/tooling/plugin/package.json
@@ -24,5 +24,9 @@
     "@types/node": "catalog:",
     "typescript": "catalog:",
     "@typescript/native-preview": "catalog:"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/synthetic-sciences/openscience.git"
   }
 }

--- a/tooling/repo/publish.ts
+++ b/tooling/repo/publish.ts
@@ -59,11 +59,17 @@ if (Script.release) {
   await $`gh release edit v${Script.version} --draft=false`.nothrow()
 }
 
+// Sections keep publishing past an earlier failure so a broken CLI publish
+// doesn't block the SDK, but any failure must fail the workflow at the end —
+// a green run previously meant nothing reached npm at all.
+const failures: string[] = []
+
 console.log("\n=== cli ===\n")
 try {
   await import(`../../backend/cli/script/publish.ts`)
 } catch (e) {
   console.error("CLI publish failed:", e)
+  failures.push("cli")
 }
 
 console.log("\n=== sdk ===\n")
@@ -71,6 +77,7 @@ try {
   await import(`../sdk/js/script/publish.ts`)
 } catch (e) {
   console.error("SDK publish failed:", e)
+  failures.push("sdk")
 }
 
 console.log("\n=== plugin ===\n")
@@ -78,6 +85,7 @@ try {
   await import(`../plugin/script/publish.ts`)
 } catch (e) {
   console.error("Plugin publish failed:", e)
+  failures.push("plugin")
 }
 
 console.log("\n=== launcher (openscience) ===\n")
@@ -104,10 +112,17 @@ try {
   // without polluting node_modules/.bin in the npx temp tree.
   delete launcherPkg.dependencies
   await Bun.file(`${launcherDir}/package.json`).write(JSON.stringify(launcherPkg, null, 2))
-  await $`cd ${launcherDir} && npm publish --access public --tag ${Script.channel}`.nothrow()
+  const result = await $`cd ${launcherDir} && npm publish --access public --tag ${Script.channel}`.nothrow()
+  if (result.exitCode !== 0) throw new Error(`npm publish exited with ${result.exitCode}`)
 } catch (e) {
   console.error("Launcher publish failed:", e)
+  failures.push("launcher")
 }
 
 const dir = new URL("../..", import.meta.url).pathname
 process.chdir(dir)
+
+if (failures.length > 0) {
+  console.error(`\npublish failed for: ${failures.join(", ")}`)
+  process.exit(1)
+}

--- a/tooling/sdk/js/package.json
+++ b/tooling/sdk/js/package.json
@@ -29,5 +29,9 @@
   "dependencies": {},
   "publishConfig": {
     "directory": "dist"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/synthetic-sciences/openscience.git"
   }
 }


### PR DESCRIPTION
The publish workflow ran green while **every npm publish silently failed** with:

```
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@synsci%2fopenscience-linux-x64-baseline
Error verifying sigstore provenance bundle: Failed to validate repository information:
package.json: "repository.url" is "", expected to match "https://github.com/synthetic-sciences/openscience"
```

With `NPM_CONFIG_PROVENANCE=true`, npm requires every published manifest's `repository.url` to match the repository the workflow runs from — case-sensitively. The generated platform/meta manifests had no repository field, sdk/plugin had none either, and root/launcher used a different-case path.

- stamp `repository` into the generated platform + wrapper manifests (build/publish scripts)
- add `repository` to the sdk and plugin packages
- normalize existing repository URLs to the canonical lowercase path
- the release orchestrator now records per-section failures and exits non-zero — a green publish run means packages really shipped (this failure mode was invisible because sections swallowed errors)

Verified: turbo typecheck clean. The v1.2.3 GitHub release with all 11 platform archives already shipped from the previous run; nothing was published to npm at 1.2.3, so re-dispatching after this merge will cleanly publish 1.2.3 everywhere.