### PR TITLE
feat(release): publish checksums.txt and verify downloads in the installer

### DIFF
--- a/backend/cli/script/build.ts
+++ b/backend/cli/script/build.ts
@@ -207,15 +207,21 @@ for (const item of targets) {
 }
 
 if (Script.release) {
+  const checksums: string[] = []
   for (const key of Object.keys(binaries)) {
-    const archiveName = key.replace(`${pkg.name}-`, "openscience-")
+    const archiveName = key.replace(`${pkg.name}-`, "openscience-") + (key.includes("linux") ? ".tar.gz" : ".zip")
     if (key.includes("linux")) {
-      await $`tar -czf ${path.resolve(dir, `dist/${archiveName}.tar.gz`)} *`.cwd(`dist/${key}/bin`)
+      await $`tar -czf ${path.resolve(dir, `dist/${archiveName}`)} *`.cwd(`dist/${key}/bin`)
     } else {
-      await $`zip -r ${path.resolve(dir, `dist/${archiveName}.zip`)} *`.cwd(`dist/${key}/bin`)
+      await $`zip -r ${path.resolve(dir, `dist/${archiveName}`)} *`.cwd(`dist/${key}/bin`)
     }
+    const bytes = await Bun.file(path.resolve(dir, `dist/${archiveName}`)).arrayBuffer()
+    const hash = new Bun.CryptoHasher("sha256").update(bytes).digest("hex")
+    checksums.push(`${hash}  ${archiveName}`)
   }
-  await $`gh release upload v${Script.version} ./dist/*.zip ./dist/*.tar.gz --clobber`
+  // sha256sum-compatible manifest; the install script verifies against it
+  await Bun.write(path.resolve(dir, "dist/checksums.txt"), checksums.join("\n") + "\n")
+  await $`gh release upload v${Script.version} ./dist/*.zip ./dist/*.tar.gz ./dist/checksums.txt --clobber`
 }
 
 export { binaries }

--- a/frontend/landing/public/install
+++ b/frontend/landing/public/install
@@ -331,6 +331,32 @@ download_and_install() {
         exit 1
     fi
 
+    # Verify against the release's checksums.txt when a sha256 tool exists.
+    # Releases published before checksums.txt simply skip verification.
+    local shatool=""
+    if command -v sha256sum >/dev/null 2>&1; then
+        shatool="sha256sum"
+    elif command -v shasum >/dev/null 2>&1; then
+        shatool="shasum -a 256"
+    fi
+    if [ -n "$shatool" ]; then
+        local checksums_url="${url%/*}/checksums.txt"
+        local expected
+        expected=$(curl -fsSL "$checksums_url" 2>/dev/null | awk -v f="$filename" '$2 == f {print $1}') || expected=""
+        if [ -n "$expected" ]; then
+            local actual
+            actual=$($shatool "$tmp_dir/$filename" | awk '{print $1}')
+            if [ "$actual" != "$expected" ]; then
+                echo -e "${RED}Checksum mismatch for ${filename}${NC}"
+                echo -e "${MUTED}expected: ${expected}${NC}"
+                echo -e "${MUTED}actual:   ${actual}${NC}"
+                rm -rf "$tmp_dir"
+                exit 1
+            fi
+            print_message info "${MUTED}Checksum verified${NC}"
+        fi
+    fi
+
     if [ "$os" = "linux" ]; then
         tar -xzf "$tmp_dir/$filename" -C "$tmp_dir"
     else

--- a/install
+++ b/install
@@ -331,6 +331,32 @@ download_and_install() {
         exit 1
     fi
 
+    # Verify against the release's checksums.txt when a sha256 tool exists.
+    # Releases published before checksums.txt simply skip verification.
+    local shatool=""
+    if command -v sha256sum >/dev/null 2>&1; then
+        shatool="sha256sum"
+    elif command -v shasum >/dev/null 2>&1; then
+        shatool="shasum -a 256"
+    fi
+    if [ -n "$shatool" ]; then
+        local checksums_url="${url%/*}/checksums.txt"
+        local expected
+        expected=$(curl -fsSL "$checksums_url" 2>/dev/null | awk -v f="$filename" '$2 == f {print $1}') || expected=""
+        if [ -n "$expected" ]; then
+            local actual
+            actual=$($shatool "$tmp_dir/$filename" | awk '{print $1}')
+            if [ "$actual" != "$expected" ]; then
+                echo -e "${RED}Checksum mismatch for ${filename}${NC}"
+                echo -e "${MUTED}expected: ${expected}${NC}"
+                echo -e "${MUTED}actual:   ${actual}${NC}"
+                rm -rf "$tmp_dir"
+                exit 1
+            fi
+            print_message info "${MUTED}Checksum verified${NC}"
+        fi
+    fi
+
     if [ "$os" = "linux" ]; then
         tar -xzf "$tmp_dir/$filename" -C "$tmp_dir"
     else


### PR DESCRIPTION
Fixes #50.

The build step now computes sha256 digests for every release archive as it creates them and uploads a `checksums.txt` (sha256sum format) with the release assets. The install script downloads it from the same release directory as the archive and verifies before extraction:

- match: prints "Checksum verified" and proceeds
- mismatch: fails with the expected and actual digests
- release predates checksums.txt, or no sha256 tool on the system: skips verification, exactly as before

Verified with a sandboxed `HOME`, clean `PATH`, pinned `--version 1.2.3` install: full download runs, verification skips gracefully (that release has no checksums file), binary lands and reports its version. The checksum-parsing awk was exercised against a synthetic manifest. Both install-script copies stay in sync (`diff -q` in CI keeps it that way after #66).
