### PR TITLE
fix(provider): register the hosted demo loader under its real id (synsci)

### DIFF
--- a/backend/cli/src/provider/provider.ts
+++ b/backend/cli/src/provider/provider.ts
@@ -196,13 +196,19 @@ export namespace Provider {
         },
       }
     },
-    async openscience(input) {
+    // Keyed on the catalog provider id `synsci` (the Atlas wire-contract id) — a
+    // stale `openscience` key here never matched database["openscience"], so the
+    // loop logged "Provider does not exist in model list openscience" and this
+    // loader never ran: the zero-cost demo's `apiKey: "public"` sentinel was
+    // never set (new keyless users couldn't use the demo at all) and the
+    // "drop paid models when no key" gating was skipped.
+    async synsci(input) {
       const hasKey = await (async () => {
         const env = Env.all()
         if (input.env.some((item) => env[item])) return true
         if (await Auth.get(input.id)) return true
         const config = await Config.get()
-        if (config.provider?.["synsci"]?.options?.apiKey) return true
+        if (config.provider?.[input.id]?.options?.apiKey) return true
         return false
       })()
 


### PR DESCRIPTION
**Audit finding #16 (High).** The `CUSTOM_LOADERS` entry for the zero-cost hosted demo was keyed `openscience`, but the catalog provider id is `synsci` (confirmed: `models-api.json` uses `"id":"synsci"`, and everything else — `managedProviderAllowed`, `getSmallModel`, `defaultModel` — keys off `synsci`). The loader loop did `database["openscience"]` → undefined → logged `Provider does not exist in model list openscience` and `continue`d, so the loader **never ran**:

- the demo's `apiKey: "public"` sentinel was never set → a brand-new user with no key couldn't use the zero-cost demo at all;
- the "drop paid models when no key" gating was skipped.

Rename the loader key to `synsci` (the id that must not change, per the wire contract) and read the provider via `input.id`. Only keyless users are affected — it enables the demo they currently can't reach; a user with a `synsci` key is unchanged (`hasKey → options {}`).

Typecheck + full backend suite (929 tests) green.