### PR TITLE
fix(science): preserve cancellation through connector fallbacks (#96)

### DIFF
--- a/backend/cli/src/science/connectors/chemistry/bindingdb.ts
+++ b/backend/cli/src/science/connectors/chemistry/bindingdb.ts
@@ -1,5 +1,5 @@
 import type { Connector, ConnectorHit } from "../types"
-import { getJSON } from "../http"
+import { getJSON, orFallback } from "../http"
 
 /**
  * BindingDB — measured binding affinities between proteins and small molecules.
@@ -47,7 +47,11 @@ export const bindingdb: Connector = {
 
   async search(query, opts) {
     const limit = Math.min(opts?.limit ?? 10, 25)
-    const body = await getJSON<unknown>(ligandsUrl(query.trim()), { signal: opts?.signal }).catch(() => undefined)
+    const body = await orFallback(
+      getJSON<unknown>(ligandsUrl(query.trim()), { signal: opts?.signal }),
+      undefined,
+      opts?.signal,
+    )
     const affinities = affinitiesOf(body)
     return affinities.slice(0, limit).map<ConnectorHit>((a) => {
       const mid = a.monomerid != null ? String(a.monomerid) : ""
@@ -64,6 +68,6 @@ export const bindingdb: Connector = {
 
   async fetch(id, opts) {
     // id is a UniProt accession; returns the full ligand-affinity set for the target.
-    return getJSON(ligandsUrl(id.trim()), { signal: opts?.signal }).catch(() => ({ affinities: [] }))
+    return orFallback(getJSON(ligandsUrl(id.trim()), { signal: opts?.signal }), { affinities: [] }, opts?.signal)
   },
 }

--- a/backend/cli/src/science/connectors/chemistry/gtopdb.ts
+++ b/backend/cli/src/science/connectors/chemistry/gtopdb.ts
@@ -1,5 +1,5 @@
 import type { Connector, ConnectorHit } from "../types"
-import { getJSON } from "../http"
+import { getJSON, orFallback } from "../http"
 
 /**
  * Guide to PHARMACOLOGY (GtoPdb) — IUPHAR/BPS ligand & target pharmacology.
@@ -45,7 +45,7 @@ export const gtopdb: Connector = {
   async search(query, opts) {
     const limit = Math.min(opts?.limit ?? 10, 25)
     const url = `${BASE}/ligands?name=${encodeURIComponent(query)}`
-    const data = await getJSON<Ligand[]>(url, { signal: opts?.signal }).catch(() => [])
+    const data = await orFallback(getJSON<Ligand[]>(url, { signal: opts?.signal }), [], opts?.signal)
     const ligands = Array.isArray(data) ? data : []
     return ligands.slice(0, limit).map<ConnectorHit>((l) => {
       const id = l.ligandId != null ? String(l.ligandId) : ""
@@ -62,8 +62,8 @@ export const gtopdb: Connector = {
   async fetch(id, opts) {
     const base = `${BASE}/ligands/${encodeURIComponent(id)}`
     const [ligand, structure] = await Promise.all([
-      getJSON<Ligand>(base, { signal: opts?.signal }).catch(() => ({}) as Ligand),
-      getJSON<Structure>(`${base}/structure`, { signal: opts?.signal }).catch(() => ({}) as Structure),
+      orFallback(getJSON<Ligand>(base, { signal: opts?.signal }), {} as Ligand, opts?.signal),
+      orFallback(getJSON<Structure>(`${base}/structure`, { signal: opts?.signal }), {} as Structure, opts?.signal),
     ])
     return { ...ligand, ...structure }
   },

--- a/backend/cli/src/science/connectors/chemistry/pubchem.ts
+++ b/backend/cli/src/science/connectors/chemistry/pubchem.ts
@@ -1,5 +1,5 @@
 import type { Connector, ConnectorHit } from "../types"
-import { getJSON } from "../http"
+import { getJSON, orFallback } from "../http"
 
 /**
  * PubChem — NCBI's public chemical database (PUG REST). No key required.
@@ -42,16 +42,24 @@ export const pubchem: Connector = {
   async search(query, opts) {
     const limit = Math.min(opts?.limit ?? 10, 25)
     const cidUrl = `${BASE}/compound/name/${encodeURIComponent(query)}/cids/JSON?name_type=word`
-    const cidData = await getJSON<{ IdentifierList?: { CID?: number[] } }>(cidUrl, {
-      signal: opts?.signal,
-    }).catch(() => ({}) as { IdentifierList?: { CID?: number[] } })
+    const cidData = await orFallback(
+      getJSON<{ IdentifierList?: { CID?: number[] } }>(cidUrl, {
+        signal: opts?.signal,
+      }),
+      {} as { IdentifierList?: { CID?: number[] } },
+      opts?.signal,
+    )
     const cids = (cidData.IdentifierList?.CID ?? []).slice(0, limit)
     if (!cids.length) return []
 
     const propUrl = `${BASE}/compound/cid/${cids.join(",")}/property/${FIELDS}/JSON`
-    const propData = await getJSON<{ PropertyTable?: { Properties?: Property[] } }>(propUrl, {
-      signal: opts?.signal,
-    }).catch(() => ({}) as { PropertyTable?: { Properties?: Property[] } })
+    const propData = await orFallback(
+      getJSON<{ PropertyTable?: { Properties?: Property[] } }>(propUrl, {
+        signal: opts?.signal,
+      }),
+      {} as { PropertyTable?: { Properties?: Property[] } },
+      opts?.signal,
+    )
     const props = propData.PropertyTable?.Properties ?? []
 
     return props.map<ConnectorHit>((p) => {

--- a/backend/cli/src/science/connectors/chemistry/surechembl.ts
+++ b/backend/cli/src/science/connectors/chemistry/surechembl.ts
@@ -1,5 +1,5 @@
 import type { Connector, ConnectorHit } from "../types"
-import { getJSON, request } from "../http"
+import { getJSON, request, orFallback } from "../http"
 
 /**
  * SureChEMBL — chemistry mined from the patent literature (EMBL-EBI). Public API,
@@ -40,11 +40,15 @@ function pickTitle(doc: Document): string {
 
 async function searchContent(query: string, itemsPerPage: number, signal?: AbortSignal): Promise<Document[]> {
   const url = `${BASE}/search/content?query=${encodeURIComponent(query)}&page=1&itemsPerPage=${itemsPerPage}`
-  const res = await request(url, {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+  const res = await orFallback(
+    request(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      signal,
+    }),
+    undefined,
     signal,
-  }).catch(() => undefined)
+  )
   if (!res) return []
   const body = res.json<{ data?: { results?: { documents?: Document[] } } }>()
   const docs = body.data?.results?.documents
@@ -76,9 +80,13 @@ export const surechembl: Connector = {
 
   async fetch(id, opts) {
     if (/^\d+$/.test(id.trim())) {
-      const data = await getJSON<{ data?: Chemical[] }>(`${BASE}/chemical/id/${encodeURIComponent(id.trim())}`, {
-        signal: opts?.signal,
-      }).catch(() => ({}) as { data?: Chemical[] })
+      const data = await orFallback(
+        getJSON<{ data?: Chemical[] }>(`${BASE}/chemical/id/${encodeURIComponent(id.trim())}`, {
+          signal: opts?.signal,
+        }),
+        {} as { data?: Chemical[] },
+        opts?.signal,
+      )
       const records = Array.isArray(data.data) ? data.data : []
       return records[0] ?? {}
     }

--- a/backend/cli/src/science/connectors/http.ts
+++ b/backend/cli/src/science/connectors/http.ts
@@ -261,6 +261,26 @@ export async function getText(url: string, opts?: HttpOptions): Promise<string> 
   return res.text()
 }
 
+/**
+ * Await `p`, but on failure return `fallback` instead — UNLESS the caller's
+ * `signal` was aborted, in which case rethrow so cancellation propagates.
+ *
+ * Connectors use this instead of a blanket `.catch(() => fallback)`: that
+ * pattern swallows the AbortError `request()` deliberately rethrows on caller
+ * abort, so a cancelled `science_search` looked like "no results" instead of a
+ * clean cancellation. An internal request timeout still falls back (the caller
+ * didn't cancel), which is the intended behavior — one slow source shouldn't
+ * fail the whole search.
+ */
+export async function orFallback<T>(p: Promise<T>, fallback: T, signal?: AbortSignal): Promise<T> {
+  try {
+    return await p
+  } catch (err) {
+    if (signal?.aborted) throw err
+    return fallback
+  }
+}
+
 /** Clear the in-memory cache (test/debug helper). */
 export function clearCache(): void {
   cache.clear()

--- a/backend/cli/src/science/connectors/literature/biorxiv.ts
+++ b/backend/cli/src/science/connectors/literature/biorxiv.ts
@@ -1,5 +1,5 @@
 import type { Connector, ConnectorHit, SearchOptions } from "../types"
-import { getJSON } from "../http"
+import { getJSON, orFallback } from "../http"
 import { raw, snippet } from "./shared"
 
 /**
@@ -66,12 +66,20 @@ function toHit(p: Paper, score?: number): ConnectorHit {
 }
 
 async function recent(s: Server, count: number, opts?: SearchOptions): Promise<Paper[]> {
-  const data = await getJSON<Details>(`${BASE}/${s}/${count}`, { signal: opts?.signal }).catch(() => ({}) as Details)
+  const data = await orFallback(
+    getJSON<Details>(`${BASE}/${s}/${count}`, { signal: opts?.signal }),
+    {} as Details,
+    opts?.signal,
+  )
   return (data.collection ?? []).map((p) => ({ ...p, server: p.server ?? s }))
 }
 
 async function byDoi(s: Server, doi: string, opts?: SearchOptions | undefined): Promise<Paper[]> {
-  const data = await getJSON<Details>(`${BASE}/${s}/${doi}`, { signal: opts?.signal }).catch(() => ({}) as Details)
+  const data = await orFallback(
+    getJSON<Details>(`${BASE}/${s}/${doi}`, { signal: opts?.signal }),
+    {} as Details,
+    opts?.signal,
+  )
   return (data.collection ?? []).map((p) => ({ ...p, server: p.server ?? s }))
 }
 

--- a/backend/cli/src/science/connectors/literature/pubmed.ts
+++ b/backend/cli/src/science/connectors/literature/pubmed.ts
@@ -1,5 +1,5 @@
 import type { Connector, ConnectorHit } from "../types"
-import { getJSON, getText } from "../http"
+import { getJSON, getText, orFallback } from "../http"
 import { raw, snippet } from "./shared"
 
 /**
@@ -88,9 +88,13 @@ export const pubmed: Connector = {
     const record = esummary.result?.[clean]
     const summary = record && !Array.isArray(record) ? record : undefined
 
-    const abstract = await getText(`${BASE}/efetch.fcgi?db=pubmed&rettype=abstract&retmode=text&id=${clean}`, {
-      signal: opts?.signal,
-    }).catch(() => undefined)
+    const abstract = await orFallback(
+      getText(`${BASE}/efetch.fcgi?db=pubmed&rettype=abstract&retmode=text&id=${clean}`, {
+        signal: opts?.signal,
+      }),
+      undefined,
+      opts?.signal,
+    )
 
     return {
       pmid: clean,

--- a/backend/cli/src/science/connectors/omics/arrayexpress.ts
+++ b/backend/cli/src/science/connectors/omics/arrayexpress.ts
@@ -9,7 +9,7 @@
  * fetch(id) → /biostudies/api/v1/studies/{accession}  (full study JSON)
  */
 import type { Connector, ConnectorHit } from "../types"
-import { getJSON } from "../http"
+import { getJSON, orFallback } from "../http"
 
 const BASE = "https://www.ebi.ac.uk/biostudies/api/v1"
 
@@ -57,14 +57,22 @@ export const arrayexpress: Connector = {
   async search(query, opts) {
     const size = Math.min(Math.max(opts?.limit ?? 10, 1), 25)
     const url = `${BASE}/arrayexpress/search?query=${encodeURIComponent(query)}&pageSize=${size}`
-    const data = await getJSON<BioStudiesSearch>(url, { signal: opts?.signal }).catch(() => ({}) as BioStudiesSearch)
+    const data = await orFallback(
+      getJSON<BioStudiesSearch>(url, { signal: opts?.signal }),
+      {} as BioStudiesSearch,
+      opts?.signal,
+    )
     return (data.hits ?? []).map(toHit)
   },
 
   async fetch(id, opts) {
     const accession = id.trim()
-    return getJSON(`${BASE}/studies/${encodeURIComponent(accession)}`, {
-      signal: opts?.signal,
-    }).catch(() => ({ accession, found: false }))
+    return orFallback(
+      getJSON(`${BASE}/studies/${encodeURIComponent(accession)}`, {
+        signal: opts?.signal,
+      }),
+      { accession, found: false },
+      opts?.signal,
+    )
   },
 }

--- a/backend/cli/src/science/connectors/omics/depmap.ts
+++ b/backend/cli/src/science/connectors/omics/depmap.ts
@@ -14,7 +14,7 @@
  * fetch(id) → catalogue file whose name/url matches {id}
  */
 import type { Connector, ConnectorHit } from "../types"
-import { getText } from "../http"
+import { getText, orFallback } from "../http"
 
 const PORTAL = "https://depmap.org/portal"
 const FILES_API = `${PORTAL}/api/download/files`
@@ -78,7 +78,7 @@ function toHit(f: DepmapFile): ConnectorHit {
 }
 
 async function catalogue(signal?: AbortSignal): Promise<DepmapCatalogue | undefined> {
-  const body = await getText(FILES_API, { signal }).catch(() => "")
+  const body = await orFallback(getText(FILES_API, { signal }), "", signal)
   return safeParse(body)
 }
 

--- a/backend/cli/src/science/connectors/omics/expression-atlas.ts
+++ b/backend/cli/src/science/connectors/omics/expression-atlas.ts
@@ -11,7 +11,7 @@
  * fetch(id) → /gxa/json/experiments/{accession}
  */
 import type { Connector, ConnectorHit } from "../types"
-import { getJSON } from "../http"
+import { getJSON, orFallback } from "../http"
 
 const BASE = "https://www.ebi.ac.uk/gxa"
 
@@ -62,7 +62,11 @@ function toHit(e: GxaExperiment): ConnectorHit {
 }
 
 async function catalogue(signal?: AbortSignal): Promise<GxaExperiment[]> {
-  const data = await getJSON<GxaExperiments>(`${BASE}/json/experiments`, { signal }).catch(() => ({}) as GxaExperiments)
+  const data = await orFallback(
+    getJSON<GxaExperiments>(`${BASE}/json/experiments`, { signal }),
+    {} as GxaExperiments,
+    signal,
+  )
   return data.experiments ?? []
 }
 
@@ -83,9 +87,13 @@ export const expressionAtlas: Connector = {
 
   async fetch(id, opts) {
     const accession = id.trim()
-    const record = await getJSON(`${BASE}/json/experiments/${encodeURIComponent(accession)}`, {
-      signal: opts?.signal,
-    }).catch(() => undefined)
+    const record = await orFallback(
+      getJSON(`${BASE}/json/experiments/${encodeURIComponent(accession)}`, {
+        signal: opts?.signal,
+      }),
+      undefined,
+      opts?.signal,
+    )
     if (record) return record
     // Fallback: return the catalogue entry if the detail endpoint is unavailable.
     const experiments = await catalogue(opts?.signal)

--- a/backend/cli/src/science/connectors/omics/geo.ts
+++ b/backend/cli/src/science/connectors/omics/geo.ts
@@ -10,7 +10,7 @@
  *             full esummary record.
  */
 import type { Connector, ConnectorHit } from "../types"
-import { getJSON } from "../http"
+import { getJSON, orFallback } from "../http"
 
 const EUTILS = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils"
 
@@ -70,13 +70,17 @@ export const geo: Connector = {
 
   async search(query, opts) {
     const limit = Math.min(Math.max(opts?.limit ?? 10, 1), 25)
-    const search = await getJSON<ESearchResult>(
-      `${EUTILS}/esearch.fcgi?db=gds&term=${encodeURIComponent(query)}&retmode=json&retmax=${limit}`,
-      { signal: opts?.signal },
-    ).catch(() => ({}) as ESearchResult)
+    const search = await orFallback(
+      getJSON<ESearchResult>(
+        `${EUTILS}/esearch.fcgi?db=gds&term=${encodeURIComponent(query)}&retmode=json&retmax=${limit}`,
+        { signal: opts?.signal },
+      ),
+      {} as ESearchResult,
+      opts?.signal,
+    )
     const ids = search.esearchresult?.idlist ?? []
     if (ids.length === 0) return []
-    const summ = await summaries(ids, opts?.signal).catch(() => ({}) as ESummaryResult)
+    const summ = await orFallback(summaries(ids, opts?.signal), {} as ESummaryResult, opts?.signal)
     return ids.map((uid) => toHit(uid, summ.result?.[uid]))
   },
 
@@ -85,13 +89,17 @@ export const geo: Connector = {
     const isUid = /^\d+$/.test(trimmed)
     let uid = trimmed
     if (!isUid) {
-      const search = await getJSON<ESearchResult>(
-        `${EUTILS}/esearch.fcgi?db=gds&term=${encodeURIComponent(trimmed)}[ACCN]&retmode=json&retmax=20`,
-        { signal: opts?.signal },
-      ).catch(() => ({}) as ESearchResult)
+      const search = await orFallback(
+        getJSON<ESearchResult>(
+          `${EUTILS}/esearch.fcgi?db=gds&term=${encodeURIComponent(trimmed)}[ACCN]&retmode=json&retmax=20`,
+          { signal: opts?.signal },
+        ),
+        {} as ESearchResult,
+        opts?.signal,
+      )
       const ids = search.esearchresult?.idlist ?? []
       if (ids.length === 0) return { id: trimmed, found: false }
-      const summ = await summaries(ids, opts?.signal).catch(() => ({}) as ESummaryResult)
+      const summ = await orFallback(summaries(ids, opts?.signal), {} as ESummaryResult, opts?.signal)
       const match = ids.find((u) => summ.result?.[u]?.accession === trimmed)
       if (match) return summ.result?.[match] ?? { id: trimmed, uid: match }
       uid = ids[0]

--- a/backend/cli/src/science/connectors/omics/gtex.ts
+++ b/backend/cli/src/science/connectors/omics/gtex.ts
@@ -10,7 +10,7 @@
  * fetch(id) → gene record + /api/v2/expression/medianGeneExpression?gencodeId=...
  */
 import type { Connector, ConnectorHit } from "../types"
-import { getJSON } from "../http"
+import { getJSON, orFallback } from "../http"
 
 const BASE = "https://gtexportal.org/api/v2"
 
@@ -62,7 +62,7 @@ function toHit(g: GtexGene): ConnectorHit {
 
 async function lookupGene(geneId: string, limit: number, signal?: AbortSignal): Promise<GtexGene[]> {
   const url = `${BASE}/reference/gene?geneId=${encodeURIComponent(geneId)}&itemsPerPage=${limit}`
-  const data = await getJSON<GtexGeneResponse>(url, { signal }).catch(() => ({}) as GtexGeneResponse)
+  const data = await orFallback(getJSON<GtexGeneResponse>(url, { signal }), {} as GtexGeneResponse, signal)
   return data.data ?? []
 }
 
@@ -87,10 +87,14 @@ export const gtex: Connector = {
     const gene = isGencode ? (genes.find((g) => g.gencodeId?.startsWith(trimmed.split(".")[0])) ?? genes[0]) : genes[0]
     const gencodeId = gene?.gencodeId ?? (isGencode ? trimmed : undefined)
     if (!gencodeId) return { id: trimmed, found: false }
-    const median = await getJSON<GtexMedianResponse>(
-      `${BASE}/expression/medianGeneExpression?gencodeId=${encodeURIComponent(gencodeId)}&itemsPerPage=100`,
-      { signal: opts?.signal },
-    ).catch(() => ({}) as GtexMedianResponse)
+    const median = await orFallback(
+      getJSON<GtexMedianResponse>(
+        `${BASE}/expression/medianGeneExpression?gencodeId=${encodeURIComponent(gencodeId)}&itemsPerPage=100`,
+        { signal: opts?.signal },
+      ),
+      {} as GtexMedianResponse,
+      opts?.signal,
+    )
     return { gene: gene ?? { gencodeId }, medianExpression: median.data ?? [] }
   },
 }

--- a/backend/cli/src/science/connectors/omics/hpa.ts
+++ b/backend/cli/src/science/connectors/omics/hpa.ts
@@ -9,7 +9,7 @@
  * fetch(id) → /{ensembl}.json  (full HPA record)
  */
 import type { Connector, ConnectorHit } from "../types"
-import { getJSON } from "../http"
+import { getJSON, orFallback } from "../http"
 
 const BASE = "https://www.proteinatlas.org"
 const COLUMNS = "g,gs,eg,up,gd,chr"
@@ -50,7 +50,7 @@ export const hpa: Connector = {
 
   async search(query, opts) {
     const url = `${BASE}/api/search_download.php?search=${encodeURIComponent(query)}&format=json&columns=${COLUMNS}&compress=no`
-    const data = await getJSON<HpaGene[]>(url, { signal: opts?.signal }).catch(() => [] as HpaGene[])
+    const data = await orFallback(getJSON<HpaGene[]>(url, { signal: opts?.signal }), [] as HpaGene[], opts?.signal)
     const limit = Math.min(Math.max(opts?.limit ?? 10, 1), 25)
     return (Array.isArray(data) ? data : []).slice(0, limit).map(toHit)
   },
@@ -59,14 +59,19 @@ export const hpa: Connector = {
     const trimmed = id.trim()
     const ensembl = /^ENSG\d+/i.test(trimmed)
       ? trimmed
-      : await hpa
-          .search(trimmed, { limit: 1, signal: opts?.signal })
-          .then((hits) => hits[0]?.id)
-          .catch(() => undefined)
+      : await orFallback(
+          hpa.search(trimmed, { limit: 1, signal: opts?.signal }).then((hits) => hits[0]?.id),
+          undefined,
+          opts?.signal,
+        )
     if (!ensembl) return { id: trimmed, found: false }
-    return getJSON(`${BASE}/${encodeURIComponent(ensembl)}.json`, { signal: opts?.signal }).catch(() => ({
-      id: ensembl,
-      found: false,
-    }))
+    return orFallback(
+      getJSON(`${BASE}/${encodeURIComponent(ensembl)}.json`, { signal: opts?.signal }),
+      {
+        id: ensembl,
+        found: false,
+      },
+      opts?.signal,
+    )
   },
 }

--- a/backend/cli/src/science/connectors/omics/single-cell-atlas.ts
+++ b/backend/cli/src/science/connectors/omics/single-cell-atlas.ts
@@ -9,7 +9,7 @@
  * fetch(id) → catalogue entry for {accession}
  */
 import type { Connector, ConnectorHit } from "../types"
-import { getJSON } from "../http"
+import { getJSON, orFallback } from "../http"
 
 const BASE = "https://www.ebi.ac.uk/gxa/sc"
 
@@ -60,7 +60,11 @@ function toHit(e: ScExperiment): ConnectorHit {
 }
 
 async function catalogue(signal?: AbortSignal): Promise<ScExperiment[]> {
-  const data = await getJSON<ScExperiments>(`${BASE}/json/experiments`, { signal }).catch(() => ({}) as ScExperiments)
+  const data = await orFallback(
+    getJSON<ScExperiments>(`${BASE}/json/experiments`, { signal }),
+    {} as ScExperiments,
+    signal,
+  )
   return data.experiments ?? []
 }
 

--- a/backend/cli/src/science/connectors/pathways/biogrid.ts
+++ b/backend/cli/src/science/connectors/pathways/biogrid.ts
@@ -1,5 +1,5 @@
 import type { Connector, ConnectorHit } from "../types"
-import { getJSON } from "../http"
+import { getJSON, orFallback } from "../http"
 import { asRecord, asText, clampLimit, snippet } from "./util"
 
 /** A single interaction record from the BioGRID webservice (JSON format). */
@@ -69,7 +69,7 @@ export const biogrid: Connector = {
     const taxon = asText(opts?.organism)
     if (taxon) params.set("taxId", taxon)
     const url = `${WS}/interactions/?${params.toString()}`
-    const data = await getJSON<unknown>(url, { signal: opts?.signal }).catch(() => null)
+    const data = await orFallback(getJSON<unknown>(url, { signal: opts?.signal }), null, opts?.signal)
     const rec = asRecord(data)
     // BioGRID reports auth/other failures as `{ STATUS: "ERROR", ... }`.
     if (typeof rec["STATUS"] === "string") return []
@@ -90,7 +90,7 @@ export const biogrid: Connector = {
     }
     const params = new URLSearchParams({ accessKey: key, interactionList: id, format: "json" })
     const url = `${WS}/interactions/?${params.toString()}`
-    const data = await getJSON<unknown>(url, { signal: opts?.signal }).catch(() => null)
+    const data = await orFallback(getJSON<unknown>(url, { signal: opts?.signal }), null, opts?.signal)
     const rec = asRecord(data)
     if (typeof rec["STATUS"] === "string") return { id, error: "BioGRID request failed" }
     return rec[id] ?? data

--- a/backend/cli/src/science/connectors/pathways/intact.ts
+++ b/backend/cli/src/science/connectors/pathways/intact.ts
@@ -1,5 +1,5 @@
 import type { Connector, ConnectorHit } from "../types"
-import { getJSON } from "../http"
+import { getJSON, orFallback } from "../http"
 import { clampLimit, snippet } from "./util"
 
 /** A binary interaction row from the IntAct web service. */
@@ -40,7 +40,7 @@ export const intact: Connector = {
     const limit = clampLimit(opts?.limit, 10, 50)
     const params = new URLSearchParams({ page: "0", pageSize: String(limit) })
     const url = `${WS}/interaction/findInteractions/${encodeURIComponent(query)}?${params.toString()}`
-    const data = await getJSON<IntactPage>(url, { signal: opts?.signal }).catch(() => ({}) as IntactPage)
+    const data = await orFallback(getJSON<IntactPage>(url, { signal: opts?.signal }), {} as IntactPage, opts?.signal)
     const rows = Array.isArray(data.content) ? data.content : []
 
     return rows.slice(0, limit).map<ConnectorHit>((row) => {
@@ -61,7 +61,7 @@ export const intact: Connector = {
   async fetch(id, opts) {
     const params = new URLSearchParams({ page: "0", pageSize: "25" })
     const url = `${WS}/interaction/findInteractions/${encodeURIComponent(id)}?${params.toString()}`
-    const data = await getJSON<IntactPage>(url, { signal: opts?.signal }).catch(() => ({}) as IntactPage)
+    const data = await orFallback(getJSON<IntactPage>(url, { signal: opts?.signal }), {} as IntactPage, opts?.signal)
     const rows = Array.isArray(data.content) ? data.content : []
     return rows.find((r) => r.ac === id) ?? rows[0] ?? null
   },

--- a/backend/cli/src/science/connectors/pathways/kegg.ts
+++ b/backend/cli/src/science/connectors/pathways/kegg.ts
@@ -1,5 +1,5 @@
 import type { Connector, ConnectorHit } from "../types"
-import { getText } from "../http"
+import { getText, orFallback } from "../http"
 import { asText, clampLimit } from "./util"
 
 const REST = "https://rest.kegg.jp"
@@ -22,7 +22,7 @@ export const kegg: Connector = {
     const limit = clampLimit(opts?.limit, 10, 50)
     const database = asText(opts?.params?.["database"]) ?? "pathway"
     const url = `${REST}/find/${encodeURIComponent(database)}/${encodeURIComponent(query)}`
-    const text = await getText(url, { signal: opts?.signal }).catch(() => "")
+    const text = await orFallback(getText(url, { signal: opts?.signal }), "", opts?.signal)
 
     const hits: ConnectorHit[] = []
     for (const line of text.split("\n")) {
@@ -48,7 +48,7 @@ export const kegg: Connector = {
 
   async fetch(id, opts) {
     const url = `${REST}/get/${encodeURIComponent(id)}`
-    const text = await getText(url, { signal: opts?.signal }).catch(() => "")
+    const text = await orFallback(getText(url, { signal: opts?.signal }), "", opts?.signal)
     return { id, format: "kegg-flat", text }
   },
 }

--- a/backend/cli/src/science/connectors/pathways/opentargets.ts
+++ b/backend/cli/src/science/connectors/pathways/opentargets.ts
@@ -1,5 +1,5 @@
 import type { Connector, ConnectorHit } from "../types"
-import { getJSON } from "../http"
+import { getJSON, orFallback } from "../http"
 import { clampLimit, snippet } from "./util"
 
 /** A hit from the Open Targets `search` query. */
@@ -31,12 +31,16 @@ const FETCH_QUERY = `query Fetch($id: String!) {
 }`
 
 async function graphql<T>(query: string, variables: Record<string, unknown>, signal?: AbortSignal): Promise<T | null> {
-  return getJSON<T>(ENDPOINT, {
-    method: "POST",
-    body: JSON.stringify({ query, variables }),
-    headers: { "Content-Type": "application/json" },
+  return orFallback(
+    getJSON<T>(ENDPOINT, {
+      method: "POST",
+      body: JSON.stringify({ query, variables }),
+      headers: { "Content-Type": "application/json" },
+      signal,
+    }),
+    null,
     signal,
-  }).catch(() => null)
+  )
 }
 
 function entityUrl(hit: OtHit): string | undefined {

--- a/backend/cli/src/science/connectors/pathways/reactome.ts
+++ b/backend/cli/src/science/connectors/pathways/reactome.ts
@@ -1,5 +1,5 @@
 import type { Connector, ConnectorHit } from "../types"
-import { getJSON } from "../http"
+import { getJSON, orFallback } from "../http"
 import { asText, clampLimit, snippet, stripTags } from "./util"
 
 /** A single entry inside a Reactome search result group. */
@@ -36,7 +36,11 @@ export const reactome: Connector = {
     const species = asText(opts?.organism)
     if (species) params.set("species", species)
     const url = `${CONTENT}/search/query?${params.toString()}`
-    const data = await getJSON<ReactomeSearch>(url, { signal: opts?.signal }).catch(() => ({}) as ReactomeSearch)
+    const data = await orFallback(
+      getJSON<ReactomeSearch>(url, { signal: opts?.signal }),
+      {} as ReactomeSearch,
+      opts?.signal,
+    )
 
     const hits: ConnectorHit[] = []
     for (const group of data.results ?? []) {
@@ -58,6 +62,6 @@ export const reactome: Connector = {
 
   async fetch(id, opts) {
     const url = `${CONTENT}/data/query/${encodeURIComponent(id)}`
-    return getJSON(url, { signal: opts?.signal }).catch(() => null)
+    return orFallback(getJSON(url, { signal: opts?.signal }), null, opts?.signal)
   },
 }

--- a/backend/cli/src/science/connectors/pathways/string-db.ts
+++ b/backend/cli/src/science/connectors/pathways/string-db.ts
@@ -1,5 +1,5 @@
 import type { Connector, ConnectorHit } from "../types"
-import { getJSON } from "../http"
+import { getJSON, orFallback } from "../http"
 import { asText, clampLimit, snippet } from "./util"
 
 /** A resolved identifier from STRING's `get_string_ids` endpoint. */
@@ -47,7 +47,7 @@ export const stringdb: Connector = {
       echo_query: "1",
     })
     const url = `${API}/json/get_string_ids?${params.toString()}`
-    const data = await getJSON<StringMatch[]>(url, { signal: opts?.signal }).catch(() => [])
+    const data = await orFallback(getJSON<StringMatch[]>(url, { signal: opts?.signal }), [], opts?.signal)
     const rows = Array.isArray(data) ? data : []
 
     return rows.slice(0, limit).map<ConnectorHit>((m) => {
@@ -67,7 +67,7 @@ export const stringdb: Connector = {
     const params = new URLSearchParams({ identifiers: id, limit: "25" })
     if (species) params.set("species", species)
     const url = `${API}/json/interaction_partners?${params.toString()}`
-    const partners = await getJSON<StringPartner[]>(url, { signal: opts?.signal }).catch(() => [])
+    const partners = await orFallback(getJSON<StringPartner[]>(url, { signal: opts?.signal }), [], opts?.signal)
     return { id, partners: Array.isArray(partners) ? partners : [] }
   },
 }

--- a/backend/cli/src/science/connectors/pathways/wikipathways.ts
+++ b/backend/cli/src/science/connectors/pathways/wikipathways.ts
@@ -1,5 +1,5 @@
 import type { Connector, ConnectorHit } from "../types"
-import { getJSON } from "../http"
+import { getJSON, orFallback } from "../http"
 import { asText, clampLimit, snippet } from "./util"
 
 /** One pathway entry from the WikiPathways JSON catalog. */
@@ -23,7 +23,7 @@ interface WpResponse {
 const CATALOG = "https://www.wikipathways.org/json/findPathwaysByText.json"
 
 async function catalog(signal?: AbortSignal): Promise<WpPathway[]> {
-  const data = await getJSON<WpResponse>(CATALOG, { signal }).catch(() => ({}) as WpResponse)
+  const data = await orFallback(getJSON<WpResponse>(CATALOG, { signal }), {} as WpResponse, signal)
   return Array.isArray(data.pathwayInfo) ? data.pathwayInfo : []
 }
 

--- a/backend/cli/src/science/connectors/proteins/interpro.ts
+++ b/backend/cli/src/science/connectors/proteins/interpro.ts
@@ -10,7 +10,7 @@
  * in single-entry responses, so it is resolved defensively.
  */
 import type { Connector, ConnectorHit, FetchOptions, SearchOptions } from "../types"
-import { getJSON } from "../http"
+import { getJSON, orFallback } from "../http"
 import { asArray, clampLimit, firstString, toRaw } from "./util"
 
 interface GoTerm {
@@ -65,7 +65,11 @@ function makeConnector(db: Db, meta: Omit<Connector, "search" | "fetch">): Conne
     async search(query, opts?: SearchOptions): Promise<ConnectorHit[]> {
       const size = clampLimit(opts?.limit, 10, 25)
       const url = `${API}/${db}/?search=${encodeURIComponent(query)}&page_size=${size}`
-      const data = await getJSON<ListResponse>(url, { signal: opts?.signal }).catch(() => ({}) as ListResponse)
+      const data = await orFallback(
+        getJSON<ListResponse>(url, { signal: opts?.signal }),
+        {} as ListResponse,
+        opts?.signal,
+      )
       const hits: ConnectorHit[] = []
       for (const r of asArray<ListResult>(data.results)) {
         const m = r.metadata

--- a/backend/cli/src/science/connectors/proteins/pdbe.ts
+++ b/backend/cli/src/science/connectors/proteins/pdbe.ts
@@ -8,7 +8,7 @@
  * and cross-references.
  */
 import type { Connector, ConnectorHit, FetchOptions, SearchOptions } from "../types"
-import { getJSON } from "../http"
+import { getJSON, orFallback } from "../http"
 import { asArray, clampLimit, firstString, toRaw } from "./util"
 
 interface SolrDoc {
@@ -41,7 +41,11 @@ export const pdbe: Connector = {
     const url =
       `https://www.ebi.ac.uk/pdbe/search/pdb/select?q=${encodeURIComponent(query)}` +
       `&wt=json&rows=${rows}&fl=${encodeURIComponent(fl)}`
-    const data = await getJSON<SolrResponse>(url, { signal: opts?.signal }).catch(() => ({}) as SolrResponse)
+    const data = await orFallback(
+      getJSON<SolrResponse>(url, { signal: opts?.signal }),
+      {} as SolrResponse,
+      opts?.signal,
+    )
     const seen = new Set<string>()
     const hits: ConnectorHit[] = []
     for (const d of asArray<SolrDoc>(data.response?.docs)) {
@@ -61,10 +65,13 @@ export const pdbe: Connector = {
 
   async fetch(id, opts?: FetchOptions): Promise<unknown> {
     const key = id.toLowerCase()
-    const data = await getJSON<Record<string, unknown>>(
-      `https://www.ebi.ac.uk/pdbe/api/pdb/entry/summary/${encodeURIComponent(key)}`,
-      { signal: opts?.signal },
-    ).catch(() => ({}) as Record<string, unknown>)
+    const data = await orFallback(
+      getJSON<Record<string, unknown>>(`https://www.ebi.ac.uk/pdbe/api/pdb/entry/summary/${encodeURIComponent(key)}`, {
+        signal: opts?.signal,
+      }),
+      {} as Record<string, unknown>,
+      opts?.signal,
+    )
     // PDBe wraps records as { "<pdbid>": [ {...} ] } — unwrap when present.
     const entry = asArray(data[key])[0]
     return entry ?? data

--- a/backend/cli/src/science/connectors/proteins/rcsb-pdb.ts
+++ b/backend/cli/src/science/connectors/proteins/rcsb-pdb.ts
@@ -9,7 +9,7 @@
  * data API. Enrichment failures degrade gracefully to the bare identifier.
  */
 import type { Connector, ConnectorHit, FetchOptions, SearchOptions } from "../types"
-import { getJSON } from "../http"
+import { getJSON, orFallback } from "../http"
 import { asArray, clampLimit, firstString, toRaw } from "./util"
 
 interface SearchResult {
@@ -67,7 +67,11 @@ export const rcsbPdb: Connector = {
       request_options: { paginate: { start: 0, rows } },
     }
     const url = `https://search.rcsb.org/rcsbsearch/v2/query?json=${encodeURIComponent(JSON.stringify(payload))}`
-    const data = await getJSON<SearchResponse>(url, { signal: opts?.signal }).catch(() => ({}) as SearchResponse)
+    const data = await orFallback(
+      getJSON<SearchResponse>(url, { signal: opts?.signal }),
+      {} as SearchResponse,
+      opts?.signal,
+    )
     const hits = asArray<SearchResult>(data.result_set).filter((r) => typeof r.identifier === "string")
     const enriched = await Promise.all(
       hits.map(async (r) => {

--- a/backend/cli/src/science/connectors/proteins/uniprot.ts
+++ b/backend/cli/src/science/connectors/proteins/uniprot.ts
@@ -5,7 +5,7 @@
  * search + entry endpoints and normalize into ConnectorHit.
  */
 import type { Connector, ConnectorHit, FetchOptions, SearchOptions } from "../types"
-import { getJSON, getText } from "../http"
+import { getJSON, getText, orFallback } from "../http"
 import { asArray, clampLimit, firstString, toRaw } from "./util"
 
 interface UValue {
@@ -71,7 +71,7 @@ export const uniprot: Connector = {
     const org = opts?.organism ? ` AND organism_id:${encodeURIComponent(opts.organism)}` : ""
     const url =
       `https://rest.uniprot.org/uniprotkb/search?query=${encodeURIComponent(query)}${org}` + `&format=json&size=${size}`
-    const data = await getJSON<USearch>(url, { signal: opts?.signal }).catch(() => ({}) as USearch)
+    const data = await orFallback(getJSON<USearch>(url, { signal: opts?.signal }), {} as USearch, opts?.signal)
     return asArray<UEntry>(data.results).map<ConnectorHit>((e) => {
       const id = e.primaryAccession ?? e.uniProtkbId ?? "unknown"
       return {

--- a/backend/cli/test/science/http.test.ts
+++ b/backend/cli/test/science/http.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
-import { getJSON, getText, request, clearCache, resetRateLimits } from "../../src/science/connectors/http"
+import { getJSON, getText, request, clearCache, resetRateLimits, orFallback } from "../../src/science/connectors/http"
 
 // The shared http helper is the ONLY reliability layer under science/connectors,
 // yet had zero tests. These stub globalThis.fetch to exercise retry/backoff, the
@@ -137,5 +137,55 @@ describe("http per-host throttle", () => {
     ])
     // Two distinct hosts run concurrently — neither pays the other's interval.
     expect(Date.now() - t0).toBeLessThan(400)
+  })
+})
+
+describe("orFallback (abort-preserving fallback)", () => {
+  test("returns the fallback when the promise rejects and the signal is not aborted", async () => {
+    const result = await orFallback(
+      Promise.reject(new Error("source down")),
+      { hits: [] },
+      new AbortController().signal,
+    )
+    expect(result).toEqual({ hits: [] })
+  })
+
+  test("returns the resolved value on success, ignoring the fallback", async () => {
+    const result = await orFallback(Promise.resolve("real"), "fallback", new AbortController().signal)
+    expect(result).toBe("real")
+  })
+
+  test("rethrows (does NOT fall back) when the caller's signal is aborted", async () => {
+    const controller = new AbortController()
+    controller.abort()
+    const err = new DOMException("The operation was aborted.", "AbortError")
+    await expect(orFallback(Promise.reject(err), "fallback", controller.signal)).rejects.toThrow(/aborted/)
+  })
+
+  test("falls back when no signal is supplied", async () => {
+    const result = await orFallback(Promise.reject(new Error("nope")), 42)
+    expect(result).toBe(42)
+  })
+
+  test("a real search cancellation propagates through request() and orFallback", async () => {
+    const controller = new AbortController()
+    // Model real fetch: reject with an AbortError as soon as the signal is
+    // aborted — including when it is already aborted by the time fetch runs.
+    globalThis.fetch = ((_url: string, init?: RequestInit) =>
+      new Promise((_resolve, reject) => {
+        const sig = init?.signal
+        const fail = () => reject(new DOMException("aborted", "AbortError"))
+        if (sig?.aborted) return fail()
+        sig?.addEventListener("abort", fail, { once: true })
+      })) as unknown as typeof fetch
+
+    const search = orFallback(
+      getJSON("https://slow.test/q", { signal: controller.signal }),
+      { hits: [] },
+      controller.signal,
+    )
+    controller.abort()
+    // The cancellation surfaces instead of being masked as an empty result.
+    await expect(search).rejects.toThrow()
   })
 })


### PR DESCRIPTION
Closes #96.

## Problem

Every scientific connector wrapped its HTTP calls in a blanket `.catch(() => fallback)`. The shared `request()` helper deliberately rethrows an `AbortError` when the caller's signal is aborted, but that blanket catch swallowed it along with genuine source errors. So cancelling a running `science_search` surfaced as "no results" from each connector rather than a cancellation, and the `if (ctx.abort.aborted) throw err` guard in `science.ts` never fired because the abort never reached the tool layer.

Confirmed across 24 connectors (uniprot, pubchem, rcsb-pdb, string-db, kegg, bindingdb, geo, and more) — 44 call sites total.

## Fix

Add `orFallback(promise, fallback, signal)` to the shared HTTP layer:

```ts
export async function orFallback<T>(p: Promise<T>, fallback: T, signal?: AbortSignal): Promise<T> {
  try { return await p } catch (err) {
    if (signal?.aborted) throw err
    return fallback
  }
}
```

It returns the fallback on error **unless** the caller's signal is aborted, in which case it rethrows so cancellation propagates. An internal request timeout still falls back (the caller didn't cancel), so one slow source can't fail the whole search — that behavior is preserved.

Swapped all 44 blanket catches across the 24 connectors for `orFallback(..., signal)`, threading the in-scope abort signal each request already used.

## Tests

Added `orFallback` unit tests, including an end-to-end cancellation that now propagates through `request()` instead of being masked as an empty result. Full `test/science/` suite green (35 pass), typecheck clean.

This supersedes #132, which proposed the same helper for a subset of connectors — this covers all 44 sites with tests.