### PR TITLE
fix(server): reject code-executing git transports in the repo remote route

### DIFF
--- a/backend/cli/src/server/routes/repo.ts
+++ b/backend/cli/src/server/routes/repo.ts
@@ -23,12 +23,34 @@ interface RunResult {
   err: string
 }
 
+/** Reject remote URLs that could run arbitrary commands via git's helper
+ *  transports (`ext::`/`fake::`) or argument injection (leading `-`). Normal
+ *  https/http/ssh/git@ remotes pass. Exported for tests. */
+export function assertSafeRemoteUrl(url: unknown): string {
+  const value = String(url ?? "").trim()
+  if (!value) throw new Error("remote URL required")
+  if (value.startsWith("-")) throw new Error("invalid remote URL")
+  if (/^(ext|fake)::/i.test(value)) throw new Error("unsupported remote transport")
+  if (!/^(https?:\/\/|ssh:\/\/|git@)/i.test(value)) throw new Error("unsupported remote URL scheme")
+  return value
+}
+
 function run(command: string, args: string[], cwd: string, ok: number[] = [0]): Promise<RunResult> {
   return new Promise((resolveP, rejectP) => {
     const child = spawn(command, args, {
       stdio: ["ignore", "pipe", "pipe"],
       cwd,
-      env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
+      env: {
+        ...process.env,
+        GIT_TERMINAL_PROMPT: "0",
+        // Defense in depth: refuse the code-executing helper transports even if a
+        // malicious remote URL slips past assertSafeRemoteUrl.
+        GIT_CONFIG_COUNT: "2",
+        GIT_CONFIG_KEY_0: "protocol.ext.allow",
+        GIT_CONFIG_VALUE_0: "never",
+        GIT_CONFIG_KEY_1: "protocol.fake.allow",
+        GIT_CONFIG_VALUE_1: "never",
+      },
     })
     let out = ""
     let err = ""
@@ -165,8 +187,7 @@ async function push(directory: string, branch: unknown) {
 
 async function setRemote(directory: string, url: unknown) {
   if (!directory) throw new Error("directory required")
-  const value = String(url ?? "").trim()
-  if (!value) throw new Error("remote URL required")
+  const value = assertSafeRemoteUrl(url)
   const hasOrigin = await git(["remote", "get-url", "origin"], directory)
     .then(() => true)
     .catch(() => false)

--- a/backend/cli/test/server/repo-remote-url.test.ts
+++ b/backend/cli/test/server/repo-remote-url.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test"
+import { assertSafeRemoteUrl } from "../../src/server/routes/repo"
+
+describe("assertSafeRemoteUrl", () => {
+  test("accepts normal https / ssh / git@ remotes", () => {
+    for (const url of [
+      "https://github.com/owner/name.git",
+      "http://gitlab.example.com/g/n",
+      "ssh://git@github.com/owner/name.git",
+      "git@github.com:owner/name.git",
+    ]) {
+      expect(assertSafeRemoteUrl(url)).toBe(url)
+    }
+  })
+
+  test("trims surrounding whitespace", () => {
+    expect(assertSafeRemoteUrl("  https://github.com/o/n  ")).toBe("https://github.com/o/n")
+  })
+
+  test("rejects the code-executing git helper transports", () => {
+    expect(() => assertSafeRemoteUrl('ext::sh -c "id"')).toThrow("unsupported remote transport")
+    expect(() => assertSafeRemoteUrl("fake::whatever")).toThrow("unsupported remote transport")
+  })
+
+  test("rejects argument injection (leading dash)", () => {
+    expect(() => assertSafeRemoteUrl("--upload-pack=touch /tmp/pwned")).toThrow("invalid remote URL")
+  })
+
+  test("rejects unknown / non-remote schemes", () => {
+    expect(() => assertSafeRemoteUrl("file:///etc/passwd")).toThrow("unsupported remote URL scheme")
+    expect(() => assertSafeRemoteUrl("not a url")).toThrow("unsupported remote URL scheme")
+    expect(() => assertSafeRemoteUrl("")).toThrow("remote URL required")
+  })
+})


### PR DESCRIPTION
**Audit finding #4 (High, security).** `POST /api/repo/remote` passed the remote `url` unvalidated to `git remote add/set-url origin <url>` in an attacker-chosen `directory`; a later `push`/fetch uses it. Git's `ext::`/`fake::` helper transports execute shell commands, and a leading `-` risks argument injection — so an allowed-origin page could set the origin to `ext::sh -c "…"` → command execution.

- `assertSafeRemoteUrl` (exported, unit-tested) allows only `http(s)` / `ssh` / `git@` remotes and rejects `ext::`/`fake::` and leading-`-`.
- Hardened the git spawn env with `protocol.ext.allow=never` / `protocol.fake.allow=never` (via `GIT_CONFIG_*`) as defense in depth even if a URL slips past validation.

## Tests
`test/server/repo-remote-url.test.ts`: accepts normal https/ssh/git@ remotes; rejects `ext::`/`fake::`, leading-`-`, `file://`, and non-URLs.

Note: this is one piece of a broader server-auth gap (the local server has no per-caller auth token) — see the audit; the full fix needs coordinated SPA changes and is called out separately.