### PR TITLE
fix: constrain skill routing to skills actually loaded

### DIFF
--- a/backend/cli/src/session/prompt.ts
+++ b/backend/cli/src/session/prompt.ts
@@ -68,6 +68,10 @@ export namespace SessionPrompt {
   const ARTIFACT_AGENTS = ["research", "biology", "ml"]
   // Science agents that dispatch GPU/compute work and should honor billing.compute.
   const COMPUTE_AGENTS = new Set(["research", "biology", "physics", "ml"])
+  // Science agents whose static prompts carry a curated Skill Routing Table.
+  // They get a runtime list of the skills actually loaded so routing targets
+  // real skills instead of desynced table entries.
+  const SKILL_ROUTING_AGENTS = new Set(["research", "biology", "physics", "ml"])
 
   const state = Instance.state(
     () => {
@@ -699,6 +703,7 @@ export namespace SessionPrompt {
           ...(await SystemPrompt.environment(model)),
           ...(await InstructionPrompt.system()),
           ...(await Memory.recall()),
+          ...(SKILL_ROUTING_AGENTS.has(agent.name) ? await SystemPrompt.skills(agent) : []),
           ...artifactContext,
         ],
         messages: [

--- a/backend/cli/src/session/system.ts
+++ b/backend/cli/src/session/system.ts
@@ -10,6 +10,8 @@ import PROMPT_GEMINI from "./prompt/gemini.txt"
 import PROMPT_CODEX from "./prompt/codex_header.txt"
 import type { Provider } from "@/provider/provider"
 import { Config } from "../config/config"
+import { Skill } from "../skill"
+import { PermissionNext } from "../permission/next"
 
 export namespace SystemPrompt {
   export function instructions() {
@@ -58,6 +60,57 @@ If <name> is NOT a known skill, treat the / as literal text and respond
 normally.
 </slash-skill-invocation>`,
     ]
+  }
+
+  /** Runtime ground-truth of the skills actually loaded in the current
+   *  environment, so agents whose static instructions carry a curated Skill
+   *  Routing Table only route to skills that really resolve. Filtered by the
+   *  agent's `skill` permission, grouped by category, so the model never calls
+   *  `skill({name})` with a name the registry does not contain. */
+  export async function skills(agent: { permission: PermissionNext.Ruleset }): Promise<string[]> {
+    const accessible = (await Skill.all()).filter(
+      (skill) => PermissionNext.evaluate("skill", skill.name, agent.permission).action !== "deny",
+    )
+
+    if (accessible.length === 0) {
+      return [
+        [
+          "<available-skills>",
+          "No skills are currently loaded in this environment. Any Skill Routing Table or",
+          "`load_skill` reference in your instructions is guidance only — do NOT call the skill",
+          "tool, because no skill name will resolve. Proceed using your own knowledge.",
+          "</available-skills>",
+        ].join("\n"),
+      ]
+    }
+
+    const categories = new Map<string, Skill.Info[]>()
+    for (const skill of accessible) {
+      const cat = skill.category ?? "other"
+      const list = categories.get(cat) ?? []
+      list.push(skill)
+      categories.set(cat, list)
+    }
+
+    const lines: string[] = [
+      "<available-skills>",
+      "The Skill Routing Tables and `load_skill` references in your instructions are curated",
+      "guidance and may name skills that are NOT installed here. The list below is the",
+      "authoritative set of skills currently loaded and callable via the skill tool. Only route",
+      "to a skill that appears below — if guidance names one that is absent, it is not installed,",
+      "so pick the closest available alternative or proceed without it.",
+      "",
+    ]
+    for (const [cat, list] of [...categories.entries()].sort((a, b) => b[1].length - a[1].length)) {
+      lines.push(`### ${cat}`)
+      for (const skill of [...list].sort((a, b) => a.name.localeCompare(b.name))) {
+        const desc = skill.description.replace(/\s+/g, " ").trim()
+        const short = desc.length > 100 ? desc.slice(0, 97) + "..." : desc
+        lines.push(`- ${skill.name}${short ? ` — ${short}` : ""}`)
+      }
+    }
+    lines.push("</available-skills>")
+    return [lines.join("\n")]
   }
 
   export async function planModeInstructions(): Promise<string[]> {

--- a/backend/cli/test/session/system-skills.test.ts
+++ b/backend/cli/test/session/system-skills.test.ts
@@ -1,0 +1,77 @@
+import { test, expect } from "bun:test"
+import { SystemPrompt } from "../../src/session/system"
+import { Instance } from "../../src/project/instance"
+import { PermissionNext } from "../../src/permission/next"
+import { tmpdir } from "../fixture/fixture"
+import path from "path"
+
+async function writeSkill(dir: string, name: string, description: string, category?: string) {
+  const skillDir = path.join(dir, ".openscience", "skill", name)
+  await Bun.write(
+    path.join(skillDir, "SKILL.md"),
+    `---
+name: ${name}
+description: ${description}
+${category ? `category: ${category}\n` : ""}---
+
+# ${name}
+`,
+  )
+}
+
+test("skills() lists only loaded skills, not desynced routing-table entries", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      // A skill that is actually installed...
+      await writeSkill(dir, "scanpy", "Single-cell RNA-seq analysis with scanpy.", "biology")
+      // ...but NOT `peft`, which the static ml Skill Routing Table advertises.
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const [section] = await SystemPrompt.skills({ permission: [] })
+      expect(section).toContain("scanpy")
+      // The old routing table references `peft`; it is not loaded, so it must
+      // not appear in the runtime availability list.
+      expect(section).not.toContain("peft")
+      expect(section).toContain("<available-skills>")
+      expect(section).toContain("### biology")
+    },
+  })
+})
+
+test("skills() excludes skills denied by the agent permission", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      await writeSkill(dir, "scanpy", "Single-cell RNA-seq analysis.", "biology")
+      await writeSkill(dir, "secret-skill", "Should be hidden by permission.", "biology")
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const permission: PermissionNext.Ruleset = [{ permission: "skill", pattern: "secret-skill", action: "deny" }]
+      const [section] = await SystemPrompt.skills({ permission })
+      expect(section).toContain("scanpy")
+      expect(section).not.toContain("secret-skill")
+    },
+  })
+})
+
+test("skills() tells the model not to route when no skills are loaded", async () => {
+  await using tmp = await tmpdir({ git: true })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const [section] = await SystemPrompt.skills({ permission: [] })
+      expect(section).toContain("No skills are currently loaded")
+      expect(section).toContain("do NOT call the skill")
+    },
+  })
+})


### PR DESCRIPTION
### What does this PR do?

The science agents' prompts carry a static "Skill Routing Table" (`ml.txt`, `biology.txt`, `physics.txt`) that names skills like `peft`/`unsloth`. When those skills aren't loaded in the current environment, the model still routes to them and `skill({name})` fails with `Skill "<name>" not found`. This injects a runtime `<available-skills>` section built from the actual loaded registry (permission-filtered, grouped by category), so the model only routes to skills that resolve; when none are loaded it tells the model not to call the skill tool at all.

The curated routing tables are left intact as guidance — the runtime section just overlays ground truth on top. Gated to the four science agents (`research`, `biology`, `physics`, `ml`) so lightweight agents don't get the extra tokens, and it lands in the stable (cache-friendly) system prefix.

### How did you verify your code works?

Added `test/session/system-skills.test.ts`: loads `scanpy` but not `peft`, asserts the section lists `scanpy` and omits `peft`; also covers permission-denied filtering and the empty-registry path. `bun test test/session/system-skills.test.ts` → 3 pass. `prettier --check` clean.

### Checklist

- [ ] `bun run typecheck` — note: the `tsgo` native binary isn't available for my arch locally; `tsc --noEmit` on the changed files is clean (only the pre-existing `llm.ts` TS2589 remains on baseline).
- [x] `bun test` (system-skills) passes
- [x] `bunx prettier --check` clean
- [ ] Linked issue (none found)
- [ ] Screenshots (n/a)