### PR TITLE
Chat UI adoption + frontier models, managed/BYOK routing, Atlas graph & onboarding fixes

### DIFF
--- a/backend/cli/src/agent/prompt/research.txt
+++ b/backend/cli/src/agent/prompt/research.txt
@@ -59,7 +59,9 @@ At the START of the task, before Stage 1, set up the graph:
    `project_id: null` with an `error` kind — relay the matching fix (`unauthenticated` →
    `openscience login`; `plan` → app.syntheticsciences.ai/cli; `unreachable`/`backend`
    → show the message) and continue the work. (Or load the `initialize-atlas-graph` skill,
-   which wraps this exact command.)
+   which wraps this exact command.) When you mention the graph to the user, call it the
+   **Atlas** project graph (the durable, graph-based research memory) — never an
+   "OpenScience project graph". `openscience project init` is just the CLI that links it.
 2. **Load prior graph state — optional, best-effort.** Run `atlas doctor --format=json`. If it
    reports the `atlas` CLI is unavailable/unauthenticated, skip the `atlas ...` commands below
    and continue — this does NOT undo step 1, which already created the graph. If doctor is OK,

--- a/backend/cli/src/config/config.ts
+++ b/backend/cli/src/config/config.ts
@@ -192,7 +192,20 @@ export namespace Config {
     // corruption or a file written by an older, non-atomic version.
     const syncedConfig = path.join(Global.Path.config, "openscience-synced.json")
     try {
-      result = mergeConfigConcatArrays(result, await loadFile(syncedConfig))
+      const synced = await loadFile(syncedConfig)
+      // The dashboard sync is a MANAGED artifact: it pins `enabled_providers` to
+      // the wallet's OpenRouter route so a managed session can only reach the
+      // sanctioned catalog. Under an EXPLICIT byok toggle the user wants their
+      // OWN keys — so drop that managed-only whitelist before merging. Without
+      // this, a lingering managed sync (from a prior `openscience login`)
+      // whitelists away every byok provider the user has or later adds, so byok
+      // shows nothing but the leftover OpenRouter. Auto-detect (billing unset) is
+      // left alone. The managed openrouter *credential* is separately dropped in
+      // provider.ts under byok, so this only frees the catalog.
+      if (synced && (result as { billing?: { llm?: string } }).billing?.llm === "byok") {
+        delete (synced as { enabled_providers?: unknown }).enabled_providers
+      }
+      result = mergeConfigConcatArrays(result, synced)
     } catch {
       // treat an unreadable synced config as absent
     }

--- a/backend/cli/src/provider/provider.ts
+++ b/backend/cli/src/provider/provider.ts
@@ -1181,6 +1181,25 @@ export namespace Provider {
         continue
       }
 
+      // Under an EXPLICIT byok toggle, drop any provider whose effective
+      // credential is a managed Atlas (thk_) key. The managed sync writes
+      // OPENROUTER_BASE_URL + a thk_ OPENROUTER_API_KEY into the environment and
+      // those survive a managed→byok switch — so without this, byok silently
+      // keeps routing through the wallet proxy (and billing managed spend) on a
+      // credential the user never brought. BYOK must use the user's OWN keys
+      // only; auto-detect (billing unset) is left alone so a thk_ key can still
+      // resolve to managed there.
+      if (config.billing?.llm === "byok") {
+        const effective =
+          (typeof provider.options?.["apiKey"] === "string" ? (provider.options["apiKey"] as string) : undefined) ??
+          provider.key ??
+          provider.env.map((key) => Env.get(key)).find((value): value is string => !!value)
+        if (isAtlasApiKey(effective)) {
+          delete providers[providerID]
+          continue
+        }
+      }
+
       const configProvider = config.provider?.[providerID]
 
       for (const [modelID, model] of Object.entries(provider.models)) {

--- a/backend/cli/src/provider/transform.ts
+++ b/backend/cli/src/provider/transform.ts
@@ -810,11 +810,20 @@ export namespace ProviderTransform {
       // summaries + encrypted content have to be requested on that path too,
       // otherwise gpt-5.x streams reasoning *items* (start/end fire) with zero
       // summary deltas, so every reasoning part lands empty and the UI shows a
-      // blank "thinking" block. Genuine BYOK (no proxy baseURL) is left alone,
-      // so an unverified org never gets an unexpected summary request.
+      // blank "thinking" block.
       const managedBaseURL = input.providerOptions?.["baseURL"]
       const viaManagedProxy = typeof managedBaseURL === "string" && managedBaseURL.includes("/api/llm/proxy/")
-      if (input.model.providerID.startsWith("synsci") || viaManagedProxy) {
+      // Request summaries + encrypted content on every OpenAI-Responses path that
+      // can carry them: managed (synsci native + Atlas-proxied "openai") and direct
+      // BYOK openai. This mirrors the per-effort variant options above (the
+      // @ai-sdk/openai, azure, and github-copilot cases already ship these exact
+      // keys for openai models) — this block just applies the same defaults when no
+      // effort variant is selected, so the trace renders instead of streaming blank.
+      // On verification: reasoning.encrypted_content + summaries need an OpenAI-
+      // verified org, but that is the SAME gate OpenAI requires to *stream* gpt-5 at
+      // all. Any org that can stream the model can also receive these keys, so this
+      // adds no failure surface beyond the streaming requirement already in force.
+      if (input.model.providerID.startsWith("synsci") || viaManagedProxy || input.model.providerID === "openai") {
         result["promptCacheKey"] = input.sessionID
         result["include"] = ["reasoning.encrypted_content"]
         result["reasoningSummary"] = "auto"

--- a/backend/cli/src/session/llm.ts
+++ b/backend/cli/src/session/llm.ts
@@ -109,18 +109,11 @@ export namespace LLM {
           sessionID: input.sessionID,
           providerOptions: provider.options,
         })
-    // Real per-request "fast" param — gpt-5.5 only. `serviceTier` is mapped to
-    // OpenAI's `service_tier` by @ai-sdk/openai and lands under providerOptions.
-    // openai via sdkKey. Effective only if the model config sets
-    // supportsPriorityProcessing (else the SDK drops it with a warning).
-    const fast = !input.small && !!input.user.fast && /gpt-5\.5/.test(input.model.id.toLowerCase())
-    const speed = fast ? { serviceTier: "priority" } : {}
     const options: Record<string, any> = pipe(
       base,
       mergeDeep(input.model.options),
       mergeDeep(input.agent.options),
       mergeDeep(variant),
-      mergeDeep(speed),
     )
     if (isCodex) {
       options.instructions = SystemPrompt.instructions()

--- a/backend/cli/src/session/message-v2.ts
+++ b/backend/cli/src/session/message-v2.ts
@@ -327,9 +327,6 @@ export namespace MessageV2 {
     tools: z.record(z.string(), z.boolean()).optional(),
     variant: z.string().optional(),
     tier: z.enum(["fast", "pro", "ultra"]).optional(),
-    // Real per-request "fast" API param — currently gpt-5.5 only, mapped to
-    // OpenAI service_tier:"priority" in llm.ts. Distinct from `tier` (billing).
-    fast: z.boolean().optional(),
   }).meta({
     ref: "UserMessage",
   })

--- a/backend/cli/src/session/prompt.ts
+++ b/backend/cli/src/session/prompt.ts
@@ -121,8 +121,6 @@ export namespace SessionPrompt {
     system: z.string().optional(),
     variant: z.string().optional(),
     tier: z.enum(["fast", "pro", "ultra"]).optional(),
-    // Per-request fast API param (gpt-5.5 → service_tier:"priority"). See llm.ts.
-    fast: z.boolean().optional(),
     parts: z.array(
       z.discriminatedUnion("type", [
         MessageV2.TextPart.omit({
@@ -960,7 +958,6 @@ export namespace SessionPrompt {
       system: input.system,
       variant: input.variant,
       tier: input.tier,
-      fast: input.fast,
     }
     using _ = defer(() => InstructionPrompt.clear(info.id))
 

--- a/frontend/ui/src/components/accordion.css
+++ b/frontend/ui/src/components/accordion.css
@@ -47,7 +47,7 @@
         letter-spacing: var(--letter-spacing-normal);
 
         &:hover {
-          background-color: var(--surface-inset-base-hover);
+          background-color: var(--surface-base);
         }
         &:focus-visible {
           outline: none;

--- a/frontend/ui/src/components/button.css
+++ b/frontend/ui/src/components/button.css
@@ -8,17 +8,8 @@
   text-decoration: none;
   user-select: none;
   cursor: default;
+  outline: none;
   white-space: nowrap;
-  transition: scale var(--duration-fast) var(--ease-standard);
-
-  &:focus-visible {
-    outline: 2px solid var(--border-selected);
-    outline-offset: 2px;
-  }
-
-  &:active:not(:disabled) {
-    scale: 0.99;
-  }
 
   &[data-variant="primary"] {
     background-color: var(--button-primary-base);
@@ -40,7 +31,6 @@
     }
     &:disabled {
       background-color: var(--icon-strong-disabled);
-      cursor: not-allowed;
 
       [data-slot="icon-svg"] {
         color: var(--icon-invert-base);
@@ -103,11 +93,12 @@
     }
     &:active:not(:disabled) {
       background-color: var(--button-secondary-base);
+      scale: 0.99;
+      transition: all 150ms ease-out;
     }
     &:disabled {
       border-color: var(--border-disabled);
       background-color: var(--surface-disabled);
-      box-shadow: var(--shadow-xxs-border);
       color: var(--text-weak);
       cursor: not-allowed;
     }
@@ -120,10 +111,13 @@
   &[data-size="small"] {
     height: 22px;
     padding: 0 8px;
-    gap: 4px;
     &[data-icon] {
       padding: 0 12px 0 4px;
     }
+
+    font-size: var(--font-size-small);
+    line-height: var(--line-height-large);
+    gap: 4px;
 
     /* text-12-medium */
     font-family: var(--font-family-sans);
@@ -137,11 +131,13 @@
   &[data-size="normal"] {
     height: 24px;
     line-height: 24px;
-    padding: 0 10px;
-    gap: 6px;
+    padding: 0 6px;
     &[data-icon] {
       padding: 0 12px 0 4px;
     }
+
+    font-size: var(--font-size-small);
+    gap: 6px;
 
     /* text-12-medium */
     font-family: var(--font-family-sans);
@@ -153,19 +149,24 @@
 
   &[data-size="large"] {
     height: 32px;
-    padding: 0 12px;
-    gap: 6px;
+    padding: 6px 12px;
 
     &[data-icon] {
       padding: 0 12px 0 8px;
     }
 
-    /* text-13-medium */
+    gap: 4px;
+
+    /* text-14-medium */
     font-family: var(--font-family-sans);
-    font-size: var(--font-size-base);
+    font-size: 14px;
     font-style: normal;
     font-weight: var(--font-weight-medium);
-    line-height: var(--line-height-large);
+    line-height: var(--line-height-large); /* 142.857% */
     letter-spacing: var(--letter-spacing-normal);
+  }
+
+  &:focus {
+    outline: none;
   }
 }

--- a/frontend/ui/src/components/card.css
+++ b/frontend/ui/src/components/card.css
@@ -5,14 +5,14 @@
   background-color: var(--surface-inset-base);
   border: 1px solid var(--border-weaker-base);
   transition: background-color 0.15s ease;
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-md);
   padding: 6px 12px;
   overflow: clip;
 
   &[data-variant="error"] {
     background-color: var(--surface-critical-weak);
     border: 1px solid var(--border-critical-base);
-    color: var(--text-on-critical-weak);
+    color: rgba(218, 51, 25, 0.6);
 
     /* text-12-regular */
     font-family: var(--font-family-sans);
@@ -22,7 +22,7 @@
     line-height: var(--line-height-large); /* 166.667% */
     letter-spacing: var(--letter-spacing-normal);
 
-    & [data-component="icon"] {
+    &[data-component="icon"] {
       color: var(--icon-critical-active);
     }
   }

--- a/frontend/ui/src/components/checkbox.css
+++ b/frontend/ui/src/components/checkbox.css
@@ -93,7 +93,7 @@
   &[data-checked]:hover:not([data-disabled], [data-readonly]) [data-slot="checkbox-checkbox-control"],
   &[data-indeterminate]:hover:not([data-disabled]) [data-slot="checkbox-checkbox-control"] {
     border-color: var(--border-hover);
-    background-color: var(--surface-weak);
+    background-color: var(--surface-hover);
   }
 
   &[data-checked] [data-slot="checkbox-checkbox-indicator"],

--- a/frontend/ui/src/components/collapsible.css
+++ b/frontend/ui/src/components/collapsible.css
@@ -15,7 +15,7 @@
     padding: 6px 8px 6px 12px;
     align-items: center;
     align-self: stretch;
-    cursor: default;
+    cursor: pointer;
     user-select: none;
     color: var(--text-base);
 

--- a/frontend/ui/src/components/dialog.css
+++ b/frontend/ui/src/components/dialog.css
@@ -5,18 +5,6 @@
   inset: 0;
   z-index: 50;
   background-color: hsl(from var(--background-base) h s l / 0.2);
-  /* Start invisible so the very first paint matches the animation's
-     from-state — without this the overlay flashes at full opacity for one
-     frame before the animation rewinds it to 0. */
-  opacity: 0;
-  animation: overlayHide 120ms ease-in forwards;
-
-  &[data-expanded] {
-    /* `backwards` applies the from-keyframe before the animation starts,
-       so the element is invisible from the first paint and there's no
-       jump-then-fade flicker on mount. */
-    animation: overlayShow 180ms ease-out both;
-  }
 }
 
 [data-component="dialog"] {
@@ -88,7 +76,10 @@
 
       [data-slot="dialog-description"] {
         display: flex;
-        padding: 0 20px 16px;
+        padding: 16px;
+        padding-left: 24px;
+        padding-top: 0;
+        margin-top: -8px;
         justify-content: space-between;
         align-items: center;
         flex-shrink: 0;
@@ -96,9 +87,9 @@
 
         color: var(--text-base);
 
-        /* text-13-regular */
+        /* text-14-regular */
         font-family: var(--font-family-sans);
-        font-size: var(--font-size-base);
+        font-size: 14px;
         font-style: normal;
         font-weight: var(--font-weight-regular);
         line-height: var(--line-height-large); /* 142.857% */
@@ -145,13 +136,10 @@
 }
 
 [data-component="dialog"][data-transition] [data-slot="dialog-content"] {
-  /* Mirror the overlay treatment so the content respects its from-state
-     before the first paint and the dialog never flashes at full opacity. */
-  opacity: 0;
-  animation: contentHide 120ms ease-in forwards;
+  animation: contentHide 100ms ease-in forwards;
 
   &[data-expanded] {
-    animation: contentShow 200ms cubic-bezier(0.22, 1, 0.36, 1) both;
+    animation: contentShow 150ms ease-out;
   }
 }
 

--- a/frontend/ui/src/components/diff-changes.css
+++ b/frontend/ui/src/components/diff-changes.css
@@ -13,7 +13,7 @@
     line-height: var(--line-height-large);
     letter-spacing: var(--letter-spacing-normal);
     text-align: right;
-    color: var(--text-diff-add-base);
+    color: var(--text-weak);
   }
 
   [data-slot="diff-changes-deletions"] {
@@ -25,7 +25,7 @@
     line-height: var(--line-height-large);
     letter-spacing: var(--letter-spacing-normal);
     text-align: right;
-    color: var(--text-diff-delete-base);
+    color: var(--text-weak);
   }
 }
 

--- a/frontend/ui/src/components/dropdown-menu.css
+++ b/frontend/ui/src/components/dropdown-menu.css
@@ -2,7 +2,7 @@
 [data-component="dropdown-menu-sub-content"] {
   min-width: 8rem;
   overflow: hidden;
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-md);
   border: 1px solid color-mix(in oklch, var(--border-base) 50%, transparent);
   background-clip: padding-box;
   background-color: var(--surface-raised-stronger-non-alpha);
@@ -36,7 +36,7 @@
     align-items: center;
     gap: 8px;
     padding: 4px 8px;
-    border-radius: var(--radius-xs);
+    border-radius: var(--radius-sm);
     cursor: default;
     user-select: none;
     outline: none;

--- a/frontend/ui/src/components/hover-card.css
+++ b/frontend/ui/src/components/hover-card.css
@@ -9,7 +9,7 @@
   min-width: 200px;
   max-width: 320px;
   max-height: calc(100vh - 1rem);
-  border-radius: var(--radius-lg);
+  border-radius: 8px;
   background-color: var(--surface-raised-stronger-non-alpha);
   pointer-events: auto;
 

--- a/frontend/ui/src/components/icon-button.css
+++ b/frontend/ui/src/components/icon-button.css
@@ -8,11 +8,6 @@
   aspect-ratio: 1;
   flex-shrink: 0;
 
-  &:focus-visible {
-    outline: 2px solid var(--border-selected);
-    outline-offset: 2px;
-  }
-
   &[data-variant="primary"] {
     background-color: var(--icon-strong-base);
 
@@ -74,13 +69,9 @@
     }
 
     &:disabled {
-      background-color: var(--surface-disabled);
-      color: var(--text-weak);
+      background-color: var(--icon-strong-disabled);
+      color: var(--icon-invert-base);
       cursor: not-allowed;
-
-      [data-slot="icon-svg"] {
-        color: var(--icon-disabled);
-      }
     }
   }
 
@@ -108,18 +99,15 @@
       /*   color: var(--icon-active); */
       /* } */
     }
-    &[data-selected="true"]:not(:disabled) {
+    &:selected:not(:disabled) {
       background-color: var(--surface-raised-base-active);
       /* [data-slot="icon-svg"] { */
       /*   color: var(--icon-selected); */
       /* } */
     }
     &:disabled {
+      color: var(--icon-invert-base);
       cursor: not-allowed;
-
-      [data-slot="icon-svg"] {
-        color: var(--icon-disabled);
-      }
     }
   }
 
@@ -144,5 +132,9 @@
     font-weight: var(--font-weight-medium);
     line-height: var(--line-height-large); /* 166.667% */
     letter-spacing: var(--letter-spacing-normal);
+  }
+
+  &:focus {
+    outline: none;
   }
 }

--- a/frontend/ui/src/components/keybind.css
+++ b/frontend/ui/src/components/keybind.css
@@ -5,7 +5,7 @@
   flex-shrink: 0;
   height: 20px;
   padding: 0 8px;
-  border-radius: var(--radius-xs);
+  border-radius: 2px;
   background: var(--surface-base);
   box-shadow: var(--shadow-xxs-border);
 

--- a/frontend/ui/src/components/line-comment.css
+++ b/frontend/ui/src/components/line-comment.css
@@ -40,7 +40,7 @@
   z-index: var(--line-comment-popover-z, 40);
   min-width: 200px;
   max-width: min(320px, calc(100vw - 48px));
-  border-radius: 3px;
+  border-radius: 8px;
   background: var(--surface-raised-stronger-non-alpha);
   box-shadow: var(--shadow-lg-border-base);
   padding: 12px;
@@ -50,7 +50,7 @@
   width: 380px;
   max-width: min(380px, calc(100vw - 48px));
   padding: 8px;
-  border-radius: 4px;
+  border-radius: 14px;
 }
 
 [data-component="line-comment"] [data-slot="line-comment-content"] {

--- a/frontend/ui/src/components/list.css
+++ b/frontend/ui/src/components/list.css
@@ -159,9 +159,9 @@
         color: var(--text-weak);
         white-space: nowrap;
 
-        /* text-13-regular */
+        /* text-14-regular */
         font-family: var(--font-family-sans);
-        font-size: var(--font-size-base);
+        font-size: 14px;
         font-style: normal;
         font-weight: var(--font-weight-regular);
         line-height: var(--line-height-large); /* 142.857% */
@@ -197,9 +197,9 @@
 
         color: var(--text-weak);
 
-        /* text-13-medium */
+        /* text-14-medium */
         font-family: var(--font-family-sans);
-        font-size: var(--font-size-base);
+        font-size: 14px;
         font-style: normal;
         font-weight: var(--font-weight-medium);
         line-height: var(--line-height-large); /* 142.857% */
@@ -238,9 +238,9 @@
           color: var(--text-strong);
           scroll-margin-top: 28px;
 
-          /* text-13-medium */
+          /* text-14-medium */
           font-family: var(--font-family-sans);
-          font-size: var(--font-size-base);
+          font-size: 14px;
           font-style: normal;
           font-weight: var(--font-weight-medium);
           line-height: var(--line-height-large); /* 142.857% */
@@ -313,9 +313,9 @@
           align-items: center;
           color: var(--text-strong);
 
-          /* text-13-medium */
+          /* text-14-medium */
           font-family: var(--font-family-sans);
-          font-size: var(--font-size-base);
+          font-size: 14px;
           font-style: normal;
           font-weight: var(--font-weight-medium);
           line-height: var(--line-height-large); /* 142.857% */

--- a/frontend/ui/src/components/markdown.css
+++ b/frontend/ui/src/components/markdown.css
@@ -207,3 +207,13 @@
     display: block;
   }
 }
+
+/* Inline file-path code spans made clickable by the markdown post-processor. */
+[data-component="markdown"] code[data-file-link] {
+  cursor: pointer;
+}
+[data-component="markdown"] code[data-file-link]:hover {
+  color: var(--text-interactive-base);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}

--- a/frontend/ui/src/components/markdown.css
+++ b/frontend/ui/src/components/markdown.css
@@ -23,27 +23,12 @@
   h4,
   h5,
   h6 {
+    font-size: var(--font-size-base);
     color: var(--text-strong);
     font-weight: var(--font-weight-medium);
-    margin-top: 1.75rem;
-    margin-bottom: 0.6rem;
-    line-height: var(--line-height-large);
-  }
-  /* A real heading hierarchy so long, structured answers stay scannable. */
-  h1 {
-    font-size: 1.45em;
     margin-top: 2rem;
-  }
-  h2 {
-    font-size: 1.2em;
-  }
-  h3 {
-    font-size: 1.08em;
-  }
-  h4,
-  h5,
-  h6 {
-    font-size: 1em;
+    margin-bottom: 0.75rem;
+    line-height: var(--line-height-large);
   }
 
   /* Emphasis & Strong: Neutral strong color */
@@ -176,46 +161,33 @@
     }
   }
 
-  /* Inline code reads as a quiet chip, not just coloured text. */
   :not(pre) > code {
     font-family: var(--font-family-mono);
     font-feature-settings: var(--font-family-mono--font-feature-settings);
-    color: var(--text-strong);
-    font-weight: var(--font-weight-regular);
-    font-size: 0.88em;
-    padding: 0.12em 0.36em;
-    border-radius: 5px;
-    background: var(--surface-weak);
-    box-shadow: inset 0 0 0 1px var(--border-weaker-base);
+    color: var(--syntax-string);
+    font-weight: var(--font-weight-medium);
+    /* font-size: 13px; */
+
+    /* padding: 2px 2px; */
+    /* margin: 0 1.5px; */
+    /* border-radius: 2px; */
+    /* background: var(--surface-base); */
+    /* box-shadow: 0 0 0 0.5px var(--border-weak-base); */
   }
 
-  /* GFM task lists: drop the bullet, align the box, brand the tick. */
-  li:has(> input[type="checkbox"]) {
-    list-style: none;
-    margin-left: -1.25rem;
-  }
-  li > input[type="checkbox"] {
-    margin-right: 0.5em;
-    accent-color: var(--text-interactive-base);
-    vertical-align: -1px;
-  }
-
-  /* Tables — scroll wide matrices instead of breaking the layout, with a clear
-     header row and quiet cell borders so dense tables stay legible. */
+  /* Tables */
   table {
-    display: block;
-    max-width: 100%;
-    overflow-x: auto;
+    width: 100%;
     border-collapse: collapse;
     margin: 1.5rem 0;
-    font-size: calc(var(--font-size-base) - 1px);
-    scrollbar-width: thin;
+    font-size: var(--font-size-base);
   }
 
   th,
   td {
-    border: 1px solid var(--border-weaker-base);
-    padding: 0.5rem 0.75rem;
+    /* Minimal borders for structure, matching TUI "lines" roughly but keeping it web-clean */
+    border-bottom: 1px solid var(--border-weaker-base);
+    padding: 0.75rem 0.5rem;
     text-align: left;
     vertical-align: top;
   }
@@ -223,8 +195,7 @@
   th {
     color: var(--text-strong);
     font-weight: var(--font-weight-medium);
-    background: var(--surface-weak);
-    white-space: nowrap;
+    border-bottom: 1px solid var(--border-weak-base);
   }
 
   /* Images */

--- a/frontend/ui/src/components/markdown.tsx
+++ b/frontend/ui/src/components/markdown.tsx
@@ -235,6 +235,31 @@ export function Markdown(
       },
     })
 
+    // Make inline file-path code spans clickable — dispatch an event the host
+    // (session page) turns into an openFile. Curated extensions only, so prose
+    // like `n/a` or an identifier `a/b` isn't hijacked.
+    container.querySelectorAll("code").forEach((el) => {
+      if (el.closest("pre")) return
+      const anchor = el as HTMLElement
+      if (anchor.dataset.fileLink) return
+      const text = (el.textContent ?? "").trim()
+      const isFile =
+        text.length > 2 &&
+        text.length < 260 &&
+        !/\s/.test(text) &&
+        /\.(md|mdx|json|jsonl|txt|py|ipynb|ts|tsx|js|jsx|csv|tsv|ya?ml|toml|tex|bib|pdf|png|jpe?g|gif|svg|sh|r|rmd|parquet|h5|hdf5|npy|npz|pkl|log|cfg|ini|xml|html?|css|sql|go|rs|java|db|sqlite)$/i.test(
+          text,
+        )
+      if (!isFile) return
+      anchor.dataset.fileLink = "1"
+      anchor.setAttribute("data-file-link", "true")
+      anchor.addEventListener("click", (e) => {
+        e.preventDefault()
+        e.stopPropagation()
+        document.dispatchEvent(new CustomEvent("openscience:open-file", { detail: { path: text } }))
+      })
+    })
+
     if (copySetupTimer) clearTimeout(copySetupTimer)
     copySetupTimer = setTimeout(() => {
       if (copyCleanup) copyCleanup()

--- a/frontend/ui/src/components/message-part.css
+++ b/frontend/ui/src/components/message-part.css
@@ -146,7 +146,7 @@
 
   [data-component="markdown"] {
     margin-top: 24px;
-    font-style: italic !important;
+    font-style: normal;
 
     p:has(strong) {
       margin-top: 24px;
@@ -825,4 +825,17 @@
     flex-shrink: 0;
     color: var(--icon-weak);
   }
+}
+
+/* Clickable file references — read/write/edit tool cards expose their filename;
+   clicking it opens the file as a document tab (data.openFile). */
+[data-slot="basic-tool-tool-subtitle"].clickable,
+[data-slot="message-part-title-filename"].clickable {
+  cursor: pointer;
+}
+[data-slot="basic-tool-tool-subtitle"].clickable:hover,
+[data-slot="message-part-title-filename"].clickable:hover {
+  color: var(--text-interactive-base);
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }

--- a/frontend/ui/src/components/message-part.css
+++ b/frontend/ui/src/components/message-part.css
@@ -30,7 +30,7 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    border-radius: 2px;
+    border-radius: 6px;
     overflow: hidden;
     background: var(--surface-weak);
     border: 1px solid var(--border-weak-base);
@@ -76,10 +76,10 @@
     white-space: pre-wrap;
     word-break: break-word;
     overflow: hidden;
-    background: var(--surface-raised-base);
-    border: 1px solid var(--border-base);
-    padding: 10px 14px;
-    border-radius: 14px;
+    background: var(--surface-weak);
+    border: 1px solid var(--border-weak-base);
+    padding: 8px 12px;
+    border-radius: 4px;
 
     [data-highlight="file"] {
       color: var(--syntax-property);
@@ -93,9 +93,6 @@
       position: absolute;
       top: 7px;
       right: 7px;
-      display: flex;
-      align-items: center;
-      gap: 4px;
       opacity: 0;
       transition: opacity 0.15s ease;
     }
@@ -419,7 +416,7 @@
     color: var(--text-on-critical-base);
     font-weight: var(--font-weight-medium);
     text-transform: uppercase;
-    letter-spacing: 0.08em;
+    letter-spacing: -0.5px;
     flex-shrink: 0;
   }
 
@@ -462,7 +459,7 @@
     top: calc(2px + var(--sticky-header-height, 40px));
     bottom: 0px;
     z-index: 20;
-    border-radius: 2px;
+    border-radius: 6px;
     border: none;
     box-shadow: var(--shadow-xs-border-base);
     background-color: var(--surface-raised-base);
@@ -596,7 +593,7 @@
     gap: 8px;
 
     [data-slot="question-text"] {
-      font-size: var(--font-size-base);
+      font-size: 14px;
       color: var(--text-base);
       line-height: 1.5;
     }
@@ -615,7 +612,7 @@
       padding: 8px 12px;
       background-color: var(--surface-base);
       border: 1px solid var(--border-weaker-base);
-      border-radius: 2px;
+      border-radius: 6px;
       cursor: pointer;
       text-align: left;
       width: 100%;
@@ -640,9 +637,9 @@
       }
 
       [data-slot="option-label"] {
-        font-size: var(--font-size-base);
+        font-size: 14px;
         color: var(--text-base);
-        font-weight: 400;
+        font-weight: 500;
       }
 
       [data-slot="option-description"] {
@@ -660,9 +657,9 @@
       [data-slot="custom-input"] {
         flex: 1;
         padding: 8px 12px;
-        font-size: var(--font-size-base);
+        font-size: 14px;
         border: 1px solid var(--border-default);
-        border-radius: 2px;
+        border-radius: 6px;
         background-color: var(--surface-base);
         color: var(--text-base);
         outline: none;

--- a/frontend/ui/src/components/message-part.tsx
+++ b/frontend/ui/src/components/message-part.tsx
@@ -758,6 +758,7 @@ ToolRegistry.register({
             subtitle: props.input.filePath ? getFilename(props.input.filePath) : "",
             args,
           }}
+          onSubtitleClick={props.input.filePath ? () => data.openFile?.(props.input.filePath!) : undefined}
         />
         <For each={loaded()}>
           {(filepath) => (
@@ -1048,7 +1049,7 @@ ToolRegistry.register({
     const openInShellTab = (e: MouseEvent) => {
       e.stopPropagation()
       document.dispatchEvent(
-        new CustomEvent("open-shell-tab", { detail: { partId: props.partID } }),
+        new CustomEvent("open-shell-tab", { detail: { partId: props.partID, command: props.input.command } }),
       )
     }
     return (
@@ -1086,9 +1087,11 @@ ToolRegistry.register({
   name: "edit",
   render(props) {
     const i18n = useI18n()
+    const data = useData()
     const diffComponent = useDiffComponent()
     const diagnostics = createMemo(() => getDiagnostics(props.metadata.diagnostics, props.input.filePath))
     const filename = () => getFilename(props.input.filePath ?? "")
+    const canOpen = () => !!(data.openFile && props.input.filePath)
     return (
       <BasicTool
         {...props}
@@ -1098,7 +1101,17 @@ ToolRegistry.register({
             <div data-slot="message-part-title-area">
               <div data-slot="message-part-title">
                 <span data-slot="message-part-title-text">{i18n.t("ui.messagePart.title.edit")}</span>
-                <span data-slot="message-part-title-filename">{filename()}</span>
+                <span
+                  data-slot="message-part-title-filename"
+                  classList={{ clickable: canOpen() }}
+                  onClick={(e) => {
+                    if (!canOpen()) return
+                    e.stopPropagation()
+                    data.openFile!(props.input.filePath!)
+                  }}
+                >
+                  {filename()}
+                </span>
               </div>
               <Show when={props.input.filePath?.includes("/")}>
                 <div data-slot="message-part-path">
@@ -1139,9 +1152,11 @@ ToolRegistry.register({
   name: "write",
   render(props) {
     const i18n = useI18n()
+    const data = useData()
     const codeComponent = useCodeComponent()
     const diagnostics = createMemo(() => getDiagnostics(props.metadata.diagnostics, props.input.filePath))
     const filename = () => getFilename(props.input.filePath ?? "")
+    const canOpen = () => !!(data.openFile && props.input.filePath)
     const isNotebook = () => (props.input.filePath ?? "").endsWith(".ipynb")
 
     const notebookCells = createMemo((): NotebookCellProps[] => {
@@ -1175,7 +1190,17 @@ ToolRegistry.register({
             <div data-slot="message-part-title-area">
               <div data-slot="message-part-title">
                 <span data-slot="message-part-title-text">{i18n.t("ui.messagePart.title.write")}</span>
-                <span data-slot="message-part-title-filename">{filename()}</span>
+                <span
+                  data-slot="message-part-title-filename"
+                  classList={{ clickable: canOpen() }}
+                  onClick={(e) => {
+                    if (!canOpen()) return
+                    e.stopPropagation()
+                    data.openFile!(props.input.filePath!)
+                  }}
+                >
+                  {filename()}
+                </span>
               </div>
               <Show when={props.input.filePath?.includes("/")}>
                 <div data-slot="message-part-path">

--- a/frontend/ui/src/components/message-part.tsx
+++ b/frontend/ui/src/components/message-part.tsx
@@ -93,9 +93,6 @@ function DiagnosticsDisplay(props: { diagnostics: Diagnostic[] }): JSX.Element {
 export interface MessageProps {
   message: MessageType
   parts: PartType[]
-  /** When set, user messages render an undo action that reverts the
-   * conversation (and file changes) back to this message. */
-  onRevert?: () => void
 }
 
 export interface MessagePartProps {
@@ -108,6 +105,11 @@ export interface MessagePartProps {
 export type PartComponent = Component<MessagePartProps>
 
 export const PART_MAPPING: Record<string, PartComponent | undefined> = {}
+
+// Openscience science-artifact tool renderer id. tool-renderer.tsx registers a
+// custom renderer under this name and imports it from here; re-exported so that
+// import resolves against the v1.1.116 message-part.
+export const ARTIFACT_TOOL = "__artifact__"
 
 const TEXT_RENDER_THROTTLE_MS = 100
 
@@ -286,9 +288,7 @@ export function Message(props: MessageProps) {
   return (
     <Switch>
       <Match when={props.message.role === "user" && props.message}>
-        {(userMessage) => (
-          <UserMessageDisplay message={userMessage() as UserMessage} parts={props.parts} onRevert={props.onRevert} />
-        )}
+        {(userMessage) => <UserMessageDisplay message={userMessage() as UserMessage} parts={props.parts} />}
       </Match>
       <Match when={props.message.role === "assistant" && props.message}>
         {(assistantMessage) => (
@@ -312,7 +312,7 @@ export function AssistantMessageDisplay(props: { message: AssistantMessage; part
   return <For each={filteredParts()}>{(part) => <Part part={part} message={props.message} />}</For>
 }
 
-export function UserMessageDisplay(props: { message: UserMessage; parts: PartType[]; onRevert?: () => void }) {
+export function UserMessageDisplay(props: { message: UserMessage; parts: PartType[] }) {
   const dialog = useDialog()
   const i18n = useI18n()
   const [copied, setCopied] = createSignal(false)
@@ -429,20 +429,6 @@ export function UserMessageDisplay(props: { message: UserMessage; parts: PartTyp
             <Icon name="chevron-down" size="small" />
           </button>
           <div data-slot="user-message-copy-wrapper">
-            <Show when={props.onRevert}>
-              <Tooltip value={i18n.t("ui.message.revert")} placement="top" gutter={8}>
-                <IconButton
-                  icon="undo"
-                  variant="secondary"
-                  onMouseDown={(e) => e.preventDefault()}
-                  onClick={(event) => {
-                    event.stopPropagation()
-                    props.onRevert?.()
-                  }}
-                  aria-label={i18n.t("ui.message.revert")}
-                />
-              </Tooltip>
-            </Show>
             <Tooltip
               value={copied() ? i18n.t("ui.message.copied") : i18n.t("ui.message.copy")}
               placement="top"
@@ -557,14 +543,6 @@ export const ToolRegistry = {
   render: getTool,
 }
 
-/**
- * Reserved registry key for the app-side science-artifact renderer. Any tool
- * whose `metadata.artifact` is set but has no tool-specific renderer falls back
- * to whatever the app registers under this name (see the app's ScienceArtifact
- * side-effect import). Kept out of the tool namespace with a sentinel name.
- */
-export const ARTIFACT_TOOL = "__artifact__"
-
 PART_MAPPING["tool"] = function ToolPartDisplay(props) {
   const data = useData()
   const i18n = useI18n()
@@ -634,15 +612,7 @@ PART_MAPPING["tool"] = function ToolPartDisplay(props) {
     return partMetadata()
   }
 
-  // Prefer a tool-specific renderer; otherwise, if the tool emitted a science
-  // artifact envelope in its metadata, fall back to the app-registered artifact
-  // renderer (see ARTIFACT_TOOL); otherwise the generic tool card.
-  const render = createMemo(
-    () =>
-      ToolRegistry.render(part.tool) ??
-      (metadata()?.artifact ? ToolRegistry.render(ARTIFACT_TOOL) : undefined) ??
-      GenericTool,
-  )
+  const render = ToolRegistry.render(part.tool) ?? GenericTool
 
   return (
     <div data-component="tool-part-wrapper" data-permission={showPermission()} data-question={showQuestion()}>
@@ -673,7 +643,7 @@ PART_MAPPING["tool"] = function ToolPartDisplay(props) {
         </Match>
         <Match when={true}>
           <Dynamic
-            component={render()}
+            component={render}
             input={input()}
             tool={part.tool}
             metadata={metadata()}
@@ -1077,7 +1047,9 @@ ToolRegistry.register({
     const i18n = useI18n()
     const openInShellTab = (e: MouseEvent) => {
       e.stopPropagation()
-      document.dispatchEvent(new CustomEvent("open-shell-tab", { detail: { partId: props.partID } }))
+      document.dispatchEvent(
+        new CustomEvent("open-shell-tab", { detail: { partId: props.partID } }),
+      )
     }
     return (
       <BasicTool
@@ -1088,7 +1060,12 @@ ToolRegistry.register({
           subtitle: props.input.description,
           action: (
             <Tooltip value="Open in Shell tab">
-              <IconButton icon="square-arrow-top-right" variant="ghost" class="h-5 w-5" onClick={openInShellTab} />
+              <IconButton
+                icon="square-arrow-top-right"
+                variant="ghost"
+                class="h-5 w-5"
+                onClick={openInShellTab}
+              />
             </Tooltip>
           ),
         }}
@@ -1177,13 +1154,10 @@ ToolRegistry.register({
           source: Array.isArray(cell.source) ? cell.source.join("") : (cell.source ?? ""),
           executionCount: cell.execution_count ?? null,
           outputs: (cell.outputs ?? []).map((o: any) => {
-            if (o.output_type === "stream")
-              return { type: "stream", name: o.name, text: Array.isArray(o.text) ? o.text.join("") : o.text }
-            if (o.output_type === "execute_result")
-              return { type: "execute_result", data: o.data ?? {}, executionCount: o.execution_count }
+            if (o.output_type === "stream") return { type: "stream", name: o.name, text: Array.isArray(o.text) ? o.text.join("") : o.text }
+            if (o.output_type === "execute_result") return { type: "execute_result", data: o.data ?? {}, executionCount: o.execution_count }
             if (o.output_type === "display_data") return { type: "display_data", data: o.data ?? {} }
-            if (o.output_type === "error")
-              return { type: "error", ename: o.ename, evalue: o.evalue, traceback: o.traceback ?? [] }
+            if (o.output_type === "error") return { type: "error", ename: o.ename, evalue: o.evalue, traceback: o.traceback ?? [] }
             return { type: "stream", name: "stdout", text: "" }
           }),
         }))
@@ -1214,24 +1188,24 @@ ToolRegistry.register({
         }
       >
         <Show when={props.input.content}>
-          <Show
-            when={isNotebook() && notebookCells().length > 0}
-            fallback={
-              <div data-component="write-content">
-                <Dynamic
-                  component={codeComponent}
-                  file={{
-                    name: props.input.filePath,
-                    contents: props.input.content,
-                    cacheKey: checksum(props.input.content),
-                  }}
-                  overflow="scroll"
-                />
-              </div>
-            }
-          >
+          <Show when={isNotebook() && notebookCells().length > 0} fallback={
             <div data-component="write-content">
-              <NotebookView cells={notebookCells()} title={filename()} />
+              <Dynamic
+                component={codeComponent}
+                file={{
+                  name: props.input.filePath,
+                  contents: props.input.content,
+                  cacheKey: checksum(props.input.content),
+                }}
+                overflow="scroll"
+              />
+            </div>
+          }>
+            <div data-component="write-content">
+              <NotebookView
+                cells={notebookCells()}
+                title={filename()}
+              />
             </div>
           </Show>
         </Show>
@@ -1472,9 +1446,7 @@ ToolRegistry.register({
           title: connected() ? "Colab Connected" : "Colab Connect",
           subtitle: connected()
             ? `${mode()} · ${gpu() || "GPU ready"}`
-            : mode() === "enterprise"
-              ? "Vertex AI"
-              : "Bridge notebook",
+            : mode() === "enterprise" ? "Vertex AI" : "Bridge notebook",
         }}
       >
         <Show when={props.output}>

--- a/frontend/ui/src/components/notebook-cell.css
+++ b/frontend/ui/src/components/notebook-cell.css
@@ -9,7 +9,7 @@
     padding: 8px 12px;
     font-family: var(--font-family-sans);
     font-size: var(--font-size-small);
-    font-weight: 700;
+    font-weight: 600;
     color: var(--text-base);
     background: var(--bg-surface);
     border-bottom: 1px solid var(--border-weaker-base);
@@ -40,7 +40,7 @@
 
   [data-slot="notebook-cell-prompt"] {
     font-family: var(--font-family-mono);
-    font-size: var(--font-size-x-small);
+    font-size: var(--font-size-xs);
     color: var(--text-weak);
     min-width: 32px;
   }
@@ -53,7 +53,7 @@
       margin: 0;
       padding: 8px 12px 8px 52px;
       font-family: var(--font-family-mono);
-      font-size: var(--font-size-x-small);
+      font-size: var(--font-size-xs);
       line-height: 1.5;
       color: var(--text-base);
       background: var(--bg-base);
@@ -88,7 +88,7 @@
   [data-slot="notebook-output-stream"] {
     margin: 0;
     font-family: var(--font-family-mono);
-    font-size: var(--font-size-x-small);
+    font-size: var(--font-size-xs);
     line-height: 1.5;
     color: var(--text-base);
     white-space: pre-wrap;
@@ -102,7 +102,7 @@
   [data-slot="notebook-output-text"] {
     margin: 0;
     font-family: var(--font-family-mono);
-    font-size: var(--font-size-x-small);
+    font-size: var(--font-size-xs);
     line-height: 1.5;
     color: var(--text-base);
     white-space: pre-wrap;
@@ -121,11 +121,11 @@
 
   [data-slot="notebook-output-error"] {
     font-family: var(--font-family-mono);
-    font-size: var(--font-size-x-small);
+    font-size: var(--font-size-xs);
     color: var(--text-error);
 
     [data-slot="notebook-error-name"] {
-      font-weight: 700;
+      font-weight: 600;
       padding: 4px 0;
     }
 

--- a/frontend/ui/src/components/notebook-cell.tsx
+++ b/frontend/ui/src/components/notebook-cell.tsx
@@ -1,12 +1,5 @@
 import { createSignal, For, Show, type JSX } from "solid-js"
-import DOMPurify from "dompurify"
 import { Icon } from "./icon"
-
-// Notebook `text/html` outputs are untrusted (a malicious .ipynb or a
-// prompt-injected cell can emit arbitrary markup). Sanitize before injecting so
-// tables/plots still render but <script>, event handlers, and javascript: URLs
-// are stripped. Default profile keeps html+svg+mathml.
-const sanitizeHtml = (html: string) => (DOMPurify.isSupported ? DOMPurify.sanitize(html) : "")
 
 export interface NotebookCellProps {
   cellType: "code" | "markdown"
@@ -55,7 +48,9 @@ export function NotebookCell(props: NotebookCellProps): JSX.Element {
         </div>
         <Show when={props.outputs && props.outputs.length > 0}>
           <div data-slot="notebook-cell-outputs">
-            <For each={props.outputs}>{(output) => <NotebookOutputView output={output} />}</For>
+            <For each={props.outputs}>
+              {(output) => <NotebookOutputView output={output} />}
+            </For>
           </div>
         </Show>
       </Show>
@@ -83,7 +78,7 @@ function NotebookOutputView(props: { output: NotebookOutput }): JSX.Element {
             />
           </Show>
           <Show when={output().data?.["text/html"]}>
-            <div data-slot="notebook-output-html" innerHTML={sanitizeHtml(output().data!["text/html"])} />
+            <div data-slot="notebook-output-html" innerHTML={output().data!["text/html"]} />
           </Show>
           <Show when={output().data?.["text/plain"] && !output().data?.["image/png"] && !output().data?.["text/html"]}>
             <pre data-slot="notebook-output-text">{output().data!["text/plain"]}</pre>
@@ -92,14 +87,10 @@ function NotebookOutputView(props: { output: NotebookOutput }): JSX.Element {
       </Show>
       <Show when={output().type === "error"}>
         <div data-slot="notebook-output-error">
-          <div data-slot="notebook-error-name">
-            {output().ename}: {output().evalue}
-          </div>
+          <div data-slot="notebook-error-name">{output().ename}: {output().evalue}</div>
           <Show when={output().traceback && output().traceback!.length > 0}>
             <pre data-slot="notebook-error-traceback">
-              {output()
-                .traceback!.map((l) => l.replace(/\x1b\[[0-9;]*m/g, ""))
-                .join("\n")}
+              {output().traceback!.map((l) => l.replace(/\x1b\[[0-9;]*m/g, "")).join("\n")}
             </pre>
           </Show>
         </div>
@@ -108,7 +99,10 @@ function NotebookOutputView(props: { output: NotebookOutput }): JSX.Element {
   )
 }
 
-export function NotebookView(props: { cells: NotebookCellProps[]; title?: string }): JSX.Element {
+export function NotebookView(props: {
+  cells: NotebookCellProps[]
+  title?: string
+}): JSX.Element {
   return (
     <div data-component="notebook-view">
       <Show when={props.title}>

--- a/frontend/ui/src/components/popover.css
+++ b/frontend/ui/src/components/popover.css
@@ -6,7 +6,7 @@
   z-index: 50;
   min-width: 200px;
   max-width: 320px;
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-md);
   background-color: var(--surface-raised-stronger-non-alpha);
 
   border: 1px solid color-mix(in oklch, var(--border-base) 50%, transparent);

--- a/frontend/ui/src/components/radio-group.css
+++ b/frontend/ui/src/components/radio-group.css
@@ -64,7 +64,7 @@
     font-size: var(--font-size-small);
     font-weight: var(--font-weight-medium);
     border-radius: var(--radius-md);
-    cursor: default;
+    cursor: pointer;
     display: flex;
     flex-wrap: nowrap;
     gap: calc(var(--spacing) * 1);
@@ -95,7 +95,7 @@
 
   /* Hover state for unchecked, enabled items */
   [data-slot="radio-group-item-input"]:not([data-checked], [data-disabled]) + [data-slot="radio-group-item-label"] {
-    cursor: default;
+    cursor: pointer;
     user-select: none;
   }
 

--- a/frontend/ui/src/components/select.css
+++ b/frontend/ui/src/components/select.css
@@ -48,7 +48,7 @@
     [data-slot="select-select-trigger"] {
       padding: 6px 6px 6px 12px;
       box-shadow: none;
-      border-radius: var(--radius-xs);
+      border-radius: 6px;
       min-width: 160px;
       height: 32px;
       justify-content: flex-end;
@@ -94,17 +94,11 @@
   min-width: 104px;
   max-width: 23rem;
   overflow: hidden;
-  border-radius: var(--radius-lg);
-  border: 1px solid color-mix(in oklch, var(--border-base) 50%, transparent);
-  background-clip: padding-box;
+  border-radius: var(--radius-md);
   background-color: var(--surface-raised-stronger-non-alpha);
   padding: 4px;
-  box-shadow: var(--shadow-md);
-  z-index: 50;
-
-  &[data-closed] {
-    animation: select-close 0.15s ease-out;
-  }
+  box-shadow: var(--shadow-xs-border);
+  z-index: 60;
 
   &[data-expanded] {
     animation: select-open 0.15s ease-out;
@@ -131,9 +125,9 @@
     position: relative;
     display: flex;
     align-items: center;
-    padding: 4px 8px;
-    gap: 8px;
-    border-radius: var(--radius-xs);
+    padding: 2px 8px;
+    gap: 12px;
+    border-radius: 4px;
     cursor: default;
 
     /* text-12-medium */
@@ -146,6 +140,9 @@
 
     color: var(--text-strong);
 
+    transition:
+      background-color 0.2s ease-in-out,
+      color 0.2s ease-in-out;
     outline: none;
     user-select: none;
 
@@ -167,12 +164,15 @@
     &:focus {
       outline: none;
     }
+    &:hover {
+      background: var(--surface-raised-base-hover);
+    }
   }
 }
 
 [data-component="select-content"][data-trigger-style="settings"] {
   min-width: 160px;
-  border-radius: var(--radius-lg);
+  border-radius: 8px;
   padding: 0;
 
   [data-slot="select-select-content-list"] {
@@ -193,21 +193,10 @@
 @keyframes select-open {
   from {
     opacity: 0;
-    transform: scale(0.96);
+    transform: scale(0.95);
   }
   to {
     opacity: 1;
     transform: scale(1);
-  }
-}
-
-@keyframes select-close {
-  from {
-    opacity: 1;
-    transform: scale(1);
-  }
-  to {
-    opacity: 0;
-    transform: scale(0.96);
   }
 }

--- a/frontend/ui/src/components/session-review.css
+++ b/frontend/ui/src/components/session-review.css
@@ -179,7 +179,7 @@
     max-width: 100%;
     max-height: 60vh;
     object-fit: contain;
-    border-radius: 3px;
+    border-radius: 8px;
     border: 1px solid var(--border-weak-base);
     background: var(--background-base);
   }

--- a/frontend/ui/src/components/session-turn.css
+++ b/frontend/ui/src/components/session-turn.css
@@ -57,7 +57,7 @@
     position: sticky;
     top: var(--session-title-height, 0px);
     z-index: 20;
-    background-color: var(--background-stronger);
+    background-color: var(--background-base);
     margin-left: -9px;
     padding-left: 9px;
     /* padding-bottom: 12px; */
@@ -72,7 +72,7 @@
       bottom: 0;
       left: 0;
       right: 0;
-      background-color: var(--background-stronger);
+      background-color: var(--background-base);
       z-index: -1;
     }
 
@@ -83,7 +83,7 @@
       left: 0;
       right: 0;
       height: 32px;
-      background: linear-gradient(to bottom, var(--background-stronger), transparent);
+      background: linear-gradient(to bottom, var(--background-base), transparent);
       pointer-events: none;
     }
   }
@@ -498,9 +498,32 @@
     align-items: center;
     gap: 8px;
     color: var(--text-weak);
+    /* Bigger, obviously-clickable hit area for the show/hide-steps toggle.
+       Negative inline margin keeps the enlarged target from shifting layout. */
+    cursor: pointer;
+    padding: 6px 10px;
+    margin: -6px -10px;
+    border-radius: 8px;
+    border: 1px solid transparent;
+    transition:
+      background 0.12s ease,
+      border-color 0.12s ease,
+      color 0.12s ease;
+
+    &:hover {
+      background: var(--surface-raised-base);
+      border-color: var(--border-weak-base);
+      color: var(--text-base);
+    }
+
+    &:focus-visible {
+      border-color: var(--border-base);
+    }
 
     [data-slot="session-turn-trigger-icon"] {
       color: var(--icon-base);
+      flex-shrink: 0;
+      transition: transform 0.15s ease;
     }
 
     [data-component="spinner"] {

--- a/frontend/ui/src/components/session-turn.css
+++ b/frontend/ui/src/components/session-turn.css
@@ -82,8 +82,8 @@
       top: 100%;
       left: 0;
       right: 0;
-      height: 16px;
-      background: linear-gradient(to bottom, var(--background-stronger), transparent 100%);
+      height: 32px;
+      background: linear-gradient(to bottom, var(--background-stronger), transparent);
       pointer-events: none;
     }
   }
@@ -147,7 +147,7 @@
     height: 22px;
     width: 22px;
     border: none;
-    border-radius: 2px;
+    border-radius: 6px;
     background: transparent;
     cursor: pointer;
     color: var(--text-weak);
@@ -179,7 +179,7 @@
   [data-slot="session-turn-message-title"] {
     width: 100%;
     font-size: var(--font-size-large);
-    font-weight: 400;
+    font-weight: 500;
     color: var(--text-strong);
     overflow: hidden;
     text-overflow: ellipsis;
@@ -222,10 +222,6 @@
     [data-slot="session-turn-response"] {
       position: relative;
       width: 100%;
-      border: 1px solid var(--border-base);
-      border-radius: 14px;
-      padding: 16px 18px;
-      background: var(--surface-raised-base);
     }
 
     [data-slot="session-turn-response-copy-wrapper"] {
@@ -247,10 +243,11 @@
     }
   }
 
-  /* The answer is obviously the answer in a chat layout — drop the "RESPONSE"
-     eyebrow so the assistant bubble reads cleanly. */
   [data-slot="session-turn-summary-title"] {
-    display: none;
+    font-size: 13px;
+    /* text-12-medium */
+    font-weight: 500;
+    color: var(--text-weak);
   }
 
   [data-slot="session-turn-markdown"],
@@ -261,7 +258,7 @@
 
   [data-slot="session-turn-markdown"] {
     &[data-diffs="true"] {
-      font-size: var(--font-size-large);
+      font-size: 15px;
     }
 
     &[data-fade="true"] > * {
@@ -519,7 +516,7 @@
   }
 
   [data-slot="session-turn-retry-message"] {
-    font-weight: 400;
+    font-weight: 500;
     color: var(--syntax-critical);
   }
 
@@ -539,7 +536,7 @@
   [data-slot="session-turn-details-text"] {
     font-size: 13px;
     /* text-12-medium */
-    font-weight: 400;
+    font-weight: 500;
   }
 
   .error-card {

--- a/frontend/ui/src/components/session-turn.tsx
+++ b/frontend/ui/src/components/session-turn.tsx
@@ -568,6 +568,10 @@ export function SessionTurn(
                                   fill="none"
                                   xmlns="http://www.w3.org/2000/svg"
                                   data-slot="session-turn-trigger-icon"
+                                  style={{
+                                    transform: props.stepsExpanded ? "rotate(0deg)" : "rotate(-90deg)",
+                                    transition: "transform 0.15s ease",
+                                  }}
                                 >
                                   <path
                                     d="M8.125 1.875H1.875L5 8.125L8.125 1.875Z"
@@ -622,7 +626,7 @@ export function SessionTurn(
                               message={assistantMessage}
                               responsePartId={responsePartId()}
                               hideResponsePart={hideResponsePart()}
-                              hideReasoning={!working()}
+                              hideReasoning={false}
                             />
                           )}
                         </For>

--- a/frontend/ui/src/components/session-turn.tsx
+++ b/frontend/ui/src/components/session-turn.tsx
@@ -4,7 +4,6 @@ import {
   Message as MessageType,
   Part as PartType,
   type PermissionRequest,
-  type QuestionRequest,
   TextPart,
   ToolPart,
 } from "@synsci/sdk/v2/client"
@@ -93,7 +92,6 @@ function AssistantMessageItem(props: {
   responsePartId: string | undefined
   hideResponsePart: boolean
   hideReasoning: boolean
-  hideTools?: string[]
 }) {
   const data = useData()
   const emptyParts: PartType[] = []
@@ -112,11 +110,6 @@ function AssistantMessageItem(props: {
 
     if (props.hideReasoning) {
       parts = parts.filter((part) => part?.type !== "reasoning")
-    }
-
-    if (props.hideTools && props.hideTools.length > 0) {
-      const skip = new Set(props.hideTools)
-      parts = parts.filter((part) => !(part?.type === "tool" && skip.has((part as ToolPart).tool)))
     }
 
     if (!props.hideResponsePart) return parts
@@ -140,8 +133,6 @@ export function SessionTurn(
     stepsExpanded?: boolean
     onStepsExpandedToggle?: () => void
     onUserInteracted?: () => void
-    onRevertMessage?: (messageID: string) => void
-    hideTools?: string[]
     classes?: {
       root?: string
       content?: string
@@ -158,8 +149,7 @@ export function SessionTurn(
   const emptyFiles: FilePart[] = []
   const emptyAssistant: AssistantMessage[] = []
   const emptyPermissions: PermissionRequest[] = []
-  const emptyQuestions: QuestionRequest[] = []
-  const emptyPromptParts: { part: ToolPart; message: AssistantMessage }[] = []
+  const emptyPermissionParts: { part: ToolPart; message: AssistantMessage }[] = []
   const emptyDiffs: FileDiff[] = []
   const idle = { type: "idle" as const }
 
@@ -272,41 +262,23 @@ export function SessionTurn(
   const permissionCount = createMemo(() => permissions().length)
   const nextPermission = createMemo(() => permissions()[0])
 
-  const questions = createMemo(() => data.store.question?.[props.sessionID] ?? emptyQuestions)
-  const questionCount = createMemo(() => questions().length)
-  const nextQuestion = createMemo(() => questions()[0])
+  const permissionParts = createMemo(() => {
+    if (props.stepsExpanded) return emptyPermissionParts
 
-  const findPromptPart = (request: PermissionRequest | QuestionRequest | undefined) => {
-    if (!request?.tool) return undefined
+    const next = nextPermission()
+    if (!next || !next.tool) return emptyPermissionParts
 
-    const message = findLast(assistantMessages(), (m) => m.id === request.tool!.messageID)
-    if (!message) return undefined
+    const message = findLast(assistantMessages(), (m) => m.id === next.tool!.messageID)
+    if (!message) return emptyPermissionParts
 
     const parts = data.store.part[message.id] ?? emptyParts
     for (const part of parts) {
       if (part?.type !== "tool") continue
       const tool = part as ToolPart
-      if (tool.callID === request.tool!.callID) return { part: tool, message }
+      if (tool.callID === next.tool?.callID) return [{ part: tool, message }]
     }
 
-    return undefined
-  }
-
-  // Pending permission and question prompts render inside their tool part,
-  // which is hidden while steps are collapsed — surface those parts below
-  // the trigger so the user can respond without expanding steps.
-  const promptParts = createMemo(() => {
-    if (props.stepsExpanded) return emptyPromptParts
-
-    const result: { part: ToolPart; message: AssistantMessage }[] = []
-    const permission = findPromptPart(nextPermission())
-    if (permission) result.push(permission)
-
-    const question = findPromptPart(nextQuestion())
-    if (question && question.part.id !== permission?.part.id) result.push(question)
-
-    if (result.length === 0) return emptyPromptParts
-    return result
+    return emptyPermissionParts
   })
 
   const shellModePart = createMemo(() => {
@@ -387,10 +359,7 @@ export function SessionTurn(
   const responsePartId = createMemo(() => lastTextPart()?.id)
   const messageDiffs = createMemo(() => message()?.summary?.diffs ?? emptyDiffs)
   const hasDiffs = createMemo(() => messageDiffs().length > 0)
-  // Relocate the answer text out of the collapsed steps and into the top-level
-  // Response block ALWAYS (not just after finishing), so it streams live like a
-  // chat message instead of appearing only once the turn completes.
-  const hideResponsePart = createMemo(() => !!responsePartId())
+  const hideResponsePart = createMemo(() => !working() && !!responsePartId())
 
   const [copied, setCopied] = createSignal(false)
 
@@ -507,14 +476,11 @@ export function SessionTurn(
   })
 
   createEffect(
-    on(
-      () => permissionCount() + questionCount(),
-      (count, prev) => {
-        if (!count) return
-        if (prev !== undefined && count <= prev) return
-        autoScroll.forceScrollToBottom()
-      },
-    ),
+    on(permissionCount, (count, prev) => {
+      if (!count) return
+      if (prev !== undefined && count <= prev) return
+      autoScroll.forceScrollToBottom()
+    }),
   )
 
   let lastStatusChange = Date.now()
@@ -576,11 +542,7 @@ export function SessionTurn(
                     <div data-slot="session-turn-sticky" ref={setStickyRef}>
                       {/* User Message */}
                       <div data-slot="session-turn-message-content" aria-live="off">
-                        <Message
-                          message={msg()}
-                          parts={stickyParts()}
-                          onRevert={props.onRevertMessage ? () => props.onRevertMessage?.(msg().id) : undefined}
-                        />
+                        <Message message={msg()} parts={stickyParts()} />
                       </div>
 
                       {/* Trigger (sticky) */}
@@ -653,15 +615,14 @@ export function SessionTurn(
                     </div>
                     {/* Response */}
                     <Show when={props.stepsExpanded && assistantMessages().length > 0}>
-                      <div data-slot="session-turn-collapsible-content-inner" aria-live="off">
+                      <div data-slot="session-turn-collapsible-content-inner" aria-hidden={working()}>
                         <For each={assistantMessages()}>
                           {(assistantMessage) => (
                             <AssistantMessageItem
                               message={assistantMessage}
                               responsePartId={responsePartId()}
                               hideResponsePart={hideResponsePart()}
-                              hideReasoning={false}
-                              hideTools={props.hideTools}
+                              hideReasoning={!working()}
                             />
                           )}
                         </For>
@@ -672,17 +633,19 @@ export function SessionTurn(
                         </Show>
                       </div>
                     </Show>
-                    <Show when={!props.stepsExpanded && promptParts().length > 0}>
+                    <Show when={!props.stepsExpanded && permissionParts().length > 0}>
                       <div data-slot="session-turn-permission-parts">
-                        <For each={promptParts()}>{({ part, message }) => <Part part={part} message={message} />}</For>
+                        <For each={permissionParts()}>
+                          {({ part, message }) => <Part part={part} message={message} />}
+                        </For>
                       </div>
                     </Show>
                     {/* Response */}
                     <div class="sr-only" aria-live="polite">
                       {!working() && response() ? response() : ""}
                     </div>
-                    <Show when={response() || hasDiffs()}>
-                      <div data-slot="session-turn-summary-section" data-streaming={working() && !!response()}>
+                    <Show when={!working() && (response() || hasDiffs())}>
+                      <div data-slot="session-turn-summary-section">
                         <div data-slot="session-turn-summary-header">
                           <h2 data-slot="session-turn-summary-title">{i18n.t("ui.sessionTurn.summary.response")}</h2>
                           <div data-slot="session-turn-response">

--- a/frontend/ui/src/components/switch.css
+++ b/frontend/ui/src/components/switch.css
@@ -23,7 +23,7 @@
     width: 28px;
     height: 16px;
     flex-shrink: 0;
-    border-radius: 999px;
+    border-radius: 3px;
     border: 1px solid var(--border-weak-base);
     background: var(--surface-base);
     transition:
@@ -36,11 +36,15 @@
     height: 14px;
     box-sizing: content-box;
 
-    border-radius: 999px;
+    border-radius: 2px;
     border: 1px solid var(--border-base);
     background: var(--icon-invert-base);
 
-    box-shadow: var(--shadow-xs);
+    /* shadows/shadow-xs */
+    box-shadow:
+      0 1px 2px -1px rgba(19, 16, 16, 0.04),
+      0 1px 2px 0 rgba(19, 16, 16, 0.06),
+      0 1px 3px 0 rgba(19, 16, 16, 0.08);
 
     transform: translateX(-1px);
     transition:
@@ -100,8 +104,8 @@
   }
 
   &[data-checked]:hover:not([data-disabled], [data-readonly]) [data-slot="switch-control"] {
-    border-color: color-mix(in srgb, var(--icon-strong-base) 90%, var(--text-base));
-    background-color: color-mix(in srgb, var(--icon-strong-base) 90%, var(--text-base));
+    border-color: var(--border-hover);
+    background-color: var(--surface-hover);
   }
 
   &[data-disabled] {

--- a/frontend/ui/src/components/tabs.css
+++ b/frontend/ui/src/components/tabs.css
@@ -44,12 +44,12 @@
     gap: 12px;
     color: var(--text-base);
 
-    /* text-13-medium */
+    /* text-14-medium */
     font-family: var(--font-family-sans);
-    font-size: var(--font-size-base);
+    font-size: 14px;
     font-style: normal;
     font-weight: var(--font-weight-medium);
-    line-height: var(--line-height-large);
+    line-height: var(--line-height-large); /* 142.857% */
     letter-spacing: var(--letter-spacing-normal);
 
     white-space: nowrap;
@@ -70,8 +70,8 @@
       text-overflow: ellipsis;
 
       &:focus-visible {
-        outline: 2px solid var(--border-selected);
-        outline-offset: -2px;
+        outline: none;
+        box-shadow: none;
       }
     }
 
@@ -90,8 +90,8 @@
       color: var(--text-weaker);
     }
     &:focus-visible {
-      outline: 2px solid var(--border-selected);
-      outline-offset: -2px;
+      outline: none;
+      box-shadow: none;
     }
     &:has([data-hidden]) {
       [data-slot="tabs-trigger-close-button"] {
@@ -278,7 +278,7 @@
 
     [data-slot="tabs-trigger-wrapper"] {
       height: 26px;
-      border-radius: var(--radius-xs);
+      border-radius: 6px;
       color: var(--text-weak);
 
       &:not(:has([data-selected])):hover:not(:disabled) {
@@ -314,7 +314,7 @@
       width: 100%;
       height: 32px;
       border: none;
-      border-radius: var(--radius-xs);
+      border-radius: 8px;
       background-color: transparent;
 
       [data-slot="tabs-trigger"] {
@@ -353,7 +353,7 @@
       [data-slot="tabs-trigger-wrapper"] {
         height: 32px;
         border: none;
-        border-radius: var(--radius-xs);
+        border-radius: 8px;
 
         [data-slot="tabs-trigger"] {
           border: none;

--- a/frontend/ui/src/components/tag.css
+++ b/frontend/ui/src/components/tag.css
@@ -26,9 +26,9 @@
     height: 22px;
     padding: 0 8px;
 
-    /* text-12-medium */
+    /* text-14-medium */
     font-family: var(--font-family-sans);
-    font-size: var(--font-size-small);
+    font-size: 14px;
     font-style: normal;
     font-weight: var(--font-weight-medium);
     line-height: var(--line-height-large); /* 142.857% */

--- a/frontend/ui/src/components/text-field.css
+++ b/frontend/ui/src/components/text-field.css
@@ -7,7 +7,7 @@
 
     /* text-14-regular */
     font-family: var(--font-family-sans);
-    font-size: var(--font-size-base);
+    font-size: 14px;
     font-style: normal;
     font-weight: var(--font-weight-regular);
     line-height: var(--line-height-large); /* 142.857% */
@@ -53,7 +53,13 @@
 
       &:focus-within:not(:has([data-readonly])) {
         border-color: transparent;
-        box-shadow: var(--shadow-xs-border-select);
+        /* border/shadow-xs/select */
+        box-shadow:
+          0 0 0 3px var(--border-weak-selected),
+          0 0 0 1px var(--border-selected),
+          0 1px 2px -1px rgba(19, 16, 16, 0.25),
+          0 1px 2px 0 rgba(19, 16, 16, 0.08),
+          0 1px 3px 0 rgba(19, 16, 16, 0.12);
       }
 
       &:has([data-invalid]) {
@@ -81,7 +87,7 @@
 
       /* text-14-regular */
       font-family: var(--font-family-sans);
-      font-size: var(--font-size-base);
+      font-size: 14px;
       font-style: normal;
       font-weight: var(--font-weight-regular);
       line-height: var(--line-height-large); /* 142.857% */

--- a/frontend/ui/src/components/toast.css
+++ b/frontend/ui/src/components/toast.css
@@ -96,12 +96,12 @@
   [data-slot="toast-title"] {
     color: var(--text-invert-strong);
 
-    /* text-13-medium */
+    /* text-14-medium */
     font-family: var(--font-family-sans);
-    font-size: var(--font-size-base);
+    font-size: 14px;
     font-style: normal;
     font-weight: var(--font-weight-medium);
-    line-height: var(--line-height-large);
+    line-height: var(--line-height-large); /* 142.857% */
     letter-spacing: var(--letter-spacing-normal);
 
     margin: 0;
@@ -168,7 +168,7 @@
   [data-slot="toast-progress-fill"] {
     height: 100%;
     width: var(--kb-toast-progress-fill-width);
-    background-color: var(--surface-brand-base);
+    background-color: var(--color-primary);
     transition: width 250ms linear;
   }
 }

--- a/frontend/ui/src/context/data.tsx
+++ b/frontend/ui/src/context/data.tsx
@@ -57,6 +57,7 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
     onQuestionReply?: QuestionReplyFn
     onQuestionReject?: QuestionRejectFn
     onNavigateToSession?: NavigateToSessionFn
+    onOpenFile?: (path: string) => void
   }) => {
     return {
       get store() {
@@ -69,6 +70,7 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
       replyToQuestion: props.onQuestionReply,
       rejectQuestion: props.onQuestionReject,
       navigateToSession: props.onNavigateToSession,
+      openFile: props.onOpenFile,
     }
   },
 })

--- a/frontend/ui/src/i18n/en.ts
+++ b/frontend/ui/src/i18n/en.ts
@@ -61,7 +61,7 @@ export const dict = {
   "ui.tool.grep": "Grep",
   "ui.tool.webfetch": "Webfetch",
   "ui.tool.shell": "Shell",
-  "ui.tool.patch": "Patch",
+  "ui.tool.patch": "Files",
   "ui.tool.todos": "To-dos",
   "ui.tool.todos.read": "Read to-dos",
   "ui.tool.questions": "Questions",
@@ -94,7 +94,7 @@ export const dict = {
   "ui.patch.action.deleted": "Deleted",
   "ui.patch.action.created": "Created",
   "ui.patch.action.moved": "Moved",
-  "ui.patch.action.patched": "Patched",
+  "ui.patch.action.patched": "Updated",
 
   "ui.question.subtitle.answered": "{{count}} answered",
   "ui.question.answer.none": "(no answer)",

--- a/frontend/ui/src/styles/index.css
+++ b/frontend/ui/src/styles/index.css
@@ -2,6 +2,7 @@
 
 @import "./colors.css" layer(theme);
 @import "./theme.css" layer(theme);
+@import "./legacy-compat.css" layer(theme);
 
 @import "./base.css" layer(base);
 /* katex CSS is NOT imported globally — it's ~790 rules (the bulk of the app's

--- a/frontend/ui/src/styles/legacy-compat.css
+++ b/frontend/ui/src/styles/legacy-compat.css
@@ -1,0 +1,38 @@
+/* Legacy (v1.1.116) token aliases -> current theme tokens.
+ *
+ * The adopted v1.1.116 chat component CSS references an older, flatter token
+ * vocabulary than the current theme. Rather than clobber the current tokens
+ * (newer screens and the right pane depend on them), alias the handful of
+ * legacy names onto their current equivalents so the reskin renders in the
+ * current palette instead of falling back to unset values.
+ *
+ * Purely additive: no current token is redefined here. `var()` resolves live,
+ * so these forward to whatever the active theme sets on :root at runtime. */
+:root {
+  /* Backgrounds / surfaces */
+  --bg-base: var(--background-base);
+  --bg-surface: var(--surface-base);
+  --bg-surface-hover: var(--surface-base-hover);
+
+  /* Borders */
+  --border-default: var(--border-weak-base);
+  --border-warning-strong: var(--border-warning-base);
+
+  /* Semantic accents (legacy called danger/info/positive; current: critical/info/success) */
+  --color-semantic-danger: var(--icon-critical-base);
+  --color-semantic-info: var(--icon-info-base);
+  --color-semantic-positive: var(--icon-success-base);
+
+  /* Semantic foreground text (no dedicated current text-* token; the icon-* hue matches) */
+  --text-critical-base: var(--icon-critical-base);
+  --text-success-base: var(--icon-success-base);
+  --text-warning-base: var(--icon-warning-base);
+
+  /* Misc */
+  --icon-weak: var(--icon-weak-base);
+  --font-size-xs: 0.6875rem; /* 11px — keybind glyphs */
+
+  /* Layout fallbacks for tokens components set per-instance at runtime */
+  --list-divider-inset: 0px;
+  --line-comment-open-z: 5;
+}

--- a/frontend/workspace/src/components/dialog-manage-models.tsx
+++ b/frontend/workspace/src/components/dialog-manage-models.tsx
@@ -11,7 +11,10 @@ export const DialogManageModels: Component = () => {
   const language = useLanguage()
 
   return (
-    <Dialog title={language.t("dialog.model.manage")} description={language.t("dialog.model.manage.description")}>
+    <Dialog
+      title={language.t("dialog.model.manage")}
+      description={language.t("dialog.model.manage.description")}
+    >
       <List
         search={{ placeholder: language.t("dialog.model.search.placeholder"), autofocus: true }}
         emptyMessage={language.t("dialog.model.empty")}
@@ -37,9 +40,9 @@ export const DialogManageModels: Component = () => {
         }}
       >
         {(i) => (
-          <div class="w-full flex items-center justify-between gap-3 text-13-regular">
-            <span class="truncate min-w-0">{i.name}</span>
-            <div class="shrink-0" onClick={(e) => e.stopPropagation()}>
+          <div class="w-full flex items-center justify-between gap-x-3">
+            <span>{i.name}</span>
+            <div onClick={(e) => e.stopPropagation()}>
               <Switch
                 checked={
                   !!local.model.visible({

--- a/frontend/workspace/src/components/dialog-select-model-unpaid.tsx
+++ b/frontend/workspace/src/components/dialog-select-model-unpaid.tsx
@@ -3,20 +3,15 @@ import { Dialog } from "@synsci/ui/dialog"
 import { List, type ListRef } from "@synsci/ui/list"
 import { Tag } from "@synsci/ui/tag"
 import { Tooltip } from "@synsci/ui/tooltip"
-import { type Component, createMemo, onCleanup, onMount, Show } from "solid-js"
+import { type Component, onCleanup, onMount, Show } from "solid-js"
 import { useLocal } from "@/context/local"
 import { ModelTooltip } from "./model-tooltip"
 import { useLanguage } from "@/context/language"
-import { isFreeCost } from "@/utils/model-cost"
 
 export const DialogSelectModelUnpaid: Component = () => {
   const local = useLocal()
   const dialog = useDialog()
   const language = useLanguage()
-
-  // Genuinely free ($0 in + $0 out) models across every connected provider —
-  // OpenRouter `:free`, local/Ollama, and any zero-cost model. No brand gating.
-  const freeModels = createMemo(() => local.model.list().filter((m) => isFreeCost(m.cost)))
 
   let listRef: ListRef | undefined
   const handleKey = (e: KeyboardEvent) => {
@@ -38,48 +33,45 @@ export const DialogSelectModelUnpaid: Component = () => {
     >
       <div class="flex flex-col gap-3 px-2.5">
         <div class="text-14-medium text-text-base px-2.5">{language.t("dialog.model.unpaid.freeModels.title")}</div>
-        <Show
-          when={freeModels().length > 0}
-          fallback={
-            <div class="text-12-regular text-text-weaker px-2.5">{language.t("dialog.model.unpaid.empty")}</div>
-          }
+        <List
+          class="[&_[data-slot=list-scroll]]:overflow-visible"
+          ref={(ref) => (listRef = ref)}
+          items={local.model.list}
+          current={local.model.current()}
+          key={(x) => `${x.provider.id}:${x.id}`}
+          itemWrapper={(item, node) => (
+            <Tooltip
+              class="w-full"
+              placement="right-start"
+              gutter={12}
+              value={
+                <ModelTooltip
+                  model={item}
+                  latest={item.latest}
+                  free={item.provider.id === "synsci" && (!item.cost || item.cost.input === 0)}
+                />
+              }
+            >
+              {node}
+            </Tooltip>
+          )}
+          onSelect={(x) => {
+            local.model.set(x ? { modelID: x.id, providerID: x.provider.id } : undefined, {
+              recent: true,
+            })
+            dialog.close()
+          }}
         >
-          <List
-            class="[&_[data-slot=list-scroll]]:overflow-visible"
-            ref={(ref) => (listRef = ref)}
-            items={freeModels}
-            current={local.model.current()}
-            key={(x) => `${x.provider.id}:${x.id}`}
-            itemWrapper={(item, node) => (
-              <Tooltip
-                class="w-full"
-                placement="right-start"
-                gutter={12}
-                value={<ModelTooltip model={item} latest={item.latest} free={isFreeCost(item.cost)} />}
-              >
-                {node}
-              </Tooltip>
-            )}
-            onSelect={(x) => {
-              local.model.set(x ? { modelID: x.id, providerID: x.provider.id } : undefined, {
-                recent: true,
-              })
-              dialog.close()
-            }}
-          >
-            {(i) => (
-              <div class="w-full flex items-center gap-2 text-13-regular">
-                <span class="truncate min-w-0">{i.name}</span>
-                <Show when={i.latest}>
-                  <Tag>{language.t("model.tag.latest")}</Tag>
-                </Show>
-                <span class="ml-auto shrink-0 pl-2">
-                  <Tag>{language.t("model.tag.free")}</Tag>
-                </span>
-              </div>
-            )}
-          </List>
-        </Show>
+          {(i) => (
+            <div class="w-full flex items-center gap-x-2.5">
+              <span>{i.name}</span>
+              <Tag>{language.t("model.tag.free")}</Tag>
+              <Show when={i.latest}>
+                <Tag>{language.t("model.tag.latest")}</Tag>
+              </Show>
+            </div>
+          )}
+        </List>
       </div>
     </Dialog>
   )

--- a/frontend/workspace/src/components/dialog-select-model.tsx
+++ b/frontend/workspace/src/components/dialog-select-model.tsx
@@ -10,6 +10,8 @@ import { Tag } from "@synsci/ui/tag"
 import { Dialog } from "@synsci/ui/dialog"
 import { List } from "@synsci/ui/list"
 import { Tooltip } from "@synsci/ui/tooltip"
+import { ProviderIcon } from "@synsci/ui/provider-icon"
+import type { IconName } from "@synsci/ui/icons/provider"
 import { DialogManageModels } from "./dialog-manage-models"
 import { ModelTooltip } from "./model-tooltip"
 import { useLanguage } from "@/context/language"
@@ -32,7 +34,7 @@ const ModelList: Component<{
 
   return (
     <List
-      class={`flex-1 min-h-0 [&_[data-slot=list-scroll]]:flex-1 [&_[data-slot=list-scroll]]:min-h-0 ${props.class ?? ""}`}
+      class={`flex-1 min-h-0 [&_[data-slot=list-scroll]]:flex-1 [&_[data-slot=list-scroll]]:min-h-0 [&_[data-slot=list-search-input]]:!text-[13px] [&_[data-slot=list-header]]:!text-[11px] [&_[data-slot=list-header]]:!uppercase [&_[data-slot=list-header]]:!tracking-wider [&_[data-slot=list-item]]:!py-1 [&_[data-slot=list-search]]:!p-1.5 ${props.class ?? ""}`}
       search={{ placeholder: language.t("dialog.model.search.placeholder"), autofocus: true, action: props.action }}
       emptyMessage={language.t("dialog.model.empty")}
       key={(x) => `${x.provider.id}:${x.id}`}
@@ -74,13 +76,16 @@ const ModelList: Component<{
     >
       {(i) => (
         <div class="w-full flex items-center gap-x-2 text-13-regular">
+          <ProviderIcon id={i.provider.id as IconName} class="size-4 shrink-0 opacity-90" />
           <span class="truncate">{i.name}</span>
-          <Show when={i.provider.id === "synsci" && (!i.cost || i.cost?.input === 0)}>
-            <Tag>{language.t("model.tag.free")}</Tag>
-          </Show>
-          <Show when={i.latest}>
-            <Tag>{language.t("model.tag.latest")}</Tag>
-          </Show>
+          <span class="flex items-center gap-x-1.5 ml-auto shrink-0">
+            <Show when={i.provider.id === "synsci" && (!i.cost || i.cost?.input === 0)}>
+              <Tag>{language.t("model.tag.free")}</Tag>
+            </Show>
+            <Show when={i.latest}>
+              <Tag>{language.t("model.tag.latest")}</Tag>
+            </Show>
+          </span>
         </div>
       )}
     </List>
@@ -182,7 +187,7 @@ export function ModelSelectorPopover<T extends ValidComponent = "div">(props: {
       <Kobalte.Portal>
         <Kobalte.Content
           ref={(el) => setStore("content", el)}
-          class="w-72 h-80 flex flex-col p-2 rounded-md border border-border-base bg-surface-raised-stronger-non-alpha shadow-md z-50 outline-none overflow-hidden"
+          class="w-[264px] h-[min(52vh,288px)] flex flex-col p-1.5 rounded-md border border-border-base bg-surface-raised-stronger-non-alpha shadow-md z-50 outline-none overflow-hidden"
           onEscapeKeyDown={(event) => {
             setStore("dismiss", "escape")
             setStore("open", false)

--- a/frontend/workspace/src/components/dialog-select-model.tsx
+++ b/frontend/workspace/src/components/dialog-select-model.tsx
@@ -13,52 +13,6 @@ import { Tooltip } from "@synsci/ui/tooltip"
 import { DialogManageModels } from "./dialog-manage-models"
 import { ModelTooltip } from "./model-tooltip"
 import { useLanguage } from "@/context/language"
-import { isFreeCost, pricingLines } from "@/utils/model-cost"
-
-// ── Reasoning-effort variants ────────────────────────────────────────────────
-// models.dev exposes optional per-model `variants` (low/medium/high/…) that map
-// to provider reasoning-effort options. Surface them inline so an open-weight
-// reasoning model reads the same as a proprietary one.
-const VARIANT_LABEL: Record<string, string> = {
-  none: "None",
-  minimal: "Minimal",
-  low: "Low",
-  medium: "Medium",
-  high: "High",
-  xhigh: "Extra High",
-  max: "Max",
-}
-
-type VariantModel = { variants?: Record<string, { disabled?: boolean } | undefined> }
-
-function variantKeys(model: VariantModel): string[] {
-  const v = model.variants
-  if (!v) return []
-  return Object.keys(v).filter((k) => !v[k]?.disabled)
-}
-
-function variantHint(model: VariantModel): string | undefined {
-  const keys = variantKeys(model)
-  if (keys.length === 0) return undefined
-  return keys.map((k) => VARIANT_LABEL[k] ?? k).join(" · ")
-}
-
-// ── Credential source badge ──────────────────────────────────────────────────
-// Honest, provider-derived source for the composer's model rows. BYOK is the
-// first-class path for the OSS client, so anything with a raw key reads "Key".
-const SIGNED_IN = new Set(["github-copilot"])
-
-function sourceBadge(providerID: string): { label: string; tone: "managed" | "signin" | "byok" } {
-  if (providerID === "synsci") return { label: "Managed", tone: "managed" }
-  if (SIGNED_IN.has(providerID)) return { label: "Sign-in", tone: "signin" }
-  return { label: "Key", tone: "byok" }
-}
-
-const SOURCE_CLASS: Record<"managed" | "signin" | "byok", string> = {
-  managed: "text-text-strong",
-  signin: "text-text-weak",
-  byok: "text-text-weaker",
-}
 
 const ModelList: Component<{
   provider?: string
@@ -100,7 +54,13 @@ const ModelList: Component<{
           placement="right-start"
           gutter={12}
           forceMount={false}
-          value={<ModelTooltip model={item} latest={item.latest} free={isFreeCost(item.cost)} />}
+          value={
+            <ModelTooltip
+              model={item}
+              latest={item.latest}
+              free={item.provider.id === "synsci" && (!item.cost || item.cost.input === 0)}
+            />
+          }
         >
           {node}
         </Tooltip>
@@ -112,41 +72,17 @@ const ModelList: Component<{
         props.onSelect()
       }}
     >
-      {(i) => {
-        const free = isFreeCost(i.cost)
-        const price = pricingLines(i.cost)
-        const source = sourceBadge(i.provider.id)
-        const hint = variantHint(i as unknown as VariantModel)
-        return (
-          <div class="w-full flex items-center gap-3 py-0.5">
-            <div class="flex flex-col min-w-0 gap-0.5">
-              <div class="flex items-center gap-1.5 min-w-0">
-                <span class="truncate text-13-regular text-text-strong">{i.name}</span>
-                <Show when={i.latest}>
-                  <Tag>{language.t("model.tag.latest")}</Tag>
-                </Show>
-              </div>
-              <div class="flex items-center gap-1.5 text-11-regular text-text-weaker min-w-0">
-                <span class={`shrink-0 ${SOURCE_CLASS[source.tone]}`}>{source.label}</span>
-                <Show when={hint}>
-                  <span class="shrink-0 text-text-weaker/70">·</span>
-                  <span class="truncate">{hint}</span>
-                </Show>
-              </div>
-            </div>
-            <span class="ml-auto shrink-0 flex items-center pl-2">
-              <Show when={!free} fallback={<Tag>{language.t("model.tag.free")}</Tag>}>
-                <span class="text-11-regular text-text-weaker tabular-nums">
-                  {language.t("model.tag.pricing", {
-                    input: price.input!,
-                    output: price.output!,
-                  })}
-                </span>
-              </Show>
-            </span>
-          </div>
-        )
-      }}
+      {(i) => (
+        <div class="w-full flex items-center gap-x-2 text-13-regular">
+          <span class="truncate">{i.name}</span>
+          <Show when={i.provider.id === "synsci" && (!i.cost || i.cost?.input === 0)}>
+            <Tag>{language.t("model.tag.free")}</Tag>
+          </Show>
+          <Show when={i.latest}>
+            <Tag>{language.t("model.tag.latest")}</Tag>
+          </Show>
+        </div>
+      )}
     </List>
   )
 }
@@ -246,7 +182,7 @@ export function ModelSelectorPopover<T extends ValidComponent = "div">(props: {
       <Kobalte.Portal>
         <Kobalte.Content
           ref={(el) => setStore("content", el)}
-          class="w-[340px] h-[min(70vh,420px)] flex flex-col p-2 rounded-md border border-border-base bg-surface-raised-stronger-non-alpha shadow-md z-50 outline-none overflow-hidden"
+          class="w-72 h-80 flex flex-col p-2 rounded-md border border-border-base bg-surface-raised-stronger-non-alpha shadow-md z-50 outline-none overflow-hidden"
           onEscapeKeyDown={(event) => {
             setStore("dismiss", "escape")
             setStore("open", false)
@@ -270,7 +206,7 @@ export function ModelSelectorPopover<T extends ValidComponent = "div">(props: {
           <ModelList
             provider={props.provider}
             onSelect={() => setStore("open", false)}
-            class="p-0.5"
+            class="p-1"
             action={
               <Tooltip placement="top" forceMount={false} value={language.t("dialog.model.manage")}>
                 <IconButton
@@ -295,17 +231,17 @@ export const DialogSelectModel: Component<{ provider?: string }> = (props) => {
   const language = useLanguage()
 
   return (
-    <Dialog title={language.t("dialog.model.select.title")}>
-      <div class="flex flex-col h-[min(68vh,540px)] min-h-0">
-        <ModelList provider={props.provider} onSelect={() => dialog.close()} class="px-1" />
-        <Button
-          variant="ghost"
-          class="mt-3 mb-1 ml-1 text-text-base self-start"
-          onClick={() => dialog.show(() => <DialogManageModels />)}
-        >
-          {language.t("dialog.model.manage")}
-        </Button>
-      </div>
+    <Dialog
+      title={language.t("dialog.model.select.title")}
+    >
+      <ModelList provider={props.provider} onSelect={() => dialog.close()} />
+      <Button
+        variant="ghost"
+        class="ml-3 mt-5 mb-6 text-text-base self-start"
+        onClick={() => dialog.show(() => <DialogManageModels />)}
+      >
+        {language.t("dialog.model.manage")}
+      </Button>
     </Dialog>
   )
 }

--- a/frontend/workspace/src/components/dialog-select-model.tsx
+++ b/frontend/workspace/src/components/dialog-select-model.tsx
@@ -246,7 +246,7 @@ export function ModelSelectorPopover<T extends ValidComponent = "div">(props: {
       <Kobalte.Portal>
         <Kobalte.Content
           ref={(el) => setStore("content", el)}
-          class="w-[360px] h-[min(70vh,440px)] flex flex-col p-1.5 rounded-lg border border-border-weak-base bg-surface-raised-stronger-non-alpha shadow-lg z-50 outline-none overflow-hidden"
+          class="w-[340px] h-[min(70vh,420px)] flex flex-col p-2 rounded-md border border-border-base bg-surface-raised-stronger-non-alpha shadow-md z-50 outline-none overflow-hidden"
           onEscapeKeyDown={(event) => {
             setStore("dismiss", "escape")
             setStore("open", false)

--- a/frontend/workspace/src/components/model-tooltip.tsx
+++ b/frontend/workspace/src/components/model-tooltip.tsx
@@ -1,6 +1,5 @@
 import { Show, type Component } from "solid-js"
 import { useLanguage } from "@/context/language"
-import { pricingLines, type ModelCost } from "@/utils/model-cost"
 
 type InputKey = "text" | "image" | "audio" | "video" | "pdf"
 type InputMap = Record<InputKey, boolean>
@@ -19,7 +18,6 @@ type ModelInfo = {
     input: Array<string>
   }
   reasoning?: boolean
-  cost?: ModelCost
   limit: {
     context: number
   }
@@ -75,7 +73,6 @@ export const ModelTooltip: Component<{ model: ModelInfo; latest?: boolean; free?
       : language.t("model.tooltip.reasoning.none")
   }
   const context = () => language.t("model.tooltip.context", { limit: props.model.limit.context.toLocaleString() })
-  const pricing = () => pricingLines(props.model.cost)
 
   return (
     <div class="flex flex-col gap-1 py-1">
@@ -89,21 +86,6 @@ export const ModelTooltip: Component<{ model: ModelInfo; latest?: boolean; free?
       </Show>
       <div class="text-12-regular text-text-invert-base">{reasoning()}</div>
       <div class="text-12-regular text-text-invert-base">{context()}</div>
-      <Show
-        when={!pricing().free}
-        fallback={<div class="text-12-regular text-text-invert-base">{language.t("model.tooltip.pricing.free")}</div>}
-      >
-        <div class="text-12-regular text-text-invert-base">
-          {language.t("model.tooltip.pricing.io", { input: pricing().input!, output: pricing().output! })}
-        </div>
-        <Show when={pricing().cache}>
-          {(cache) => (
-            <div class="text-12-regular text-text-invert-base">
-              {language.t("model.tooltip.pricing.cache", { cache: cache() })}
-            </div>
-          )}
-        </Show>
-      </Show>
     </div>
   )
 }

--- a/frontend/workspace/src/components/prompt-input.tsx
+++ b/frontend/workspace/src/components/prompt-input.tsx
@@ -121,14 +121,6 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   const globalSync = useGlobalSync()
   const platform = usePlatform()
   const local = useLocal()
-  // Fast (priority) speed toggle — gpt-5.5 only, where it maps to OpenAI
-  // service_tier: priority (plumbed in src/session/llm.ts). Reset per model.
-  const supportsFast = createMemo(() => {
-    const id = local.model.current()?.id
-    return !!id && /gpt-5\.5/.test(id.toLowerCase())
-  })
-  const [fast, setFast] = createSignal(false)
-  createEffect(on(() => local.model.current()?.id, () => setFast(false), { defer: true }))
   const files = useFile()
   const prompt = usePrompt()
   const commentCount = createMemo(() => prompt.context.items().filter((item) => !!item.comment?.trim()).length)
@@ -1611,7 +1603,6 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
         messageID,
         parts: requestParts,
         variant,
-        fast: supportsFast() ? fast() : undefined,
       })
     }
 
@@ -1896,7 +1887,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
             onKeyDown={handleKeyDown}
             classList={{
               "select-text": true,
-              "w-full p-3 pr-12 text-14-regular text-text-strong focus:outline-none whitespace-pre-wrap": true,
+              "w-full p-3 pr-12 text-[15px] leading-relaxed text-text-strong focus:outline-none whitespace-pre-wrap": true,
               "[&_[data-type=file]]:text-syntax-property": true,
               "[&_[data-type=agent]]:text-syntax-type": true,
               "font-mono!": store.mode === "shell",
@@ -1915,7 +1906,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
           </Show>
         </div>
         <div class="relative p-3 flex items-center justify-between">
-          <div class="flex items-center justify-start gap-0.5">
+          <div data-slot="prompt-controls" class="flex items-center justify-start gap-2">
             <Switch>
               <Match when={store.mode === "shell"}>
                 <div class="flex items-center gap-2 px-2 h-6">
@@ -1939,6 +1930,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                     })()}
                     current={local.agent.current()?.name ?? ""}
                     onSelect={local.agent.set}
+                    label={(name) => (name === "ml" ? "ML" : name)}
                     class="capitalize"
                     variant="ghost"
                   />
@@ -1956,6 +1948,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                       label={(name) => {
                         if (!name) return "mode"
                         if (name === "research") return "default"
+                        if (name === "ml") return "ML"
                         return name
                       }}
                       class="capitalize"
@@ -2014,20 +2007,6 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                       {local.model.variant.current() ?? language.t("common.default")}
                     </Button>
                   </TooltipKeybind>
-                </Show>
-                {/* Speed toggle — gpt-5.5 priority processing (normal / fast) */}
-                <Show when={supportsFast()}>
-                  <Tooltip placement="top" value="Response speed — fast uses priority processing (gpt-5.5)">
-                    <Button
-                      data-action="model-fast-toggle"
-                      variant="ghost"
-                      class="text-text-base group-hover/prompt-input:inline-block capitalize"
-                      onClick={() => setFast((v) => !v)}
-                      aria-pressed={fast()}
-                    >
-                      {fast() ? "fast" : "normal"}
-                    </Button>
-                  </Tooltip>
                 </Show>
                 <Show when={permission.permissionsEnabled() && params.id}>
                   <TooltipKeybind

--- a/frontend/workspace/src/components/prompt-input.tsx
+++ b/frontend/workspace/src/components/prompt-input.tsx
@@ -121,6 +121,14 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   const globalSync = useGlobalSync()
   const platform = usePlatform()
   const local = useLocal()
+  // Fast (priority) speed toggle — gpt-5.5 only, where it maps to OpenAI
+  // service_tier: priority (plumbed in src/session/llm.ts). Reset per model.
+  const supportsFast = createMemo(() => {
+    const id = local.model.current()?.id
+    return !!id && /gpt-5\.5/.test(id.toLowerCase())
+  })
+  const [fast, setFast] = createSignal(false)
+  createEffect(on(() => local.model.current()?.id, () => setFast(false), { defer: true }))
   const files = useFile()
   const prompt = usePrompt()
   const commentCount = createMemo(() => prompt.context.items().filter((item) => !!item.comment?.trim()).length)
@@ -1603,6 +1611,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
         messageID,
         parts: requestParts,
         variant,
+        fast: supportsFast() ? fast() : undefined,
       })
     }
 
@@ -2005,6 +2014,20 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                       {local.model.variant.current() ?? language.t("common.default")}
                     </Button>
                   </TooltipKeybind>
+                </Show>
+                {/* Speed toggle — gpt-5.5 priority processing (normal / fast) */}
+                <Show when={supportsFast()}>
+                  <Tooltip placement="top" value="Response speed — fast uses priority processing (gpt-5.5)">
+                    <Button
+                      data-action="model-fast-toggle"
+                      variant="ghost"
+                      class="text-text-base group-hover/prompt-input:inline-block capitalize"
+                      onClick={() => setFast((v) => !v)}
+                      aria-pressed={fast()}
+                    >
+                      {fast() ? "fast" : "normal"}
+                    </Button>
+                  </Tooltip>
                 </Show>
                 <Show when={permission.permissionsEnabled() && params.id}>
                   <TooltipKeybind

--- a/frontend/workspace/src/components/prompt-input.tsx
+++ b/frontend/workspace/src/components/prompt-input.tsx
@@ -1738,7 +1738,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
         classList={{
           "group/prompt-input": true,
           "bg-surface-raised-stronger-non-alpha shadow-xs-border relative": true,
-          "rounded-[4px] overflow-clip focus-within:shadow-xs-border": true,
+          "rounded-[14px] overflow-clip focus-within:shadow-xs-border": true,
           "border-icon-info-active border-dashed": store.dragging,
           [props.class ?? ""]: !!props.class,
         }}
@@ -1774,7 +1774,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                   >
                     <div
                       classList={{
-                        "group shrink-0 flex flex-col rounded-xs pl-2 pr-1 py-1 max-w-[200px] h-12 transition-all transition-transform shadow-xs-border hover:shadow-xs-border-hover": true,
+                        "group shrink-0 flex flex-col rounded-[6px] pl-2 pr-1 py-1 max-w-[200px] h-12 transition-all transition-transform shadow-xs-border hover:shadow-xs-border-hover": true,
                         "cursor-pointer hover:bg-surface-interactive-weak": !!item.commentID && !active(),
                         "cursor-pointer bg-surface-interactive-hover hover:bg-surface-interactive-hover shadow-xs-border-hover":
                           active(),

--- a/frontend/workspace/src/components/session/session-new-view.tsx
+++ b/frontend/workspace/src/components/session/session-new-view.tsx
@@ -2,6 +2,7 @@ import { Show, createMemo } from "solid-js"
 import { DateTime } from "luxon"
 import { useSync } from "@/context/sync"
 import { useLanguage } from "@/context/language"
+import { useModels } from "@/context/models"
 import { Icon } from "@synsci/ui/icon"
 import { getDirectory, getFilename } from "@synsci/util/path"
 
@@ -16,6 +17,12 @@ interface NewSessionViewProps {
 export function NewSessionView(props: NewSessionViewProps) {
   const sync = useSync()
   const language = useLanguage()
+  const models = useModels()
+  // No connected provider ⇒ no models ⇒ nothing to send. On BYOK this most
+  // often means no key is set (or the only synced credential was the managed
+  // wallet, which byok deliberately drops). Tell the user plainly instead of
+  // leaving them at a dead composer.
+  const noModel = createMemo(() => models.list().length === 0)
 
   const sandboxes = createMemo(() => sync.project?.sandboxes ?? [])
   const options = createMemo(() => [MAIN_WORKTREE, ...sandboxes(), CREATE_WORKTREE])
@@ -47,6 +54,17 @@ export function NewSessionView(props: NewSessionViewProps) {
   return (
     <div class="size-full flex flex-col justify-end items-start gap-4 flex-[1_0_0] self-stretch max-w-200 mx-auto px-6 pb-[calc(var(--prompt-height,11.25rem)+64px)]">
       <div class="text-20-medium text-text-weaker">{language.t("command.session.new")}</div>
+      <Show when={noModel()}>
+        <div class="flex flex-col gap-1.5 rounded-lg border border-border-base bg-surface-raised-base px-4 py-3 self-stretch max-w-full">
+          <div class="text-13-medium text-text-strong">No model connected</div>
+          <div class="text-12-regular text-text-weak leading-relaxed">
+            You don't have a provider key set. Bring your own with{" "}
+            <code class="text-text-base">openscience keys signin</code> (OpenAI · Anthropic · Gemini, or ChatGPT /
+            Codex — no API key needed), or use managed credits with{" "}
+            <code class="text-text-base">openscience login</code>.
+          </div>
+        </div>
+      </Show>
       <div class="flex justify-center items-center gap-3">
         <Icon name="folder" size="small" />
         <div class="text-12-medium text-text-weak select-text">

--- a/frontend/workspace/src/context/models.tsx
+++ b/frontend/workspace/src/context/models.tsx
@@ -7,6 +7,47 @@ import { Persist, persisted } from "@/utils/persist"
 
 export type ModelKey = { providerID: string; modelID: string }
 
+// The curated "frontier" set shown in the model picker by default. Everything
+// else stays in the catalog and is one click away in Manage Models, but the
+// default toggle is just these. Matched by canonicalKey() so a BYOK-native id
+// and the managed OpenRouter "vendor/model" slug for the same model collapse to
+// one entry (folds dots<->dashes and the z-ai/zai/zhipuai alias).
+//
+// NOTE: two requested entries don't exist in the live catalog yet — they're
+// kept here so they light up the moment they ship: `openai/gpt-5-5-mini` (the
+// 5.5 tier currently ships only gpt-5.5 + gpt-5.5-pro) and kimi-k2.7 (only the
+// coding flagship `kimi-k2.7-code` exists, which is what's listed below).
+export const FRONTIER_MODELS = new Set([
+  "openai/gpt-5-5", // gpt-5.5
+  "openai/gpt-5-5-mini", // gpt-5.5-mini (not shipped yet)
+  "anthropic/claude-sonnet-5",
+  "anthropic/claude-opus-4-8", // native dashes == OpenRouter anthropic/claude-opus-4.8
+  "anthropic/claude-fable-5",
+  "zai/glm-5-2", // native zai/zhipuai, OpenRouter z-ai/glm-5.2
+  "moonshotai/kimi-k2-7-code", // "kimi k2.7" -> the only k2.7 flagship that exists
+  "deepseek/deepseek-v4-pro",
+  "deepseek/deepseek-v4-flash",
+])
+
+/** Stable key that matches a native id AND an OpenRouter vendor/model slug for
+ *  the same model: strips the OpenRouter "~" alias marker, folds the GLM vendor
+ *  aliases, lowercases, and normalizes dots to dashes. */
+export function canonicalKey(providerID: string, modelID: string): string {
+  let vendor = providerID
+  let base = modelID
+  const slash = modelID.lastIndexOf("/")
+  if (slash >= 0) {
+    vendor = modelID.slice(0, slash)
+    base = modelID.slice(slash + 1)
+  }
+  vendor = vendor.replace(/^~/, "").toLowerCase()
+  if (vendor === "z-ai" || vendor === "zhipuai") vendor = "zai"
+  base = base.replace(/^~/, "").toLowerCase().replace(/\./g, "-")
+  return `${vendor}/${base}`
+}
+
+const isFrontier = (model: ModelKey) => FRONTIER_MODELS.has(canonicalKey(model.providerID, model.modelID))
+
 type Visibility = "show" | "hide"
 type User = ModelKey & { visibility: Visibility; favorite?: boolean }
 type Store = {
@@ -82,16 +123,25 @@ export const { use: useModels, provider: ModelsProvider } = createSimpleContext(
       setStore("user", store.user.length, { ...model, visibility: state })
     }
 
+    // Are any of the connected providers exposing a frontier model at all? If
+    // not (e.g. a lone local model, or a BYOK key with no frontier tier), the
+    // frontier-only default would empty the picker — so fall back to show-all.
+    const frontierAvailable = createMemo(() =>
+      available().some((m) => isFrontier({ providerID: m.provider.id, modelID: m.id })),
+    )
+
     const visible = (model: ModelKey) => {
       const key = `${model.providerID}:${model.modelID}`
       const state = visibility().get(key)
+      // Explicit user choice always wins (set via Manage Models, or implicitly
+      // when a model is selected — see local.set()).
       if (state === "hide") return false
-      // Default to visible: any available model surfaces in the picker
-      // unless the user has explicitly hidden it. The picker is grouped
-      // by provider and scrolls, so a long list is fine — having useful
-      // dated/legacy models silently filtered out was the worse failure
-      // mode.
-      return true
+      if (state === "show") return true
+      // Default: only the curated frontier set surfaces in the picker. The full
+      // catalog stays one click away in Manage Models. If no frontier model is
+      // connected, show everything so the picker is never empty.
+      if (!frontierAvailable()) return true
+      return isFrontier(model)
     }
 
     const setVisibility = (model: ModelKey, state: boolean) => {

--- a/frontend/workspace/src/context/sync.tsx
+++ b/frontend/workspace/src/context/sync.tsx
@@ -323,6 +323,34 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
             }),
           )
         },
+        rename: async (sessionID: string, title: string) => {
+          const directory = sdk.directory
+          const client = sdk.client
+          const [, setStore] = globalSync.child(directory)
+          // Optimistically retitle in place so the row renames instantly; if the
+          // backend rejects it we roll the title back so the UI stays honest.
+          let prev: string | undefined
+          setStore(
+            produce((draft) => {
+              const match = Binary.search(draft.session, sessionID, (s) => s.id)
+              if (match.found) {
+                prev = draft.session[match.index].title
+                draft.session[match.index].title = title
+              }
+            }),
+          )
+          try {
+            await client.session.update({ sessionID, title })
+          } catch (e) {
+            setStore(
+              produce((draft) => {
+                const match = Binary.search(draft.session, sessionID, (s) => s.id)
+                if (match.found && prev !== undefined) draft.session[match.index].title = prev
+              }),
+            )
+            throw e
+          }
+        },
         delete: async (sessionID: string) => {
           const directory = sdk.directory
           const client = sdk.client

--- a/frontend/workspace/src/pages/directory-layout.tsx
+++ b/frontend/workspace/src/pages/directory-layout.tsx
@@ -10,6 +10,7 @@ import type { QuestionAnswer } from "@synsci/sdk/v2"
 import { decode64 } from "@/utils/base64"
 import { showToast } from "@synsci/ui/toast"
 import { useLanguage } from "@/context/language"
+import { centerTabs } from "@/thesis/store/centerTabs"
 
 export default function Layout(props: ParentProps) {
   const params = useParams()
@@ -51,6 +52,16 @@ export default function Layout(props: ParentProps) {
               navigate(`/${params.dir}/session/${sessionID}`)
             }
 
+            // Open a file referenced in the chat (tool cards, diffs) as a
+            // center-tab document — same surface the Files tab / explorer use.
+            // Tool filePaths are usually absolute; FileView wants a path relative
+            // to the re-rooted directory, so strip the project prefix here.
+            const openFile = (path: string) => {
+              const dir = directory()
+              const rel = dir && path.startsWith(dir + "/") ? path.slice(dir.length + 1) : path
+              centerTabs.openFile(dir, rel)
+            }
+
             return (
               <DataProvider
                 data={sync.data}
@@ -59,6 +70,7 @@ export default function Layout(props: ParentProps) {
                 onQuestionReply={replyToQuestion}
                 onQuestionReject={rejectQuestion}
                 onNavigateToSession={navigateToSession}
+                onOpenFile={openFile}
               >
                 <LocalProvider>{props.children}</LocalProvider>
               </DataProvider>

--- a/frontend/workspace/src/pages/session.tsx
+++ b/frontend/workspace/src/pages/session.tsx
@@ -17,7 +17,7 @@ import { useSync } from "@/context/sync"
 import { useSDK } from "@/context/sdk"
 import { useLayout } from "@/context/layout"
 import { useTheme } from "@synsci/ui/theme"
-import { Composer } from "@/thesis/Composer"
+import { PromptInput } from "@/components/prompt-input"
 import { Wordmark } from "@/thesis/Wordmark"
 import { AppHeader, HeaderIconButton, HeaderDivider } from "@/thesis/AppHeader"
 import { RightPane } from "@/thesis/RightPane"
@@ -146,8 +146,8 @@ export default function Page(): JSX.Element {
   )
 
   // Hydrate child (sub-agent) sessions of the active session regardless of
-  // which right-pane tab is open, so the Agents view and inline turn status
-  // populate immediately and survive a reload.
+  // which right-pane tab is open, so the inline turn status and back-to-parent
+  // navigation populate immediately and survive a reload.
   const hydratedChildren = new Set<string>()
   createEffect(() => {
     const id = params.id
@@ -396,52 +396,74 @@ export default function Page(): JSX.Element {
                 flex: 1,
                 "min-height": 0,
                 "flex-direction": "column",
+                position: "relative",
               }}
             >
               <Switch>
                 <Match when={params.id && messages().length > 0}>
                   <div
                     ref={attachScroll}
-                    class="thesis-scroll thesis-chat-scroll"
+                    class="thesis-scroll thesis-chat-scroll session-scroller"
                     style={{
                       flex: 1,
                       "min-height": 0,
                       "overflow-y": "auto",
                       "overflow-x": "hidden",
-                      "padding-top": "12px",
+                      position: "relative",
                     }}
                   >
-                    <For each={turnMessages()}>
-                      {(message, index) => (
-                        <div
-                          data-message-id={message.id}
-                          style={{
-                            "min-width": 0,
-                            width: "100%",
-                            "max-width": "100%",
-                          }}
-                        >
-                          <SessionTurn
-                            sessionID={params.id!}
-                            messageID={message.id}
-                            lastUserMessageID={lastUserMessage()?.id}
-                            stepsExpanded={stepsExpanded()[message.id] ?? false}
-                            onStepsExpandedToggle={() => toggleSteps(message.id)}
-                            onRevertMessage={(id) => void revertTo(id)}
-                            hideTools={["task"]}
-                            classes={{
-                              root: "min-w-0 w-full relative",
-                              content: "flex flex-col justify-between !overflow-visible",
-                              container: "w-full px-4 md:px-8",
-                            }}
-                          />
-                          {/* Space, not a rule — the bubbles already separate turns. */}
-                          <Show when={index() < turnMessages().length - 1}>
-                            <div style={{ height: "22px" }} />
-                          </Show>
+                    {/* Sticky title + back-to-parent (sub-agent) header */}
+                    <Show when={activeSession()?.title || activeSession()?.parentID}>
+                      <div class="sticky top-0 z-30 bg-background-stronger w-full">
+                        <div class="w-full px-4 md:px-6 md:max-w-200 md:mx-auto">
+                          <div class="h-10 flex items-center gap-1.5">
+                            <Show when={activeSession()?.parentID}>
+                              <button
+                                type="button"
+                                class="flex items-center justify-center size-7 shrink-0 rounded-md text-text-weak hover:text-text-base hover:bg-surface-base-hover transition-colors"
+                                aria-label="Back to parent session"
+                                onClick={() => navigate(`/${params.dir}/session/${activeSession()!.parentID}`)}
+                              >
+                                <IconChevronLeft />
+                              </button>
+                            </Show>
+                            <Show when={activeSession()?.title}>
+                              <h1 class="text-14-medium text-text-strong truncate">{activeSession()!.title}</h1>
+                            </Show>
+                          </div>
                         </div>
-                      )}
-                    </For>
+                      </div>
+                    </Show>
+
+                    {/* Centered conversation column with 2px between-turn divider */}
+                    <div class="w-full md:max-w-200 md:mx-auto flex flex-col items-start justify-start pt-3 pb-[calc(10rem+64px)]">
+                      <For each={turnMessages()}>
+                        {(message, index) => (
+                          <div data-message-id={message.id} class="min-w-0 w-full max-w-full">
+                            <SessionTurn
+                              sessionID={params.id!}
+                              messageID={message.id}
+                              lastUserMessageID={lastUserMessage()?.id}
+                              stepsExpanded={stepsExpanded()[message.id] ?? false}
+                              onStepsExpandedToggle={() => toggleSteps(message.id)}
+                              onRevertMessage={(id) => void revertTo(id)}
+                              hideTools={["task"]}
+                              classes={{
+                                root: "min-w-0 w-full relative",
+                                content: "flex flex-col justify-between !overflow-visible",
+                                container: "w-full px-4 md:px-6",
+                              }}
+                            />
+                            {/* The v1.1.116 between-turns rule */}
+                            <Show when={index() < turnMessages().length - 1}>
+                              <div class="w-full px-4 md:px-6 pt-2 pb-1">
+                                <div class="h-[2px] bg-border-weak-base rounded-full" />
+                              </div>
+                            </Show>
+                          </div>
+                        )}
+                      </For>
+                    </div>
                   </div>
                 </Match>
                 <Match when={true}>
@@ -449,47 +471,50 @@ export default function Page(): JSX.Element {
                 </Match>
               </Switch>
 
-              <Show when={revertInfo()}>
-                <div style={{ padding: "8px 16px 0" }}>
-                  <div
-                    style={{
-                      display: "flex",
-                      "align-items": "center",
-                      gap: "12px",
-                      padding: "8px 12px",
-                      border: "1px solid var(--color-border)",
-                      "border-radius": "4px",
-                      "font-size": "12px",
-                      "font-family": FONT_SANS,
-                      color: "var(--color-text-muted)",
-                      background: "var(--color-bg)",
-                    }}
-                  >
-                    <span style={{ flex: 1, "min-width": 0 }}>
-                      Conversation reverted. {revertedCount()} turn{revertedCount() === 1 ? "" : "s"} hidden and file
-                      changes rolled back. Sending a new message makes this permanent.
-                    </span>
-                    <button
-                      type="button"
-                      onClick={() => void restoreRevert()}
+              {/* Prompt dock — gradient fade + centered PromptInput (v1.1.116) */}
+              <div class="absolute inset-x-0 bottom-0 pt-12 pb-4 flex flex-col justify-center items-center z-50 px-4 md:px-0 bg-gradient-to-t from-background-stronger via-background-stronger to-transparent pointer-events-none">
+                <div class="w-full px-4 pointer-events-auto md:max-w-200 md:mx-auto">
+                  <Show when={revertInfo()}>
+                    <div
+                      class="mb-3"
                       style={{
+                        display: "flex",
+                        "align-items": "center",
+                        gap: "12px",
+                        padding: "8px 12px",
                         border: "1px solid var(--color-border)",
-                        background: "transparent",
-                        color: "inherit",
-                        padding: "4px 10px",
-                        "border-radius": "4px",
+                        "border-radius": "8px",
                         "font-size": "12px",
-                        cursor: "pointer",
-                        "white-space": "nowrap",
+                        "font-family": FONT_SANS,
+                        color: "var(--color-text-muted)",
+                        background: "var(--color-bg)",
                       }}
                     >
-                      restore
-                    </button>
-                  </div>
+                      <span style={{ flex: 1, "min-width": 0 }}>
+                        Conversation reverted. {revertedCount()} turn{revertedCount() === 1 ? "" : "s"} hidden and file
+                        changes rolled back. Sending a new message makes this permanent.
+                      </span>
+                      <button
+                        type="button"
+                        onClick={() => void restoreRevert()}
+                        style={{
+                          border: "1px solid var(--color-border)",
+                          background: "transparent",
+                          color: "inherit",
+                          padding: "4px 10px",
+                          "border-radius": "8px",
+                          "font-size": "12px",
+                          cursor: "pointer",
+                          "white-space": "nowrap",
+                        }}
+                      >
+                        restore
+                      </button>
+                    </div>
+                  </Show>
+                  <PromptInput />
                 </div>
-              </Show>
-
-              <Composer />
+              </div>
             </div>
 
             {/* files — the host explorer, mounted on first visit */}

--- a/frontend/workspace/src/pages/session.tsx
+++ b/frontend/workspace/src/pages/session.tsx
@@ -25,11 +25,13 @@ import { RightPane } from "@/thesis/RightPane"
 import { FileExplorer } from "@/thesis/FileExplorer"
 import { FileView } from "@/thesis/FilePreview"
 import { centerTabs } from "@/thesis/store/centerTabs"
-import { FONT_MONO, FONT_SANS, FONT_SERIF, sectionTitle } from "@/styles/tokens"
+import { FONT_MONO, FONT_SANS, FONT_SERIF } from "@/styles/tokens"
 import { uiStore } from "@/thesis/store/ui"
 import { useGlobalKeys } from "@/thesis/useGlobalKeys"
 import { useDialog } from "@synsci/ui/context/dialog"
 import { useModels } from "@/context/models"
+import { useCommand, type CommandOption } from "@/context/command"
+import { useLanguage } from "@/context/language"
 import { openSetupDialog } from "@/thesis/SetupDialog"
 import { confirmDialog } from "@/thesis/dialogs"
 import { DialogSettings } from "@/components/dialog-settings"
@@ -108,6 +110,17 @@ export default function Page(): JSX.Element {
     } catch (e: any) {
       console.error("session.delete failed", e)
       toast.error("could not delete", e?.message ?? String(e))
+    }
+  }
+
+  async function renameSession(sessionID: string, title: string) {
+    const trimmed = title.trim()
+    if (!trimmed) return
+    try {
+      await sync.session.rename(sessionID, trimmed)
+    } catch (e: any) {
+      console.error("session.rename failed", e)
+      toast.error("could not rename", e?.message ?? String(e))
     }
   }
 
@@ -190,6 +203,35 @@ export default function Page(): JSX.Element {
   // New-session worktree selection, shared between the empty-state view and the
   // composer (matches the v1.1.116 new-session flow).
   const [newSessionWorktree, setNewSessionWorktree] = createSignal("main")
+
+  // A `path.md` mentioned in an assistant message dispatches this; open it as a
+  // document tab (same surface as the Files tab / a tool-card filename click).
+  onMount(() => {
+    const onOpenFile = (e: Event) => {
+      const path = (e as CustomEvent).detail?.path
+      if (typeof path !== "string" || !path) return
+      const dir = projectPath()
+      const rel = dir && path.startsWith(dir + "/") ? path.slice(dir.length + 1) : path
+      centerTabs.openFile(dir, rel)
+    }
+    document.addEventListener("openscience:open-file", onOpenFile)
+    onCleanup(() => document.removeEventListener("openscience:open-file", onOpenFile))
+
+    // "Open in Shell tab" on a bash tool card → reveal the right pane's terminal
+    // and re-run the command there (the RightPane picks up terminalCommand).
+    const onShell = (e: Event) => {
+      const command = (e as CustomEvent).detail?.command
+      if (typeof command !== "string" || !command) return
+      uiStore.setRightPaneOpen(true)
+      uiStore.setTerminalCommand({
+        command: "bash",
+        args: ["-lc", command],
+        title: command.length > 24 ? command.slice(0, 24) + "…" : command,
+      })
+    }
+    document.addEventListener("open-shell-tab", onShell)
+    onCleanup(() => document.removeEventListener("open-shell-tab", onShell))
+  })
   const turnMessages = createMemo(() => {
     const revertID = revertInfo()?.messageID
     return messages().filter((m) => m.role === "user" && (!revertID || m.id < revertID))
@@ -229,6 +271,40 @@ export default function Page(): JSX.Element {
       toast.error("restore failed", e?.message ?? String(e))
     }
   }
+
+  // Undo/redo were orphaned when the chat surface was reskinned — revertTo()
+  // had no trigger. Re-expose them as first-class commands (palette + /undo,
+  // /redo slash) so undo works again. Undo reverts the last turn; redo restores
+  // a pending revert until the next message makes it permanent.
+  const commands = useCommand()
+  const language = useLanguage()
+  commands.register(() => {
+    const id = params.id
+    if (!id || id === "new") return []
+    const list: CommandOption[] = []
+    const last = lastUserMessage()
+    if (last && !revertInfo()) {
+      list.push({
+        id: "session.undo",
+        title: language.t("command.session.undo"),
+        description: language.t("command.session.undo.description"),
+        category: language.t("command.category.session"),
+        slash: "undo",
+        onSelect: () => void revertTo(last.id),
+      })
+    }
+    if (revertInfo()) {
+      list.push({
+        id: "session.redo",
+        title: language.t("command.session.redo"),
+        description: language.t("command.session.redo.description"),
+        category: language.t("command.category.session"),
+        slash: "redo",
+        onSelect: () => void restoreRevert(),
+      })
+    }
+    return list
+  })
 
   const [stepsExpanded, setStepsExpanded] = createSignal<Record<string, boolean>>({})
   const toggleSteps = (id: string) => setStepsExpanded((prev) => ({ ...prev, [id]: !prev[id] }))
@@ -368,6 +444,7 @@ export default function Page(): JSX.Element {
           onNew={() => void newSession()}
           onSelect={(id) => navigate(`/${params.dir}/session/${id}`)}
           onDelete={(id) => void deleteSession(id)}
+          onRename={(id, title) => void renameSession(id, title)}
         />
 
         <div
@@ -432,7 +509,10 @@ export default function Page(): JSX.Element {
                               </button>
                             </Show>
                             <Show when={activeSession()?.title}>
-                              <h1 class="text-14-medium text-text-strong truncate">{activeSession()!.title}</h1>
+                              <EditableTitle
+                                title={activeSession()!.title!}
+                                onRename={(t) => void renameSession(activeSession()!.id, t)}
+                              />
                             </Show>
                           </div>
                         </div>
@@ -474,7 +554,7 @@ export default function Page(): JSX.Element {
               </Switch>
 
               {/* Prompt dock — gradient fade + centered PromptInput (v1.1.116) */}
-              <div class="absolute inset-x-0 bottom-0 pt-12 pb-4 flex flex-col justify-center items-center z-50 px-4 md:px-0 bg-gradient-to-t from-background-stronger via-background-stronger to-transparent pointer-events-none">
+              <div class="absolute inset-x-0 bottom-0 pt-12 pb-4 flex flex-col justify-center items-center z-50 px-4 md:px-0 bg-gradient-to-t from-background-base via-background-base to-transparent pointer-events-none">
                 <div class="w-full px-4 pointer-events-auto md:max-w-200 md:mx-auto">
                   <Show when={revertInfo()}>
                     <div
@@ -764,6 +844,76 @@ function Header(props: {
   )
 }
 
+// The conversation title in the sticky chat header — double-click to rename,
+// mirroring the sidebar's SessionRow. Enter/blur commits, Esc cancels.
+function EditableTitle(props: { title: string; onRename: (t: string) => void }): JSX.Element {
+  const [editing, setEditing] = createSignal(false)
+  const [draft, setDraft] = createSignal("")
+  const start = () => {
+    setDraft(props.title)
+    setEditing(true)
+  }
+  const commit = () => {
+    if (!editing()) return
+    const next = draft().trim()
+    setEditing(false)
+    if (next && next !== props.title) props.onRename(next)
+  }
+  return (
+    <Show
+      when={editing()}
+      fallback={
+        <h1
+          class="text-14-medium text-text-strong truncate"
+          style={{ cursor: "text" }}
+          title="Double-click to rename"
+          onDblClick={start}
+        >
+          {props.title}
+        </h1>
+      }
+    >
+      <input
+        ref={(el) =>
+          queueMicrotask(() => {
+            el.focus()
+            el.select()
+          })
+        }
+        class="text-14-medium text-text-strong truncate"
+        value={draft()}
+        onInput={(e) => setDraft(e.currentTarget.value)}
+        onKeyDown={(e) => {
+          e.stopPropagation()
+          if (e.key === "Enter") {
+            e.preventDefault()
+            commit()
+          } else if (e.key === "Escape") {
+            e.preventDefault()
+            setEditing(false)
+          }
+        }}
+        onBlur={commit}
+        spellcheck={false}
+        autocomplete="off"
+        style={{
+          all: "unset",
+          "box-sizing": "border-box",
+          flex: 1,
+          "min-width": 0,
+          "font-family": FONT_SANS,
+          background: "var(--color-surface-solid)",
+          "box-shadow": "inset 0 0 0 1px var(--color-border-strong)",
+          "border-radius": "6px",
+          padding: "1px 6px",
+          margin: "0 -6px",
+          color: "var(--color-text-strong, var(--color-text))",
+        }}
+      />
+    </Show>
+  )
+}
+
 function SessionsSidebar(props: {
   sessions: SyncSession[]
   activeId: string | undefined
@@ -772,7 +922,15 @@ function SessionsSidebar(props: {
   onNew: () => void
   onSelect: (id: string) => void
   onDelete: (id: string) => void
+  onRename: (id: string, title: string) => void
 }): JSX.Element {
+  const [query, setQuery] = createSignal("")
+  const searching = () => query().trim().length > 0
+  const filtered = createMemo(() => {
+    const q = query().trim().toLowerCase()
+    if (!q) return props.sessions
+    return props.sessions.filter((s) => (s.title || "session").toLowerCase().includes(q))
+  })
   return (
     <aside
       class="thesis-scroll"
@@ -788,7 +946,7 @@ function SessionsSidebar(props: {
     >
       <div
         style={{
-          padding: "12px 14px 8px",
+          padding: "12px 12px 8px",
           display: "flex",
           "flex-direction": "column",
           gap: "8px",
@@ -802,9 +960,10 @@ function SessionsSidebar(props: {
             cursor: "pointer",
             display: "flex",
             "align-items": "center",
+            "justify-content": "center",
             gap: "6px",
             padding: "7px 12px",
-            "border-radius": "4px",
+            "border-radius": "8px",
             background: "var(--color-surface-solid)",
             border: "1px solid var(--color-border-strong)",
             "font-family": FONT_MONO,
@@ -818,26 +977,108 @@ function SessionsSidebar(props: {
           onFocusIn={(e) => (e.currentTarget.style.background = "var(--color-bg-elevated)")}
           onFocusOut={(e) => (e.currentTarget.style.background = "var(--color-surface-solid)")}
         >
-          <IconPlus size={11} strokeWidth={2} />
-          {props.creating ? "creating…" : "new session"}
+          <IconPlus size={12} strokeWidth={2} />
+          {props.creating ? "creating…" : "New session"}
         </button>
+
+        {/* Search — filters the loaded list live; Esc clears. */}
+        <div style={{ position: "relative", display: "flex", "align-items": "center" }}>
+          <span
+            style={{
+              position: "absolute",
+              left: "10px",
+              display: "inline-flex",
+              "align-items": "center",
+              color: "var(--color-text-faint)",
+              "pointer-events": "none",
+            }}
+          >
+            <IconSearch size={13} strokeWidth={1.6} />
+          </span>
+          <input
+            value={query()}
+            onInput={(e) => setQuery(e.currentTarget.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Escape") {
+                e.preventDefault()
+                setQuery("")
+                e.currentTarget.blur()
+              }
+            }}
+            placeholder="Search sessions"
+            spellcheck={false}
+            autocomplete="off"
+            style={{
+              all: "unset",
+              "box-sizing": "border-box",
+              width: "100%",
+              padding: "8px 28px 8px 30px",
+              "border-radius": "8px",
+              background: "var(--color-surface-solid)",
+              border: "1px solid var(--color-border)",
+              "font-family": FONT_MONO,
+              "font-size": "12.5px",
+              color: "var(--color-text)",
+              transition: "border-color 120ms ease",
+            }}
+            onFocusIn={(e) => (e.currentTarget.style.borderColor = "var(--color-border-strong)")}
+            onFocusOut={(e) => (e.currentTarget.style.borderColor = "var(--color-border)")}
+          />
+          <Show when={searching()}>
+            <button
+              type="button"
+              title="clear search"
+              aria-label="clear search"
+              onClick={() => setQuery("")}
+              style={{
+                all: "unset",
+                position: "absolute",
+                right: "8px",
+                cursor: "pointer",
+                display: "inline-flex",
+                "align-items": "center",
+                "justify-content": "center",
+                width: "18px",
+                height: "18px",
+                "border-radius": "5px",
+                color: "var(--color-text-faint)",
+              }}
+              onMouseEnter={(e) => (e.currentTarget.style.color = "var(--color-text)")}
+              onMouseLeave={(e) => (e.currentTarget.style.color = "var(--color-text-faint)")}
+            >
+              <IconX size={12} strokeWidth={1.8} />
+            </button>
+          </Show>
+        </div>
       </div>
+
+      {/* Quiet section label — sentence case, no shouty uppercase. */}
       <div
         style={{
-          ...sectionTitle,
-          padding: "0 14px 6px",
+          display: "flex",
+          "align-items": "baseline",
+          "justify-content": "space-between",
+          padding: "2px 14px 6px",
+          "font-family": FONT_MONO,
+          "font-size": "11px",
+          color: "var(--color-text-faint)",
         }}
       >
-        sessions · {props.sessions.length}
+        <span>{searching() ? "Results" : "Sessions"}</span>
+        <span style={{ "font-variant-numeric": "tabular-nums" }}>
+          {searching() ? `${filtered().length} of ${props.sessions.length}` : props.sessions.length}
+        </span>
       </div>
-      <div style={{ display: "flex", "flex-direction": "column", gap: "1px", padding: "0 8px" }}>
-        <For each={props.sessions}>
+
+      <div style={{ display: "flex", "flex-direction": "column", gap: "1px", padding: "0 8px 10px" }}>
+        <For each={filtered()}>
           {(s) => (
             <SessionRow
               session={s}
               active={props.activeId === s.id}
               onSelect={() => props.onSelect(s.id)}
               onDelete={() => props.onDelete(s.id)}
+              onRename={(title) => props.onRename(s.id, title)}
             />
           )}
         </For>
@@ -851,7 +1092,20 @@ function SessionsSidebar(props: {
               "line-height": 1.55,
             }}
           >
-            no sessions yet · click <span style={{ color: "var(--color-text-muted)" }}>+ new session</span> above
+            No sessions yet — click <span style={{ color: "var(--color-text-muted)" }}>New session</span> above.
+          </div>
+        </Show>
+        <Show when={props.sessions.length > 0 && filtered().length === 0}>
+          <div
+            style={{
+              padding: "12px 10px",
+              "font-family": FONT_MONO,
+              "font-size": "11px",
+              color: "var(--color-text-faint)",
+              "line-height": 1.55,
+            }}
+          >
+            No sessions match “{query().trim()}”.
           </div>
         </Show>
       </div>
@@ -864,14 +1118,39 @@ function SessionRow(props: {
   active: boolean
   onSelect: () => void
   onDelete: () => void
+  onRename: (title: string) => void
 }): JSX.Element {
   const [hover, setHover] = createSignal(false)
+  const [editing, setEditing] = createSignal(false)
+  const [draft, setDraft] = createSignal("")
+  const startEdit = () => {
+    setDraft(props.session.title || "")
+    setEditing(true)
+  }
+  const commit = () => {
+    if (!editing()) return
+    const next = draft().trim()
+    setEditing(false)
+    if (next && next !== (props.session.title || "")) props.onRename(next)
+  }
+  const cancel = () => {
+    setEditing(false)
+    setDraft("")
+  }
   return (
     <div
       role="button"
       tabindex="0"
-      onClick={props.onSelect}
+      onClick={() => {
+        if (editing()) return
+        props.onSelect()
+      }}
+      onDblClick={(e) => {
+        e.stopPropagation()
+        startEdit()
+      }}
       onKeyDown={(e) => {
+        if (editing()) return
         if (e.key === "Enter" || e.key === " ") {
           e.preventDefault()
           props.onSelect()
@@ -884,13 +1163,13 @@ function SessionRow(props: {
         if (!e.currentTarget.contains(e.relatedTarget as Node | null)) setHover(false)
       }}
       style={{
-        cursor: "pointer",
+        cursor: editing() ? "text" : "pointer",
         display: "flex",
         "flex-direction": "column",
-        gap: "2px",
-        padding: "6px 10px",
-        "padding-right": hover() ? "32px" : "10px",
-        "border-radius": "4px",
+        gap: "3px",
+        padding: "8px 12px",
+        "padding-right": hover() && !editing() ? "34px" : "12px",
+        "border-radius": "8px",
         background: props.active ? "var(--color-bg-elevated)" : hover() ? "var(--color-accent-subtle)" : "transparent",
         transition: "background 120ms ease, padding 120ms ease",
         position: "relative",
@@ -898,25 +1177,71 @@ function SessionRow(props: {
     >
       <div style={{ display: "flex", "align-items": "center", gap: "8px" }}>
         <StatusDot status={props.active ? "active" : "muted"} size={9} />
-        <span
-          style={{
-            "font-family": FONT_MONO,
-            "font-size": "12px",
-            color: props.active ? "var(--color-text)" : "var(--color-text-muted)",
-            "font-weight": 400,
-            flex: 1,
-            overflow: "hidden",
-            "text-overflow": "ellipsis",
-            "white-space": "nowrap",
-          }}
+        <Show
+          when={editing()}
+          fallback={
+            <span
+              title="Double-click to rename"
+              style={{
+                "font-family": FONT_MONO,
+                "font-size": "12.5px",
+                color: props.active ? "var(--color-text)" : "var(--color-text-muted)",
+                "font-weight": 400,
+                flex: 1,
+                overflow: "hidden",
+                "text-overflow": "ellipsis",
+                "white-space": "nowrap",
+              }}
+            >
+              {props.session.title || "session"}
+            </span>
+          }
         >
-          {props.session.title || "session"}
-        </span>
+          <input
+            ref={(el) =>
+              queueMicrotask(() => {
+                el.focus()
+                el.select()
+              })
+            }
+            value={draft()}
+            onInput={(e) => setDraft(e.currentTarget.value)}
+            onClick={(e) => e.stopPropagation()}
+            onPointerDown={(e) => e.stopPropagation()}
+            onKeyDown={(e) => {
+              e.stopPropagation()
+              if (e.key === "Enter") {
+                e.preventDefault()
+                commit()
+              } else if (e.key === "Escape") {
+                e.preventDefault()
+                cancel()
+              }
+            }}
+            onBlur={commit}
+            spellcheck={false}
+            autocomplete="off"
+            style={{
+              all: "unset",
+              "box-sizing": "border-box",
+              flex: 1,
+              "min-width": 0,
+              padding: "1px 5px",
+              "margin-left": "-5px",
+              "border-radius": "5px",
+              background: "var(--color-surface-solid)",
+              "box-shadow": "inset 0 0 0 1px var(--color-border-strong)",
+              "font-family": FONT_MONO,
+              "font-size": "12.5px",
+              color: "var(--color-text)",
+            }}
+          />
+        </Show>
       </div>
       <div
         style={{
           "font-family": FONT_MONO,
-          "font-size": "10px",
+          "font-size": "10.5px",
           color: "var(--color-text-faint)",
           "letter-spacing": "0.04em",
           "padding-left": "17px",
@@ -924,7 +1249,7 @@ function SessionRow(props: {
       >
         {props.session.time?.updated ? DateTime.fromMillis(props.session.time.updated).toRelative() : "—"}
       </div>
-      <Show when={hover()}>
+      <Show when={hover() && !editing()}>
         <button
           type="button"
           title="delete session"

--- a/frontend/workspace/src/pages/session.tsx
+++ b/frontend/workspace/src/pages/session.tsx
@@ -450,8 +450,6 @@ export default function Page(): JSX.Element {
                               lastUserMessageID={lastUserMessage()?.id}
                               stepsExpanded={stepsExpanded()[message.id] ?? false}
                               onStepsExpandedToggle={() => toggleSteps(message.id)}
-                              onRevertMessage={(id) => void revertTo(id)}
-                              hideTools={["task"]}
                               classes={{
                                 root: "min-w-0 w-full relative",
                                 content: "flex flex-col justify-between !overflow-visible",

--- a/frontend/workspace/src/pages/session.tsx
+++ b/frontend/workspace/src/pages/session.tsx
@@ -18,6 +18,7 @@ import { useSDK } from "@/context/sdk"
 import { useLayout } from "@/context/layout"
 import { useTheme } from "@synsci/ui/theme"
 import { PromptInput } from "@/components/prompt-input"
+import { NewSessionView } from "@/components/session/session-new-view"
 import { Wordmark } from "@/thesis/Wordmark"
 import { AppHeader, HeaderIconButton, HeaderDivider } from "@/thesis/AppHeader"
 import { RightPane } from "@/thesis/RightPane"
@@ -186,6 +187,9 @@ export default function Page(): JSX.Element {
   // makes the revert permanent server-side).
   const activeSession = createMemo(() => (params.id ? sync.session.get(params.id) : undefined))
   const revertInfo = createMemo(() => activeSession()?.revert)
+  // New-session worktree selection, shared between the empty-state view and the
+  // composer (matches the v1.1.116 new-session flow).
+  const [newSessionWorktree, setNewSessionWorktree] = createSignal("main")
   const turnMessages = createMemo(() => {
     const revertID = revertInfo()?.messageID
     return messages().filter((m) => m.role === "user" && (!revertID || m.id < revertID))
@@ -467,7 +471,7 @@ export default function Page(): JSX.Element {
                   </div>
                 </Match>
                 <Match when={true}>
-                  <ChatWelcome />
+                  <NewSessionView worktree={newSessionWorktree()} onWorktreeChange={setNewSessionWorktree} />
                 </Match>
               </Switch>
 
@@ -512,7 +516,10 @@ export default function Page(): JSX.Element {
                       </button>
                     </div>
                   </Show>
-                  <PromptInput />
+                  <PromptInput
+                    newSessionWorktree={newSessionWorktree()}
+                    onNewSessionWorktreeReset={() => setNewSessionWorktree("main")}
+                  />
                 </div>
               </div>
             </div>

--- a/frontend/workspace/src/styles/thesis.css
+++ b/frontend/workspace/src/styles/thesis.css
@@ -155,6 +155,29 @@
   outline: none !important;
 }
 
+/* Composer control chips — agent / model / effort / speed were ghost buttons
+   with no resting surface, so they read as plain low-contrast text. Give them a
+   subtle chip (surface + hairline) so they're clearly interactive, and lift the
+   contrast on hover. Scoped to the control row, so send / attach are untouched. */
+[data-slot="prompt-controls"] [data-component="button"][data-variant="ghost"] {
+  background: transparent;
+  box-shadow: inset 0 0 0 1px var(--border-weak-base);
+  color: var(--text-base);
+  font-size: 14px;
+  border-radius: 11px;
+}
+[data-slot="prompt-controls"] [data-component="button"][data-variant="ghost"]:hover:not(:disabled) {
+  background: transparent;
+  box-shadow: inset 0 0 0 1px var(--border-base);
+  color: var(--text-strong);
+}
+/* The agent/mode <Select> trigger renders its value at 13px (--font-size-base)
+   while the ghost buttons above are bumped to 14px — match them so the whole
+   control row is one consistent size. */
+[data-slot="prompt-controls"] [data-component="select"] [data-slot="select-select-trigger-value"] {
+  font-size: 14px;
+}
+
 /* The old light-mode "cream neutralisation" remap block is gone: the default
    openscience theme now ships the product's neutral greys directly, so the ui
    semantic layer needs no app-side patching (and non-default themes render

--- a/frontend/workspace/src/styles/thesis.css
+++ b/frontend/workspace/src/styles/thesis.css
@@ -145,6 +145,16 @@
   outline: none !important;
 }
 
+/* The v1.1.116 chat + composer buttons carry their own subtle focus treatment
+   (button.css shadow-xs-border-focus). Suppress the app-wide hard teal
+   :focus-visible box on interactive elements inside the conversation and the
+   PromptInput so the controls (agent / model / effort / speed) read like the
+   old UI instead of a harsh 2px outline. Focus stays visible via button.css. */
+[data-component="prompt-input"] :is(button, [role="button"], a, [tabindex]):focus-visible,
+.session-scroller :is(button, [role="button"], a, [tabindex]):focus-visible {
+  outline: none !important;
+}
+
 /* The old light-mode "cream neutralisation" remap block is gone: the default
    openscience theme now ships the product's neutral greys directly, so the ui
    semantic layer needs no app-side patching (and non-default themes render

--- a/frontend/workspace/src/thesis/Composer.tsx
+++ b/frontend/workspace/src/thesis/Composer.tsx
@@ -58,11 +58,6 @@ const SOURCE_DOT: Record<ModelSource, { color: string; opacity: number; meters: 
 // (low/medium/high/xhigh/none/minimal, exactly as the backend emits them) and
 // persists the choice via models.variant. No relabeling.
 //
-// A model exposes a REAL per-request "fast" API param only for gpt-5.5, where it
-// maps to OpenAI service_tier: priority (plumbed as providerOptions.openai.serviceTier
-// in src/session/llm.ts). Opus-4.8 speed:"fast" is real but not plumbable through the
-// installed @ai-sdk/anthropic, so no fast toggle is shown for it.
-const isGpt55 = (modelID: string) => /gpt-5\.5/.test(modelID.toLowerCase())
 
 // Collapse a model id to its FAMILY so the picker shows one current entry per
 // family and folds dated snapshots / superseded majors behind a "show older"
@@ -222,7 +217,6 @@ export function Composer(): JSX.Element {
     agent: string
     model: ModelKey
     variant: string | undefined
-    fast: boolean | undefined
   }
   const [queue, setQueue] = createSignal<QueuedPrompt[]>([])
   const [inflight, setInflight] = createSignal(false)
@@ -336,21 +330,6 @@ export function Composer(): JSX.Element {
     if (m) models.variant.set(m, value)
   }
 
-  // Fast toggle — only gpt-5.5 has a real plumbable per-request "fast" param
-  // (OpenAI service_tier: priority). Sent as `fast` on the prompt; the backend
-  // guards it to gpt-5.5. Reset when the model changes (state is per-model).
-  const supportsFast = createMemo(() => {
-    const m = model()
-    return !!m && isGpt55(m.modelID)
-  })
-  const [fast, setFast] = createSignal(false)
-  createEffect(
-    on(
-      () => model()?.providerID + "/" + model()?.modelID,
-      () => setFast(false),
-      { defer: true },
-    ),
-  )
 
   // Context tier (Cursor "MAX mode" analogue). Only meaningful when the model
   // prices the >200k window differently. This is a price-preview + intent signal;
@@ -737,7 +716,6 @@ export function Composer(): JSX.Element {
       agent: agent(),
       model: chosen,
       variant: models.variant.get(chosen),
-      fast: isGpt55(chosen.modelID) ? fast() : undefined,
     }
     // Clear the input immediately in both paths so typing can continue.
     setText("")
@@ -822,7 +800,6 @@ export function Composer(): JSX.Element {
           model: p.model,
           agent: p.agent,
           variant: p.variant,
-          fast: p.fast,
           parts: promptParts,
         } as any)
         .catch((e: any) => {
@@ -1556,7 +1533,7 @@ export function Composer(): JSX.Element {
 
                       {/* controls for the selected model — one home for effort /
                           speed / context, so every list row stays uniform */}
-                      <Show when={!!model() && (variantKeys().length > 0 || supportsFast() || hasLongTier())}>
+                      <Show when={!!model() && (variantKeys().length > 0 || hasLongTier())}>
                         <div
                           onClick={(e) => e.stopPropagation()}
                           style={{
@@ -1576,19 +1553,6 @@ export function Composer(): JSX.Element {
                                 options={variantKeys().map((k) => ({ id: k, label: k }))}
                                 value={effort() ?? ""}
                                 onPick={(id) => setEffort(id)}
-                              />
-                            </span>
-                          </Show>
-                          <Show when={supportsFast()}>
-                            <span style={{ display: "inline-flex", "align-items": "center", gap: "6px" }}>
-                              <span style={CONTROL_LABEL}>speed</span>
-                              <Segmented
-                                options={[
-                                  { id: "normal", label: "normal" },
-                                  { id: "fast", label: "fast" },
-                                ]}
-                                value={fast() ? "fast" : "normal"}
-                                onPick={(id) => setFast(id === "fast")}
                               />
                             </span>
                           </Show>

--- a/frontend/workspace/src/thesis/SetupDialog.tsx
+++ b/frontend/workspace/src/thesis/SetupDialog.tsx
@@ -292,6 +292,24 @@ export function SetupDialog(props: { onDismiss?: () => void }): JSX.Element {
               back
             </Button>
           </div>
+          {/* ChatGPT / Codex is OAuth (no API key). Its interactive flow runs from
+              the CLI (local callback on :1455), so surface it plainly here instead
+              of leaving it terminal-only and undiscoverable. */}
+          <div
+            style={{
+              "margin-top": "4px",
+              "padding-top": "12px",
+              "border-top": "1px solid var(--color-border)",
+              "font-family": FONT_MONO,
+              "font-size": "11px",
+              color: "var(--color-text-muted)",
+              "line-height": 1.55,
+            }}
+          >
+            Have a ChatGPT Plus / Pro / Business plan? Use it instead of an API key — run{" "}
+            <code style={{ color: "var(--color-text)" }}>openscience signin codex</code> in your terminal to sign in
+            with ChatGPT (Codex).
+          </div>
         </Show>
       </div>
     </Dialog>

--- a/frontend/workspace/src/thesis/ThesisCanvas.tsx
+++ b/frontend/workspace/src/thesis/ThesisCanvas.tsx
@@ -304,7 +304,9 @@ export function ThesisCanvas(): JSX.Element {
 
   const [viewMode, setViewModeRaw] = createSignal<ViewMode>(readViewMode())
   const [graphStyle, setGraphStyleRaw] = createSignal<GraphStyle>(readGraphStyle())
-  const mode = createMemo<Mode>(() => (viewMode() === "timeline" ? "timeline" : graphStyle()))
+  // Orbit is the one and only graph view — cards and timeline are retired.
+  // Pinned here so any previously-saved dashboard.viewMode/graphStyle is ignored.
+  const mode = createMemo<Mode>(() => "orbit")
   const setViewMode = (m: ViewMode) => {
     try {
       localStorage.setItem(VIEW_MODE_KEY, m)
@@ -789,26 +791,6 @@ export function ThesisCanvas(): JSX.Element {
           <Show when={loading() && nodes().length > 0}>
             <AsciiSpinner size={10} color="var(--color-text-faint)" />
           </Show>
-        </div>
-
-        {/* Mode segmented control */}
-        <div
-          style={{
-            display: "inline-flex",
-            "align-items": "center",
-            gap: "2px",
-            padding: "2px",
-            "border-radius": "4px",
-            border: "1px solid var(--color-border)",
-            background: "var(--color-bg-subtle)",
-            "flex-shrink": 0,
-          }}
-        >
-          <For each={MODES}>
-            {(opt) => (
-              <ModeSeg active={mode() === opt.k} Icon={opt.Icon} label={opt.label} onClick={() => setMode(opt.k)} />
-            )}
-          </For>
         </div>
 
         {/* Actions */}

--- a/frontend/workspace/vite-thesis.js
+++ b/frontend/workspace/vite-thesis.js
@@ -26,7 +26,7 @@ const API_BASE = (
   process.env.SYNSC_API_BASE ||
   process.env.MANAGED_API_BASE ||
   process.env.ATLAS_BASE_URL ||
-  "https://api.syntheticsciences.ai"
+  "https://app.syntheticsciences.ai"
 ).replace(/\/+$/, "")
 
 const cache = new Map() // key -> { at: number, body: string, status: number }
@@ -239,7 +239,11 @@ async function handle(req, res) {
     } else if (method === "GET" && path === "health") {
       return send(res, 200, { ok: !!sessionToken() })
     } else {
-      return send(res, 404, { error: "unknown atlas route", path, method })
+      // Mirror the backend bridge's `.all("/*") → 200 {}`: quietly answer any
+      // other path the SPA probes (e.g. GET /project for a folder with no linked
+      // graph) with an empty object, so dev doesn't spam 404s where production
+      // returns 200. The graph list + per-graph tree above are the real routes.
+      return send(res, 200, {})
     }
 
     if (method === "GET") cache.set(cacheKey, { at: Date.now(), body, status: 200 })


### PR DESCRIPTION
## Summary

Adopts the refined v1.1.116 chat surface into OpenScience and layers on a batch of model-catalog, billing, Atlas-graph, and onboarding fixes.

### Chat / message UI
- Full v1.1.116 message + model-selector surface
- Clickable file paths (prose + read/edit/write cards) open the file; bash cards open a shell tab
- Reasoning toggle: rotating disclosure, bigger hit area, traces persist after the reply
- Sticky sent-bubble gradient recoloured to the page background (no lighter band)
- Neutral diff counts + "Files"/"Updated" wording

### Models & composer
- Frontier-only default picker (full catalog still reachable via Manage Models); robust native ↔ OpenRouter id matching (`claude-opus-4-8` ↔ `claude-opus-4.8`, `z-ai`/`zai`/`zhipuai`)
- Crisper picker, `ml` → **ML**, consistent control-row font
- Removed the gpt-5.5 fast/priority speed toggle end to end (UI + `serviceTier` plumbing + schema)

### Sessions & Atlas graph
- Sidebar: live search, double-click inline rename, editable conversation title, more padding
- Re-exposed the orphaned revert/unrevert as `/undo` and `/redo`
- Orbit-only graph (dropped the cards + timeline toggle)
- Dev graph bridge pointed at the correct `app.` host (was 502'ing) + quiet `/project` probe

### Billing / providers
- Managed = 100% OpenRouter via the Atlas gateway (verified both sides)
- BYOK no longer routes through the managed wallet after a managed→byok switch: drops managed `thk_` providers and skips the synced `enabled_providers` whitelist

### Onboarding
- No-provider-key empty state with clear next steps
- Discoverable Codex (ChatGPT) OAuth in the BYOK setup dialog

## Testing
- typecheck: 7/7 packages
- backend suite: 975 pass / 1 skip / 0 fail
