### PR TITLE
feat(settings): Spend controls in the workspace, compute keys actually applied

### DIFF
--- a/backend/cli/src/config/config.ts
+++ b/backend/cli/src/config/config.ts
@@ -965,9 +965,10 @@ export namespace Config {
         .object({
           llm: z
             .enum(["managed", "byok"])
+            .nullable()
             .optional()
             .describe(
-              "How LLM inference is paid for. 'managed' routes through the Atlas wallet (metered credits); 'byok' uses your own provider API keys or first-party OAuth (ChatGPT/Claude Pro/Copilot) and is never billed. Unset = auto-detect from the resolved credential.",
+              "How LLM inference is paid for. 'managed' routes through the Atlas wallet (metered credits); 'byok' uses your own provider API keys or first-party OAuth (ChatGPT/Claude Pro/Copilot) and is never billed. Unset or null = auto-detect from the resolved credential.",
             ),
           compute: z
             .enum(["managed", "byok"])

--- a/backend/cli/src/index.ts
+++ b/backend/cli/src/index.ts
@@ -100,6 +100,12 @@ const cli = yargs(hideBin(process.argv))
       .then((m) => m.applyCredentialEnv())
       .catch(() => {})
 
+    // Same for BYOK GPU provider keys (settings ▸ Compute) — decrypt and inject
+    // under the canonical env var names the compute skills read.
+    await import("./server/routes/settings/compute")
+      .then((m) => m.ComputeSettings.applyComputeEnv())
+      .catch(() => {})
+
     // Retry any failed usage reports from previous sessions
     OpenScience.flushPendingUsage().catch(() => {})
   })

--- a/backend/cli/src/server/routes/settings/billing.ts
+++ b/backend/cli/src/server/routes/settings/billing.ts
@@ -22,8 +22,10 @@ export const BillingState = z.object({
 })
 export type BillingState = z.infer<typeof BillingState>
 
+// `llm: null` sets the toggle back to auto (auto-detect from the resolved
+// credential); omitting a field leaves it untouched.
 const BillingPatch = z.object({
-  llm: z.enum(["managed", "byok"]).optional(),
+  llm: z.enum(["managed", "byok"]).nullable().optional(),
   compute: z.enum(["managed", "byok"]).optional(),
 })
 
@@ -78,6 +80,8 @@ export const BillingSettingsRoutes = lazy(() =>
         // Mirror the LLM toggle to the account-scoped server billing mode, then force
         // a fresh sync so the right provider credentials (managed proxy token vs the
         // user's BYOK keys) are re-injected into the environment for the next call.
+        // Auto (null) has no server-side counterpart — the account mode stays put and
+        // the gate auto-detects from the resolved credential per call.
         if (patch.llm) {
           await OpenScience.setBillingMode(patch.llm).catch((e) =>
             log.warn("setBillingMode failed", { error: e instanceof Error ? e.message : String(e) }),

--- a/backend/cli/src/server/routes/settings/compute.ts
+++ b/backend/cli/src/server/routes/settings/compute.ts
@@ -5,6 +5,8 @@ import crypto from "crypto"
 import path from "path"
 import fs from "fs/promises"
 import { Global } from "../../../global"
+import { Env } from "../../../env"
+import { OpenScience } from "../../../openscience"
 import { errors } from "../../error"
 import { lazy } from "../../../util/lazy"
 
@@ -20,6 +22,15 @@ import { lazy } from "../../../util/lazy"
 //     NEVER returned to the client — only presence + metadata are surfaced.
 //   • SSH hosts the agent can dispatch runs to.
 //   • Model endpoints (local or remote inference URLs).
+//
+// How a stored key actually does something: applyComputeEnv() (mirroring
+// applyCredentialEnv in ./credentials.ts) decrypts each connected provider's
+// key and injects it into the process environment under the canonical env var
+// names the real consumers read — the cloud-compute/ml-training skills and
+// every bash subprocess via OpenScience.subprocessEnv. It runs at CLI/server
+// boot (index.ts) and again after each provider connect/disconnect, so a saved
+// key applies live without a restart. Decrypted values are registered for
+// output redaction, and an explicit shell export always wins.
 
 export namespace ComputeSettings {
   const storePath = path.join(Global.Path.data, "settings-compute.json")
@@ -43,6 +54,19 @@ export namespace ComputeSettings {
     const enc = Buffer.concat([cipher.update(plain, "utf8"), cipher.final()])
     const tag = cipher.getAuthTag()
     return Buffer.concat([iv, tag, enc]).toString("base64")
+  }
+
+  // Inverse of encrypt(): iv(12) | tag(16) | ciphertext. Throws on a bad
+  // key/tag, which callers treat as "unreadable key, skip it".
+  async function decrypt(payload: string): Promise<string> {
+    const key = await machineKey()
+    const buf = Buffer.from(payload, "base64")
+    const iv = buf.subarray(0, 12)
+    const tag = buf.subarray(12, 28)
+    const enc = buf.subarray(28)
+    const decipher = crypto.createDecipheriv("aes-256-gcm", key, iv)
+    decipher.setAuthTag(tag)
+    return Buffer.concat([decipher.update(enc), decipher.final()]).toString("utf8")
   }
 
   // ── GPU provider catalog ──
@@ -133,6 +157,83 @@ export namespace ComputeSettings {
 
   function id() {
     return crypto.randomUUID().slice(0, 8)
+  }
+
+  // ── Runtime env injection ──
+  // This is the ONLY thing that turns a stored provider key into a working one.
+
+  // Canonical env var names each provider's real consumers read (skill scripts,
+  // session prompts, dashboard sync). Where two spellings exist in the wild
+  // both are set. Modal is handled separately — its single pasted key
+  // ("ak-… : as-…") splits into a token id + secret pair.
+  const PROVIDER_ENV: Record<string, string[]> = {
+    tensorpool: ["TENSORPOOL_KEY", "TENSORPOOL_API_KEY"],
+    lambda: ["LAMBDA_API_KEY", "LAMBDA_LABS_API_KEY"],
+    prime: ["PRIME_API_KEY", "PRIME_INTELLECT_API_KEY"],
+    vast: ["VAST_API_KEY"],
+    runpod: ["RUNPOD_API_KEY"],
+  }
+
+  /** Map one provider's decrypted key to the canonical env var names its real
+   *  consumers read. Modal's combined "token_id : token_secret" key is split;
+   *  a half-pasted modal key maps to nothing (both vars are required). */
+  function mapProviderEnv(target: string, key: string): Record<string, string> {
+    if (target === "modal") {
+      const [token, secret] = key.split(":").map((part) => part.trim())
+      if (!token || !secret) return {}
+      return { MODAL_TOKEN_ID: token, MODAL_TOKEN_SECRET: secret }
+    }
+    return Object.fromEntries((PROVIDER_ENV[target] ?? []).map((name) => [name, key]))
+  }
+
+  // Env keys this module has set, so a re-apply after save can update our own
+  // values while still never clobbering an explicit shell export.
+  const ownedKeys = new Set<string>()
+
+  /** Decrypt stored GPU provider keys and inject them into the process
+   *  environment so the real consumers use them (see the module header).
+   *  Explicit shell exports always win. Registers key values for redaction.
+   *  Best-effort; never throws. Call at boot and after every connect/disconnect. */
+  export async function applyComputeEnv(): Promise<void> {
+    try {
+      const stored = await read()
+      const env: Record<string, string> = {}
+      const secrets: string[] = []
+      for (const [target, entry] of Object.entries(stored.providers)) {
+        const key = await decrypt(entry.key).catch(() => undefined)
+        // Unreadable (rotated key / corrupt) — skip; the UI still shows it connected.
+        if (!key) continue
+        for (const [name, value] of Object.entries(mapProviderEnv(target, key))) {
+          env[name] = value
+          secrets.push(value)
+        }
+      }
+      // Drop vars we previously injected that are gone now (provider removed) —
+      // but never touch a key the user exported in their own shell.
+      for (const name of [...ownedKeys]) {
+        if (name in env) continue
+        delete process.env[name]
+        try {
+          Env.remove(name)
+        } catch {
+          /* Instance state not initialized — process.env delete is enough */
+        }
+        ownedKeys.delete(name)
+      }
+      for (const [name, value] of Object.entries(env)) {
+        if (process.env[name] && !ownedKeys.has(name)) continue
+        process.env[name] = value
+        ownedKeys.add(name)
+        try {
+          Env.set(name, value)
+        } catch {
+          // Instance state not initialized yet — process.env alone is enough here.
+        }
+      }
+      OpenScience.registerSecretValues(secrets)
+    } catch {
+      // best-effort; a broken store must not break boot or a save response
+    }
   }
 
   // Build the client-facing view — never includes the encrypted key.
@@ -240,7 +341,9 @@ export const ComputeSettingsRoutes = lazy(() =>
       async (c) => {
         const target = c.req.valid("param").id
         if (!ComputeSettings.isProvider(target)) return c.json({ error: "Unknown provider" }, 400)
-        return c.json(await ComputeSettings.connectProvider(target, c.req.valid("json").key.trim()))
+        const info = await ComputeSettings.connectProvider(target, c.req.valid("json").key.trim())
+        await ComputeSettings.applyComputeEnv() // apply the new key to the running process
+        return c.json(info)
       },
     )
     .delete(
@@ -253,7 +356,11 @@ export const ComputeSettingsRoutes = lazy(() =>
         },
       }),
       validator("param", z.object({ id: z.string() })),
-      async (c) => c.json(await ComputeSettings.disconnectProvider(c.req.valid("param").id)),
+      async (c) => {
+        const info = await ComputeSettings.disconnectProvider(c.req.valid("param").id)
+        await ComputeSettings.applyComputeEnv() // re-sync process env after removal
+        return c.json(info)
+      },
     )
     .post(
       "/ssh",

--- a/backend/cli/src/session/billing-gate.ts
+++ b/backend/cli/src/session/billing-gate.ts
@@ -24,9 +24,10 @@ export type CredentialSource = "byok" | "managed" | "oauth-free"
 export type BillingMode = "managed" | "byok"
 
 /** The user-facing LLM spend toggle (Settings → Spend). `undefined` = auto-detect
- *  from the resolved credential (legacy behaviour). */
+ *  from the resolved credential (legacy behaviour; `null` in the config file —
+ *  the toggle set back to auto — normalizes to the same thing). */
 export async function llmBillingMode(): Promise<BillingMode | undefined> {
-  return (await Config.get()).billing?.llm
+  return (await Config.get()).billing?.llm ?? undefined
 }
 
 /** The user-facing compute spend toggle. Defaults to "byok" (own GPU providers). */

--- a/backend/cli/test/server/settings-billing.test.ts
+++ b/backend/cli/test/server/settings-billing.test.ts
@@ -34,3 +34,20 @@ test("PUT persists the toggle without baking resolved secrets into the config fi
   const written = JSON.parse(text)
   expect(written.billing).toEqual({ llm: "byok" })
 })
+
+test("PUT llm null sets the toggle back to auto", async () => {
+  await fs.mkdir(Global.Path.config, { recursive: true })
+  await Bun.write(file, JSON.stringify({ billing: { llm: "managed" } }, null, 2))
+
+  const res = await BillingSettingsRoutes().request("/", {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ llm: null }),
+  })
+  expect(res.status).toBe(200)
+  const state = await res.json()
+  expect(state.llm).toBeNull()
+
+  const written = JSON.parse(await Bun.file(file).text())
+  expect(written.billing.llm).toBeNull()
+})

--- a/backend/cli/test/server/settings-compute.test.ts
+++ b/backend/cli/test/server/settings-compute.test.ts
@@ -1,0 +1,80 @@
+import { test, expect, afterAll } from "bun:test"
+import { ComputeSettingsRoutes } from "../../src/server/routes/settings/compute"
+
+// Every env var the compute store can own — cleaned up so other test files
+// never see leftovers from this one.
+const VARS = [
+  "MODAL_TOKEN_ID",
+  "MODAL_TOKEN_SECRET",
+  "TENSORPOOL_KEY",
+  "TENSORPOOL_API_KEY",
+  "LAMBDA_API_KEY",
+  "LAMBDA_LABS_API_KEY",
+  "PRIME_API_KEY",
+  "PRIME_INTELLECT_API_KEY",
+  "VAST_API_KEY",
+  "RUNPOD_API_KEY",
+]
+
+afterAll(() => {
+  for (const name of VARS) delete process.env[name]
+})
+
+function connect(provider: string, key: string) {
+  return ComputeSettingsRoutes().request(`/provider/${provider}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ key }),
+  })
+}
+
+test("connecting a provider applies its key to the process env under every canonical name", async () => {
+  const res = await connect("tensorpool", "tp-test-secret-123")
+  expect(res.status).toBe(200)
+
+  // The saved key is live immediately — no restart needed.
+  expect(process.env["TENSORPOOL_KEY"]).toBe("tp-test-secret-123")
+  expect(process.env["TENSORPOOL_API_KEY"]).toBe("tp-test-secret-123")
+
+  // The key itself never travels back to the client.
+  const body = await res.text()
+  expect(body).not.toContain("tp-test-secret-123")
+  const info = JSON.parse(body)
+  expect(info.providers.find((p: { id: string }) => p.id === "tensorpool").connected).toBe(true)
+})
+
+test("modal's combined key splits into token id + secret", async () => {
+  const res = await connect("modal", "ak-test-id : as-test-secret")
+  expect(res.status).toBe(200)
+  expect(process.env["MODAL_TOKEN_ID"]).toBe("ak-test-id")
+  expect(process.env["MODAL_TOKEN_SECRET"]).toBe("as-test-secret")
+})
+
+test("an explicit shell export always wins over a stored key", async () => {
+  process.env["VAST_API_KEY"] = "from-shell"
+  const res = await connect("vast", "vast-stored-key")
+  expect(res.status).toBe(200)
+  expect(process.env["VAST_API_KEY"]).toBe("from-shell")
+})
+
+test("disconnecting a provider removes the injected vars but never a shell export", async () => {
+  for (const provider of ["tensorpool", "modal", "vast"]) {
+    const res = await ComputeSettingsRoutes().request(`/provider/${provider}`, { method: "DELETE" })
+    expect(res.status).toBe(200)
+  }
+  expect(process.env["TENSORPOOL_KEY"]).toBeUndefined()
+  expect(process.env["TENSORPOOL_API_KEY"]).toBeUndefined()
+  expect(process.env["MODAL_TOKEN_ID"]).toBeUndefined()
+  expect(process.env["MODAL_TOKEN_SECRET"]).toBeUndefined()
+  // The shell export was never owned by the store, so removal leaves it alone.
+  expect(process.env["VAST_API_KEY"]).toBe("from-shell")
+})
+
+test("re-saving a key updates the injected value in place", async () => {
+  await connect("runpod", "rpa_first")
+  expect(process.env["RUNPOD_API_KEY"]).toBe("rpa_first")
+  await connect("runpod", "rpa_second")
+  expect(process.env["RUNPOD_API_KEY"]).toBe("rpa_second")
+  await ComputeSettingsRoutes().request("/provider/runpod", { method: "DELETE" })
+  expect(process.env["RUNPOD_API_KEY"]).toBeUndefined()
+})

--- a/frontend/workspace/src/components/settings/Spend.tsx
+++ b/frontend/workspace/src/components/settings/Spend.tsx
@@ -1,0 +1,217 @@
+// Spend — managed (Atlas wallet) vs bring-your-own-key, toggled independently
+// for LLM inference and compute. Everything is wired to a real endpoint:
+//   • State + wallet → GET /settings/billing (client.settings.billing.get).
+//   • Toggles → PUT /settings/billing (client.settings.billing.update), which
+//     persists `billing.llm` / `billing.compute` in the global config AND keeps
+//     the account-scoped server billing mode in sync — one source of truth.
+//   • Buy credits → opens the Atlas top-up / checkout (URLS.dashboardCli).
+import { Component, Show, createSignal, onMount, type JSX } from "solid-js"
+import { Button } from "@synsci/ui/button"
+import type { SettingsBillingGetResponse } from "@synsci/sdk/v2/client"
+import { useGlobalSDK } from "@/context/global-sdk"
+import { usePlatform } from "@/context/platform"
+import { URLS } from "@/config/urls"
+import { FONT_SANS } from "@/styles/tokens"
+
+type Billing = SettingsBillingGetResponse
+
+const money = (n: number) => `$${(n < 0 ? 0 : n).toFixed(n >= 100 ? 0 : 2)}`
+
+const LLM_MODES = [
+  {
+    value: "managed" as const,
+    title: "Managed",
+    body: "LLM calls route through your Atlas wallet — metered credits, no API keys needed.",
+  },
+  {
+    value: "byok" as const,
+    title: "BYOK",
+    body: "Your own provider keys or OAuth subscriptions (Claude Pro, ChatGPT, Copilot). Never billed here.",
+  },
+  {
+    value: null,
+    title: "Auto",
+    body: "Detect from the credential backing each call — managed proxy tokens bill the wallet, your own keys don't.",
+  },
+]
+
+const COMPUTE_MODES = [
+  {
+    value: "managed" as const,
+    title: "Managed",
+    body: "Atlas-provisioned GPUs, billed to your wallet.",
+  },
+  {
+    value: "byok" as const,
+    title: "BYOK",
+    body: "Your own connected GPU providers (Settings → Compute). Your provider bills you directly.",
+  },
+]
+
+export default function Spend() {
+  const sdk = useGlobalSDK()
+  const platform = usePlatform()
+
+  const [billing, setBilling] = createSignal<Billing>()
+  const [error, setError] = createSignal<string>()
+  const [busy, setBusy] = createSignal(false)
+
+  const load = async () => {
+    const res = await sdk.client.settings.billing.get()
+    if (res.data) return setBilling(res.data)
+    setError("Couldn't load spend settings.")
+  }
+  onMount(() => void load())
+
+  const update = async (patch: { llm?: "managed" | "byok" | null; compute?: "managed" | "byok" }) => {
+    setBusy(true)
+    setError(undefined)
+    const res = await sdk.client.settings.billing.update(patch)
+    if (res.data) setBilling(res.data)
+    if (!res.data) setError("Couldn't save spend settings.")
+    setBusy(false)
+  }
+
+  const wallet = () => billing()?.wallet
+  const balance = () => {
+    const w = wallet()
+    if (!w || !w.signedIn || w.balanceUsd < 0) return "—"
+    return money(w.balanceUsd)
+  }
+
+  return (
+    <div class="flex flex-col h-full overflow-y-auto no-scrollbar px-4 pb-10 sm:px-8">
+      <div class="sticky top-0 z-10 bg-[linear-gradient(to_bottom,var(--surface-raised-stronger-non-alpha)_calc(100%_-_24px),transparent)]">
+        <div class="flex flex-col gap-1 pt-8 pb-8 max-w-[760px]">
+          <h2 class="text-16-medium text-text-strong">Spend</h2>
+          <p class="text-13-regular text-text-weak">
+            Choose what runs on your Atlas wallet and what runs on your own keys — independently for LLM inference and
+            compute.
+          </p>
+        </div>
+      </div>
+
+      <div class="flex flex-col gap-8 w-full max-w-[760px]">
+        <Show when={error()}>
+          <div
+            style={{
+              "font-family": FONT_SANS,
+              "font-size": "12px",
+              color: "var(--color-error)",
+              border: "1px solid var(--color-error-muted)",
+              "border-radius": "4px",
+              padding: "10px 12px",
+            }}
+          >
+            {error()}
+          </div>
+        </Show>
+
+        {/* Wallet */}
+        <Section title="Wallet" description="Managed spend debits this balance.">
+          <div class="border border-border-weak-base rounded-[4px] overflow-hidden bg-surface-base/40">
+            <div class="flex flex-wrap items-center justify-between gap-4 px-4 py-4">
+              <div class="flex flex-col gap-0.5">
+                <span class="text-12-regular text-text-weak">Atlas session</span>
+                <span class="text-13-medium text-text-strong">
+                  {wallet() ? (wallet()!.signedIn ? "Signed in" : "Signed out") : "—"}
+                </span>
+              </div>
+              <div class="flex flex-col gap-0.5">
+                <span class="text-12-regular text-text-weak">Wallet balance</span>
+                <span class="text-16-medium text-text-strong">{balance()}</span>
+              </div>
+              <Button size="small" variant="secondary" onClick={() => platform.openLink(URLS.dashboardCli)}>
+                buy credits
+              </Button>
+            </div>
+            <Show when={wallet() && !wallet()!.signedIn}>
+              <div class="px-4 py-3 border-t border-border-weak-base">
+                <p class="text-12-regular text-text-weak">
+                  Not connected to Atlas — run <span class="text-text-strong">openscience login</span> to use managed
+                  spend. BYOK works without an account.
+                </p>
+              </div>
+            </Show>
+          </div>
+        </Section>
+
+        {/* LLM spend */}
+        <Section title="LLM spend" description="How model inference is paid for.">
+          <div class="grid grid-cols-1 sm:grid-cols-3 gap-2.5">
+            {LLM_MODES.map((mode) => (
+              <ModeCard
+                active={billing() !== undefined && billing()!.llm === mode.value}
+                disabled={busy() || billing() === undefined}
+                title={mode.title}
+                body={mode.body}
+                onClick={() => void update({ llm: mode.value })}
+              />
+            ))}
+          </div>
+        </Section>
+
+        {/* Compute spend */}
+        <Section title="Compute spend" description="How GPU provisioning and training runs are paid for.">
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-2.5">
+            {COMPUTE_MODES.map((mode) => (
+              <ModeCard
+                active={billing()?.compute === mode.value}
+                disabled={busy() || billing() === undefined}
+                title={mode.title}
+                body={mode.body}
+                onClick={() => void update({ compute: mode.value })}
+              />
+            ))}
+          </div>
+        </Section>
+      </div>
+    </div>
+  )
+}
+
+const Section: Component<{ title: string; description?: string; children: JSX.Element }> = (props) => (
+  <div class="flex flex-col gap-3">
+    <div class="flex flex-col gap-0.5">
+      <h3 class="text-13-medium text-text-weak tracking-wide">{props.title}</h3>
+      <Show when={props.description}>
+        <p class="text-12-regular text-text-weak">{props.description}</p>
+      </Show>
+    </div>
+    {props.children}
+  </div>
+)
+
+const ModeCard: Component<{ active: boolean; disabled: boolean; title: string; body: string; onClick: () => void }> = (
+  props,
+) => (
+  <button
+    type="button"
+    disabled={props.disabled}
+    onClick={props.onClick}
+    style={{
+      all: "unset",
+      cursor: props.disabled ? "default" : "pointer",
+      opacity: props.disabled ? 0.6 : 1,
+      display: "flex",
+      "flex-direction": "column",
+      gap: "5px",
+      padding: "14px 16px",
+      "border-radius": "4px",
+      border: "1px solid var(--color-border)",
+      "box-shadow": props.active ? "inset 0 0 0 1px var(--color-text-interactive-base, var(--color-text))" : "none",
+      background: props.active ? "var(--color-surface-interactive-weak, var(--color-accent-subtle))" : "transparent",
+      transition: "border-color 120ms, box-shadow 120ms, background 120ms",
+    }}
+  >
+    <div style={{ display: "flex", "align-items": "center", "justify-content": "space-between" }}>
+      <span class="text-14-medium text-text-strong">{props.title}</span>
+      <Show when={props.active}>
+        <span style={{ "font-family": FONT_SANS, "font-size": "11px", color: "var(--color-text-muted)" }}>active</span>
+      </Show>
+    </div>
+    <span class="text-12-regular text-text-weak" style={{ "line-height": 1.5 }}>
+      {props.body}
+    </span>
+  </button>
+)

--- a/frontend/workspace/src/components/settings/Usage.tsx
+++ b/frontend/workspace/src/components/settings/Usage.tsx
@@ -195,7 +195,7 @@ export default function Usage() {
                   >
                     <Show
                       when={managed()}
-                      fallback="You're on BYOK — provider calls are billed directly by each provider. Switch to managed mode (Credentials) to bill from this wallet."
+                      fallback="You're on BYOK — provider calls are billed directly by each provider. Switch LLM spend to managed in Settings → Spend to bill from this wallet."
                     >
                       Managed calls debit this wallet. Top up any time — credits never expire.
                     </Show>

--- a/frontend/workspace/src/components/settings/registry.ts
+++ b/frontend/workspace/src/components/settings/registry.ts
@@ -31,6 +31,7 @@ export type SettingsPanelId =
   | "network"
   | "permissions"
   | "credentials"
+  | "spend"
   | "storage"
   | "usage"
   | "general"
@@ -60,6 +61,7 @@ export const SETTINGS_PANELS: SettingsPanel[] = [
   // ── Workspace ──
   { id: "permissions", title: "Permissions", icon: "check", section: "workspace", component: lazy(() => import("./Permissions")) },
   { id: "credentials", title: "Credentials", icon: "providers", section: "workspace", component: lazy(() => import("./Credentials")) },
+  { id: "spend", title: "Spend", icon: "sliders", section: "workspace", component: lazy(() => import("./Spend")) },
   { id: "storage", title: "Storage", icon: "folder", section: "workspace", component: lazy(() => import("./Storage")) },
   { id: "usage", title: "Usage", icon: "bullet-list", section: "workspace", component: lazy(() => import("./Usage")) },
   { id: "general", title: "General", icon: "settings-gear", section: "workspace", component: lazy(() => import("./General")) },

--- a/tooling/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/tooling/sdk/js/src/v2/gen/sdk.gen.ts
@@ -966,7 +966,7 @@ export class Billing extends HeyApiClient {
    */
   public update<ThrowOnError extends boolean = false>(
     parameters?: {
-      llm?: "managed" | "byok"
+      llm?: "managed" | "byok" | null
       compute?: "managed" | "byok"
     },
     options?: Options<never, ThrowOnError>,

--- a/tooling/sdk/js/src/v2/gen/types.gen.ts
+++ b/tooling/sdk/js/src/v2/gen/types.gen.ts
@@ -1607,9 +1607,9 @@ export type Config = {
    */
   billing?: {
     /**
-     * How LLM inference is paid for. 'managed' routes through the Atlas wallet (metered credits); 'byok' uses your own provider API keys or first-party OAuth (ChatGPT/Claude Pro/Copilot) and is never billed. Unset = auto-detect from the resolved credential.
+     * How LLM inference is paid for. 'managed' routes through the Atlas wallet (metered credits); 'byok' uses your own provider API keys or first-party OAuth (ChatGPT/Claude Pro/Copilot) and is never billed. Unset or null = auto-detect from the resolved credential.
      */
-    llm?: "managed" | "byok"
+    llm?: "managed" | "byok" | null
     /**
      * How GPU/compute is paid for. 'managed' runs on Atlas-provisioned compute billed to your wallet (via the bundled atlas CLI); 'byok' uses your own connected GPU providers (Modal, Tinker, TensorPool, …). Unset = byok.
      */
@@ -3120,7 +3120,7 @@ export type SettingsBillingGetResponse = SettingsBillingGetResponses[keyof Setti
 
 export type SettingsBillingUpdateData = {
   body?: {
-    llm?: "managed" | "byok"
+    llm?: "managed" | "byok" | null
     compute?: "managed" | "byok"
   }
   path?: never


### PR DESCRIPTION
Fixes #71
Fixes #72

## Compute keys are now applied (#71)

The Compute panel encrypted and stored GPU provider keys, showed a green "connected" badge — and nothing ever read them back. This adds `ComputeSettings.applyComputeEnv()`, mirroring `applyCredentialEnv` in the credentials store exactly:

- Decrypts each connected provider's key and injects it into the process env under the canonical names the real consumers (cloud-compute / ml-training skills, session prompts, bash subprocesses via `subprocessEnv`) read. Where two spellings exist in the wild, both are set: `TENSORPOOL_KEY`/`TENSORPOOL_API_KEY`, `LAMBDA_API_KEY`/`LAMBDA_LABS_API_KEY`, `PRIME_API_KEY`/`PRIME_INTELLECT_API_KEY`, `VAST_API_KEY`, `RUNPOD_API_KEY`. Modal's combined `ak-… : as-…` key splits into `MODAL_TOKEN_ID` + `MODAL_TOKEN_SECRET` (a half-pasted key maps to nothing rather than half a credential).
- Runs at the same boot location as `applyCredentialEnv` (index.ts middleware) and again after every provider connect/disconnect, so a saved key applies live without a restart.
- Same semantics as the credentials store: removed entries are cleaned out of the env, an explicit shell export always wins, decrypted values are registered for output redaction, and the whole thing is best-effort (a corrupt store never breaks boot or a save response).

`last_used` is left as-is: there is no code path that observes an actual compute run (usage reporting is LLM-step-only), so any timestamp written here — e.g. at boot-time injection — would just mean "CLI started", which is more misleading than "never". Wiring it honestly needs a compute-run hook and is out of scope.

## Spend panel + copy fixes (#72)

Error copy pointed at "Settings → Spend", which didn't exist, and the only way to flip `billing.llm` was hand-editing `openscience.json`. This ships the panel:

- New **Spend** panel in the workspace settings rail (registered in `registry.ts`), reading GET `/settings/billing` and writing PUT `/settings/billing` through the generated SDK (`client.settings.billing.get/update`).
- **LLM spend**: managed / byok / auto. Auto (unset) is now round-trippable — the PUT accepts `llm: null` to clear the toggle back to auto-detect (config schema made nullable, `llmBillingMode()` normalizes null to undefined, SDK types regenerated from the OpenAPI spec — the gen diff is exactly the nullable field).
- **Compute spend**: managed / byok.
- Wallet card shows the signed-in state + balance from the GET, with a sign-in hint when there's no Atlas session.
- The PUT handler still mirrors the LLM toggle to the server-side account billing mode via `OpenScience.setBillingMode` + resync (verified, unchanged) — so the gate (config) and the Usage panel (account mode) stay in sync through the one control. Auto skips the mirror since it has no server-side counterpart.
- `Usage.tsx` no longer says "Switch to managed mode (Credentials)" — it points at Settings → Spend. `processor.ts` already said Settings → Spend, which is now true, so it's untouched.

## Verification

- `cd backend/cli && bun test` — 836 pass, 0 fail (includes new tests below).
- `bun run typecheck` — clean across all 6 packages.
- `bun run --cwd frontend/workspace build` — passes.
- New `test/server/settings-compute.test.ts` exercises the real routes + store (no mocks): connect applies every canonical var, modal splits, shell exports win, disconnect removes injected vars but never a shell export, re-save updates in place, and the key never appears in a response body. There was no pre-existing `applyCredentialEnv` test to mirror, so this follows the `settings-billing.test.ts` route-test pattern instead.
- New billing test: PUT `llm: null` persists null and reads back as auto.
- Exercised live against `openscience serve`: GET/PUT `/settings/billing` round-trips managed/byok/null (null persists correctly through both the JSON merge and JSONC patch paths), and compute provider connect stores ciphertext only and never returns the key.
