### PR TITLE
fix: point install, upgrade, and docs URLs at openscience.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Give it a goal. It reads the literature, writes and runs code, runs the experime
 [![CI](https://github.com/synthetic-sciences/OpenScience/actions/workflows/ci.yml/badge.svg)](https://github.com/synthetic-sciences/OpenScience/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/%40synsci%2Fopenscience?label=%40synsci%2Fopenscience&color=0d9488)](https://www.npmjs.com/package/@synsci/openscience)
 [![license](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-[![docs](https://img.shields.io/badge/docs-syntheticsciences.ai-0d9488.svg)](https://syntheticsciences.ai/docs)
+[![docs](https://img.shields.io/badge/docs-openscience.sh-0d9488.svg)](https://openscience.sh/docs)
 
-[Install](#install) · [Quickstart](#quickstart) · [Docs](https://syntheticsciences.ai/docs) · [Atlas](#atlas)
+[Install](#install) · [Quickstart](#quickstart) · [Docs](https://openscience.sh/docs) · [Atlas](#atlas)
 
 </div>
 
@@ -88,7 +88,7 @@ OpenScience runs a local server that hosts the workspace UI, the agent runtime, 
 
 ## Configuration
 
-Global config lives in `~/.config/openscience/openscience.json`. Project config lives in `openscience.json` or a `.openscience/` directory at the repo root ([schema](https://syntheticsciences.ai/config.json)). Custom agents, commands, tools, plugins, and themes load from those directories.
+Global config lives in `~/.config/openscience/openscience.json`. Project config lives in `openscience.json` or a `.openscience/` directory at the repo root ([schema](https://openscience.sh/config.json)). Custom agents, commands, tools, plugins, and themes load from those directories.
 
 ## Development
 

--- a/backend/cli/bin/openscience
+++ b/backend/cli/bin/openscience
@@ -111,6 +111,6 @@ if (isBinary("/usr/local/bin/openscience")) {
 }
 
 console.error("openscience binary not found.")
-console.error("Install with: curl -fsSL https://syntheticsciences.ai/install | bash")
+console.error("Install with: curl -fsSL https://openscience.sh/install | bash")
 console.error("Or set OPENSCIENCE_BIN_PATH environment variable.")
 process.exit(1)

--- a/backend/cli/src/installation/index.ts
+++ b/backend/cli/src/installation/index.ts
@@ -134,10 +134,10 @@ export namespace Installation {
     let cmd
     switch (method) {
       case "curl":
-        // The bash installer moved to app.syntheticsciences.ai with the
-        // openscience-dashboard retirement. Override via OPENSCIENCE_INSTALL_URL if
-        // hosting the script elsewhere.
-        cmd = $`curl -fsSL ${process.env.OPENSCIENCE_INSTALL_URL || "https://app.syntheticsciences.ai/install"} | bash`.env({
+        // openscience.sh/install serves the repo install script. The app
+        // subdomain serves the dashboard SPA, so piping it into bash fails.
+        // Override via OPENSCIENCE_INSTALL_URL if hosting the script elsewhere.
+        cmd = $`curl -fsSL ${process.env.OPENSCIENCE_INSTALL_URL || "https://openscience.sh/install"} | bash`.env({
           ...process.env,
           VERSION: target,
         })

--- a/frontend/docs/src/components/Lander.astro
+++ b/frontend/docs/src/components/Lander.astro
@@ -23,7 +23,7 @@ const discord = config.social.filter(s => s.icon === 'discord')[0];
 
 const command = "curl -fsSL"
 const protocol = "https://"
-const url = "syntheticsciences.ai/install"
+const url = "openscience.sh/install"
 const bash = "| bash"
 
 let darkImage: ImageMetadata | undefined;
@@ -121,9 +121,9 @@ if (image) {
       </div>
       <div class="col4">
         <h3>Installer</h3>
-        <button class="command" data-command="curl -fsSL https://syntheticsciences.ai/install | bash">
+        <button class="command" data-command="curl -fsSL https://openscience.sh/install | bash">
           <code>
-            <span>curl -fsSL</span> <span class="highlight">syntheticsciences.ai/install</span> <span>| bash</span>
+            <span>curl -fsSL</span> <span class="highlight">openscience.sh/install</span> <span>| bash</span>
           </code>
           <span class="copy">
             <CopyIcon />

--- a/frontend/landing/public/install
+++ b/frontend/landing/public/install
@@ -20,8 +20,8 @@ Options:
         --no-modify-path    Don't modify shell config files (.zshrc, .bashrc, etc.)
 
 Examples:
-    curl -fsSL https://syntheticsciences.ai/install | bash
-    curl -fsSL https://syntheticsciences.ai/install | bash -s -- --version 1.0.180
+    curl -fsSL https://openscience.sh/install | bash
+    curl -fsSL https://openscience.sh/install | bash -s -- --version 1.0.180
     ./install --binary /path/to/openscience
 EOF
 }
@@ -449,6 +449,6 @@ echo -e ""
 echo -e "cd <project>  ${MUTED}# Open directory${NC}"
 echo -e "openscience         ${MUTED}# Run command${NC}"
 echo -e ""
-echo -e "${MUTED}For more information visit ${NC}https://syntheticsciences.ai/docs"
+echo -e "${MUTED}For more information visit ${NC}https://openscience.sh/docs"
 echo -e ""
 echo -e ""

--- a/frontend/landing/src/pages/Landing.tsx
+++ b/frontend/landing/src/pages/Landing.tsx
@@ -27,7 +27,7 @@ const MONO_N = "font-terminal text-[11px] tracking-[0.08em] text-foreground/40";
 const LABEL = "text-[14px] text-muted-foreground";
 
 const GITHUB = "https://github.com/synthetic-sciences/openscience";
-const DOCS = "https://syntheticsciences.ai/docs";
+const DOCS = "https://openscience.sh/docs";
 const NPM_CMD = "npm i -g @synsci/openscience";
 const CURL_CMD = "curl -fsSL https://openscience.sh/install | bash";
 

--- a/install
+++ b/install
@@ -20,8 +20,8 @@ Options:
         --no-modify-path    Don't modify shell config files (.zshrc, .bashrc, etc.)
 
 Examples:
-    curl -fsSL https://syntheticsciences.ai/install | bash
-    curl -fsSL https://syntheticsciences.ai/install | bash -s -- --version 1.0.180
+    curl -fsSL https://openscience.sh/install | bash
+    curl -fsSL https://openscience.sh/install | bash -s -- --version 1.0.180
     ./install --binary /path/to/openscience
 EOF
 }
@@ -449,6 +449,6 @@ echo -e ""
 echo -e "cd <project>  ${MUTED}# Open directory${NC}"
 echo -e "openscience         ${MUTED}# Run command${NC}"
 echo -e ""
-echo -e "${MUTED}For more information visit ${NC}https://syntheticsciences.ai/docs"
+echo -e "${MUTED}For more information visit ${NC}https://openscience.sh/docs"
 echo -e ""
 echo -e ""


### PR DESCRIPTION
Fixes #43. Fixes #36.

The `syntheticsciences.ai/{install,docs,config.json}` URL family returns 404, and the CLI self-upgrade default pointed at the app subdomain, which serves the dashboard SPA. `openscience upgrade` therefore piped HTML into bash:

```
■  Upgrade failed
■  /bin/bash: line 1: syntax error near unexpected token `newline'
│  /bin/bash: line 1: `<!doctype html>'
```

`https://openscience.sh/install` serves the repo install script byte-for-byte (verified with diff), so everything now points there:

- `backend/cli/src/installation/index.ts`: self-upgrade default URL (the #43 bug)
- `install` + `frontend/landing/public/install`: usage examples and the post-install docs pointer (kept identical, verified with diff)
- `backend/cli/bin/openscience`: the npm wrapper's "binary not found" help text
- `README.md`: docs badge, docs nav link, config schema link
- `frontend/landing/src/pages/Landing.tsx`: DOCS link
- `frontend/docs/src/components/Lander.astro`: the copy-pasteable install one-liner on the docs site

Not touched here: the `$schema: https://syntheticsciences.ai/config.json` references spread across docs examples, tests, and the config-writing code paths, plus the share-link and Referer hosts. Those are tracked in #36 — worth deciding between a bulk rewrite and standing up redirects on syntheticsciences.ai (redirects would also fix URLs baked into already-shipped binaries and SDKs).

Verified: `bash -n` on both install scripts, backend typecheck, landing `vite build`.
