### PR TITLE
fix(billing): classify credentials by value, key managed-proxy guard off the effective credential

### DIFF
--- a/backend/cli/src/provider/provider.ts
+++ b/backend/cli/src/provider/provider.ts
@@ -88,10 +88,15 @@ export namespace Provider {
   }
 
   function requireAtlasProxyForManagedKey(provider: Info, options: Record<string, any>) {
-    const hasManagedKey =
-      isAtlasApiKey(options["apiKey"]) ||
-      provider.env.some((key) => isAtlasApiKey(Env.get(key)))
-    if (!hasManagedKey) return
+    // Key off the EFFECTIVE credential, not raw env. A managed thk_ value can
+    // sit unused in env while an auth.json key wins resolution; demanding
+    // proxy routing for it hard-failed every call with advice (`connect
+    // sync`) that re-delivers the same env and can never fix it.
+    const effective =
+      (typeof options["apiKey"] === "string" ? (options["apiKey"] as string) : undefined) ??
+      provider.key ??
+      provider.env.map((key) => Env.get(key)).find((value): value is string => !!value)
+    if (!isAtlasApiKey(effective)) return
     if (isAtlasProxyBaseURL(options["baseURL"])) return
     throw new Error(
       `${provider.id} is using a managed Atlas key without an Atlas proxy URL. ` +

--- a/backend/cli/src/server/routes/provider.ts
+++ b/backend/cli/src/server/routes/provider.ts
@@ -52,8 +52,16 @@ export const ProviderRoutes = lazy(() =>
           mapValues(filteredProviders, (x) => Provider.fromModelsDevProvider(x)),
           connected,
         )
+        // Never hand raw credentials to the browser. The UI only needs to
+        // know that a provider is connected and where its key came from
+        // (`source`), not the key itself.
+        const redacted = Object.values(providers).map((item) => {
+          const options = { ...item.options }
+          if (typeof options["apiKey"] === "string" && options["apiKey"].length > 0) options["apiKey"] = ""
+          return { ...item, key: undefined, options }
+        })
         return c.json({
-          all: Object.values(providers),
+          all: redacted,
           default: mapValues(providers, (item) => Provider.sort(Object.values(item.models))[0].id),
           connected: Object.keys(connected),
         })

--- a/backend/cli/src/server/server.ts
+++ b/backend/cli/src/server/server.ts
@@ -188,6 +188,9 @@ export namespace Server {
             const providerID = c.req.valid("param").providerID
             const info = c.req.valid("json")
             await Auth.set(providerID, info)
+            // Don't depend on the client remembering to call global.sync —
+            // stale provider state would keep serving the old credential.
+            Provider.invalidate()
             return c.json(true)
           },
         )
@@ -218,6 +221,7 @@ export namespace Server {
           async (c) => {
             const providerID = c.req.valid("param").providerID
             await Auth.remove(providerID)
+            Provider.invalidate()
             return c.json(true)
           },
         )

--- a/backend/cli/src/session/billing-gate.ts
+++ b/backend/cli/src/session/billing-gate.ts
@@ -74,22 +74,20 @@ export async function resolveCredentialSource(
 
   const provider = await Provider.getProvider(providerID).catch(() => undefined)
 
-  // 1) Managed: a thk_* proxy token or a dashboard-synced secret. Check the
-  //    resolved key, any explicit apiKey option, and the provider's env vars.
+  // 1) Managed: a thk_* proxy token. Classified by VALUE, not by how the
+  //    credential arrived: the dashboard sync also delivers the user's own
+  //    keys (OPENROUTER_API_KEY etc.), and treating "arrived via sync" as
+  //    "managed" wallet-gated and billed BYOK keys — exactly what this
+  //    module's contract forbids. It was also boot-order dependent (the
+  //    synced-secret set is empty until an in-process sync runs).
   const optionKey = provider?.options?.["apiKey"]
   const resolvedKey = typeof provider?.key === "string" ? provider.key : undefined
   const explicitKey = typeof optionKey === "string" ? optionKey : undefined
-  if (
-    OpenScience.isManagedKeyValue(resolvedKey) ||
-    OpenScience.isManagedKeyValue(explicitKey) ||
-    OpenScience.isSyncedSecretValue(resolvedKey) ||
-    OpenScience.isSyncedSecretValue(explicitKey)
-  ) {
+  if (OpenScience.isManagedKeyValue(resolvedKey) || OpenScience.isManagedKeyValue(explicitKey)) {
     return "managed"
   }
   const envKeys = provider?.env ?? []
   for (const key of envKeys) {
-    if (OpenScience.isSyncedSecretKey(key)) return "managed"
     if (OpenScience.isManagedKeyValue(Env.get(key))) return "managed"
   }
 


### PR DESCRIPTION
Fixes #69. Fixes #70. Fixes #74. Fixes #75.

Four related credential fixes:

**#69** — `requireAtlasProxyForManagedKey` inspected raw env vars, so with managed sync active plus an older `auth login` key for the same provider, the resolved (local) key would be pinned to the public endpoint while the guard still saw the unused `thk_` value in env and threw — and its advice, `openscience connect sync`, re-delivers the same env, so the error was unescapable. The guard now keys off the effective resolved credential, using the same resolution order as `pinByokToPublicEndpoint`. Local-key-beats-synced-key precedence now actually works.

**#70** — `resolveCredentialSource` classified any dashboard-synced env var as managed. The sync response explicitly also carries user-owned keys (OpenRouter, Together, ...), so a user's own dashboard-connected key got wallet-gated at $0 and usage-reported for billing, contradicting the module's own written contract. It was also boot-order dependent. Managed is now decided by credential value (`thk_` prefix) wherever it appears (resolved key, explicit option, env).

**#74** — `GET /provider` returned each provider's raw `key` (including the managed `thk_` token) to the browser, despite the Credentials UI promising values are never returned. The route now drops `key` and blanks any `options.apiKey`; `connected` and `source` still tell the UI everything it renders.

**#75** — the auth PUT/DELETE routes now call `Provider.invalidate()` themselves rather than depending on the SPA's follow-up `global.sync`.

Backend suite: 830 pass / 0 fail. Typecheck clean.
