### PR TITLE
fix(science): surface the arXiv PDF link in science_search output (#133)

### DIFF
--- a/backend/cli/src/tool/science.ts
+++ b/backend/cli/src/tool/science.ts
@@ -123,6 +123,11 @@ export const ScienceSearchTool = Tool.define("science_search", {
     const rows = hits.map((h) => {
       const lines = [`## ${h.title}`, `**id**: ${h.id}${h.score !== undefined ? ` · score: ${h.score}` : ""}`]
       if (h.url) lines.push(`**url**: ${h.url}`)
+      // Surface a direct PDF link when a connector extracted one (e.g. arXiv
+      // parses its self-closing `title="pdf"` link into extra.pdf) — otherwise
+      // the agent sees the record but not the full-text URL already in hand.
+      const pdf = typeof h.extra?.pdf === "string" ? h.extra.pdf : undefined
+      if (pdf) lines.push(`**pdf**: ${pdf}`)
       if (h.summary) lines.push(h.summary)
       return lines.join("\n")
     })

--- a/backend/cli/test/science/science-tool.test.ts
+++ b/backend/cli/test/science/science-tool.test.ts
@@ -78,6 +78,14 @@ describe("science_search degradation (arxiv)", () => {
     expect(result.output).toContain("Attention Is All You Need")
   })
 
+  test("renders the arXiv PDF link the connector extracted", async () => {
+    stubFetch(() => new Response(PAPER_FEED, { status: 200 }))
+    const result = await search("attention is all you need")
+    // The connector parses the self-closing title="pdf" link into extra.pdf;
+    // the renderer must surface it so the agent sees the full-text URL.
+    expect(result.output).toContain("**pdf**: http://arxiv.org/pdf/1706.03762v7")
+  })
+
   test("sustained 429 degrades to an actionable rate-limited result, not a raw HTTP 429", async () => {
     stubFetch(() => new Response("rate limited", { status: 429, headers: { "Retry-After": "0" } }))
     const result = await search("anything")


### PR DESCRIPTION
Closes #133.

## Problem

The arXiv connector parses the self-closing `<link title="pdf" …/>` into `hit.extra.pdf`, but the generic `science_search` renderer only prints `id`, canonical `url`, and `summary`. A research agent could find an arXiv record without seeing the direct PDF URL the connector already extracted.

## Fix

When a hit carries a string `extra.pdf`, render it as `**pdf**: <url>`. The connector contract is unchanged, no new tool is added, and it makes the existing arXiv retrieval hardening visible to literature-review workflows.

## Tests

Added a regression test driven end-to-end through the real `science_search` tool (the existing arXiv fixture already carries a `title="pdf"` link), asserting the PDF URL appears in the output. `test/science/` green, typecheck clean.

Supersedes #134, which proposed the same change.