### PR TITLE
ci(e2e): scope the nightly run to the browser suite

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,8 +21,12 @@ jobs:
             host: ubuntu-latest
             playwright: bunx playwright install --with-deps
             workdir: .
+            # Only the browser suite. The backend unit suite already runs in
+            # ci.yml on every push/PR; re-running it here fails (this job never
+            # configures a git identity) and reads the seeded XDG dirs as its
+            # global config.
             command: |
-              bun turbo test
+              bun turbo test --filter=@synsci/workspace
           # Windows e2e:local skipped — chronically failing since
           # 2026-04-28 across all PRs from all authors. Root cause is
           # the in-process Playwright/bun/Vite spawn chain not


### PR DESCRIPTION
Follow-up to #149 (its second commit missed the merge window).

`bun turbo test` also re-ran the backend unit suite inside the E2E job, where it fails wholesale: this workflow never configures a git identity, so every worktree-creating test dies with `fatal: empty ident name`, and the seeded XDG dirs leak into the suite as its global config. That suite already runs in ci.yml on every push and PR — re-running it here only adds noise and runner contention with Chromium.

Filter to `@synsci/workspace` so the nightly tests what it exists for.

Verification: dispatched E2E run on this change is in progress; the previous dispatch (with only the #149 boot fix) got past the server boot and failed exactly on the backend-suite git-identity errors this removes.