### PR TITLE
fix(models): compute "latest" badge from release_date, not a stale name tag

### DIFF
--- a/frontend/workspace/src/context/models.tsx
+++ b/frontend/workspace/src/context/models.tsx
@@ -44,13 +44,32 @@ export const { use: useModels, provider: ModelsProvider } = createSimpleContext(
       return map
     })
 
-    const list = createMemo(() =>
-      available().map((m) => ({
-        ...m,
-        name: m.name.replace("(latest)", "").trim(),
-        latest: m.name.includes("(latest)"),
-      })),
-    )
+    // "latest" = the newest model per (provider, family), decided by release_date
+    // rather than a catalog "(latest)" name string. That string goes stale the
+    // moment a newer model ships — e.g. Opus 4.8 lands but 4.5 keeps the tag — so
+    // it mislabelled superseded models as latest across every provider.
+    const list = createMemo(() => {
+      const items = available()
+      const newestByFamily = new Map<string, string>()
+      for (const m of items) {
+        const family = m.family?.trim()
+        const released = m.release_date?.trim()
+        if (!family || !released) continue
+        const key = `${m.provider.id}:${family}`
+        const current = newestByFamily.get(key)
+        if (!current || released > current) newestByFamily.set(key, released)
+      }
+      return items.map((m) => {
+        const family = m.family?.trim()
+        const released = m.release_date?.trim()
+        const latest = !!family && !!released && newestByFamily.get(`${m.provider.id}:${family}`) === released
+        return {
+          ...m,
+          name: m.name.replace("(latest)", "").trim(),
+          latest,
+        }
+      })
+    })
 
     const find = (key: ModelKey) => list().find((m) => m.id === key.modelID && m.provider.id === key.providerID)
 


### PR DESCRIPTION
## Problem

The model picker flags a model **latest** whenever its catalog name contains `(latest)`. That string goes stale the moment a newer model ships — so with Opus 4.8 and Sonnet 5 released, `Claude Opus 4.5 (latest)` and `Claude Sonnet 4.5 (latest)` kept the tag and superseded models read as "latest". The same staleness hit every provider whose catalog aliases lag (openai, mistral, openrouter, …).

![before: Opus 4.5 wrongly badged latest while Opus 4.8 is selected]

## Fix

Compute `latest` as the newest model per `(provider, family)` by `release_date`, in `context/models.tsx` — ignoring the `(latest)` name string (still stripped from display names).

- Provider-agnostic, driven by real dates: within each family the model with the max `release_date` wins.
- Models missing `family`/`release_date` are never flagged (no false positives).
- Deprecated models are already filtered upstream by `normalizeProviderList`.
- One change covers every consumer — both picker dialogs and `Composer.tsx`'s default-model fallback read the computed `.latest`.

## Result (verified against the live catalog)

- **anthropic** → Opus **4.8**, Sonnet **5**, Haiku 4.5, Fable 5 get `latest` — not the old 4.5s.
- **openai / google / groq / mistral / deepseek / xai** → newest of each family flagged (e.g. GPT-5.5, Gemini 3.5 Flash, Grok 4.3, DeepSeek V4).

## Verification

- Frontend `typecheck` (exit 0), prettier clean, gitleaks clean.
- Simulated the algorithm over `GET /provider` catalog data across 7 providers — badges match the newest release per family.

## Notes / trade-offs (date-accurate, called out for review)

- Where a family's newest entry is a `-preview` the catalog marks `active` (e.g. `gemini-3.1-pro-preview`), it is flagged latest since it genuinely is the most recent.
- A family exposing a dated alias + concrete model on the same date gets two badges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)