### PR TITLE
ci(e2e): boot the server with valid flags + capture its log

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -4,7 +4,7 @@ runs:
   using: "composite"
   steps:
     - name: Cache Bun
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
         restore-keys: ${{ runner.os }}-bun-

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -115,7 +115,11 @@ jobs:
       - name: Run openscience server
         if: matrix.settings.name != 'windows'
         working-directory: backend/cli
-        run: bun dev -- --print-logs --log-level WARN serve --port 4096 --hostname 127.0.0.1 &
+        # `serve` is loopback-only and rejects --hostname (yargs exits 1 with
+        # help text), so don't pass one. Keep the log on disk: a backgrounded
+        # process loses its output once this step ends, which made boot
+        # failures undiagnosable.
+        run: bun dev -- --print-logs --log-level WARN serve --port 4096 > "$RUNNER_TEMP/openscience-server.log" 2>&1 &
         env:
           OPENSCIENCE_DISABLE_SHARE: "true"
           OPENSCIENCE_DISABLE_LSP_DOWNLOAD: "true"
@@ -135,6 +139,7 @@ jobs:
             curl -fsS "http://127.0.0.1:4096/global/health" > /dev/null && exit 0
             sleep 1
           done
+          echo "::error::openscience server never became healthy on 127.0.0.1:4096"
           exit 1
 
       - name: run
@@ -158,6 +163,10 @@ jobs:
           OPENSCIENCE_CLIENT: "app"
         timeout-minutes: 30
 
+      - name: Print server log
+        if: failure() && matrix.settings.name != 'windows'
+        run: cat "$RUNNER_TEMP/openscience-server.log" || true
+
       - name: Upload Playwright artifacts
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -168,3 +177,4 @@ jobs:
           path: |
             frontend/workspace/e2e/test-results
             frontend/workspace/e2e/playwright-report
+            ${{ runner.temp }}/openscience-server.log


### PR DESCRIPTION
## Problem

The nightly E2E workflow has failed on every run since it landed (Jul 6, 7, 8). The server step passes `--hostname 127.0.0.1` to `openscience serve`, but serve is loopback-only and doesn't accept that flag: yargs prints the help text and exits 1, nothing ever listens on port 4096, and the health-check loop times out after 120s.

Worse, the failure was undiagnosable: the server is backgrounded with `&`, so its output (the yargs help + exit) disappeared when the step ended. Three red runs produced zero useful logs.

## Fix

- Drop `--hostname` from the serve invocation (verified locally: serve boots and `/global/health` answers without it)
- Redirect server output to `$RUNNER_TEMP/openscience-server.log`, print it in a `failure()` step, and include it in the uploaded Playwright artifacts, so the next boot failure explains itself
- Bump the `actions/cache` pin in the shared setup-bun action from v4 to the v6.1.0 SHA that publish.yml already trusts, silencing the Node 20 deprecation warning emitted on every job of every workflow

## Verification

Reproduced the exact CI failure locally with the workflow's env and command (yargs help + exit 1), then confirmed the fixed invocation boots and serves `{"healthy":true}` on `/global/health`.