### PR TITLE
fix(workspace): credential source badges, sign-out feedback, live wallet refresh

### DIFF
--- a/frontend/workspace/src/components/settings/Credentials.tsx
+++ b/frontend/workspace/src/components/settings/Credentials.tsx
@@ -3,6 +3,7 @@
 // secret is write-only: values are never returned after saving.
 import { type Component, type JSX, For, Show, createMemo, createSignal, onMount } from "solid-js"
 import { Button } from "@synsci/ui/button"
+import type { Provider } from "@synsci/sdk/v2/client"
 import { useGlobalSDK } from "@/context/global-sdk"
 import { usePlatform } from "@/context/platform"
 import { useProviders } from "@/hooks/use-providers"
@@ -33,6 +34,27 @@ const PROVIDER_LABEL: Record<string, string> = {
   deepseek: "DeepSeek",
 }
 const BYOK_PROVIDERS = ["anthropic", "openai", "google", "openrouter", "groq", "mistral", "xai", "deepseek"] as const
+
+// Where a connected provider's credential actually lives. Only "api" keys sit in
+// the local auth store — the others reappear after a remove, so remove is gated.
+const SOURCE_INFO: Record<Provider["source"], { label: string; removable: boolean; title: string }> = {
+  api: { label: "local", removable: true, title: "API key stored in the local auth store on this machine" },
+  env: {
+    label: "env",
+    removable: false,
+    title: "API key from an environment variable or dashboard sync — unset it where it is defined to remove it",
+  },
+  config: {
+    label: "config",
+    removable: false,
+    title: "API key set in openscience.json — edit the config file to remove it",
+  },
+  custom: {
+    label: "custom",
+    removable: false,
+    title: "Custom provider defined in openscience.json — edit the config file to remove it",
+  },
+}
 
 export const Credentials: Component = () => {
   const sdk = useGlobalSDK()
@@ -129,6 +151,9 @@ export const Credentials: Component = () => {
   const [keyValue, setKeyValue] = createSignal("")
   const [savingKey, setSavingKey] = createSignal(false)
   const connectedProviders = createMemo(() => providers.connected().filter((p) => p.id !== "synsci"))
+  // The list endpoint's generated type omits `source`, but the payload carries it
+  // for every connected provider (see Provider in @synsci/sdk/v2/client).
+  const sourceInfo = (p: { id: string }) => SOURCE_INFO[(p as { source?: Provider["source"] }).source ?? "api"]
   const saveKey = async () => {
     if (savingKey()) return
     const key = keyValue().trim()
@@ -372,10 +397,32 @@ export const Credentials: Component = () => {
                     <div class="flex items-center gap-2.5 min-w-0">
                       <StatusDot status="active" />
                       <span class="text-13-regular text-text-strong truncate">{PROVIDER_LABEL[p.id] ?? p.id}</span>
+                      <span
+                        class="flex-shrink-0 px-2 py-0.5 rounded-full text-11-regular border"
+                        style={{
+                          color: "var(--color-text-faint)",
+                          "border-color": "var(--color-border)",
+                          background: "transparent",
+                        }}
+                        title={sourceInfo(p).title}
+                      >
+                        {sourceInfo(p).label}
+                      </span>
                     </div>
-                    <Button size="small" variant="secondary" onClick={() => void removeKey(p.id)}>
-                      remove
-                    </Button>
+                    <Show
+                      when={sourceInfo(p).removable}
+                      fallback={
+                        <span title={sourceInfo(p).title}>
+                          <Button size="small" variant="secondary" disabled>
+                            remove
+                          </Button>
+                        </span>
+                      }
+                    >
+                      <Button size="small" variant="secondary" onClick={() => void removeKey(p.id)}>
+                        remove
+                      </Button>
+                    </Show>
                   </div>
                 )}
               </For>

--- a/frontend/workspace/src/components/settings/General.tsx
+++ b/frontend/workspace/src/components/settings/General.tsx
@@ -8,13 +8,14 @@
 import { Component, Show, createMemo, createSignal, onMount, type JSX } from "solid-js"
 import { Button } from "@synsci/ui/button"
 import { Select } from "@synsci/ui/select"
+import { showToast } from "@synsci/ui/toast"
 import { useGlobalSDK } from "@/context/global-sdk"
 import { useGlobalSync } from "@/context/global-sync"
 import { useModels } from "@/context/models"
 import { usePlatform } from "@/context/platform"
 import { useServer } from "@/context/server"
 import { URLS } from "@/config/urls"
-import { FONT_SANS } from "@/styles/tokens"
+import { FONT_CODE, FONT_SANS } from "@/styles/tokens"
 import { AppearanceSections } from "../settings-general"
 import { settingsApi } from "./api"
 
@@ -85,8 +86,12 @@ export default function General() {
     if (!window.confirm("Disconnect this local server from OpenScience?")) return
     setBusy(true)
     try {
-      await sdk.client.account.logout()
+      const res = await sdk.client.account.logout()
+      if (res.error)
+        throw new Error(typeof res.error === "string" ? res.error : "The server could not clear the session")
       setAccount({ session: false })
+    } catch (err) {
+      showToast({ variant: "error", title: "Sign out failed", description: message(err) })
     } finally {
       setBusy(false)
     }
@@ -166,6 +171,15 @@ export default function General() {
                 sign out
               </Button>
             </Row>
+            <Show when={account()?.session === false}>
+              <div class="px-4 py-3">
+                <p class="text-12-regular text-text-weak">
+                  Signed out — run{" "}
+                  <code style={{ "font-family": FONT_CODE, "font-size": "11px" }}>openscience connect login</code> in a
+                  terminal to reconnect this machine.
+                </p>
+              </div>
+            </Show>
           </div>
         </Section>
 
@@ -236,6 +250,10 @@ export default function General() {
       </div>
     </div>
   )
+}
+
+function message(err: unknown) {
+  return err instanceof Error ? err.message : String(err)
 }
 
 const Section: Component<{ title: string; description?: string; children: JSX.Element }> = (props) => (

--- a/frontend/workspace/src/components/settings/Usage.tsx
+++ b/frontend/workspace/src/components/settings/Usage.tsx
@@ -6,7 +6,7 @@
 //     the actual cost + tokens recorded on assistant messages across sessions.
 //   • Extra usage budget → /settings/preferences (real JSON store).
 //   • Buy credits → opens the Atlas top-up / checkout (URLS.dashboardCli).
-import { Component, For, Show, createMemo, createSignal, onMount, type JSX } from "solid-js"
+import { Component, For, Show, createMemo, createSignal, onCleanup, onMount, type JSX } from "solid-js"
 import { useParams } from "@solidjs/router"
 import { Button } from "@synsci/ui/button"
 import { useGlobalSDK } from "@/context/global-sdk"
@@ -78,7 +78,14 @@ export default function Usage() {
       setBudgetDraft(prefs.extra_budget_usd ? String(prefs.extra_budget_usd) : "")
     } catch {}
   }
-  onMount(() => void load())
+  // Refetch when the window regains focus so a dashboard top-up (buy credits
+  // opens a new tab) shows up as soon as the user comes back.
+  const focus = () => void load()
+  onMount(() => {
+    void load()
+    window.addEventListener("focus", focus)
+  })
+  onCleanup(() => window.removeEventListener("focus", focus))
 
   const saveBudget = async () => {
     const value = Math.max(0, Number(budgetDraft()) || 0)
@@ -94,6 +101,10 @@ export default function Usage() {
     }
   }
 
+  // Distinguish "no data yet" and "signed out" from real account values — the
+  // panel must not present "Free"/"byok" defaults as if they came from Atlas.
+  const loading = () => account() === undefined
+  const signedOut = () => account()?.session === false
   const plan = () => (account()?.user?.subscription_plan as string | undefined) ?? "Free"
   const balance = () => account()?.balance_usd
   const managed = () => account()?.billing_mode?.mode === "managed"
@@ -138,19 +149,32 @@ export default function Usage() {
             <div class="flex flex-wrap items-center justify-between gap-4 px-4 py-4 border-b border-border-weak-base">
               <div class="flex flex-col gap-0.5">
                 <span class="text-12-regular text-text-weak">Plan</span>
-                <span class="text-16-medium text-text-strong capitalize">{plan()}</span>
+                <Show
+                  when={!loading() && !signedOut()}
+                  fallback={<span class="text-16-medium text-text-weak">{loading() ? "…" : "—"}</span>}
+                >
+                  <span class="text-16-medium text-text-strong capitalize">{plan()}</span>
+                </Show>
               </div>
               <div class="flex flex-col gap-0.5">
                 <span class="text-12-regular text-text-weak">Wallet balance</span>
-                <span class="text-16-medium text-text-strong">
-                  {typeof balance() === "number" && balance()! >= 0 ? money(balance()!) : "—"}
-                </span>
+                <Show
+                  when={!loading() && !signedOut() && typeof balance() === "number" && balance()! >= 0}
+                  fallback={<span class="text-16-medium text-text-weak">{loading() ? "…" : "—"}</span>}
+                >
+                  <span class="text-16-medium text-text-strong">{money(balance()!)}</span>
+                </Show>
               </div>
               <div class="flex flex-col gap-0.5">
                 <span class="text-12-regular text-text-weak">Billing</span>
-                <span class="text-13-medium text-text-strong capitalize">
-                  {account()?.billing_mode?.mode ?? "byok"}
-                </span>
+                <Show
+                  when={!loading() && !signedOut()}
+                  fallback={<span class="text-13-medium text-text-weak">{loading() ? "…" : "—"}</span>}
+                >
+                  <span class="text-13-medium text-text-strong capitalize">
+                    {account()?.billing_mode?.mode ?? "byok"}
+                  </span>
+                </Show>
               </div>
               <Button size="small" variant="primary" onClick={() => platform.openLink(URLS.dashboardCli)}>
                 buy credits
@@ -158,11 +182,24 @@ export default function Usage() {
             </div>
             <div class="px-4 py-3">
               <p class="text-12-regular text-text-weak">
-                <Show
-                  when={managed()}
-                  fallback="You're on BYOK — provider calls are billed directly by each provider. Switch to managed mode (Credentials) to bill from this wallet."
-                >
-                  Managed calls debit this wallet. Top up any time — credits never expire.
+                <Show when={!loading()} fallback="Checking your Atlas account…">
+                  <Show
+                    when={!signedOut()}
+                    fallback={
+                      <>
+                        Not connected — run{" "}
+                        <code style={{ "font-family": FONT_CODE, "font-size": "11px" }}>openscience connect login</code>{" "}
+                        in a terminal to see your plan and wallet.
+                      </>
+                    }
+                  >
+                    <Show
+                      when={managed()}
+                      fallback="You're on BYOK — provider calls are billed directly by each provider. Switch to managed mode (Credentials) to bill from this wallet."
+                    >
+                      Managed calls debit this wallet. Top up any time — credits never expire.
+                    </Show>
+                  </Show>
                 </Show>
               </p>
             </div>


### PR DESCRIPTION
Three Settings-panel fixes in the workspace app.

Fixes #73
Fixes #76
Fixes #77

## Credentials — provider key source badges (#73)

The `/provider` payload already carries `source` (`env | api | custom | config`) for every connected provider — the wire type in `@synsci/sdk/v2/client` (`Provider["source"]`), which main now explicitly preserves while redacting keys (#80). The panel renders a pill badge next to each connected provider (`local`, `env`, `config`, `custom`, same badge styling as the Compute panel) with a `title` explaining where the key lives. Since only `source: "api"` keys sit in the local auth store, the remove button is disabled for the other sources, with a tooltip saying the key comes from an env var / dashboard sync or `openscience.json` and has to be removed there — instead of the old silent no-op where the provider reappeared as connected after the delete.

The list endpoint's generated response type omits `source` (its OpenAPI schema is the models.dev catalog shape), so the component reads it through a narrow typed accessor keyed to the SDK's `Provider["source"]` union, defaulting to `api` (current behavior) if absent.

## General — sign-out feedback + reconnect guidance (#76)

`signOut` was `try/finally` with no catch, and the SDK client defaults to `throwOnError: false`, so a failed logout surfaced neither as a rejection nor in the UI. It now checks `res.error`, converts it to an `Error`, and toasts failures through the shared `showToast` mechanism (same pattern as Connectors/Skills/Specialists). Whenever the account is signed out — including right after a successful sign-out — the Account card shows muted guidance copy: run `openscience connect login` in a terminal to reconnect this machine.

## Usage — live wallet refresh + honest loading states (#77)

- The panel now refetches account/usage/preferences on window `focus` (listener added in `onMount`, removed in `onCleanup`), so a dashboard top-up ("buy credits" opens a new tab) shows up as soon as the user returns. Refetches keep the previous values until new data arrives, so there's no flashing.
- Plan / Wallet balance / Billing render `…` while loading and `—` when signed out, instead of presenting the `"Free"` / `"byok"` fallbacks as if they were real account data. The footer copy also distinguishes loading ("Checking your Atlas account…") and signed-out (connect-login guidance) from the managed/BYOK explanations.

## Verification

- `bun run typecheck` — clean at repo root (6/6 tasks).
- `bun run --cwd frontend/workspace build` — passes.
- `prettier --check` clean on all lines added here (the three files carry some pre-existing formatting drift that was deliberately left untouched to keep the diff scoped).

Manual-verification reasoning (no UI e2e in CI yet):

- **#73**: the server route (`backend/cli/src/server/routes/provider.ts`) returns `Provider.Info` objects for connected providers, which always include `source` (`env` from env loading, `api` from `Auth.all()`, `config`/`custom` from config merging in `backend/cli/src/provider/provider.ts`); the badge map covers the full `Provider["source"]` union so every connected provider gets a badge, and the `?? "api"` fallback preserves today's remove behavior if the field were ever missing.
- **#76**: `account.logout` returns `{ error }` on non-2xx (hey-api client, `throwOnError` defaults to false) and rejects on network failure — both paths now land in the same catch and toast. The guidance copy keys off `account()?.session === false`, which is set both by `GET /account` when signed out and locally after a successful logout.
- **#77**: `GET /account` returns `session: false`, `balance_usd: -1`, `billing_mode: null` when signed out, so the signed-out branches are reachable and the existing `balance >= 0` guard already treats `-1` as unknown; `account() === undefined` only holds before the first response, so the loading placeholders can't mask real data.
