### PR TITLE
fix(cli): keep the banner glyphs aligned through yargs' help formatter

### DIFF
--- a/backend/cli/src/cli/ui.ts
+++ b/backend/cli/src/cli/ui.ts
@@ -87,7 +87,13 @@ export namespace UI {
 
     for (const line of glyphs.lines) {
       if (pad) result.push(pad)
-      for (const ch of line) {
+      // yargs' help formatter trims leading whitespace per line, which
+      // destroys the glyph indentation (the O's top row shifts left and the
+      // letters shear). Braille blank (U+2800) renders as a blank cell but
+      // isn't whitespace, so the margin survives formatting.
+      const lead = line.length - line.trimStart().length
+      result.push("⠀".repeat(lead))
+      for (const ch of line.slice(lead)) {
         if (structural.has(ch)) {
           result.push(dim, ch, reset)
         } else if (ch === " ") {


### PR DESCRIPTION
The yargs/cliui help formatter trims leading whitespace on every line, which stripped the relative indentation out of the ANSI-shadow banner — the O's top and bottom rows shifted left and the letters sheared (the logo.ts art itself was always correct). The renderer now emits braille blanks (U+2800) for each line's leading margin: they render as blank cells but aren't whitespace, so no formatter can collapse them.

Verified by capturing `--help` output: all twelve banner rows keep their glyph alignment. Typecheck and CLI tests pass.