### PR TITLE
fix(settings): persist only the billing delta so resolved secrets never hit disk

### DIFF
--- a/backend/cli/src/server/routes/settings/billing.ts
+++ b/backend/cli/src/server/routes/settings/billing.ts
@@ -69,9 +69,10 @@ export const BillingSettingsRoutes = lazy(() =>
       validator("json", BillingPatch),
       async (c) => {
         const patch = c.req.valid("json")
-        const cfg = await Config.getGlobal()
-        const next = { ...cfg, billing: { ...(cfg.billing ?? {}), ...patch } }
-        await Config.updateGlobal(next)
+        // Persist only the delta. updateGlobal deep-merges into the raw file;
+        // writing back Config.getGlobal() would bake resolved {env:}/{file:}
+        // secrets into openscience.json in plaintext.
+        await Config.updateGlobal({ billing: patch })
         log.info("update", { keys: Object.keys(patch) })
 
         // Mirror the LLM toggle to the account-scoped server billing mode, then force

--- a/backend/cli/test/server/settings-billing.test.ts
+++ b/backend/cli/test/server/settings-billing.test.ts
@@ -1,0 +1,36 @@
+import { test, expect, afterEach } from "bun:test"
+import path from "path"
+import fs from "fs/promises"
+import { Global } from "../../src/global"
+import { BillingSettingsRoutes } from "../../src/server/routes/settings/billing"
+
+const file = path.join(Global.Path.config, "openscience.json")
+
+afterEach(async () => {
+  await fs.rm(file, { force: true }).catch(() => {})
+})
+
+test("PUT persists the toggle without baking resolved secrets into the config file", async () => {
+  process.env["SPEND_TOGGLE_TEST_KEY"] = "sk-live-super-secret-123"
+  await fs.mkdir(Global.Path.config, { recursive: true })
+  await Bun.write(
+    file,
+    JSON.stringify({ provider: { openrouter: { options: { apiKey: "{env:SPEND_TOGGLE_TEST_KEY}" } } } }, null, 2),
+  )
+
+  const res = await BillingSettingsRoutes().request("/", {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ llm: "byok" }),
+  })
+  expect(res.status).toBe(200)
+  const state = await res.json()
+  expect(state.llm).toBe("byok")
+
+  const text = await Bun.file(file).text()
+  expect(text).toContain("{env:SPEND_TOGGLE_TEST_KEY}")
+  expect(text).not.toContain("sk-live-super-secret-123")
+
+  const written = JSON.parse(text)
+  expect(written.billing).toEqual({ llm: "byok" })
+})


### PR DESCRIPTION
Fixes #51.

The Spend toggle PUT handler round-tripped the entire resolved global config:

```ts
const cfg = await Config.getGlobal()
const next = { ...cfg, billing: { ...(cfg.billing ?? {}), ...patch } }
await Config.updateGlobal(next)
```

`getGlobal()` resolves `{env:VAR}` and `{file:...}` references, so flipping a toggle in Settings wrote the literal secrets into `~/.config/openscience/openscience.json` and destroyed the env indirection.

`updateGlobal` already deep-merges into the raw on-disk file, so the route now passes only the delta:

```ts
await Config.updateGlobal({ billing: patch })
```

Added a regression test that drives the real route against an isolated config containing `"apiKey": "{env:...}"` and asserts the reference survives, the resolved value never hits disk, and only `billing` is written. It fails on main (the failure output shows the plaintext key in the file) and passes here.

Full backend suite: 829 pass / 0 fail. Typecheck clean.
