### PR TITLE
ci(test): make the intended bun test timeout actually apply

### DIFF
--- a/backend/cli/bunfig.toml
+++ b/backend/cli/bunfig.toml
@@ -1,3 +1,6 @@
 [test]
 preload = ["./test/preload.ts"]
-timeout = 10000  # 10 seconds (default is 5000ms)
+# NOTE: bun ignores a `timeout` key here (verified: a 7s sleep test still
+# dies at the 5000ms default with this file present). The per-test default
+# timeout only applies via the CLI flag - see `--timeout` in package.json's
+# test script.

--- a/backend/cli/package.json
+++ b/backend/cli/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "preinstall": "node ./script/preinstall.mjs || exit 0",
     "typecheck": "tsgo --noEmit",
-    "test": "bun test",
+    "test": "bun test --timeout 15000",
     "build": "bun run script/build.ts",
     "dev": "bun run --conditions=browser ./src/index.ts"
   },

--- a/backend/cli/test/openscience/sync-precedence.test.ts
+++ b/backend/cli/test/openscience/sync-precedence.test.ts
@@ -1,5 +1,6 @@
 import { test, expect, afterEach } from "bun:test"
 import path from "path"
+import fs from "fs/promises"
 import { OpenScience } from "../../src/openscience"
 import { Global } from "../../src/global"
 
@@ -9,9 +10,15 @@ import { Global } from "../../src/global"
 // billed managed one (the "billing flip" bug).
 
 const realFetch = globalThis.fetch
-afterEach(() => {
+afterEach(async () => {
   globalThis.fetch = realFetch
   delete process.env["ANTHROPIC_API_KEY"]
+  // seedSession() writes a real session file into the SHARED per-process test
+  // data dir. Leaving it behind turned every later test in the suite into an
+  // "authenticated" one - skill discovery, billing-mode and atlas-bridge then
+  // reached for the live Atlas API mid-suite (and hung CI whenever prod
+  // hiccuped). Always clear it.
+  await fs.rm(path.join(Global.Path.data, "openscience-session.json"), { force: true }).catch(() => {})
 })
 
 async function seedSession() {

--- a/backend/cli/test/preload.ts
+++ b/backend/cli/test/preload.ts
@@ -52,6 +52,17 @@ process.env["OPENSCIENCE_DISABLE_DEFAULT_PLUGINS"] = "true"
 // Disable bundled skills to isolate skill discovery tests
 process.env["OPENSCIENCE_DISABLE_BUNDLED_SKILLS"] = "true"
 
+// Hermetic API base: several suite paths reach the Atlas backend whenever a
+// session file exists, and session-file.test.ts writes one into the shared
+// per-process test data dir - so later tests (skill discovery's
+// fetchLearnedSkills, billing-mode, atlas-bridge) silently depended on the
+// LIVE production API. When prod hiccuped, those tests hung to their timeout
+// and CI went red on an unrelated commit. Point the base at an unroutable
+// local port so any accidental call fails in milliseconds (ECONNREFUSED),
+// which every fetcher already handles as "offline -> null". Tests that need
+// a real server (fake-atlas fixtures) override this per-test.
+process.env["OPENSCIENCE_API_BASE"] = "http://127.0.0.1:9"
+
 // Clear provider env vars to ensure clean test state
 delete process.env["ANTHROPIC_API_KEY"]
 delete process.env["ANTHROPIC_BASE_URL"]


### PR DESCRIPTION
## What broke

The post-merge CI run on main failed: all six skill-discovery tests in `backend/cli/test/skill/skill.test.ts` timed out. The failure was unrelated to the merged change (#137 — a 3-line string map addition); the same commit passed the PR-branch run minutes earlier.

## Root causes (two, layered)

**1. The intended test timeout never applied.** `backend/cli/bunfig.toml` sets `timeout = 10000` under `[test]` — but bun silently ignores a `timeout` key in bunfig (verified: a 7s sleep test still dies at the 5000ms default with that file present). The default per-test timeout only exists as the `--timeout` CLI flag.

**2. The suite was secretly calling the production API.** `sync-precedence.test.ts` seeds `openscience-session.json` into the shared per-process test data dir and never removed it, so every test file sorting after it ran "authenticated". With a session present, skill discovery (`fetchLearnedSkills`), billing-mode, and atlas-bridge all reach for the live Atlas API — `atlasFetch` defaults to a **60s** timeout, so when prod hiccuped (it had a machine outage in exactly that window), those tests hung to death and CI reddened on an unrelated commit. The atlas-bridge *"fails fast as unauthenticated (no network)"* test was in fact only passing **because** prod answered its leaked-session call with a 401.

## Fixes

- `package.json`: `bun test --timeout 15000` (the layer bun actually honors); dead bunfig key replaced with a warning note.
- `test/preload.ts`: `OPENSCIENCE_API_BASE` → unroutable local port, so any accidental API call fails in milliseconds (ECONNREFUSED → offline → null) instead of hanging on prod.
- `sync-precedence.test.ts`: afterEach clears the seeded session file.

## Verification

Full `backend/cli` suite: **975 pass / 0 fail**, and 3x faster (71s → 26s) with the hidden network round-trips gone. The 7s timeout probe fails at 5s under the old setup and passes with the flag, under CI's exact invocation.