### PR TITLE
fix(proteins): match O/P/Q UniProt accessions in looksLikeAccession

### DIFF
--- a/backend/cli/src/science/connectors/proteins/util.ts
+++ b/backend/cli/src/science/connectors/proteins/util.ts
@@ -30,9 +30,14 @@ export function asArray<T = unknown>(value: unknown): T[] {
   return Array.isArray(value) ? (value as T[]) : []
 }
 
-/** True when a string looks like a UniProt accession (e.g. P00520, A0A0B5AC95). */
+/** True when a string looks like a UniProt accession (e.g. P00520, A0A0B5AC95).
+ *  The leading character must accept O, P and Q: Swiss-Prot accessions
+ *  overwhelmingly begin with them (P04637, P38398, O43426, Q9Y6K9, and this
+ *  file's own P00520 example). An earlier `[A-NR-Z0-9]` class silently excluded
+ *  O/P/Q, so the AlphaFold and SIFTS connectors skipped their fast-path exact-ac
+ *  lookup for the most common human proteins. */
 export function looksLikeAccession(value: string): boolean {
-  return /^[A-NR-Z0-9][A-Z0-9]{5,9}$/i.test(value.trim())
+  return /^[A-Z0-9][A-Z0-9]{5,9}$/i.test(value.trim())
 }
 
 interface UniProtLite {

--- a/backend/cli/test/science/proteins-util.test.ts
+++ b/backend/cli/test/science/proteins-util.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test"
+import { clampLimit, firstString, looksLikeAccession } from "../../src/science/connectors/proteins/util"
+
+describe("looksLikeAccession", () => {
+  test("accepts Swiss-Prot accessions that begin with O, P or Q", () => {
+    // The O/P/Q prefixes cover most human proteins; the old [A-NR-Z0-9] class
+    // excluded them, breaking the AlphaFold/SIFTS exact-ac fast path.
+    for (const ac of ["P04637", "P38398", "O43426", "Q9Y6K9", "P00520"]) {
+      expect(looksLikeAccession(ac)).toBe(true)
+    }
+  })
+
+  test("accepts long (10-char) TrEMBL accessions", () => {
+    expect(looksLikeAccession("A0A0B5AC95")).toBe(true)
+  })
+
+  test("trims surrounding whitespace before matching", () => {
+    expect(looksLikeAccession("  P04637  ")).toBe(true)
+  })
+
+  test("rejects free-text names and out-of-range lengths", () => {
+    expect(looksLikeAccession("p53")).toBe(false)
+    expect(looksLikeAccession("tumor protein")).toBe(false)
+    expect(looksLikeAccession("A")).toBe(false)
+    expect(looksLikeAccession("A0A0B5AC95X1")).toBe(false)
+  })
+})
+
+describe("clampLimit", () => {
+  test("clamps into [1, max] and defaults when unset", () => {
+    expect(clampLimit(undefined, 5, 25)).toBe(5)
+    expect(clampLimit(0, 5, 25)).toBe(1)
+    expect(clampLimit(999, 5, 25)).toBe(25)
+    expect(clampLimit(3.9, 5, 25)).toBe(3)
+  })
+})
+
+describe("firstString", () => {
+  test("returns the first non-empty string", () => {
+    expect(firstString(undefined, "", "  ", "hit", "next")).toBe("hit")
+    expect(firstString(1, null, {})).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## What
`looksLikeAccession` guarded the AlphaFold and SIFTS connectors' fast-path exact-accession lookup with `/^[A-NR-Z0-9][A-Z0-9]{5,9}$/i`. The first character class `[A-NR-Z0-9]` skips **O, P and Q** — the letters that begin most Swiss-Prot accessions (P04637, P38398, O43426, Q9Y6K9, and the function's own `P00520` docstring example).

When the guard returns `false`, the connector skips the direct `accession` lookup and falls through to the slower free-text name search, so the most common human proteins never hit the fast path.

## Fix
Widen the leading character to `[A-Z0-9]`.

## Tests
Adds `test/science/proteins-util.test.ts` covering O/P/Q prefixes, 10-char TrEMBL accessions, whitespace trimming, and rejection of free-text names / out-of-range lengths.