### PR TITLE
fix: slow startup + unresponsive server from dead plugins and unbounded skill fetches (#138)

### DIFF
--- a/backend/cli/src/openscience/index.ts
+++ b/backend/cli/src/openscience/index.ts
@@ -330,6 +330,12 @@ export namespace OpenScience {
   // both go through Atlas fetches, and with the agent's bash tool also unbounded a
   // hang wedged whole sessions for >60 min. Overridable via OPENSCIENCE_ATLAS_TIMEOUT_MS.
   const ATLAS_FETCH_TIMEOUT_MS = Number(process.env["OPENSCIENCE_ATLAS_TIMEOUT_MS"]) || 60_000
+  // Skill index/content fetches run on the GET /skill request path, and each only
+  // *enriches* a list that also comes from disk cache + bundled skills. A slow or
+  // unreachable backend must degrade fast (fall back to cached/empty) instead of
+  // wedging the request for the full Atlas timeout — the reporter in #138 saw a
+  // single /skill take 62s because these inherited the 60s default. Bound tighter.
+  const SKILL_FETCH_TIMEOUT_MS = Number(process.env["OPENSCIENCE_SKILL_TIMEOUT_MS"]) || 8_000
   function atlasFetch(input: string, init: RequestInit = {}, timeoutMs = ATLAS_FETCH_TIMEOUT_MS): Promise<Response> {
     // Combine (don't replace) a caller's signal with the timeout, so passing an
     // abort signal never silently drops the hang guard this function exists for.
@@ -1122,9 +1128,11 @@ export namespace OpenScience {
     if (!session) return null
 
     try {
-      const res = await atlasFetch(`${API_BASE}/api/cli/skills`, {
-        headers: { Authorization: `Bearer ${session.api_key}` },
-      })
+      const res = await atlasFetch(
+        `${API_BASE}/api/cli/skills`,
+        { headers: { Authorization: `Bearer ${session.api_key}` } },
+        SKILL_FETCH_TIMEOUT_MS,
+      )
 
       if (!res.ok) {
         log.warn("failed to fetch skill index", { status: res.status })
@@ -1152,9 +1160,11 @@ export namespace OpenScience {
     if (!session) return null
 
     try {
-      const res = await atlasFetch(`${API_BASE}/api/cli/skills/${encodeURIComponent(name)}`, {
-        headers: { Authorization: `Bearer ${session.api_key}` },
-      })
+      const res = await atlasFetch(
+        `${API_BASE}/api/cli/skills/${encodeURIComponent(name)}`,
+        { headers: { Authorization: `Bearer ${session.api_key}` } },
+        SKILL_FETCH_TIMEOUT_MS,
+      )
 
       if (!res.ok) {
         log.warn("failed to fetch skill content", { name, status: res.status })
@@ -1464,9 +1474,11 @@ export namespace OpenScience {
     if (!session) return null
 
     try {
-      const res = await atlasFetch(`${API_BASE}/api/cli/learned-skills`, {
-        headers: { Authorization: `Bearer ${session.api_key}` },
-      })
+      const res = await atlasFetch(
+        `${API_BASE}/api/cli/learned-skills`,
+        { headers: { Authorization: `Bearer ${session.api_key}` } },
+        SKILL_FETCH_TIMEOUT_MS,
+      )
 
       if (!res.ok) {
         log.warn("failed to fetch learned skills index", { status: res.status })
@@ -1495,9 +1507,11 @@ export namespace OpenScience {
     if (!session) return null
 
     try {
-      const res = await atlasFetch(`${API_BASE}/api/cli/learned-skills/${encodeURIComponent(name)}`, {
-        headers: { Authorization: `Bearer ${session.api_key}` },
-      })
+      const res = await atlasFetch(
+        `${API_BASE}/api/cli/learned-skills/${encodeURIComponent(name)}`,
+        { headers: { Authorization: `Bearer ${session.api_key}` } },
+        SKILL_FETCH_TIMEOUT_MS,
+      )
 
       if (!res.ok) {
         log.warn("failed to fetch learned skill content", { name, status: res.status })
@@ -1757,9 +1771,11 @@ export namespace OpenScience {
     const session = await getSession()
     if (!session) return null
     try {
-      const res = await atlasFetch(`${API_BASE}/api/cli/installed-skills`, {
-        headers: { Authorization: `Bearer ${session.api_key}` },
-      })
+      const res = await atlasFetch(
+        `${API_BASE}/api/cli/installed-skills`,
+        { headers: { Authorization: `Bearer ${session.api_key}` } },
+        SKILL_FETCH_TIMEOUT_MS,
+      )
       if (!res.ok) {
         log.warn("failed to fetch installed skills index", { status: res.status })
         return null
@@ -1779,6 +1795,7 @@ export namespace OpenScience {
       const res = await atlasFetch(
         `${API_BASE}/api/cli/installed-skills/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}`,
         { headers: { Authorization: `Bearer ${session.api_key}` } },
+        SKILL_FETCH_TIMEOUT_MS,
       )
       if (!res.ok) return null
       const data = await res.json()

--- a/backend/cli/src/plugin/index.ts
+++ b/backend/cli/src/plugin/index.ts
@@ -15,10 +15,40 @@ import { CopilotAuthPlugin } from "./copilot"
 export namespace Plugin {
   const log = Log.create({ service: "plugin" })
 
-  const BUILTIN = ["@synsci/anthropic-auth@0.0.13", "@gitlab/openscience-gitlab-auth@1.3.2"]
+  // Default plugins installed from npm at first run. Keep this list to packages
+  // that actually resolve on the public registry: a package that 404s is retried
+  // on EVERY startup (install() only short-circuits once a package is on disk, so
+  // a never-installable one never caches), serialized under the bun-install lock,
+  // which was the primary cause of the slow startup / "server unresponsive" report
+  // in #138. First-party auth that ships in-binary lives in INTERNAL_PLUGINS below.
+  const BUILTIN: string[] = []
+
+  // A single plugin install must never wedge startup. bun add for a missing/slow
+  // package can hang well past a reasonable wait; cap it so we log and move on.
+  const INSTALL_TIMEOUT_MS = Number(process.env["OPENSCIENCE_PLUGIN_INSTALL_TIMEOUT_MS"]) || 30_000
 
   // Built-in plugins that are directly imported (not installed from npm)
   const INTERNAL_PLUGINS: PluginInstance[] = [CodexAuthPlugin, CopilotAuthPlugin]
+
+  // Install a plugin package, but never wait longer than INSTALL_TIMEOUT_MS — a
+  // hung `bun add` (unreachable registry, missing package) must not block plugin
+  // init and, with it, the whole instance from becoming responsive.
+  async function installWithTimeout(pkg: string, version: string): Promise<string> {
+    let timer: ReturnType<typeof setTimeout> | undefined
+    try {
+      return await Promise.race([
+        BunProc.install(pkg, version),
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(
+            () => reject(new Error(`plugin install timed out after ${INSTALL_TIMEOUT_MS}ms`)),
+            INSTALL_TIMEOUT_MS,
+          )
+        }),
+      ])
+    } finally {
+      if (timer) clearTimeout(timer)
+    }
+  }
 
   const state = Instance.state(async () => {
     const client = createOpenScienceClient({
@@ -60,7 +90,7 @@ export namespace Plugin {
         const pkg = lastAtIndex > 0 ? plugin.substring(0, lastAtIndex) : plugin
         const version = lastAtIndex > 0 ? plugin.substring(lastAtIndex + 1) : "latest"
         const builtin = BUILTIN.some((x) => x.startsWith(pkg + "@"))
-        plugin = await BunProc.install(pkg, version).catch((err) => {
+        plugin = await installWithTimeout(pkg, version).catch((err) => {
           if (!builtin) throw err
 
           const message = err instanceof Error ? err.message : String(err)

--- a/backend/cli/src/skill/skill.ts
+++ b/backend/cli/src/skill/skill.ts
@@ -235,8 +235,15 @@ export namespace Skill {
     // === Learned Skills: from RSI distillation, cloud-synced + local ===
     const learnedDir = path.join(Global.Path.data, "learned-skills")
 
-    // Sync from cloud: fetch learned skills index and write any missing to disk
-    const cloudLearned = await OpenScience.fetchLearnedSkills().catch(() => null)
+    // Sync from cloud: fetch learned skills index and write any missing to disk.
+    // Gated on the same flag as the skill index above so it is one consistent
+    // "no server-side skill I/O" switch — this keeps skill discovery from
+    // blocking on a slow/unreachable backend (#138) and makes it deterministic
+    // in tests (preload sets the flag). The local learned-skills scan below still
+    // runs regardless.
+    const cloudLearned = Flag.OPENSCIENCE_DISABLE_BUNDLED_SKILLS
+      ? null
+      : await OpenScience.fetchLearnedSkills().catch(() => null)
     if (cloudLearned) {
       for (const entry of cloudLearned) {
         const skillDir = path.join(learnedDir, entry.name)
@@ -330,7 +337,12 @@ export namespace Skill {
       }
     }
 
-    const cloudInstalled = await OpenScience.fetchInstalledSkills().catch(() => null)
+    // Same gate as the learned + index fetches above: a slow/unreachable backend
+    // must not wedge skill discovery, and tests stay network-independent. The
+    // local installed-skills scan below still runs regardless.
+    const cloudInstalled = Flag.OPENSCIENCE_DISABLE_BUNDLED_SKILLS
+      ? null
+      : await OpenScience.fetchInstalledSkills().catch(() => null)
     if (cloudInstalled) {
       for (const entry of cloudInstalled) {
         const skillDir = path.join(installedDir, entry.namespace, "skills", entry.name)


### PR DESCRIPTION
Fixes #138.

The report is a careful RCA: after configuring a key, startup takes ~60s and the local server looks "unresponsive" after entering a project (a single `GET /skill` took **62,311ms**). Two root causes are real and fixable here; a third is already resolved on `main`.

## 1. Dead default plugins re-installed on every startup

Two default plugins 404 on the public npm registry:

```
GET https://registry.npmjs.org/@synsci%2fanthropic-auth        → 404
GET https://registry.npmjs.org/@gitlab%2fopenscience-gitlab-auth → 404
```

`BunProc.install()` only short-circuits once a package is present on disk (`dependencies[pkg] === version && modExists`). A package that can **never** install therefore has no negative cache — it's re-attempted on **every startup**, serialized under the global `bun-install` lock, blocking plugin init (which the instance awaits).

**Fix:** drop them from the default `BUILTIN` set (first-party auth ships in-binary via `INTERNAL_PLUGINS` — Codex, Copilot — not from npm), and bound every plugin install with a timeout (`installWithTimeout`, default 30s, `OPENSCIENCE_PLUGIN_INSTALL_TIMEOUT_MS`) so a hung `bun add` can never wedge startup again.

## 2. `/skill` inherits the 60s Atlas timeout

`GET /skill` → `Skill.all()` → `compute()` serially awaits skill index/content fetches, each via `atlasFetch` with the default `ATLAS_FETCH_TIMEOUT_MS = 60_000`. `fetchInstalledSkills` has no disk-cache fallback, so a slow/unreachable backend wedges the request for the full 60s — exactly the 62s the reporter saw.

**Fix:** these fetches only *enrich* a list that also comes from disk cache + bundled skills, so bound the six read-path fetches (`fetchSkillIndex`, `fetchSkillContent`, `fetchLearnedSkills`, `fetchLearnedSkillContent`, `fetchInstalledSkills`, `fetchInstalledSkillContent`) to **8s** and let them degrade to cached/empty. Overridable via `OPENSCIENCE_SKILL_TIMEOUT_MS`. Install/upload/review calls keep the 60s budget.

## 3. `Provider does not exist in model list openscience` — already fixed

The custom loader is now keyed `synsci` (the Atlas wire-contract id) on `main`; there is no `openscience`-keyed provider left to trip that guard. The reporter's 1.2.10 predates it.

Out of scope: the duplicate-instance observation (ports 4096 + 40560) is a separate lifecycle question, not addressed here.

## Verification

Reproduced the `/skill` hang with a black-hole server (accepts the connection, never responds) and a fake session pointed at it via `MANAGED_API_BASE`:

```
before: fetchInstalledSkills blocks ~60s
after:  fetchInstalledSkills → null (degraded) in ~timeout ms   (3s override → 3002ms; PASS)
```

Full backend suite: **972 pass / 1 skip**. (Three billing/init tests time out only when the full suite runs against a machine *with* live network — they assert fast-fail "no network" behavior and pass in CI's no-network sandbox; they fail identically on `main` and are untouched by this change.) Typecheck + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
