### PR TITLE
fix(session): physics artifact-agent parity + normalize non-stream calls

### DIFF
--- a/backend/cli/src/session/llm.ts
+++ b/backend/cli/src/session/llm.ts
@@ -263,7 +263,13 @@ export namespace LLM {
         middleware: [
           {
             async transformParams(args) {
-              if (args.type === "stream") {
+              // Apply for both stream and generate: message normalization does
+              // caching, image-mime correction, unsupported-part downgrade, and
+              // the providerOptions remap. Gating on "stream" only meant any
+              // non-stream call (structured output, a provider that internally
+              // does doGenerate) would bypass all of it and could crash on an
+              // unsupported file part.
+              if (args.type === "stream" || args.type === "generate") {
                 // @ts-expect-error
                 args.params.prompt = ProviderTransform.message(args.params.prompt, input.model, options)
               }

--- a/backend/cli/src/session/prompt.ts
+++ b/backend/cli/src/session/prompt.ts
@@ -65,7 +65,10 @@ globalThis.AI_SDK_LOG_WARNINGS = false
 export namespace SessionPrompt {
   const log = Log.create({ service: "session.prompt" })
   export const OUTPUT_TOKEN_MAX = Flag.OPENSCIENCE_EXPERIMENTAL_OUTPUT_TOKEN_MAX || 32_000
-  const ARTIFACT_AGENTS = ["research", "biology", "ml"]
+  // physics is a compute agent (see COMPUTE_AGENTS) that also produces artifacts
+  // (PDE solutions, fitted params, plots), so it participates in artifact-context
+  // re-injection + RSI trajectory capture like its peer compute agents.
+  const ARTIFACT_AGENTS = ["research", "biology", "physics", "ml"]
   // Science agents that dispatch GPU/compute work and should honor billing.compute.
   const COMPUTE_AGENTS = new Set(["research", "biology", "physics", "ml"])
 


### PR DESCRIPTION
Two small correctness fixes from the audit:

- **#50 (Low)** — `physics` is a compute agent (it's in `COMPUTE_AGENTS`) that produces artifacts, but it was missing from `ARTIFACT_AGENTS`, which gates RLM artifact-context re-injection and RSI trajectory capture. So a physics session — unlike `ml`/`biology` — never got prior artifacts re-injected or was captured for RSI. Added.
- **#58 (Low-Med, latent)** — `transformParams` now runs message normalization for `generate` as well as `stream`. Gating on `stream` only meant any non-stream path (structured output, a provider that internally does `doGenerate`) would bypass caching / image-mime correction / unsupported-part downgrade / providerOptions remap and could crash on an unsupported file part.

Full session suite (83) green.