### PR TITLE
fix(cli): validate URL before well-known fetch in keys add

### DIFF
--- a/backend/cli/src/cli/cmd/auth.ts
+++ b/backend/cli/src/cli/cmd/auth.ts
@@ -273,7 +273,7 @@ export const AuthLoginCommand = cmd({
       async fn() {
         UI.empty()
         prompts.intro("Add credential")
-        if (args.url) {
+        if (args.url && (args.url.startsWith("http://") || args.url.startsWith("https://"))) {
           const wellknown = await fetch(`${args.url}/.well-known/openscience`).then((x) => x.json() as any)
           prompts.log.info(`Running \`${wellknown.auth.command.join(" ")}\``)
           const proc = Bun.spawn({


### PR DESCRIPTION
## Summary

Add URL validation before the well-known fetch in \keys add\ to prevent a crash when the argument is not an HTTP(S) URL.

## Related Issue
Fixes #142

## What changed
One line in \uth.ts\: added a protocol check (\http://\ or \https://\) before entering the well-known auth flow. Non-URL arguments now fall through to the interactive provider selector instead of crashing with \etch() URL is invalid\.

## Testing done
- \	sgo --noEmit\ passes
- Auth tests pass
- Prettier formatting clean

## Checklist
- [ ] No unrelated changes bundled in