### PR TITLE
fix: query the openscience Chocolatey package for latest-version lookup

### DIFF
--- a/backend/cli/src/installation/index.ts
+++ b/backend/cli/src/installation/index.ts
@@ -228,7 +228,7 @@ export namespace Installation {
 
     if (detectedMethod === "choco") {
       return fetch(
-        "https://community.chocolatey.org/api/v2/Packages?$filter=Id%20eq%20%27synsc%27%20and%20IsLatestVersion&$select=Version",
+        "https://community.chocolatey.org/api/v2/Packages?$filter=Id%20eq%20%27openscience%27%20and%20IsLatestVersion&$select=Version",
         { headers: { Accept: "application/json;odata=verbose" } },
       )
         .then((res) => {


### PR DESCRIPTION
### What does this PR do?

The Chocolatey latest-version lookup filtered on `Id eq 'synsc'` — a leftover from before the rename. Everywhere else in the same file already uses `openscience` for Chocolatey (`choco list --limit-output openscience`, and the package name resolves to `"openscience"` for brew/choco/scoop). So the version lookup queried a non-existent package id and couldn't resolve an upgrade version on Chocolatey installs. Point it at the `openscience` package.

### How did you verify your code works?

The change makes the version-lookup id consistent with the detection/install id already used in the same module (lines using `openscience`). This is a URL built inside a `fetch()` chain with no existing unit coverage for the install-detection paths, so no unit test was added; the fix is a literal package-id correction.

### Checklist

- [ ] `bun run typecheck` — `tsgo` native binary unavailable for my arch locally; change is a string literal edit.
- [ ] `bun test` — n/a (no tests cover install-method detection; string-only change)
- [x] `bunx prettier --check` clean
- [ ] Linked issue (none found)
- [ ] Screenshots (n/a)