### PR TITLE
fix(science): expose arxiv pdf links

### DIFF
--- a/backend/cli/src/tool/science.ts
+++ b/backend/cli/src/tool/science.ts
@@ -123,6 +123,8 @@ export const ScienceSearchTool = Tool.define("science_search", {
     const rows = hits.map((h) => {
       const lines = [`## ${h.title}`, `**id**: ${h.id}${h.score !== undefined ? ` · score: ${h.score}` : ""}`]
       if (h.url) lines.push(`**url**: ${h.url}`)
+      const pdf = typeof h.extra?.pdf === "string" ? h.extra.pdf : undefined
+      if (pdf) lines.push(`**pdf**: ${pdf}`)
       if (h.summary) lines.push(h.summary)
       return lines.join("\n")
     })

--- a/backend/cli/test/science/science-tool.test.ts
+++ b/backend/cli/test/science/science-tool.test.ts
@@ -76,6 +76,7 @@ describe("science_search degradation (arxiv)", () => {
     expect(result.metadata.count).toBe(1)
     expect(result.metadata.error).toBeUndefined()
     expect(result.output).toContain("Attention Is All You Need")
+    expect(result.output).toContain("**pdf**: http://arxiv.org/pdf/1706.03762v7")
   })
 
   test("sustained 429 degrades to an actionable rate-limited result, not a raw HTTP 429", async () => {


### PR DESCRIPTION
Closes #133.

## Summary

- render `extra.pdf` as a `**pdf**:` line when a connector result provides it
- add a regression expectation to the existing `science_search` arXiv tool test

## Why

The arXiv connector already extracts the direct PDF URL into `hit.extra.pdf`, but the generic `science_search` renderer did not expose it. This lets research/literature-review agents see the PDF link without changing the connector contract or adding another tool.

## Validation

- Not run locally: cloning the repository in this environment failed twice due GitHub connection reset/timeout.
- Checked the compare diff against `main`; only `backend/cli/src/tool/science.ts` and `backend/cli/test/science/science-tool.test.ts` changed.
