### PR TITLE
fix: read Europe PMC journal name from journalInfo.journal.title

### DIFF
--- a/backend/cli/src/science/connectors/literature/europepmc.ts
+++ b/backend/cli/src/science/connectors/literature/europepmc.ts
@@ -23,6 +23,7 @@ interface Result {
   abstractText?: string
   pubYear?: string
   journalTitle?: string
+  journalInfo?: { journal?: { title?: string } }
   citedByCount?: number
 }
 
@@ -38,7 +39,8 @@ function url(r: Result): string | undefined {
 }
 
 function toHit(r: Result): ConnectorHit {
-  const meta = [r.authorString, r.journalTitle, r.pubYear].filter(Boolean).join(". ")
+  const journal = r.journalInfo?.journal?.title ?? r.journalTitle
+  const meta = [r.authorString, journal, r.pubYear].filter(Boolean).join(". ")
   return {
     id: r.source && r.id ? `${r.source}/${r.id}` : (r.id ?? ""),
     title: snippet(r.title, 300) ?? r.id ?? "Untitled",

--- a/backend/cli/test/science/europepmc.test.ts
+++ b/backend/cli/test/science/europepmc.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { europepmc } from "../../src/science/connectors/literature/europepmc"
+import { clearCache, resetRateLimits } from "../../src/science/connectors/http"
+
+const realFetch = globalThis.fetch
+
+beforeEach(() => {
+  clearCache()
+  resetRateLimits()
+})
+
+afterEach(() => {
+  globalThis.fetch = realFetch
+})
+
+describe("europepmc connector", () => {
+  // Europe PMC's resultType=core records carry the journal name at
+  // journalInfo.journal.title, not a top-level journalTitle field.
+  test("surfaces the journal name from journalInfo.journal.title", async () => {
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          resultList: {
+            result: [
+              {
+                id: "12345678",
+                source: "MED",
+                title: "A study of things",
+                authorString: "Doe J, Smith A.",
+                pubYear: "2024",
+                journalInfo: { journal: { title: "The New England Journal of Medicine" } },
+              },
+            ],
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      )) as unknown as typeof fetch
+
+    const hits = await europepmc.search("things", { limit: 1 })
+    // With no abstract, the summary falls back to the author/journal/year meta line.
+    expect(hits[0]?.summary).toContain("The New England Journal of Medicine")
+  })
+})


### PR DESCRIPTION
### What does this PR do?

Europe PMC `resultType=core` records (the connector hardcodes `resultType=core`) carry the journal name under `journalInfo.journal.title`, but `toHit` read a non-existent top-level `journalTitle`. `.filter(Boolean)` silently dropped the `undefined`, so the venue never appeared in the summary meta line (the fallback shown when a record has no abstract). This reads the nested field, aligning Europe PMC with the crossref/openalex/pubmed connectors which all include the venue.

### How did you verify your code works?

Added `test/science/europepmc.test.ts` — stubs `fetch` with a core record whose journal is under `journalInfo.journal.title` and no abstract, asserts the hit summary contains the journal name. `bun test test/science/europepmc.test.ts` → 1 pass. `prettier --check` clean.

### Checklist

- [ ] `bun run typecheck` — `tsgo` native binary unavailable for my arch locally; change is a nested-field read guarded by optional chaining.
- [x] `bun test` (europepmc) passes
- [x] `bunx prettier --check` clean
- [ ] Linked issue (none found)
- [ ] Screenshots (n/a)