### PR TITLE
fix(europepmc): read the journal name from journalInfo.journal.title

### DIFF
--- a/backend/cli/src/science/connectors/literature/europepmc.ts
+++ b/backend/cli/src/science/connectors/literature/europepmc.ts
@@ -22,8 +22,17 @@ interface Result {
   authorString?: string
   abstractText?: string
   pubYear?: string
+  // `resultType=core` records (this connector hardcodes core) nest the journal
+  // name under journalInfo.journal.title. Older/lite shapes put it top-level as
+  // journalTitle — keep both so either shape resolves.
   journalTitle?: string
+  journalInfo?: { journal?: { title?: string } }
   citedByCount?: number
+}
+
+/** The publication venue, from whichever shape the record uses. */
+export function journalName(r: Result): string | undefined {
+  return r.journalInfo?.journal?.title ?? r.journalTitle
 }
 
 interface SearchResponse {
@@ -38,7 +47,7 @@ function url(r: Result): string | undefined {
 }
 
 function toHit(r: Result): ConnectorHit {
-  const meta = [r.authorString, r.journalTitle, r.pubYear].filter(Boolean).join(". ")
+  const meta = [r.authorString, journalName(r), r.pubYear].filter(Boolean).join(". ")
   return {
     id: r.source && r.id ? `${r.source}/${r.id}` : (r.id ?? ""),
     title: snippet(r.title, 300) ?? r.id ?? "Untitled",

--- a/backend/cli/test/science/europepmc.test.ts
+++ b/backend/cli/test/science/europepmc.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test"
+import { journalName } from "../../src/science/connectors/literature/europepmc"
+
+describe("europepmc journalName", () => {
+  test("reads the nested journalInfo.journal.title from a resultType=core record", () => {
+    expect(journalName({ journalInfo: { journal: { title: "Nature" } } })).toBe("Nature")
+  })
+
+  test("falls back to the top-level journalTitle for lite-shaped records", () => {
+    expect(journalName({ journalTitle: "Cell" })).toBe("Cell")
+  })
+
+  test("prefers the nested title when both are present", () => {
+    expect(journalName({ journalTitle: "Old", journalInfo: { journal: { title: "New" } } })).toBe("New")
+  })
+
+  test("returns undefined when no journal is present", () => {
+    expect(journalName({})).toBeUndefined()
+    expect(journalName({ journalInfo: {} })).toBeUndefined()
+    expect(journalName({ journalInfo: { journal: {} } })).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## What
The Europe PMC connector hardcodes `resultType=core`, whose records nest the journal name under `journalInfo.journal.title`. `toHit` read a non-existent top-level `journalTitle`, so `.filter(Boolean)` silently dropped the `undefined` and the venue never appeared in the summary meta line (the fallback shown when a record has no abstract).

## Fix
Resolve the venue through a small `journalName()` helper that reads the nested `journalInfo.journal.title` and falls back to the top-level `journalTitle` for older/lite-shaped records.

## Tests
Adds `test/science/europepmc.test.ts` covering the nested field, the top-level fallback, nested-preferred precedence, and the no-journal case.