### PR TITLE
fix(session): correct over-200k tier threshold and clamp negative token counts

### DIFF
--- a/backend/cli/src/session/index.ts
+++ b/backend/cli/src/session/index.ts
@@ -417,7 +417,11 @@ export namespace Session {
         ? (input.usage.inputTokens ?? 0)
         : (input.usage.inputTokens ?? 0) - cacheReadInputTokens - cacheWriteInputTokens
       const safe = (value: number) => {
-        if (!Number.isFinite(value)) return 0
+        // Clamp non-finite AND negative values: for providers not in the
+        // excludes-cached set, `inputTokens - cacheRead - cacheWrite` can go
+        // negative when the provider already excludes cached tokens, which would
+        // otherwise flow a negative token count (and negative cost) downstream.
+        if (!Number.isFinite(value) || value < 0) return 0
         return value
       }
 
@@ -431,8 +435,12 @@ export namespace Session {
         },
       }
 
+      // The over-200k pricing tier keys off the full prompt size, which includes
+      // cache-CREATION tokens too. Omitting cache.write meant a mostly-cache-write
+      // request that really exceeded 200k was billed at the base tier (cost
+      // under-report).
       const costInfo =
-        input.model.cost?.experimentalOver200K && tokens.input + tokens.cache.read > 200_000
+        input.model.cost?.experimentalOver200K && tokens.input + tokens.cache.read + tokens.cache.write > 200_000
           ? input.model.cost.experimentalOver200K
           : input.model.cost
       return {

--- a/backend/cli/test/session/usage-accounting.test.ts
+++ b/backend/cli/test/session/usage-accounting.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test"
+import { Session } from "../../src/session/index"
+
+const model = (): any => ({
+  cost: {
+    input: 3,
+    output: 15,
+    cache: { read: 0.3, write: 3.75 },
+    experimentalOver200K: { input: 6, output: 22.5, cache: { read: 0.6, write: 7.5 } },
+  },
+})
+
+describe("Session.getUsage cost/token accounting", () => {
+  test("over-200k tier trips on a mostly-cache-write prompt (cache.write counts toward the threshold)", () => {
+    // 15k fresh input + 190k cache-creation = 205k > 200k → over-200k pricing.
+    const r = Session.getUsage({
+      model: model(),
+      usage: { inputTokens: 15_000, outputTokens: 100, cachedInputTokens: 0 } as any,
+      metadata: { anthropic: { cacheCreationInputTokens: 190_000 } } as any,
+    })
+    // input billed at the over-200k rate (6/M), not the base 3/M.
+    expect(r.cost).toBeCloseTo((15_000 * 6 + 100 * 22.5 + 190_000 * 7.5) / 1_000_000, 6)
+  })
+
+  test("stays on the base tier below 200k", () => {
+    const r = Session.getUsage({
+      model: model(),
+      usage: { inputTokens: 1_000, outputTokens: 100, cachedInputTokens: 0 } as any,
+    })
+    expect(r.cost).toBeCloseTo((1_000 * 3 + 100 * 15) / 1_000_000, 6)
+  })
+
+  test("clamps a would-be-negative input token count to zero (non-excludes provider)", () => {
+    // inputTokens already excludes cached, but provider isn't in the excludes set:
+    // 100 - 500 cacheRead = -400 → must clamp to 0, never negative tokens/cost.
+    const r = Session.getUsage({
+      model: model(),
+      usage: { inputTokens: 100, outputTokens: 50, cachedInputTokens: 500 } as any,
+    })
+    expect(r.tokens.input).toBe(0)
+    expect(r.cost).toBeGreaterThanOrEqual(0)
+  })
+})


### PR DESCRIPTION
Two cost/usage accounting fixes from the audit (both in the exported, unit-tested `Session.getUsage`):

- **#31 (Med)** — the over-200k pricing tier is selected on the full prompt size, which includes cache-**creation** tokens. Omitting `tokens.cache.write` meant a mostly-cache-write request that really exceeded 200k billed at the base tier (cost under-report). Now `input + cache.read + cache.write > 200_000`.
- **#42 (Low-Med)** — `safe()` now clamps negatives to 0. For providers not in the excludes-cached set, `inputTokens - cacheRead - cacheWrite` can go negative (provider already excludes cached tokens), flowing negative token counts and negative cost downstream.

## Tests
`test/session/usage-accounting.test.ts`: over-200k tier trips on a mostly-cache-write prompt; base tier below 200k; a would-be-negative input clamps to 0.