### PR TITLE
fix(sync): stop firing a full Atlas sync on every message

### DIFF
--- a/backend/cli/src/openscience/index.ts
+++ b/backend/cli/src/openscience/index.ts
@@ -305,6 +305,12 @@ export namespace OpenScience {
         api_key: data.api_key,
         user_id: data.user_id || "",
         device_name: data.device_name,
+        // Sync bookkeeping. Dropping these made refreshIfStale's TTL and
+        // version dedupe dead code: every message fired a version probe
+        // plus a full background sync, and updateSession (getSession +
+        // spread + save) erased whichever field it wasn't patching.
+        cached_v: data.cached_v,
+        last_check_ts: data.last_check_ts,
       }
     } catch {
       return null

--- a/backend/cli/test/openscience-session.test.ts
+++ b/backend/cli/test/openscience-session.test.ts
@@ -1,0 +1,30 @@
+import { test, expect, afterEach } from "bun:test"
+import path from "path"
+import fs from "fs/promises"
+import { Global } from "../src/global"
+import { OpenScience } from "../src/openscience"
+
+const file = path.join(Global.Path.data, "openscience-session.json")
+
+afterEach(async () => {
+  await fs.rm(file, { force: true }).catch(() => {})
+})
+
+test("getSession carries the sync bookkeeping fields", async () => {
+  await fs.mkdir(Global.Path.data, { recursive: true })
+  await Bun.write(
+    file,
+    JSON.stringify({
+      api_key: "thk_test.secret",
+      user_id: "user-1",
+      device_name: "test-device",
+      cached_v: 7,
+      last_check_ts: 1751700000000,
+    }),
+  )
+
+  const session = await OpenScience.getSession()
+  expect(session).not.toBeNull()
+  expect(session!.cached_v).toBe(7)
+  expect(session!.last_check_ts).toBe(1751700000000)
+})


### PR DESCRIPTION
Fixes #52.

`getSession()` rebuilt the session object with only `api_key`/`user_id`/`device_name`, dropping the two fields `refreshIfStale()` depends on: `last_check_ts` (probe TTL) and `cached_v` (version dedupe). So the TTL gate never passed and the version always looked changed — every message fired a `/api/cli/sync/version` probe plus a full background `/api/cli/sync`, each rewriting `synced-env.json`, `openscience-synced.json`, and the session file, and invalidating provider state. `updateSession` (getSession + spread + save) also erased whichever bookkeeping field it wasn't patching, which is why the probe's own timestamp never stuck.

The fix carries `cached_v` and `last_check_ts` through `getSession()`, which restores both the 10-second probe TTL and the version dedupe, and makes `updateSession` merges lossless.

Beyond the request storm itself, this shrinks the attack surface for #55 (a transient 403 during sync silently signs the user out): fewer syncs, fewer chances to trip it.

Regression test writes a session file with both fields and asserts `getSession` returns them; it fails on main and passes here. Full backend suite: 829 pass / 0 fail. Typecheck clean.
