### PR TITLE
refactor(auth): Atlas is login/logout, Codex is connect/disconnect

### DIFF
--- a/backend/cli/skills/research/initialize-atlas-graph/SKILL.md
+++ b/backend/cli/skills/research/initialize-atlas-graph/SKILL.md
@@ -27,7 +27,7 @@ Run this skill when:
    atlas doctor --format=json
    ```
    If it reports unavailable/unauthenticated, tell the user to run
-   `openscience connect login` — the graph cannot be created without a session.
+   `openscience login` — the graph cannot be created without a session.
 
 2. **Create or link the graph** (idempotent — safe to re-run; returns the
    existing graph if one already exists):
@@ -41,7 +41,7 @@ Run this skill when:
    `status`, `message` when known). Relay the fix that matches the kind — do
    NOT guess or tell the user to re-login for a network problem:
    - `"unauthenticated"` — no session, or the backend rejected the saved key.
-     Tell the user to run `openscience connect login`.
+     Tell the user to run `openscience login`.
    - `"unreachable"` — the Atlas backend at the printed `host` could not be
      reached (network/DNS error or 5xx). The user IS logged in; suggest checking
      connectivity and any `OPENSCIENCE_API_BASE`/`SYNSC_API_BASE` override, then

--- a/backend/cli/src/agent/prompt/research.txt
+++ b/backend/cli/src/agent/prompt/research.txt
@@ -57,7 +57,7 @@ At the START of the task, before Stage 1, set up the graph:
    even if `atlas` is unavailable. On success it prints `{"project_id":"<id>"}` and writes
    `.openscience/project.json`; note the project_id. ONLY skip Atlas if it prints
    `project_id: null` with an `error` kind — relay the matching fix (`unauthenticated` →
-   `openscience connect login`; `plan` → app.syntheticsciences.ai/cli; `unreachable`/`backend`
+   `openscience login`; `plan` → app.syntheticsciences.ai/cli; `unreachable`/`backend`
    → show the message) and continue the work. (Or load the `initialize-atlas-graph` skill,
    which wraps this exact command.)
 2. **Load prior graph state — optional, best-effort.** Run `atlas doctor --format=json`. If it

--- a/backend/cli/src/cli/cmd/auth.ts
+++ b/backend/cli/src/cli/cmd/auth.ts
@@ -536,6 +536,87 @@ export const AuthCodexCommand = cmd({
   },
 })
 
+/** Best-effort server-side disconnect of the Codex credential, mirroring
+ *  pushTokensToBackend's POST. Runs BEFORE the local removal so the thk_ key can
+ *  still authenticate the call. Never throws — the local Auth.remove is what
+ *  actually signs the CLI out. */
+async function disconnectCodexBackend(): Promise<void> {
+  const session = await OpenScience.getSession?.()
+  const thkToken = session?.api_key
+  if (!thkToken) return
+  try {
+    await fetch(`${managedApiBase()}/api/keys/openai-codex`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${thkToken}` },
+    })
+  } catch {
+    /* best-effort — local removal below is the source of truth */
+  }
+}
+
+/** `openscience connect [codex]` — sign in with a ChatGPT (Codex) subscription.
+ *  The connect/disconnect verb pair is Codex's; Atlas uses login/logout. */
+export const ConnectCommand = cmd({
+  command: "connect [service]",
+  describe: "connect a ChatGPT subscription (Codex) — sign in with ChatGPT",
+  builder: (yargs) =>
+    yargs.positional("service", {
+      type: "string",
+      choices: ["codex"] as const,
+      default: "codex",
+      describe: "service to connect (only `codex` today)",
+    }),
+  async handler() {
+    await Instance.provide({
+      directory: process.cwd(),
+      async fn() {
+        UI.empty()
+        prompts.intro("Connect ChatGPT (Codex)")
+        const handled = await runCodexAuthFlow()
+        if (!handled) prompts.outro("Done")
+      },
+    })
+  },
+})
+
+/** `openscience disconnect [codex]` — sign out of ChatGPT (Codex): clears the
+ *  local OAuth credential and best-effort revokes it server-side. */
+export const DisconnectCommand = cmd({
+  command: "disconnect [service]",
+  describe: "disconnect your ChatGPT subscription (Codex)",
+  builder: (yargs) =>
+    yargs.positional("service", {
+      type: "string",
+      choices: ["codex"] as const,
+      default: "codex",
+      describe: "service to disconnect (only `codex` today)",
+    }),
+  async handler() {
+    await Instance.provide({
+      directory: process.cwd(),
+      async fn() {
+        UI.empty()
+        prompts.intro("Disconnect ChatGPT (Codex)")
+
+        const existing = await Auth.get("openai-codex")
+        const backend = await backendHasCodex()
+        if (!existing && backend !== true) {
+          prompts.log.warn("ChatGPT (Codex) isn't connected.")
+          prompts.outro("Done")
+          return
+        }
+
+        // Revoke server-side while the thk_ key can still authenticate, then
+        // drop the local credential (the part that actually signs the CLI out).
+        await disconnectCodexBackend()
+        await Auth.remove("openai-codex")
+        prompts.log.success("Disconnected ChatGPT (Codex)")
+        prompts.outro("Done")
+      },
+    })
+  },
+})
+
 export const AuthLogoutCommand = cmd({
   command: ["remove", "rm", "logout"],
   describe: "remove a saved provider key",

--- a/backend/cli/src/cli/cmd/connect.ts
+++ b/backend/cli/src/cli/cmd/connect.ts
@@ -303,18 +303,8 @@ export const DevicesCommand = cmd({
   },
 })
 
-/** Back-compat umbrella: `openscience connect <login|logout|status|sync|devices>`
- *  still works and forwards to the promoted top-level commands. */
-export const ConnectCommand = cmd({
-  command: "connect",
-  describe: "Atlas account (alias for `login` / `logout` / `status` / `sync` / `devices`)",
-  builder: (yargs) =>
-    yargs
-      .command(LoginCommand)
-      .command(LogoutCommand)
-      .command(StatusCommand)
-      .command(SyncCommand)
-      .command(DevicesCommand)
-      .demandCommand(),
-  async handler() {},
-})
+// Atlas is `login` / `logout` (+ `status` / `sync` / `devices`), all top-level.
+// The `connect` / `disconnect` verbs now belong to Codex (see cli/cmd/auth.ts):
+// `connect` signs in with ChatGPT, `disconnect` signs out. Keeping the two
+// account types on distinct verb pairs removes the old ambiguity where
+// `connect login` and `login` both meant the Atlas account.

--- a/backend/cli/src/cli/cmd/skill.ts
+++ b/backend/cli/src/cli/cmd/skill.ts
@@ -308,7 +308,7 @@ const SkillListCommand = cmd({
           UI.println(
             "Only a small bundled skill set is visible; this usually means the full OpenScience skill index was not fetched.",
           )
-          UI.println("Run `openscience connect sync` or try again once online/authenticated.")
+          UI.println("Run `openscience sync` or try again once online/authenticated.")
           UI.println("")
         } else if (!showAll) {
           UI.println("Use `openscience skill list --all` to show bundled OpenScience skills.")

--- a/backend/cli/src/index.ts
+++ b/backend/cli/src/index.ts
@@ -32,17 +32,10 @@ import { EOL } from "os"
 import { WebCommand } from "./cli/cmd/web"
 import { PrCommand } from "./cli/cmd/pr"
 import { SessionCommand } from "./cli/cmd/session"
-import {
-  ConnectCommand,
-  LoginCommand,
-  LogoutCommand,
-  StatusCommand,
-  SyncCommand,
-  DevicesCommand,
-} from "./cli/cmd/connect"
+import { LoginCommand, LogoutCommand, StatusCommand, SyncCommand, DevicesCommand } from "./cli/cmd/connect"
 import { ProjectCommand } from "./cli/cmd/project"
 import { WalletCommand } from "./cli/cmd/billing"
-import { KeysCommand } from "./cli/cmd/auth"
+import { KeysCommand, ConnectCommand, DisconnectCommand } from "./cli/cmd/auth"
 import { InitCommand, DoctorCommand } from "./cli/onboard"
 import { OpenScience } from "./openscience"
 
@@ -145,6 +138,7 @@ const cli = yargs(hideBin(process.argv))
   .command(DoctorCommand)
   .command(ProjectCommand)
   .command(ConnectCommand)
+  .command(DisconnectCommand)
   .fail((msg, err) => {
     if (
       msg?.startsWith("Unknown argument") ||

--- a/backend/cli/src/openscience/index.ts
+++ b/backend/cli/src/openscience/index.ts
@@ -37,7 +37,7 @@ if (API_BASE !== DEFAULT_API_BASE) {
   }
 }
 
-// User-facing URL the CLI prints during `openscience connect login`. Defaults
+// User-facing URL the CLI prints during `openscience login`. Defaults
 // to the unified Atlas frontend's /cli route — Plan tab, key management,
 // and billing all live there. SYNSC_AUTH_URL overrides (e.g. point at a
 // staging frontend or the old auth.syntheticsciences.ai surface).
@@ -514,7 +514,7 @@ export namespace OpenScience {
     } catch {}
     // Union of what this process synced (in-memory map) and what the last
     // sync persisted (disk snapshot, replayed by preload-env.ts at boot) —
-    // a fresh `connect logout` process has only the latter.
+    // a fresh `logout` process has only the latter.
     const synced = await readSyncedSnapshot()
     for (const [key, value] of syncedSecretValues.entries()) synced.set(key, value)
     for (const name of ["synced-env.json", "openscience-synced.json"]) {

--- a/backend/cli/src/openscience/preload-env.ts
+++ b/backend/cli/src/openscience/preload-env.ts
@@ -4,7 +4,7 @@
  * Runs BEFORE any provider SDK construction (Anthropic, OpenAI,
  * @ai-sdk/google) so those SDKs see the correct ANTHROPIC_BASE_URL /
  * ANTHROPIC_API_KEY / etc. on their own startup, without waiting for
- * the asynchronous `openscience connect sync` call later in CLI boot.
+ * the asynchronous `openscience sync` call later in CLI boot.
  *
  * Without this, the first invocation after a fresh terminal session
  * would race: sync sets process.env in-process, but the SDK had

--- a/backend/cli/src/plugin/codex.ts
+++ b/backend/cli/src/plugin/codex.ts
@@ -742,7 +742,7 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
                     })
                     // Re-sync after backend now knows about the new codex
                     // credential, so `openai-codex` shows up in the local
-                    // provider list without a separate `openscience connect sync`.
+                    // provider list without a separate `openscience sync`.
                     await OpenScience.syncServices?.().catch((e: unknown) => {
                       log.warn("post-codex-login sync failed", { error: String(e) })
                     })

--- a/backend/cli/src/provider/provider.ts
+++ b/backend/cli/src/provider/provider.ts
@@ -120,7 +120,7 @@ export namespace Provider {
     if (isAtlasProxyBaseURL(options["baseURL"])) return
     throw new Error(
       `${provider.id} is using a managed Atlas key without an Atlas proxy URL. ` +
-        "Run `openscience connect sync` and try again.",
+        "Run `openscience sync` and try again.",
     )
   }
 

--- a/backend/cli/src/server/routes/atlas-bridge.ts
+++ b/backend/cli/src/server/routes/atlas-bridge.ts
@@ -406,7 +406,7 @@ export async function initProjectDetailed(directory: string): Promise<InitProjec
   if (!directory)
     return { projectId: null, failure: { kind: "backend", message: "no directory provided", host: API_BASE } }
   // Fail fast offline: no managed session means no request can succeed —
-  // don't turn a missing `openscience connect login` into a network error.
+  // don't turn a missing `openscience login` into a network error.
   if (!(await token())) return { projectId: null, failure: { kind: "unauthenticated", host: API_BASE } }
   const existing = await resolveProjectId(directory)
   if (existing) return { projectId: existing }

--- a/backend/cli/src/skill/system/initialize-atlas-graph.txt
+++ b/backend/cli/src/skill/system/initialize-atlas-graph.txt
@@ -27,7 +27,7 @@ Run this skill when:
    atlas doctor --format=json
    ```
    If it reports unavailable/unauthenticated, tell the user to run
-   `openscience connect login` — the graph cannot be created without a session.
+   `openscience login` — the graph cannot be created without a session.
 
 2. **Create or link the graph** (idempotent — safe to re-run; returns the
    existing graph if one already exists):
@@ -41,7 +41,7 @@ Run this skill when:
    `status`, `message` when known). Relay the fix that matches the kind — do
    NOT guess or tell the user to re-login for a network problem:
    - `"unauthenticated"` — no session, or the backend rejected the saved key.
-     Tell the user to run `openscience connect login`.
+     Tell the user to run `openscience login`.
    - `"unreachable"` — the Atlas backend at the printed `host` could not be
      reached (network/DNS error or 5xx). The user IS logged in; suggest checking
      connectivity and any `OPENSCIENCE_API_BASE`/`SYNSC_API_BASE` override, then

--- a/frontend/workspace/vite-thesis.js
+++ b/frontend/workspace/vite-thesis.js
@@ -44,7 +44,7 @@ function sessionToken() {
 
 async function atlasFetch(method, path, body) {
   const token = sessionToken()
-  if (!token) throw new Error("not logged in — run `openscience connect login`")
+  if (!token) throw new Error("not logged in — run `openscience login`")
   const res = await fetch(`${API_BASE}${path}`, {
     method,
     headers: {


### PR DESCRIPTION
Splits the two account types onto distinct, symmetric verb pairs and removes the ambiguity where both `connect login` and `login` meant the Atlas account.

## Before
- Atlas: top-level `login`/`logout`/`status`/`sync`/`devices` **and** a `connect` umbrella that re-aliased all of them (`connect login`, `connect logout`, …).
- Codex: `keys signin` to sign in, and **no first-class disconnect**.

## After
- **Atlas = `login` / `logout`** (plus `status`/`sync`/`devices`), all top-level. The `connect` umbrella is removed.
- **Codex = `connect` / `disconnect`**:
  - `openscience connect [codex]` — sign in with a ChatGPT subscription (reuses `runCodexAuthFlow`).
  - `openscience disconnect [codex]` — **new**: clears the local `openai-codex` OAuth credential and best-effort revokes it server-side (`DELETE /api/keys/openai-codex`) — the counterpart sign-out that was missing. `keys signin` still works.
  - `[service]` defaults to `codex` and only accepts `codex` today, so both `connect` and `connect codex` work.

## Reference-string cleanup
Every user-facing string/prompt that told users to run `openscience connect login` / `connect sync` now points at the top-level `openscience login` / `sync` (the `connect` subcommands no longer exist) — including the error in `provider.ts`, the `skill.ts` hint, `research.txt`, the `initialize-atlas-graph` skill, and the frontend dev helper. The **canonical** `initialize-atlas-graph/SKILL.md` is updated too so the embedded-vs-canonical drift test stays green.

## Verification
`typecheck` + `prettier` clean; full backend suite (929 tests) green; `--help` confirms `connect`/`disconnect` are Codex and `login`/`logout`/`sync`/`devices` remain Atlas.