### PR TITLE
docs: prefer layers for single-cell count preservation

### DIFF
--- a/backend/cli/skills/biology/anndata/SKILL.md
+++ b/backend/cli/skills/biology/anndata/SKILL.md
@@ -160,7 +160,7 @@ Common commands:
 adata = ad.concat(
     [adata1, adata2, adata3],
     axis=0,
-    join='inner',
+    join='outer',  # Preserve the union of genes/features across samples
     label='batch',
     keys=['batch1', 'batch2', 'batch3']
 )
@@ -176,6 +176,8 @@ collection = AnnCollection(
     label='dataset'
 )
 ```
+
+Use `join='inner'` to keep only shared variables/observations across all objects. Use `join='outer'` to keep the union, which is usually the right choice when preserving all genes/features in `var` across an AnnData list matters. For outer joins, sparse matrices typically fill missing values with `0`; dense matrices may contain missing values unless you set an appropriate `fill_value`.
 
 ### 4. Data Manipulation
 
@@ -217,7 +219,6 @@ Follow recommended patterns for memory efficiency, performance, and reproducibil
 - Views vs copies
 - Data storage optimization
 - Performance optimization
-- Working with raw data
 - Metadata management
 - Reproducibility
 - Error handling
@@ -236,8 +237,11 @@ adata.strings_to_categoricals()
 # Use backed mode for large files
 adata = ad.read_h5ad('large.h5ad', backed='r')
 
-# Store raw before filtering
-adata.raw = adata.copy()
+# Preserve counts before normalization
+adata.layers['counts'] = adata.X.copy()
+sc.pp.normalize_total(adata, target_sum=1e4)
+sc.pp.log1p(adata)
+adata.layers['log1p'] = adata.X.copy()
 adata = adata[:, adata.var['highly_variable']]
 ```
 
@@ -301,8 +305,8 @@ adata.obs['n_counts'] = adata.X.sum(axis=1)
 adata = adata[adata.obs['n_genes'] > 200]
 adata = adata[adata.obs['n_counts'] < 50000]
 
-# 3. Store raw
-adata.raw = adata.copy()
+# 3. Preserve raw counts in a layer before normalization
+adata.layers['counts'] = adata.X.copy()
 
 # 4. Normalize and filter
 sc.pp.normalize_total(adata, target_sum=1e4)
@@ -326,7 +330,7 @@ adata = ad.concat(
     [adata1, adata2, adata3],
     label='batch',
     keys=['batch1', 'batch2', 'batch3'],
-    join='inner'
+    join='outer'  # Preserve all genes/features across batches
 )
 
 # Apply batch correction

--- a/backend/cli/skills/biology/anndata/references/best_practices.md
+++ b/backend/cli/skills/biology/anndata/references/best_practices.md
@@ -223,34 +223,36 @@ for chunk in adata.chunked_X(chunk_size=1000):
 # More memory efficient than loading full X
 ```
 
-## Working with Raw Data
+## Preserving Count Data
 
-### Store raw before filtering
+### Store counts before normalization
 ```python
-# Original data with all genes
+# Original count data
 adata = ad.AnnData(X=counts)
 
-# Store raw before filtering
-adata.raw = adata.copy()
+# Preserve counts before normalization or transformation
+adata.layers['counts'] = adata.X.copy()
+
+# Normalize/log-transform X for analysis
+sc.pp.normalize_total(adata, target_sum=1e4)
+sc.pp.log1p(adata)
+adata.layers['log1p'] = adata.X.copy()
 
 # Filter to highly variable genes
 adata = adata[:, adata.var['highly_variable']]
 
-# Later: access original data
-original_expression = adata.raw.X
-all_genes = adata.raw.var_names
+# Later: access retained-gene counts
+counts_for_retained_genes = adata.layers['counts']
 ```
 
 ### When to use raw
 ```python
-# Use raw for:
-# - Differential expression on filtered genes
-# - Visualization of specific genes not in filtered set
-# - Accessing original counts after normalization
+# .raw appears in older Scanpy tutorials and some downstream APIs.
+# It is optional, not required for most layer-based workflows.
+# Prefer layers when you need explicit count, log-normalized, or scaled matrices.
 
-# Access raw data
-if adata.raw is not None:
-    gene_expr = adata.raw[:, 'GENE_NAME'].X
+if 'counts' in adata.layers:
+    gene_expr = adata[:, 'GENE_NAME'].layers['counts']
 else:
     gene_expr = adata[:, 'GENE_NAME'].X
 ```
@@ -507,8 +509,8 @@ if not issparse(adata.X):
     if density < 0.5:
         adata.X = csr_matrix(adata.X)
 
-# 6. Store raw before filtering genes
-adata.raw = adata.copy()
+# 6. Preserve counts before normalization or filtering
+adata.layers['counts'] = adata.X.copy()
 
 # 7. Filter to highly variable genes
 adata = adata[:, adata.var['highly_variable']].copy()

--- a/backend/cli/skills/biology/anndata/references/concatenation.md
+++ b/backend/cli/skills/biology/anndata/references/concatenation.md
@@ -36,7 +36,7 @@ print(adata_combined.shape)  # (100, 150)
 ## Join Types
 
 ### Inner join (intersection)
-Keep only variables/observations present in all objects.
+Keep only variables/observations present in all objects. Use this when all objects measured the same features or when downstream analysis should include shared features only.
 
 ```python
 import pandas as pd
@@ -57,7 +57,7 @@ print(adata_inner.n_vars)  # 40 genes (overlap)
 ```
 
 ### Outer join (union)
-Keep all variables/observations, filling missing values.
+Keep all variables/observations, filling missing values. Use this when preserving all `var` entries, genes, or features across an AnnData list matters.
 
 ```python
 # Outer join: all genes are kept
@@ -71,9 +71,11 @@ print(adata_outer.n_vars)  # 70 genes (union)
 
 ### Fill values for outer joins
 ```python
-# Specify fill value for missing data
+# Specify fill value for missing data only when zero is appropriate
 adata_filled = ad.concat([adata1, adata2], join='outer', fill_value=0)
 ```
+
+For sparse count matrices, missing genes are generally filled with zeros. For dense matrices, missing entries may be `NaN`; choose `fill_value=0` deliberately only when zero-fill matches the data and analysis.
 
 ## Tracking Data Sources
 
@@ -333,7 +335,7 @@ adata_combined = ad.concat(
     batches,
     label='batch',
     keys=['batch1', 'batch2', 'batch3'],
-    join='outer'  # Keep all genes
+    join='outer'  # Preserve the union of genes/features across batches
 )
 
 # Later: apply batch correction
@@ -364,8 +366,8 @@ print([set(adata.var_names) for adata in [adata1, adata2, adata3]])
 ```
 
 2. **Use appropriate join type**
-- `inner`: When you need the same features across all samples (most stringent)
-- `outer`: When you want to preserve all features (most inclusive)
+- `inner`: Intersection of features across all samples; use when analysis should include only shared features
+- `outer`: Union of features across all samples; use when preserving all genes/features matters
 
 3. **Track data sources**
 Always use `label` and `keys` to track which observations came from which dataset.

--- a/backend/cli/skills/biology/anndata/references/data_structure.md
+++ b/backend/cli/skills/biology/anndata/references/data_structure.md
@@ -74,20 +74,20 @@ print(adata.var.loc['ENSG00001'])
 Dictionary storing alternative matrices with the same dimensions as X.
 
 ```python
-# Store raw counts, normalized data, and scaled data
+# Store counts, log-normalized data, and scaled data
 adata = ad.AnnData(X=np.random.rand(100, 2000))
-adata.layers['raw_counts'] = np.random.randint(0, 100, (100, 2000))
-adata.layers['normalized'] = adata.X / np.sum(adata.X, axis=1, keepdims=True)
-adata.layers['scaled'] = (adata.X - adata.X.mean()) / adata.X.std()
+adata.layers['counts'] = adata.X.copy()
+adata.layers['log1p'] = normalized_log_matrix
+adata.layers['scaled'] = scaled_matrix
 
 # Access layers
-raw_data = adata.layers['raw_counts']
-normalized_data = adata.layers['normalized']
+counts = adata.layers['counts']
+log_normalized = adata.layers['log1p']
 ```
 
 Common layer uses:
-- `raw_counts`: Original count data before normalization
-- `normalized`: Log-normalized or TPM values
+- `counts`: Original count data before normalization
+- `log1p`: Log-normalized expression values
 - `scaled`: Z-scored values for analysis
 - `imputed`: Data after imputation
 
@@ -188,25 +188,20 @@ Common uns uses:
 - Cluster information
 - Tool-specific metadata
 
-### raw (Original Data Snapshot)
-Optional attribute preserving the original data matrix and variable annotations before filtering.
+### raw (Optional Snapshot)
+Optional attribute that can store a snapshot of `X` and `var`. It is common in older Scanpy tutorials, but it is not required for most workflows and can create unnecessary copies. Prefer layers when preserving count data or multiple matrix representations.
 
 ```python
-# Create AnnData and store raw state
+# Preferred: preserve counts in a layer before normalization
 adata = ad.AnnData(X=np.random.rand(100, 5000))
 adata.var['gene_name'] = [f'Gene_{i}' for i in range(5000)]
+adata.layers['counts'] = adata.X.copy()
 
-# Store raw state before filtering
-adata.raw = adata.copy()
-
-# Filter to highly variable genes
-highly_variable_mask = np.random.rand(5000) > 0.5
-adata = adata[:, highly_variable_mask]
-
-# Access original data
-original_matrix = adata.raw.X
-original_var = adata.raw.var
+# Optional/legacy: create .raw only when a downstream tool expects it
+# Assign a full copy to adata.raw in that specific case.
 ```
+
+Layers stay aligned to the current AnnData shape. After subsetting variables, `adata.layers['counts']` contains counts for the retained variables.
 
 ## Object Properties
 

--- a/backend/cli/skills/biology/scanpy/SKILL.md
+++ b/backend/cli/skills/biology/scanpy/SKILL.md
@@ -67,7 +67,7 @@ adata.obs        # Cell metadata (DataFrame)
 adata.var        # Gene metadata (DataFrame)
 adata.uns        # Unstructured annotations (dict)
 adata.obsm       # Multi-dimensional cell data (PCA, UMAP)
-adata.raw        # Raw data backup
+adata.layers     # Alternative matrices, e.g. counts before normalization
 
 # Access cell and gene names
 adata.obs_names  # Cell barcodes
@@ -105,14 +105,17 @@ python scripts/qc_analysis.py input_file.h5ad --output filtered.h5ad
 ### 2. Normalization and Preprocessing
 
 ```python
+# Preserve raw counts before normalization
+adata.layers['counts'] = adata.X.copy()
+
 # Normalize to 10,000 counts per cell
 sc.pp.normalize_total(adata, target_sum=1e4)
 
 # Log-transform
 sc.pp.log1p(adata)
 
-# Save raw counts for later
-adata.raw = adata
+# Optionally store log-normalized values for plotting
+adata.layers['log1p'] = adata.X.copy()
 
 # Identify highly variable genes
 sc.pp.highly_variable_genes(adata, n_top_genes=2000)
@@ -180,8 +183,8 @@ markers = sc.get.rank_genes_groups_df(adata, group='0')
 marker_genes = ['CD3D', 'CD14', 'MS4A1', 'NKG7', 'FCGR3A']
 
 # Visualize markers
-sc.pl.umap(adata, color=marker_genes, use_raw=True)
-sc.pl.dotplot(adata, var_names=marker_genes, groupby='leiden')
+sc.pl.umap(adata, color=marker_genes, layer='log1p')
+sc.pl.dotplot(adata, var_names=marker_genes, groupby='leiden', layer='log1p')
 
 # Manual annotation
 cluster_to_celltype = {
@@ -301,12 +304,12 @@ sc.pp.combat(adata, key='batch')
 
 ## Common Pitfalls and Best Practices
 
-1. **Always save raw counts**: `adata.raw = adata` before filtering genes
+1. **Preserve counts before normalization**: `adata.layers['counts'] = adata.X.copy()`
 2. **Check QC plots carefully**: Adjust thresholds based on dataset quality
 3. **Use Leiden over Louvain**: More efficient and better results
 4. **Try multiple clustering resolutions**: Find optimal granularity
 5. **Validate cell type annotations**: Use multiple marker genes
-6. **Use `use_raw=True` for gene expression plots**: Shows original counts
+6. **Use explicit layers for expression plots**: For example, `layer='log1p'` for log-normalized values
 7. **Check PCA variance ratio**: Determine optimal number of PCs
 8. **Save intermediate results**: Long workflows can fail partway through
 

--- a/backend/cli/skills/biology/scanpy/assets/analysis_template.py
+++ b/backend/cli/skills/biology/scanpy/assets/analysis_template.py
@@ -92,14 +92,17 @@ print("\n" + "=" * 80)
 print("NORMALIZATION")
 print("=" * 80)
 
+# Preserve raw counts before normalization
+adata.layers['counts'] = adata.X.copy()
+
 # Normalize to 10,000 counts per cell
 sc.pp.normalize_total(adata, target_sum=1e4)
 
 # Log-transform
 sc.pp.log1p(adata)
 
-# Store normalized data
-adata.raw = adata
+# Store log-normalized data for plotting and marker visualization
+adata.layers['log1p'] = adata.X.copy()
 
 # ============================================================================
 # 4. FEATURE SELECTION
@@ -209,9 +212,9 @@ marker_genes = {
 
 # Visualize marker genes
 for cell_type, genes in marker_genes.items():
-    available_genes = [g for g in genes if g in adata.raw.var_names]
+    available_genes = [g for g in genes if g in adata.var_names]
     if available_genes:
-        sc.pl.umap(adata, color=available_genes, use_raw=True,
+        sc.pl.umap(adata, color=available_genes, layer='log1p',
                    save=f'_{cell_type.replace(" ", "_")}')
 
 # Manual annotation based on marker expression (customize this mapping)

--- a/backend/cli/skills/biology/scanpy/references/api_reference.md
+++ b/backend/cli/skills/biology/scanpy/references/api_reference.md
@@ -216,7 +216,7 @@ adata.uns                  # Unstructured annotations (dict)
 adata.obsm                 # Multi-dimensional cell annotations (e.g., PCA, UMAP)
 adata.varm                 # Multi-dimensional gene annotations
 adata.layers               # Additional data layers
-adata.raw                  # Raw data backup
+adata.layers               # Alternative matrices, e.g. counts before normalization
 
 # Access
 adata.obs_names            # Cell barcodes

--- a/backend/cli/skills/biology/scanpy/references/standard_workflow.md
+++ b/backend/cli/skills/biology/scanpy/references/standard_workflow.md
@@ -44,14 +44,17 @@ sc.pl.scatter(adata, x='total_counts', y='n_genes_by_counts')
 ### 3. Normalization
 
 ```python
+# Preserve raw counts before normalization
+adata.layers['counts'] = adata.X.copy()
+
 # Normalize to 10,000 counts per cell
 sc.pp.normalize_total(adata, target_sum=1e4)
 
 # Log-transform the data
 sc.pp.log1p(adata)
 
-# Store normalized data in raw for later use
-adata.raw = adata
+# Optionally preserve log-normalized values for plotting
+adata.layers['log1p'] = adata.X.copy()
 ```
 
 ### 4. Feature Selection
@@ -199,7 +202,7 @@ sc.pl.umap(adata, color='T_cell_score')
 ## Best Practices
 
 1. Always visualize QC metrics before filtering
-2. Save raw counts before normalization (`adata.raw = adata`)
+2. Preserve raw counts before normalization (`adata.layers['counts'] = adata.X.copy()`)
 3. Use Leiden instead of Louvain for clustering (more efficient)
 4. Try multiple clustering resolutions to find optimal granularity
 5. Validate cell type annotations with known marker genes


### PR DESCRIPTION
## Summary
- Clarify AnnData concatenation guidance around `join='outer'` for preserving the union of variables/features.
- Replace default `.raw` preservation recommendations with explicit `adata.layers['counts'] = adata.X.copy()` workflows.
- Align Scanpy workflow docs and analysis template with layers-first count preservation guidance.

## Test Plan
- [x] `git diff --check HEAD~1 HEAD`
- [x] `grep -R "adata\\.raw = adata\\|adata\\.raw = adata.copy()\\|use_raw=True\\|Always save raw counts\\|Raw data backup\\|Store raw" backend/cli/skills/biology/anndata backend/cli/skills/biology/scanpy || true`
- [x] `grep -R "layers\\['counts'\\] = adata.X.copy()" backend/cli/skills/biology/anndata backend/cli/skills/biology/scanpy`
- [ ] Bun validation/tests not run per maintainer instruction; changes are skill docs/template only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)