### PR TITLE
fix(transform): stream reasoning correctly on the OpenRouter managed path

### DIFF
--- a/backend/cli/src/provider/transform.ts
+++ b/backend/cli/src/provider/transform.ts
@@ -733,8 +733,15 @@ export namespace ProviderTransform {
       result["usage"] = {
         include: true,
       }
-      if (input.model.api.id.includes("gemini-3")) {
-        result["reasoning"] = { effort: "high" }
+      // OpenRouter streams reasoning through its unified `reasoning` /
+      // `reasoning_details` fields, but ONLY when reasoning is explicitly
+      // requested — without a `reasoning` object the upstream reasons silently
+      // and OR drops the trace, so every reasoning part lands empty. Request it
+      // by default for every reasoning-capable model (a selected effort variant
+      // overrides this via mergeDeep in llm.ts). This is the single normalized
+      // reasoning path that all managed wallet inference now flows through.
+      if (input.model.capabilities.reasoning) {
+        result["reasoning"] = { effort: input.model.api.id.includes("gemini-3") ? "high" : "medium" }
       }
     }
 
@@ -765,7 +772,16 @@ export namespace ProviderTransform {
       }
     }
 
-    if (input.model.api.id.includes("gpt-5") && !input.model.api.id.includes("gpt-5-chat")) {
+    // OpenRouter-routed gpt-5 (e.g. "openai/gpt-5") is handled by the unified
+    // OpenRouter reasoning branch above. The OpenAI-Responses-only keys below
+    // (reasoningEffort / reasoningSummary / include: reasoning.encrypted_content)
+    // are meaningless to OR's /chat/completions and were silently making managed
+    // gpt-5 reasoning stream blank — exclude the OR npm here.
+    if (
+      input.model.api.id.includes("gpt-5") &&
+      !input.model.api.id.includes("gpt-5-chat") &&
+      input.model.api.npm !== "@openrouter/ai-sdk-provider"
+    ) {
       if (!input.model.api.id.includes("gpt-5-pro")) {
         result["reasoningEffort"] = "medium"
       }
@@ -802,6 +818,13 @@ export namespace ProviderTransform {
   }
 
   export function smallOptions(model: Provider.Model) {
+    // OpenRouter first: an OR-routed gpt-5 / gemini model must use OR's unified
+    // `reasoning` shape, not the OpenAI/Google keys the branches below emit. OR
+    // silently ignores `reasoningEffort`, so without this a small OR call (title
+    // / summary / compaction) would still reason and bill. Small = skip it.
+    if (model.api.npm === "@openrouter/ai-sdk-provider" || model.providerID === "openrouter") {
+      return { reasoning: { enabled: false } }
+    }
     if (model.providerID === "openai" || model.api.id.includes("gpt-5")) {
       if (model.api.id.includes("5.")) {
         return { reasoningEffort: "low" }
@@ -814,12 +837,6 @@ export namespace ProviderTransform {
         return { thinkingConfig: { thinkingLevel: "low" } }
       }
       return { thinkingConfig: { thinkingBudget: 0 } }
-    }
-    if (model.providerID === "openrouter") {
-      if (model.api.id.includes("google")) {
-        return { reasoning: { enabled: false } }
-      }
-      return { reasoningEffort: "minimal" }
     }
     return {}
   }

--- a/backend/cli/test/provider/transform-reasoning.test.ts
+++ b/backend/cli/test/provider/transform-reasoning.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "bun:test"
+import { ProviderTransform } from "../../src/provider/transform"
+
+const sessionID = "sess-reasoning-1"
+const PROXY_OR = "https://atlas.test/api/llm/proxy/openrouter/v1"
+const PROXY_OAI = "https://atlas.test/api/llm/proxy/openai/v1"
+
+const model = (overrides: Partial<any> = {}): any => ({
+  id: "test/model",
+  providerID: "test",
+  api: { id: "model", url: "https://example.com", npm: "@ai-sdk/openai" },
+  name: "Test",
+  capabilities: {
+    temperature: true,
+    reasoning: true,
+    attachment: false,
+    toolcall: true,
+    input: { text: true, audio: false, image: false, video: false, pdf: false },
+    output: { text: true, audio: false, image: false, video: false, pdf: false },
+    interleaved: false,
+  },
+  cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+  limit: { context: 200_000, output: 64_000 },
+  status: "active",
+  options: {},
+  headers: {},
+  release_date: "2025-01-01",
+  ...overrides,
+})
+
+const orModel = (id: string, apiId: string, extra: Partial<any> = {}) =>
+  model({
+    id,
+    providerID: "openrouter",
+    api: { id: apiId, url: "https://openrouter.ai/api/v1", npm: "@openrouter/ai-sdk-provider" },
+    ...extra,
+  })
+
+describe("ProviderTransform.options — managed OpenRouter reasoning", () => {
+  test("reasoning-capable OR model requests unified reasoning + usage, no OpenAI keys", () => {
+    const result = ProviderTransform.options({
+      model: orModel("openrouter/anthropic/claude-sonnet-4", "anthropic/claude-sonnet-4"),
+      sessionID,
+      providerOptions: { baseURL: PROXY_OR },
+    })
+    expect(result.usage).toEqual({ include: true })
+    expect(result.reasoning).toEqual({ effort: "medium" })
+    expect(result.reasoningEffort).toBeUndefined()
+    expect(result.reasoningSummary).toBeUndefined()
+    expect(result.include).toBeUndefined()
+  })
+
+  test("OR-routed gpt-5 uses reasoning.effort (not the OpenAI keys), even via the managed proxy", () => {
+    const result = ProviderTransform.options({
+      model: orModel("openrouter/openai/gpt-5", "openai/gpt-5"),
+      sessionID,
+      providerOptions: { baseURL: PROXY_OR },
+    })
+    expect(result.usage).toEqual({ include: true })
+    expect(result.reasoning).toEqual({ effort: "medium" })
+    expect(result.reasoningEffort).toBeUndefined()
+    expect(result.reasoningSummary).toBeUndefined()
+    expect(result.include).toBeUndefined()
+    expect(result.textVerbosity).toBeUndefined()
+  })
+
+  test("OR gemini-3 keeps high effort", () => {
+    const result = ProviderTransform.options({
+      model: orModel("openrouter/google/gemini-3-pro", "google/gemini-3-pro"),
+      sessionID,
+      providerOptions: {},
+    })
+    expect(result.reasoning).toEqual({ effort: "high" })
+    expect(result.usage).toEqual({ include: true })
+  })
+
+  test("OR non-reasoning model gets usage but no reasoning object", () => {
+    const result = ProviderTransform.options({
+      model: orModel("openrouter/some/chat", "some/chat", {
+        capabilities: { ...model().capabilities, reasoning: false },
+      }),
+      sessionID,
+      providerOptions: {},
+    })
+    expect(result.usage).toEqual({ include: true })
+    expect(result.reasoning).toBeUndefined()
+  })
+})
+
+describe("ProviderTransform.options — BYOK / direct paths stay untouched", () => {
+  test("direct OpenAI gpt-5 (BYOK) keeps its OpenAI reasoning keys, no OR keys", () => {
+    const result = ProviderTransform.options({
+      model: model({
+        id: "openai/gpt-5",
+        providerID: "openai",
+        api: { id: "gpt-5", url: "https://api.openai.com/v1", npm: "@ai-sdk/openai" },
+      }),
+      sessionID,
+      providerOptions: {},
+    })
+    expect(result.store).toBe(false)
+    expect(result.reasoningEffort).toBe("medium")
+    expect(result.promptCacheKey).toBe(sessionID)
+    expect(result.reasoning).toBeUndefined()
+    expect(result.usage).toBeUndefined()
+  })
+
+  test("direct OpenAI-proxy gpt-5 (openai npm) still gets summary + encrypted content", () => {
+    const result = ProviderTransform.options({
+      model: model({
+        id: "openai/gpt-5",
+        providerID: "openai",
+        api: { id: "gpt-5", url: PROXY_OAI, npm: "@ai-sdk/openai" },
+      }),
+      sessionID,
+      providerOptions: { baseURL: PROXY_OAI },
+    })
+    expect(result.reasoningSummary).toBe("auto")
+    expect(result.include).toEqual(["reasoning.encrypted_content"])
+    expect(result.reasoning).toBeUndefined()
+  })
+})
+
+describe("ProviderTransform.smallOptions — OpenRouter", () => {
+  test("small OR calls disable reasoning via the unified shape", () => {
+    const result = ProviderTransform.smallOptions(orModel("openrouter/openai/gpt-5-nano", "openai/gpt-5-nano"))
+    expect(result).toEqual({ reasoning: { enabled: false } })
+  })
+})


### PR DESCRIPTION
Follow-up to the managed⇒OpenRouter routing PR: once wallet inference goes through OpenRouter, its reasoning has to actually stream. OpenRouter exposes reasoning via its unified `reasoning` / `reasoning_details` fields, but **only when a `reasoning` object is requested**. Three gaps left managed reasoning blank:

1. **`options()` only requested reasoning for gemini-3.** Every other reasoning-capable OpenRouter model (Claude, GPT, DeepSeek, …) got `usage.include` but no `reasoning` object → the upstream reasoned silently and OR dropped the trace. Now request `reasoning:{effort}` for every reasoning-capable OR model (medium; gemini-3 high). A selected effort variant still overrides via `mergeDeep` in `llm.ts`.
2. **OR-routed gpt-5 fell into the OpenAI-Responses block** and got `reasoningEffort` / `reasoningSummary` / `include: reasoning.encrypted_content` — keys OR ignores — so it requested no reasoning in OR's shape. Exclude the OR npm from that block.
3. **`smallOptions()` OpenRouter branch was dead code**: a small OR `gpt-5-nano` matched the `gpt-5` check first and returned the OpenAI `reasoningEffort: "minimal"` key (ignored by OR → reasoning still ran and billed on title/summary/compaction). Check OpenRouter first and disable reasoning via OR's unified `reasoning:{enabled:false}`. (This was a real bug the plan's original edit missed — the new test caught it.)

Direct OpenAI (BYOK + the openai-via-proxy edge) is untouched.

## Tests
`test/provider/transform-reasoning.test.ts`: OR reasoning requested for Claude/GPT/gemini-3; OR gpt-5 uses `reasoning.effort` not the OpenAI keys; non-reasoning OR models get no reasoning object; direct-OpenAI paths keep their existing keys; small OR disables reasoning. All 69 existing transform tests still pass.