### PR TITLE
fix(sync): actionable message for the new managed_via_openrouter reason

### DIFF
--- a/backend/cli/src/openscience/index.ts
+++ b/backend/cli/src/openscience/index.ts
@@ -149,6 +149,7 @@ type SyncedServiceReason =
   | "ineligible_plan"
   | "proxy_disabled"
   | "managed_key_unconfigured"
+  | "managed_via_openrouter"
 
 interface SyncedService {
   connected: boolean
@@ -192,6 +193,8 @@ function describeReason(provider: string, reason: SyncedServiceReason | undefine
       return `${provider}: Atlas managed mode is disabled on this deployment — BYOK only.`
     case "managed_key_unconfigured":
       return `${provider}: Atlas managed mode unavailable on this deployment — ask the admin.`
+    case "managed_via_openrouter":
+      return `${provider}: wallet access to ${provider} models routes through the openrouter provider — pick them there, or add your own ${provider} key for direct access.`
     default:
       return `${provider}: not connected.`
   }


### PR DESCRIPTION
## What

Atlas' `/api/cli/sync` now hands out managed-proxy env **exclusively for the openrouter provider** — managed wallet inference is OpenRouter-only, and the OR curated whitelist carries the Anthropic/OpenAI/Google flagships as OR slugs (`anthropic/claude-opus-4.8`, `openai/gpt-5.5`, `google/gemini-2.5-pro`, …). Keyless users now see the direct `anthropic`/`openai`/`gemini` providers disconnected with a new reason code: `managed_via_openrouter`.

This PR adds that code to the `SyncedServiceReason` union and gives `describeReason` an actionable one-liner (use the openrouter provider for wallet access, or attach a BYOK key for direct access) instead of falling through to the generic "not connected".

## Why

Without it, a wallet user who runs `openscience connect sync` sees `anthropic: not connected.` with no hint that Claude/GPT/Gemini are one provider over, under openrouter.

## Verification

Additive union member + one switch case; `bunx tsc --noEmit` shows no new errors versus the base branch (the pre-existing `llm.ts` TS2589 is unrelated). Unknown reason codes already fell to the default branch, so old servers are unaffected.

Companion to the Atlas-side changes pushed to `synthetic-sciences/atlas` main (`758ff04`, `d1a010b`).