### PR TITLE
fix(atlas): wire the canvas Initialize button to the deterministic endpoint

### DIFF
--- a/frontend/workspace/src/thesis/ThesisCanvas.tsx
+++ b/frontend/workspace/src/thesis/ThesisCanvas.tsx
@@ -851,16 +851,16 @@ export function ThesisCanvas(): JSX.Element {
                   when={selectedGraph()}
                   fallback={
                     <InitHero
-                      onInit={() => {
-                        // One-click: drop the skill invocation in the composer and send it.
-                        // The initialize-atlas-graph skill runs `openscience project init`
-                        // (idempotent) and seeds the graph; the canvas picks it up on the
-                        // next unlinked-refresh poll below.
-                        uiStore.setPrefill("/initialize-atlas-graph")
-                        uiStore.setPrefillSend(true)
-                      }}
-                      // Secondary: drop the same skill invocation in the composer WITHOUT
-                      // sending, so the user can review/edit before running it.
+                      // Primary: hit the deterministic find-or-create endpoint
+                      // directly (POST /api/thesis/project/init via thesisAPI) so
+                      // the button reliably creates the graph without depending on
+                      // the agent or the `atlas` binary. initGraph() refetches and
+                      // selects the new root, and toasts a typed error on failure.
+                      onInit={() => void initGraph()}
+                      // Secondary: route through the agent — drop the
+                      // initialize-atlas-graph skill invocation in the composer
+                      // WITHOUT sending, so the user can review/run it (useful when
+                      // the direct call reports a plan/auth issue to resolve in chat).
                       onChat={() => uiStore.setPrefill("/initialize-atlas-graph")}
                       busy={initializing()}
                     />


### PR DESCRIPTION
The web half of "Atlas doesn't create the graph."

## Bug
The canvas's **"initialize this project's graph"** button dropped `/initialize-atlas-graph` into the chat composer and sent it — i.e. it asked the **agent** to create the graph, inheriting every fragility of the prompt path (skipped when the `atlas` binary is absent, or on a short task). Meanwhile `initGraph()` — which calls `thesisAPI.initProject` → `POST /api/thesis/project/init` (the deterministic find-or-create endpoint that returns a `project_id`), then refetches and selects the new root — was **defined but wired to nothing** (dead code), and `busy={initializing()}` was dead with it.

## Fix
Point the primary button at `initGraph()` so it deterministically creates the graph without the agent or the `atlas` binary, and toasts a typed error on failure (`initializing()` now drives the busy state). The secondary "chat" action still drops the skill invocation (without sending) so the user can review/run it — handy when the direct call reports a plan/auth issue to resolve in chat.

## Verification
`typecheck` (workspace `tsgo -b`) + `prettier` clean; `bun run --cwd frontend/workspace build` succeeds.