### PR TITLE
fix(openscience): stamp queued usage with its account so a flush can't bill the wrong one

### DIFF
--- a/backend/cli/src/openscience/index.ts
+++ b/backend/cli/src/openscience/index.ts
@@ -4,7 +4,7 @@ import fs from "fs/promises"
 import { existsSync, readFileSync, writeFileSync, chmodSync } from "fs"
 import { createRequire } from "module"
 import { fileURLToPath } from "url"
-import { randomUUID } from "crypto"
+import { randomUUID, createHash } from "crypto"
 import { Global } from "../global"
 import { Log } from "../util/log"
 import { Lock } from "../util/lock"
@@ -1235,12 +1235,29 @@ export namespace OpenScience {
 
   const pendingQueuePath = path.join(Global.Path.data, "usage-queue.jsonl")
 
-  async function persistToQueue(params: UsageParams) {
+  /** Stable per-account tag stored with a queued usage row so a later flush can't
+   *  bill a DIFFERENT account for it. user_id when known, else a short hash of the
+   *  api_key (never the raw key, which must not sit in the queue file). */
+  function accountTag(session: OpenScienceSession): string {
+    if (session.user_id) return session.user_id
+    return "k:" + createHash("sha256").update(session.api_key).digest("hex").slice(0, 16)
+  }
+
+  /** Whether a queued row tagged `rowAccount` may be flushed under `currentAccount`.
+   *  A row with no tag is legacy/accountless → best-effort send under the current
+   *  account; a row tagged for a DIFFERENT account is never sent (kept until that
+   *  account is active). Pure + exported for tests. */
+  export function shouldFlushForAccount(rowAccount: string | undefined, currentAccount: string): boolean {
+    return !rowAccount || rowAccount === currentAccount
+  }
+
+  async function persistToQueue(params: UsageParams, account?: string) {
     try {
       // Serialize against flushPendingUsage so an append can't land between
       // the flusher's read and its final rewrite (which would delete it).
       using _ = await Lock.write(pendingQueuePath)
-      await fs.appendFile(pendingQueuePath, JSON.stringify(params) + "\n")
+      const row = account ? { ...params, __account: account } : params
+      await fs.appendFile(pendingQueuePath, JSON.stringify(row) + "\n")
       log.info("usage queued for retry", { service: params.service })
     } catch (e) {
       log.warn("failed to persist usage to queue", { error: e instanceof Error ? e.message : String(e) })
@@ -1330,7 +1347,7 @@ export namespace OpenScience {
       return { recorded: false, modelBlocked: true }
     }
     if (!result.permanent) {
-      await persistToQueue(params)
+      await persistToQueue(params, accountTag(session))
     }
     return null
   }
@@ -1349,11 +1366,18 @@ export namespace OpenScience {
 
       const session = await getSession()
       if (!session) return
+      const currentAccount = accountTag(session)
 
       const retry: string[] = []
       for (const line of lines) {
         try {
-          const params: UsageParams = JSON.parse(line)
+          const { __account, ...params } = JSON.parse(line) as UsageParams & { __account?: string }
+          // Never bill the active account for usage another account generated —
+          // keep it queued until that account is the one flushing.
+          if (!shouldFlushForAccount(__account, currentAccount)) {
+            retry.push(line)
+            continue
+          }
           const result = await sendReport(params, session)
           if (!result.ok && !result.permanent) {
             retry.push(line)

--- a/backend/cli/test/openscience/usage-queue-account.test.ts
+++ b/backend/cli/test/openscience/usage-queue-account.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test"
+import { OpenScience } from "../../src/openscience"
+
+describe("OpenScience.shouldFlushForAccount", () => {
+  test("flushes a row tagged for the current account", () => {
+    expect(OpenScience.shouldFlushForAccount("user-1", "user-1")).toBe(true)
+  })
+
+  test("refuses a row tagged for a DIFFERENT account (never bill the wrong one)", () => {
+    expect(OpenScience.shouldFlushForAccount("user-1", "user-2")).toBe(false)
+  })
+
+  test("flushes a legacy/accountless row under the current account (best-effort)", () => {
+    expect(OpenScience.shouldFlushForAccount(undefined, "user-1")).toBe(true)
+    expect(OpenScience.shouldFlushForAccount("", "user-1")).toBe(true)
+  })
+})


### PR DESCRIPTION
**Audit finding #14 (High, billing).** Queued usage rows carried no account identity, so `flushPendingUsage` sent **every** row under whatever session was active at startup. If usage was queued under account A (e.g. while the session file was transiently unreadable) and account B later logged in, the startup flush billed **B** for A's usage — and `dropUsageQueue` only runs on an explicit logout, not a silent account swap.

- Each queued row is now stamped with a stable account tag (`user_id`, else a short SHA-256 of the `api_key` — never the raw key, which must not sit in the queue file).
- On flush, a row tagged for a **different** account is kept in the queue rather than sent (it flushes when that account is active again); legacy/untagged rows remain best-effort under the current account (backward-compatible).

## Tests
`test/openscience/usage-queue-account.test.ts` covers the pure `shouldFlushForAccount` decision (same account → flush, different → refuse, accountless → best-effort). Full backend suite (949) green.