### PR TITLE
fix(openscience): harden atlasFetch signal, version coercion, atomic temp, env prefixes

### DIFF
--- a/backend/cli/src/openscience/index.ts
+++ b/backend/cli/src/openscience/index.ts
@@ -307,7 +307,11 @@ export namespace OpenScience {
   // hang wedged whole sessions for >60 min. Overridable via OPENSCIENCE_ATLAS_TIMEOUT_MS.
   const ATLAS_FETCH_TIMEOUT_MS = Number(process.env["OPENSCIENCE_ATLAS_TIMEOUT_MS"]) || 60_000
   function atlasFetch(input: string, init: RequestInit = {}, timeoutMs = ATLAS_FETCH_TIMEOUT_MS): Promise<Response> {
-    return fetch(input, { ...init, signal: init.signal ?? AbortSignal.timeout(timeoutMs) })
+    // Combine (don't replace) a caller's signal with the timeout, so passing an
+    // abort signal never silently drops the hang guard this function exists for.
+    const timeout = AbortSignal.timeout(timeoutMs)
+    const signal = init.signal ? AbortSignal.any([init.signal, timeout]) : timeout
+    return fetch(input, { ...init, signal })
   }
 
   export async function getSession(): Promise<OpenScienceSession | null> {
@@ -409,7 +413,13 @@ export namespace OpenScience {
       })
       if (!res.ok) return // fail open — keep current env
       const body = await res.json()
-      v = typeof body?.v === "number" ? body.v : null
+      // Coerce numeric strings too: a backend/proxy that returns {"v":"5"} would
+      // otherwise leave v=null forever, so cached_v never updates and the CLI
+      // keeps deferring the background sync for the TTL — dashboard changes never
+      // land, with no error surfaced.
+      const raw = body?.v
+      const num = typeof raw === "number" ? raw : typeof raw === "string" ? Number(raw) : NaN
+      v = Number.isFinite(num) ? num : null
     } catch {
       return // network failure → use current env, retry next message
     }
@@ -718,7 +728,11 @@ export namespace OpenScience {
    *  a torn openscience-synced.json throws during config load and bricks the CLI
    *  until it's removed by hand. */
   async function atomicWrite(filepath: string, content: string, options?: { mode?: number }): Promise<void> {
-    const tmp = `${filepath}.${process.pid}.tmp`
+    // Unique per call (not just per PID): two concurrent syncs in the SAME
+    // process (e.g. a per-request /sync and the processor's background sync)
+    // would otherwise write the identical temp path, interleave, and publish a
+    // torn file or fail the rename.
+    const tmp = `${filepath}.${process.pid}.${randomUUID()}.tmp`
     await Bun.write(tmp, content, options)
     await fs.rename(tmp, filepath)
   }
@@ -972,7 +986,11 @@ export namespace OpenScience {
       if (!value) continue
       if (isManagedAtlasKey(value)) continue
       if (SHARED_PROVIDER_KEYS.has(key)) continue
-      const isSafe = SAFE_ENV_PREFIXES.some((p) => key === p || key.startsWith(p)) || SAFE_SYNCED_KEYS.has(key)
+      // Entries ending in `_` (LC_, XDG_) are true prefixes; the rest are exact
+      // names. Treating all as prefixes let HOME match HOMEBREW_GITHUB_API_TOKEN,
+      // USER match USERPROFILE, etc. — over-broad passthrough.
+      const isSafe =
+        SAFE_ENV_PREFIXES.some((p) => (p.endsWith("_") ? key.startsWith(p) : key === p)) || SAFE_SYNCED_KEYS.has(key)
       if (isSafe || !syncedSecretValues.has(key)) {
         result[key] = value
       }


### PR DESCRIPTION
Four defensive fixes in `openscience/index.ts` (from the audit):

- **#46** — `atlasFetch` **combines** a caller-supplied signal with the timeout (`AbortSignal.any`) instead of replacing it, so passing a signal never silently drops the 60s hang guard.
- **#47** — `refreshIfStale` coerces a numeric-string sync version (`{"v":"5"}`) instead of collapsing it to `null`; otherwise `cached_v` never updates and the CLI defers the background sync for the whole TTL, so dashboard changes never land.
- **#13** — `atomicWrite`'s temp path is unique per call (`pid.uuid`), so two concurrent syncs in the **same** process (a per-request `/sync` + the processor's background sync) can't write the same temp path, interleave, and publish a torn `synced-env.json`.
- **#49** — `filterEnvForSubprocess` matches `SAFE_ENV_PREFIXES` exactly for plain names and only prefix-matches entries ending in `_` (`LC_`, `XDG_`), so `HOME` no longer matches `HOMEBREW_GITHUB_API_TOKEN`, `USER` no longer matches `USERPROFILE`, etc.

Typecheck + full backend suite (936 tests) green.