### PR TITLE
fix(atlas): make graph init required and independent of the atlas binary

### DIFF
--- a/backend/cli/src/agent/prompt/research.txt
+++ b/backend/cli/src/agent/prompt/research.txt
@@ -50,19 +50,26 @@ Follow these stages. At each stage, proactively load the relevant skills — do 
 for the user to ask.
 
 **Use Atlas to persist your research — it is the project's durable, navigable memory.**
-The `atlas` CLI is authenticated from your OpenScience login. At the START of the task:
-1. Run `atlas doctor --format=json` to confirm it is available. If it reports the CLI is
-   unavailable/unauthenticated, skip Atlas silently and continue — do NOT block the work.
-2. Run `openscience project init --format=json` (dedupe-safe — finds or creates this repo's
-   Atlas project graph; this is what indexes the project) and note the returned project_id.
-   (Or load the `initialize-atlas-graph` skill.)
-3. Run `atlas nodes:list --format=json` to load prior hypotheses, runs, and decisions
-   already recorded on the graph.
-Then, as you reach milestones, record each as a graph node with `atlas nodes:create` — one
-node per hypothesis, planned experiment, or completed run (success OR failure), setting its
-`kind` accordingly; attach artifacts/results with `atlas evidence:add` and connect related
-nodes with `atlas link:add`. Re-run `atlas nodes:list` to drive the next cycle. This is
-additive: keep writing your local markdown and files exactly as before.
+At the START of the task, before Stage 1, set up the graph:
+1. **Create/link the graph — REQUIRED, do this first.** Run
+   `openscience project init --format=json`. This is a dedupe-safe find-or-create that runs
+   entirely off your OpenScience login and does NOT depend on the `atlas` binary — so run it
+   even if `atlas` is unavailable. On success it prints `{"project_id":"<id>"}` and writes
+   `.openscience/project.json`; note the project_id. ONLY skip Atlas if it prints
+   `project_id: null` with an `error` kind — relay the matching fix (`unauthenticated` →
+   `openscience connect login`; `plan` → app.syntheticsciences.ai/cli; `unreachable`/`backend`
+   → show the message) and continue the work. (Or load the `initialize-atlas-graph` skill,
+   which wraps this exact command.)
+2. **Load prior graph state — optional, best-effort.** Run `atlas doctor --format=json`. If it
+   reports the `atlas` CLI is unavailable/unauthenticated, skip the `atlas ...` commands below
+   and continue — this does NOT undo step 1, which already created the graph. If doctor is OK,
+   run `atlas nodes:list --format=json` to load prior hypotheses, runs, and decisions.
+When the `atlas` CLI is available (step 2), as you reach milestones record each as a graph node
+with `atlas nodes:create` — one node per hypothesis, planned experiment, or completed run
+(success OR failure), setting its `kind` accordingly; attach artifacts/results with
+`atlas evidence:add` and connect related nodes with `atlas link:add`. Re-run `atlas nodes:list`
+to drive the next cycle. This is additive: keep writing your local markdown and files exactly
+as before.
 
 ### Stage 1: SCOPE
 Define the research question, hypothesis, and success criteria.


### PR DESCRIPTION
The dominant root cause of "Atlas doesn't create the graph."

## Problem
The research prompt told the agent, at the start of a task:
1. Run `atlas doctor`; **if it fails, skip Atlas silently.**
2. Run `openscience project init` (the actual find-or-create).

A model reads "if doctor fails, skip Atlas" as *skip step 2 as well*. But `openscience project init` is the graph-create and it runs **entirely off the managed session — it does not touch the `atlas` binary at all**. The binary is only present when the launcher's `npm i -g @synsci/atlas` ran; install channels that skip the wizard have no `atlas`, so `atlas doctor` fails → the agent skips the whole block → **no graph is ever created**, even though a direct `openscience project init` would have succeeded. The step was also purely advisory (no BLOCKING/REQUIRED language), so it got skipped on short tasks too.

## Fix
Reorder and decouple:
- **Step 1 — `openscience project init`, REQUIRED**, run even if `atlas` is unavailable. Only skip Atlas when init *itself* prints `project_id: null` with an `error` kind, and then relay the matching fix (`unauthenticated`/`plan`/`unreachable`).
- **Step 2 — `atlas doctor` + `nodes:list`, optional/best-effort** for loading prior graph state. A failed doctor no longer undoes step 1's creation.

Prompt-only change; no code paths altered. Full backend suite (922 tests) green; no test snapshots `research.txt`.