### PR TITLE
docs: fix stale paths, branch name, boilerplate, and copyright holder

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
-- To regenerate the JavaScript SDK, run `./tooling/sdk/js/script/build.ts`.
+- To regenerate the JavaScript SDK, run `./tooling/repo/generate.ts` from the repo root.
 - ALWAYS USE PARALLEL TOOLS WHEN APPLICABLE.
-- The default branch in this repo is `dev`.
+- The default branch in this repo is `main`.
 - Prefer automation: execute requested actions without confirmation unless blocked by missing info or safety/irreversibility.
 
 ## Style Guide

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -26,14 +26,17 @@ The server binds to `127.0.0.1` and enforces a Host and Origin allowlist. There 
 
 ```
 backend/cli          The CLI, server, agent runtime, tools, and skills
-frontend/workspace         The workspace UI (SolidJS), served by the CLI
+frontend/workspace   The workspace UI (SolidJS), served by the CLI
 frontend/ui          Shared UI components, themes, and fonts
-frontend/docs         The documentation and session-share site (Astro)
+frontend/docs        The documentation and session-share site (Astro)
+frontend/landing     The marketing site (openscience.sh)
 tooling/sdk/js       The TypeScript SDK, generated from the server contract
 tooling/plugin       The plugin runtime (@synsci/plugin)
 tooling/launcher     The `npx synsci` installer
 tooling/repo         Release automation
 tooling/script       Build helper used across packages
+tooling/util         Shared TypeScript utilities (@synsci/util)
+tooling/patches      Dependency patches applied at install time
 ```
 
 ## Backend (`backend/cli`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Thanks for your interest in contributing. These changes are the most likely to b
 - Missing standard behavior
 - Documentation improvements
 
-Any UI or core product feature should go through a design discussion with the maintainers before you build it. If you are not sure whether a change would be accepted, ask in an issue or look for issues labeled [`help wanted`](https://github.com/synthetic-sciences/OpenScience/issues?q=is%3Aissue+state%3Aopen+label%3Ahelp-wanted), [`good first issue`](https://github.com/synthetic-sciences/OpenScience/issues?q=is%3Aissue+state%3Aopen+label%3A%22good+first+issue%22), or [`bug`](https://github.com/synthetic-sciences/OpenScience/issues?q=is%3Aissue+state%3Aopen+label%3Abug).
+Any UI or core product feature should go through a design discussion with the maintainers before you build it. If you are not sure whether a change would be accepted, ask in an issue or look for issues labeled [`help wanted`](https://github.com/synthetic-sciences/OpenScience/issues?q=is%3Aissue+state%3Aopen+label%3A%22help+wanted%22), [`good first issue`](https://github.com/synthetic-sciences/OpenScience/issues?q=is%3Aissue+state%3Aopen+label%3A%22good+first+issue%22), or [`bug`](https://github.com/synthetic-sciences/OpenScience/issues?q=is%3Aissue+state%3Aopen+label%3Abug).
 
 ## Development
 
@@ -40,7 +40,7 @@ bun dev web             # start the server and open the workspace
 
 ```bash
 ./backend/cli/script/build.ts --single
-./backend/cli/dist/openscience-<platform>/bin/openscience
+./backend/cli/dist/@synsci/openscience-<platform>/bin/openscience
 ```
 
 Replace `<platform>` with your platform, for example `darwin-arm64` or `linux-x64`.
@@ -51,8 +51,10 @@ Replace `<platform>` with your platform, for example `darwin-arm64` or `linux-x6
 - `frontend/workspace`: the workspace UI, written in SolidJS.
 - `frontend/ui`: shared UI components and themes.
 - `frontend/docs`: the documentation and share site.
+- `frontend/landing`: the marketing site at openscience.sh.
 - `tooling/plugin`: the source for `@synsci/plugin`.
 - `tooling/sdk/js`: the TypeScript SDK.
+- `tooling/launcher`: the `npx synsci` installer.
 
 ### Working on the workspace UI
 
@@ -99,6 +101,7 @@ Follow conventional commits, with an optional scope:
 - `chore:` maintenance and dependency updates
 - `refactor:` refactoring with no behavior change
 - `test:` tests
+- `ci:` CI and release workflow changes
 
 Examples: `docs: update contributing guide`, `fix: resolve crash on startup`, `feat(app): add dark mode`.
 

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 OpenScience
-Copyright 2025 Synthetic Sciences
+Copyright 2026 Synthetic Sciences
 
 This product includes software developed at Synthetic Sciences.
 Licensed under the Apache License, Version 2.0.
@@ -27,6 +27,3 @@ of any data source they query.
 
 Client-side rendering libraries (Mol*, igv.js, RDKit.js, KaTeX, pdf.js, 3Dmol.js)
 are dependencies declared in package.json and retain their own licenses.
-
-A full third-party dependency license listing can be generated from the package
-manifests; see THIRD_PARTY_LICENSES.md (generated) where present.

--- a/frontend/docs/README.md
+++ b/frontend/docs/README.md
@@ -1,54 +1,23 @@
-# Starlight Starter Kit: Basics
+# docs
 
-[![Built with Starlight](https://astro.badg.es/v2/built-with-starlight/tiny.svg)](https://starlight.astro.build)
+The OpenScience documentation and session-share site, built with [Astro Starlight](https://starlight.astro.build/).
 
-```
-npm create astro@latest -- --template starlight
-```
+This package is part of the bun workspace, so install dependencies from the repo root:
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/starlight/tree/main/examples/basics)
-[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/withastro/starlight/tree/main/examples/basics)
-[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/withastro/starlight&create_from_path=examples/basics)
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fwithastro%2Fstarlight%2Ftree%2Fmain%2Fexamples%2Fbasics&project-name=my-starlight-docs&repository-name=my-starlight-docs)
-
-> 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
-
-## 🚀 Project Structure
-
-Inside of your Astro + Starlight project, you'll see the following folders and files:
-
-```
-.
-├── public/
-├── src/
-│   ├── assets/
-│   ├── content/
-│   │   ├── docs/
-│   └── content.config.ts
-├── astro.config.mjs
-├── package.json
-└── tsconfig.json
+```bash
+bun install
 ```
 
-Starlight looks for `.md` or `.mdx` files in the `src/content/docs/` directory. Each file is exposed as a route based on its file name.
+Then run the dev server:
 
-Images can be added to `src/assets/` and embedded in Markdown with a relative link.
+```bash
+bun run --cwd frontend/docs dev
+```
 
-Static assets, like favicons, can be placed in the `public/` directory.
+Or build the site:
 
-## 🧞 Commands
+```bash
+bun run --cwd frontend/docs build
+```
 
-All commands are run from the root of the project, from a terminal:
-
-| Command                   | Action                                           |
-| :------------------------ | :----------------------------------------------- |
-| `npm install`             | Installs dependencies                            |
-| `npm run dev`             | Starts local dev server at `localhost:4321`      |
-| `npm run build`           | Build your production site to `./dist/`          |
-| `npm run preview`         | Preview your build locally, before deploying     |
-| `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
-| `npm run astro -- --help` | Get help using the Astro CLI                     |
-
-## 👀 Want to learn more?
-
-Check out [Starlight’s docs](https://starlight.astro.build/), read [the Astro documentation](https://docs.astro.build), or jump into the [Astro Discord server](https://astro.build/chat).
+Pages live in `src/content/docs/` as `.md`/`.mdx` files, each exposed as a route based on its file name.

--- a/frontend/landing/src/pages/Landing.tsx
+++ b/frontend/landing/src/pages/Landing.tsx
@@ -938,7 +938,7 @@ export default function Landing() {
           </div>
 
           <div className="mt-14 pt-6 border-t border-border/40 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 text-[12.5px] text-foreground/45">
-            <div>&copy; {new Date().getFullYear()} InkVell Inc. OpenScience is a Synthetic Sciences project. Apache 2.0.</div>
+            <div>&copy; {new Date().getFullYear()} Synthetic Sciences. Apache 2.0.</div>
             <a href="#top" className="link-underline hover:text-foreground inline-flex items-center gap-2">
               Back to top
               <svg width="9" height="11" viewBox="0 0 9 11" aria-hidden>


### PR DESCRIPTION
Docs hygiene sweep across the repo, one small fix per issue:

- **Built-binary path**: CONTRIBUTING now points at `./backend/cli/dist/@synsci/openscience-<platform>/bin/openscience`, matching what `build.ts` actually emits (dist dirs are named from `pkg.name`).
- **Default branch**: AGENTS.md said the default branch is `dev`; it is `main`.
- **frontend/docs README**: replaced the unedited Starlight template (npm commands that don't resolve in this bun workspace) with a short real README: `bun install` at the repo root, `bun run --cwd frontend/docs dev` / `build`.
- **Consistency sweep**: the help-wanted link now filters `label:"help wanted"` (the label has a space); NOTICE no longer points at the nonexistent THIRD_PARTY_LICENSES.md and its year is 2026; the ARCHITECTURE repo-layout block gains `frontend/landing`, `tooling/util`, and `tooling/patches` with the frontend rows re-aligned, and CONTRIBUTING's "Where things live" gains `frontend/landing` and `tooling/launcher`; AGENTS.md now points SDK regeneration at `./tooling/repo/generate.ts` (run from the repo root) like CONTRIBUTING and ARCHITECTURE; the conventional-commit list includes `ci:`.
- **Copyright holder**: the landing footer now reads "© {year} Synthetic Sciences. Apache 2.0.", agreeing with NOTICE.

Verified: `bun run build` passes in `frontend/landing`, and every path referenced in the edited docs exists.

Fixes #38
Fixes #39
Fixes #40
Fixes #41
Fixes #42
