### PR TITLE
chore(format): prettier --write on chat/model/onboarding surfaces

### DIFF
--- a/frontend/ui/src/components/message-part.tsx
+++ b/frontend/ui/src/components/message-part.tsx
@@ -1061,12 +1061,7 @@ ToolRegistry.register({
           subtitle: props.input.description,
           action: (
             <Tooltip value="Open in Shell tab">
-              <IconButton
-                icon="square-arrow-top-right"
-                variant="ghost"
-                class="h-5 w-5"
-                onClick={openInShellTab}
-              />
+              <IconButton icon="square-arrow-top-right" variant="ghost" class="h-5 w-5" onClick={openInShellTab} />
             </Tooltip>
           ),
         }}
@@ -1169,10 +1164,13 @@ ToolRegistry.register({
           source: Array.isArray(cell.source) ? cell.source.join("") : (cell.source ?? ""),
           executionCount: cell.execution_count ?? null,
           outputs: (cell.outputs ?? []).map((o: any) => {
-            if (o.output_type === "stream") return { type: "stream", name: o.name, text: Array.isArray(o.text) ? o.text.join("") : o.text }
-            if (o.output_type === "execute_result") return { type: "execute_result", data: o.data ?? {}, executionCount: o.execution_count }
+            if (o.output_type === "stream")
+              return { type: "stream", name: o.name, text: Array.isArray(o.text) ? o.text.join("") : o.text }
+            if (o.output_type === "execute_result")
+              return { type: "execute_result", data: o.data ?? {}, executionCount: o.execution_count }
             if (o.output_type === "display_data") return { type: "display_data", data: o.data ?? {} }
-            if (o.output_type === "error") return { type: "error", ename: o.ename, evalue: o.evalue, traceback: o.traceback ?? [] }
+            if (o.output_type === "error")
+              return { type: "error", ename: o.ename, evalue: o.evalue, traceback: o.traceback ?? [] }
             return { type: "stream", name: "stdout", text: "" }
           }),
         }))
@@ -1213,24 +1211,24 @@ ToolRegistry.register({
         }
       >
         <Show when={props.input.content}>
-          <Show when={isNotebook() && notebookCells().length > 0} fallback={
+          <Show
+            when={isNotebook() && notebookCells().length > 0}
+            fallback={
+              <div data-component="write-content">
+                <Dynamic
+                  component={codeComponent}
+                  file={{
+                    name: props.input.filePath,
+                    contents: props.input.content,
+                    cacheKey: checksum(props.input.content),
+                  }}
+                  overflow="scroll"
+                />
+              </div>
+            }
+          >
             <div data-component="write-content">
-              <Dynamic
-                component={codeComponent}
-                file={{
-                  name: props.input.filePath,
-                  contents: props.input.content,
-                  cacheKey: checksum(props.input.content),
-                }}
-                overflow="scroll"
-              />
-            </div>
-          }>
-            <div data-component="write-content">
-              <NotebookView
-                cells={notebookCells()}
-                title={filename()}
-              />
+              <NotebookView cells={notebookCells()} title={filename()} />
             </div>
           </Show>
         </Show>
@@ -1471,7 +1469,9 @@ ToolRegistry.register({
           title: connected() ? "Colab Connected" : "Colab Connect",
           subtitle: connected()
             ? `${mode()} · ${gpu() || "GPU ready"}`
-            : mode() === "enterprise" ? "Vertex AI" : "Bridge notebook",
+            : mode() === "enterprise"
+              ? "Vertex AI"
+              : "Bridge notebook",
         }}
       >
         <Show when={props.output}>

--- a/frontend/ui/src/components/notebook-cell.tsx
+++ b/frontend/ui/src/components/notebook-cell.tsx
@@ -48,9 +48,7 @@ export function NotebookCell(props: NotebookCellProps): JSX.Element {
         </div>
         <Show when={props.outputs && props.outputs.length > 0}>
           <div data-slot="notebook-cell-outputs">
-            <For each={props.outputs}>
-              {(output) => <NotebookOutputView output={output} />}
-            </For>
+            <For each={props.outputs}>{(output) => <NotebookOutputView output={output} />}</For>
           </div>
         </Show>
       </Show>
@@ -87,10 +85,14 @@ function NotebookOutputView(props: { output: NotebookOutput }): JSX.Element {
       </Show>
       <Show when={output().type === "error"}>
         <div data-slot="notebook-output-error">
-          <div data-slot="notebook-error-name">{output().ename}: {output().evalue}</div>
+          <div data-slot="notebook-error-name">
+            {output().ename}: {output().evalue}
+          </div>
           <Show when={output().traceback && output().traceback!.length > 0}>
             <pre data-slot="notebook-error-traceback">
-              {output().traceback!.map((l) => l.replace(/\x1b\[[0-9;]*m/g, "")).join("\n")}
+              {output()
+                .traceback!.map((l) => l.replace(/\x1b\[[0-9;]*m/g, ""))
+                .join("\n")}
             </pre>
           </Show>
         </div>
@@ -99,10 +101,7 @@ function NotebookOutputView(props: { output: NotebookOutput }): JSX.Element {
   )
 }
 
-export function NotebookView(props: {
-  cells: NotebookCellProps[]
-  title?: string
-}): JSX.Element {
+export function NotebookView(props: { cells: NotebookCellProps[]; title?: string }): JSX.Element {
   return (
     <div data-component="notebook-view">
       <Show when={props.title}>

--- a/frontend/workspace/src/components/dialog-manage-models.tsx
+++ b/frontend/workspace/src/components/dialog-manage-models.tsx
@@ -11,10 +11,7 @@ export const DialogManageModels: Component = () => {
   const language = useLanguage()
 
   return (
-    <Dialog
-      title={language.t("dialog.model.manage")}
-      description={language.t("dialog.model.manage.description")}
-    >
+    <Dialog title={language.t("dialog.model.manage")} description={language.t("dialog.model.manage.description")}>
       <List
         search={{ placeholder: language.t("dialog.model.search.placeholder"), autofocus: true }}
         emptyMessage={language.t("dialog.model.empty")}

--- a/frontend/workspace/src/components/dialog-select-model.tsx
+++ b/frontend/workspace/src/components/dialog-select-model.tsx
@@ -236,9 +236,7 @@ export const DialogSelectModel: Component<{ provider?: string }> = (props) => {
   const language = useLanguage()
 
   return (
-    <Dialog
-      title={language.t("dialog.model.select.title")}
-    >
+    <Dialog title={language.t("dialog.model.select.title")}>
       <ModelList provider={props.provider} onSelect={() => dialog.close()} />
       <Button
         variant="ghost"

--- a/frontend/workspace/src/components/session/session-new-view.tsx
+++ b/frontend/workspace/src/components/session/session-new-view.tsx
@@ -59,9 +59,8 @@ export function NewSessionView(props: NewSessionViewProps) {
           <div class="text-13-medium text-text-strong">No model connected</div>
           <div class="text-12-regular text-text-weak leading-relaxed">
             You don't have a provider key set. Bring your own with{" "}
-            <code class="text-text-base">openscience keys signin</code> (OpenAI · Anthropic · Gemini, or ChatGPT /
-            Codex — no API key needed), or use managed credits with{" "}
-            <code class="text-text-base">openscience login</code>.
+            <code class="text-text-base">openscience keys signin</code> (OpenAI · Anthropic · Gemini, or ChatGPT / Codex
+            — no API key needed), or use managed credits with <code class="text-text-base">openscience login</code>.
           </div>
         </div>
       </Show>

--- a/frontend/workspace/src/thesis/Composer.tsx
+++ b/frontend/workspace/src/thesis/Composer.tsx
@@ -330,7 +330,6 @@ export function Composer(): JSX.Element {
     if (m) models.variant.set(m, value)
   }
 
-
   // Context tier (Cursor "MAX mode" analogue). Only meaningful when the model
   // prices the >200k window differently. This is a price-preview + intent signal;
   // the long-context request flag is threaded through submit in a later pass.


### PR DESCRIPTION
Gets the Format check green: prettier-formats the 4 files touched in #147 plus notebook-cell + dialog-manage-models (already unformatted on main). Whitespace/line-wrapping only; typecheck 7/7.