### PR TITLE
fix(installation): query the openscience Chocolatey package for latest-version lookup

### DIFF
--- a/backend/cli/src/installation/index.ts
+++ b/backend/cli/src/installation/index.ts
@@ -190,6 +190,17 @@ export namespace Installation {
   export const CHANNEL = typeof OPENSCIENCE_CHANNEL === "string" ? OPENSCIENCE_CHANNEL : "local"
   export const USER_AGENT = `openscience/${CHANNEL}/${VERSION}/${Flag.OPENSCIENCE_CLIENT}`
 
+  /** OData query for the latest published version of a Chocolatey package.
+   *  The id must match what the CLI actually publishes to Chocolatey
+   *  (`openscience`) — everywhere else in this file already uses it (`choco
+   *  list --limit-output openscience`, `choco upgrade openscience`). A leftover
+   *  pre-rename `synsc` id here queried a non-existent package, so choco users
+   *  could never resolve an upgrade target (`data.d.results[0]` was undefined). */
+  export function chocoLatestVersionUrl(pkg: string = "openscience"): string {
+    const filter = encodeURIComponent(`Id eq '${pkg}' and IsLatestVersion`)
+    return `https://community.chocolatey.org/api/v2/Packages?$filter=${filter}&$select=Version`
+  }
+
   export async function latest(installMethod?: Method) {
     const detectedMethod = installMethod || (await method())
 
@@ -227,10 +238,7 @@ export namespace Installation {
     }
 
     if (detectedMethod === "choco") {
-      return fetch(
-        "https://community.chocolatey.org/api/v2/Packages?$filter=Id%20eq%20%27synsc%27%20and%20IsLatestVersion&$select=Version",
-        { headers: { Accept: "application/json;odata=verbose" } },
-      )
+      return fetch(chocoLatestVersionUrl(), { headers: { Accept: "application/json;odata=verbose" } })
         .then((res) => {
           if (!res.ok) throw new Error(res.statusText)
           return res.json()

--- a/backend/cli/test/installation/choco-url.test.ts
+++ b/backend/cli/test/installation/choco-url.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test"
+import { Installation } from "../../src/installation"
+
+describe("Installation.chocoLatestVersionUrl", () => {
+  test("queries the openscience package, not the pre-rename synsc id", () => {
+    const url = Installation.chocoLatestVersionUrl()
+    expect(url).toContain(encodeURIComponent("Id eq 'openscience'"))
+    expect(url).not.toContain("synsc")
+  })
+
+  test("keeps the OData query options ($filter/$select) literal", () => {
+    const url = Installation.chocoLatestVersionUrl()
+    expect(url.startsWith("https://community.chocolatey.org/api/v2/Packages?$filter=")).toBe(true)
+    expect(url).toContain("&$select=Version")
+    expect(url).toContain(encodeURIComponent("IsLatestVersion"))
+  })
+})


### PR DESCRIPTION
## What
The Chocolatey latest-version lookup filtered on `Id eq 'synsc'` — a leftover from before the rename. Everywhere else in the same file already uses `openscience` for Chocolatey (`choco list --limit-output openscience`, `choco upgrade openscience`), so the version query hit a non-existent package id and `data.d.results[0].Version` threw — choco users could never resolve an upgrade target.

## Fix
Build the OData query through a testable `chocoLatestVersionUrl()` helper keyed on the real `openscience` package id.

## Tests
Adds `test/installation/choco-url.test.ts` asserting the URL targets `openscience` (never `synsc`) and keeps the `$filter`/`$select` OData options literal.