### PR TITLE
fix(codex): recover from refresh-token rotation races instead of dying

### DIFF
--- a/backend/cli/src/plugin/codex.ts
+++ b/backend/cli/src/plugin/codex.ts
@@ -431,20 +431,49 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
             // Check if token needs refresh
             if (!currentAuth.access || currentAuth.expires < Date.now()) {
               log.info("refreshing codex access token")
-              const tokens = await refreshAccessTokenSingleFlight(currentAuth.refresh)
-              const newAccountId = extractAccountId(tokens) || authWithAccount.accountId
-              await input.client.auth.set({
-                path: { id: "openai-codex" },
-                body: {
-                  type: "oauth",
-                  refresh: tokens.refresh_token,
-                  access: tokens.access_token,
-                  expires: Date.now() + (tokens.expires_in ?? 3600) * 1000,
-                  ...(newAccountId && { accountId: newAccountId }),
-                },
-              })
-              currentAuth.access = tokens.access_token
-              authWithAccount.accountId = newAccountId
+              let tokens: TokenResponse | undefined
+              try {
+                tokens = await refreshAccessTokenSingleFlight(currentAuth.refresh)
+              } catch (e) {
+                // ChatGPT rotates the refresh token on every refresh, and the
+                // single-flight guard only covers this process. When two
+                // openscience processes (CLI + workspace server) race a
+                // refresh — common while requests are being retried against an
+                // exhausted usage limit — the loser is left holding a revoked
+                // token and every later refresh fails, even after the limit
+                // resets. The winner has already persisted the rotated pair,
+                // so re-read auth before giving up.
+                const latest = (await getAuth()) as typeof currentAuth & { accountId?: string }
+                if (latest.type === "oauth" && latest.access && latest.expires > Date.now()) {
+                  currentAuth.access = latest.access
+                  authWithAccount.accountId = latest.accountId ?? authWithAccount.accountId
+                } else {
+                  if (latest.type === "oauth" && latest.refresh && latest.refresh !== currentAuth.refresh) {
+                    tokens = await refreshAccessTokenSingleFlight(latest.refresh).catch(() => undefined)
+                  }
+                  if (!tokens) {
+                    log.warn("codex token refresh failed", { error: String(e) })
+                    throw new Error(
+                      "Codex sign-in expired. Reconnect it with `openscience auth login` and choose Codex — Sign in with ChatGPT.",
+                    )
+                  }
+                }
+              }
+              if (tokens) {
+                const newAccountId = extractAccountId(tokens) || authWithAccount.accountId
+                await input.client.auth.set({
+                  path: { id: "openai-codex" },
+                  body: {
+                    type: "oauth",
+                    refresh: tokens.refresh_token,
+                    access: tokens.access_token,
+                    expires: Date.now() + (tokens.expires_in ?? 3600) * 1000,
+                    ...(newAccountId && { accountId: newAccountId }),
+                  },
+                })
+                currentAuth.access = tokens.access_token
+                authWithAccount.accountId = newAccountId
+              }
             }
 
             // Build headers


### PR DESCRIPTION
Users whose Codex (Sign in with ChatGPT) usage limit gets exhausted end up with a permanently broken `openai-codex` provider — **even after the ChatGPT limit resets**. Root cause: ChatGPT rotates the refresh token on every refresh, and our single-flight guard only covers one process. While requests retry against an exhausted limit, the CLI and the workspace server race the refresh; the loser keeps a revoked refresh token, and from then on every refresh throws `Token refresh failed: 400` until the user figures out they must disconnect and re-login.

The loader's refresh path now:
- on refresh failure, re-reads persisted auth (the racing winner already stored the rotated token pair)
- adopts a still-valid access token, or retries the refresh once with the rotated refresh token
- only then fails, with an actionable message ('Reconnect it with `openscience auth login` → Codex — Sign in with ChatGPT') instead of the raw 400

Verified: turbo typecheck clean; full backend suite 828/828; codex + billing-gate tests 20/20. The loader fetch closure has no unit harness (existing tests cover only the exported JWT helpers) — noted for future work.