### PR TITLE
fix: match O/P/Q UniProt accessions in looksLikeAccession

### DIFF
--- a/backend/cli/src/science/connectors/proteins/util.ts
+++ b/backend/cli/src/science/connectors/proteins/util.ts
@@ -32,7 +32,7 @@ export function asArray<T = unknown>(value: unknown): T[] {
 
 /** True when a string looks like a UniProt accession (e.g. P00520, A0A0B5AC95). */
 export function looksLikeAccession(value: string): boolean {
-  return /^[A-NR-Z0-9][A-Z0-9]{5,9}$/i.test(value.trim())
+  return /^[A-Z0-9][A-Z0-9]{5,9}$/i.test(value.trim())
 }
 
 interface UniProtLite {

--- a/backend/cli/test/science/proteins-util.test.ts
+++ b/backend/cli/test/science/proteins-util.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test"
+import { looksLikeAccession } from "../../src/science/connectors/proteins/util"
+
+describe("looksLikeAccession", () => {
+  // O/P/Q lead the majority of Swiss-Prot accessions. The docstring's own
+  // example (P00520) starts with P, so these must be recognized.
+  test.each(["P00520", "P04637", "P38398", "O43426", "Q9Y6K9", "A0A0B5AC95", "B7ZLR8", "P12345"])(
+    "accepts accession %s",
+    (accession) => {
+      expect(looksLikeAccession(accession)).toBe(true)
+    },
+  )
+
+  test("trims surrounding whitespace before matching", () => {
+    expect(looksLikeAccession("  P04637  ")).toBe(true)
+  })
+
+  // The guard is a loose "6-10 alphanumerics" heuristic, so the rejects are
+  // strings that fall outside that shape: too short, too long, or punctuated.
+  test.each(["TP53", "p53", "", "P0", "P04-637", "TOOLONGACCESSION12"])("rejects non-accession %p", (value) => {
+    expect(looksLikeAccession(value)).toBe(false)
+  })
+})


### PR DESCRIPTION
### What does this PR do?

`looksLikeAccession` used `/^[A-NR-Z0-9][A-Z0-9]{5,9}$/i`, whose first character class excludes **O, P and Q** — the letters that begin most Swiss-Prot accessions (P04637, P38398, O43426, and the docstring's own `P00520` example). It is used as a fast-path guard in the AlphaFold (`alphafold.ts`) and SIFTS (`sifts.ts`) connectors: when it returns false the direct exact-accession lookup is skipped and a UniProt name search runs instead. So for any O/P/Q accession the intended by-accession path never fired.

Fix widens the first class to `[A-Z0-9]`, matching the loose "6–10 alphanumerics" intent of the guard.

### How did you verify your code works?

Added `test/science/proteins-util.test.ts` covering O/P/Q accessions (incl. the docstring `P00520` example) plus length/punctuation negatives. `bun test test/science/proteins-util.test.ts` → 15 pass. `prettier --check` clean on the changed files.

### Checklist

- [ ] `bun run typecheck` — note: the `tsgo` native binary isn't available for my arch locally; change is a one-character regex edit with no type surface.
- [x] `bun test` (proteins-util) passes
- [x] `bunx prettier --check` clean
- [ ] Linked issue (none found)
- [ ] Screenshots (n/a)