### PR TITLE
fix(provider): reasoning-budget, gemini-3, interleaved-merge & catalog-refresh correctness

### DIFF
--- a/backend/cli/src/provider/models.ts
+++ b/backend/cli/src/provider/models.ts
@@ -141,6 +141,14 @@ export namespace ModelsDev {
     if (result) {
       await Bun.write(file, JSON.stringify(result))
       ModelsDev.Data.reset()
+      // Drop the memoized provider state so a long-running session picks up the
+      // refreshed catalog (new/renamed/removed models) instead of serving the
+      // snapshot captured at first build. Dynamic import avoids a static cycle
+      // (provider.ts imports ModelsDev). Best-effort.
+      try {
+        const { Provider } = await import("./provider")
+        Provider.invalidate()
+      } catch {}
     }
   }
 }

--- a/backend/cli/src/provider/provider.ts
+++ b/backend/cli/src/provider/provider.ts
@@ -977,7 +977,11 @@ export namespace Provider {
               video: model.modalities?.output?.includes("video") ?? existingModel?.capabilities.output.video ?? false,
               pdf: model.modalities?.output?.includes("pdf") ?? existingModel?.capabilities.output.pdf ?? false,
             },
-            interleaved: model.interleaved ?? false,
+            // Fall back to the catalog model's interleaved shape like every other
+            // capability above — otherwise overriding any single field (e.g. cost)
+            // on an interleaved-reasoning model dropped its {field} object, so
+            // normalizeMessages stopped relocating prior-turn reasoning.
+            interleaved: model.interleaved ?? existingModel?.capabilities.interleaved ?? false,
           },
           cost: {
             input: model?.cost?.input ?? existingModel?.cost?.input ?? 0,

--- a/backend/cli/src/provider/transform.ts
+++ b/backend/cli/src/provider/transform.ts
@@ -600,8 +600,13 @@ export namespace ProviderTransform {
           },
           max: {
             thinking: {
+              // Keep the thinking budget proportional (~3/4 of the output cap)
+              // instead of `cap - 1`: on a 32k-output model, a 31,999-token
+              // budget made maxOutputTokens() return just 1 text token, so the
+              // visible answer was truncated to a single token. Large-cap models
+              // are unaffected (still clamp at 31,999).
               type: "enabled",
-              budgetTokens: Math.min(31_999, cap - 1),
+              budgetTokens: Math.min(31_999, Math.floor((cap * 3) / 4)),
             },
           },
         }
@@ -672,13 +677,19 @@ export namespace ProviderTransform {
             },
           }
         }
-        // Gemini 3+ uses thinkingLevel
+        // Gemini 3+ uses thinkingLevel. Nest under `thinkingConfig` — the
+        // @ai-sdk/google provider only reads providerOptions.google.thinkingConfig.*,
+        // so the previous top-level keys were dropped and the selected effort was
+        // silently ignored (every call defaulted to the high thinkingLevel from
+        // options()). options()/smallOptions() already nest correctly.
         return Object.fromEntries(
           WIDELY_SUPPORTED_EFFORTS.map((effort) => [
             effort,
             {
-              includeThoughts: true,
-              thinkingLevel: effort,
+              thinkingConfig: {
+                includeThoughts: true,
+                thinkingLevel: effort,
+              },
             },
           ]),
         )

--- a/backend/cli/test/provider/transform-reasoning.test.ts
+++ b/backend/cli/test/provider/transform-reasoning.test.ts
@@ -121,6 +121,49 @@ describe("ProviderTransform.options — BYOK / direct paths stay untouched", () 
   })
 })
 
+describe("ProviderTransform.variants — Anthropic max thinking budget", () => {
+  const claude = (cap: number) =>
+    model({
+      id: "anthropic/claude-opus-4-1",
+      providerID: "anthropic",
+      api: { id: "claude-opus-4-1", url: "https://api.anthropic.com", npm: "@ai-sdk/anthropic" },
+      limit: { context: 200_000, output: cap },
+    })
+
+  test("max thinking budget leaves real text headroom on a 32k-output model", () => {
+    const v = ProviderTransform.variants(claude(32_000))
+    const budget = (v.max as any).thinking.budgetTokens
+    expect(budget).toBeLessThan(32_000)
+    const textTokens = ProviderTransform.maxOutputTokens(
+      "@ai-sdk/anthropic",
+      { thinking: { type: "enabled", budgetTokens: budget } },
+      32_000,
+      32_000,
+    )
+    // Was 1 before the fix — now a usable amount of text.
+    expect(textTokens).toBeGreaterThanOrEqual(4_096)
+  })
+
+  test("large-cap models still clamp the budget at 31,999", () => {
+    const v = ProviderTransform.variants(claude(64_000))
+    expect((v.max as any).thinking.budgetTokens).toBe(31_999)
+  })
+})
+
+describe("ProviderTransform.variants — Gemini-3 nests under thinkingConfig", () => {
+  test("effort variants are wrapped so @ai-sdk/google actually reads them", () => {
+    const gem = model({
+      id: "google/gemini-3-pro",
+      providerID: "google",
+      api: { id: "gemini-3-pro", url: "https://generativelanguage.googleapis.com", npm: "@ai-sdk/google" },
+    })
+    const v = ProviderTransform.variants(gem)
+    expect(v.low).toEqual({ thinkingConfig: { includeThoughts: true, thinkingLevel: "low" } })
+    expect(v.high).toEqual({ thinkingConfig: { includeThoughts: true, thinkingLevel: "high" } })
+    expect((v.low as any).thinkingLevel).toBeUndefined()
+  })
+})
+
 describe("ProviderTransform.smallOptions — OpenRouter", () => {
   test("small OR calls disable reasoning via the unified shape", () => {
     const result = ProviderTransform.smallOptions(orModel("openrouter/openai/gpt-5-nano", "openai/gpt-5-nano"))

--- a/backend/cli/test/provider/transform.test.ts
+++ b/backend/cli/test/provider/transform.test.ts
@@ -1814,17 +1814,15 @@ describe("ProviderTransform.variants", () => {
       })
       const result = ProviderTransform.variants(model)
       expect(Object.keys(result)).toEqual(["low", "medium", "high"])
+      // Nested under thinkingConfig so @ai-sdk/google actually reads the level.
       expect(result.low).toEqual({
-        includeThoughts: true,
-        thinkingLevel: "low",
+        thinkingConfig: { includeThoughts: true, thinkingLevel: "low" },
       })
       expect(result.medium).toEqual({
-        includeThoughts: true,
-        thinkingLevel: "medium",
+        thinkingConfig: { includeThoughts: true, thinkingLevel: "medium" },
       })
       expect(result.high).toEqual({
-        includeThoughts: true,
-        thinkingLevel: "high",
+        thinkingConfig: { includeThoughts: true, thinkingLevel: "high" },
       })
     })
   })


### PR DESCRIPTION
Four provider/transform correctness fixes from the audit:

- **#17 (High)** — `max` reasoning no longer starves text to 1 token. On a 32k-output Claude, the `max` thinking budget of `cap-1` (31,999) made `maxOutputTokens` return a single text token (empirically confirmed). Keep the budget proportional (`floor(cap*3/4)`); large-cap models still clamp at 31,999.
- **#24 (Med-High)** — Gemini-3 effort variants are nested under `thinkingConfig`. `@ai-sdk/google` only reads `providerOptions.google.thinkingConfig.*`, so the old top-level keys were dropped and effort was silently ignored (always `high`).
- **#29 (Med)** — the config-model merge falls back to the catalog model's `interleaved` shape like every other capability, so overriding one field (e.g. cost) no longer drops the interleaved-reasoning relocation in `normalizeMessages`.
- **#25 (Med)** — `ModelsDev.refresh()` now invalidates provider state (dynamic import to avoid a cycle), so a long-running session picks up the hourly catalog refresh instead of the first snapshot.

## Tests
New coverage in `transform-reasoning.test.ts` (max budget leaves ≥4k text on a 32k model; large caps clamp at 31,999; gemini-3 nests under `thinkingConfig`). Updated the existing gemini variant test to the corrected shape. All 196 provider tests green.