### PR TITLE
fix(atlas): honour a project pin only when its dedupe key matches

### DIFF
--- a/backend/cli/src/server/routes/atlas-bridge.ts
+++ b/backend/cli/src/server/routes/atlas-bridge.ts
@@ -234,16 +234,32 @@ function projectIdOf(p: any): string | null {
 // resolve. Read FIRST so a linked repo shows its graph instantly (and offline)
 // without re-hitting the API — closing the gap where the pin was written but
 // never honoured. Lives at the repo root next to .git.
-function readProjectPin(root: string): string | null {
+export interface ProjectPin {
+  project_id: string
+  /** The dedupe key this project was resolved for; absent in legacy pins. */
+  dedupe_key?: string
+}
+
+function readProjectPin(root: string): ProjectPin | null {
   // legacy `.synsci/` pins predate the OpenScience rename; still honored
   for (const dir of [".openscience", ".synsci"]) {
     try {
       const raw = readFileSync(join(root, dir, "project.json"), "utf8")
       const j = JSON.parse(raw)
-      if (typeof j?.project_id === "string" && j.project_id) return j.project_id
+      if (typeof j?.project_id === "string" && j.project_id)
+        return { project_id: j.project_id, dedupe_key: typeof j?.dedupe_key === "string" ? j.dedupe_key : undefined }
     } catch {}
   }
   return null
+}
+
+/** Trust a pin only when it carries no dedupe key (legacy/back-compat) or its
+ *  key matches the repo's freshly-computed key. A pin whose key differs belongs
+ *  to a DIFFERENT repo identity (e.g. the remote was re-pointed, or a stale
+ *  `.openscience/` was copied in) and must not shadow — or block find-or-create
+ *  of — the correct project. */
+export function pinMatchesKey(pin: ProjectPin, key: string): boolean {
+  return !pin.dedupe_key || pin.dedupe_key === key
 }
 
 function writeProjectPin(root: string, projectId: string, key: string): void {
@@ -268,10 +284,13 @@ async function resolveProjectId(directory: string): Promise<string | null> {
     // Root to the git repo top-level so a subfolder / a clone at a different
     // path resolves to the SAME project + graph as the repo itself.
     const root = await repoRoot(directory)
-    const pinned = readProjectPin(root)
-    if (pinned) return pinned
     const ctx = await repoContext(root)
     const key = computeDedupeKey(root, ctx.repo_url)
+    // Honour the local pin first (instant + offline) — but ONLY when it was
+    // resolved for THIS repo identity, so a stale pin can't shadow the right
+    // project (or block find-or-create from ever creating it).
+    const pin = readProjectPin(root)
+    if (pin && pinMatchesKey(pin, key)) return pin.project_id
     const res = await atlas("GET", `/api/agent/projects?dedupe_key=${encodeURIComponent(key)}`)
     if (!res.ok) return null
     const data = await res.json()

--- a/backend/cli/test/server/atlas-bridge.test.ts
+++ b/backend/cli/test/server/atlas-bridge.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test"
-import { classifyInitFailure, computeDedupeKey, initProjectDetailed } from "../../src/server/routes/atlas-bridge"
+import {
+  classifyInitFailure,
+  computeDedupeKey,
+  initProjectDetailed,
+  pinMatchesKey,
+} from "../../src/server/routes/atlas-bridge"
 
 describe("computeDedupeKey", () => {
   test("derives repo:<host>/<owner>/<name> from a GitHub https remote", () => {
@@ -69,6 +74,27 @@ describe("classifyInitFailure", () => {
   test("non-JSON bodies fall back to trimmed raw text", () => {
     expect(classifyInitFailure(500, "  Bad Gateway  ").message).toBe("Bad Gateway")
     expect(classifyInitFailure(500, "").message).toBeUndefined()
+  })
+})
+
+describe("pinMatchesKey", () => {
+  test("honours a legacy pin with no dedupe key (back-compat)", () => {
+    expect(pinMatchesKey({ project_id: "p1" }, "repo:github.com/o/n")).toBe(true)
+  })
+
+  test("trusts a pin whose key matches the repo's computed key", () => {
+    const key = "repo:github.com/o/n"
+    expect(pinMatchesKey({ project_id: "p1", dedupe_key: key }, key)).toBe(true)
+  })
+
+  test("rejects a pin whose key belongs to a different repo identity", () => {
+    const pin = { project_id: "p1", dedupe_key: "repo:github.com/o/OLD" }
+    expect(pinMatchesKey(pin, "repo:github.com/o/NEW")).toBe(false)
+  })
+
+  test("rejects a local-folder pin that no longer matches the resolved key", () => {
+    const pin = { project_id: "p1", dedupe_key: "local-folder:/old/path" }
+    expect(pinMatchesKey(pin, "local-folder:/new/path")).toBe(false)
   })
 })
 


### PR DESCRIPTION
One of the reasons "Atlas doesn't create/load the right graph."

## Bug
`resolveProjectId` honoured the local `.openscience/project.json` pin **unconditionally** — `readProjectPin` returned only `project_id` and threw away the `dedupe_key` that `writeProjectPin` stored next to it. So when the pin is stale or belongs to a *different* repo identity (the git remote was re-pointed to a fork, a `.openscience/` dir was copied into another repo, or the pinned project was deleted server-side), find-or-create returned the wrong/dead project id and **never created the correct graph** — which reads as "the graph won't load / shows the wrong project / stays empty."

## Fix
- `readProjectPin` now returns the stored `dedupe_key` too (`ProjectPin`).
- `resolveProjectId` computes the repo's key first and trusts the pin only when `pinMatchesKey(pin, key)` holds: a pin with no key is legacy and kept for back-compat; otherwise its key must equal the repo's freshly-computed key. A mismatched pin falls through to resolve-or-create, which rewrites the pin with the current key. The offline/fast path is preserved (the git calls that compute the key are local).

## Tests
`pinMatchesKey` coverage added to `test/server/atlas-bridge.test.ts`: legacy pin (no key) trusted; matching key trusted; a key from a different repo identity rejected; a local-folder pin that no longer matches rejected. Existing dedupe-key / failure-classification / init tests unchanged (18 pass).