### PR TITLE
fix(ui): stop dropdown menus stacking body scroll-locks (#145)

### DIFF
--- a/frontend/ui/src/components/dropdown-menu.tsx
+++ b/frontend/ui/src/components/dropdown-menu.tsx
@@ -23,7 +23,16 @@ export interface DropdownMenuSubTriggerProps extends ComponentProps<typeof Kobal
 export interface DropdownMenuSubContentProps extends ComponentProps<typeof Kobalte.SubContent> {}
 
 function DropdownMenuRoot(props: DropdownMenuProps) {
-  return <Kobalte {...props} data-component="dropdown-menu" />
+  // Default to non-modal. Kobalte's modal menu installs its own body scroll-lock
+  // (padding-right scrollbar compensation). When a menu opens inside an
+  // already-modal Dialog, the two locks stack, and Kobalte captures the
+  // already-padded body width as its "original" — so each open/close cycle
+  // leaves extra padding-right behind. Invisible on macOS overlay scrollbars,
+  // but on Windows' classic scrollbars it narrows the app a little more every
+  // time (#145: the GUI "shrinks" on repeated `...` menu clicks). A dropdown
+  // menu doesn't need a scroll-lock or focus-trap; it still dismisses on
+  // outside-click and Escape. Callers can opt back in with modal={true}.
+  return <Kobalte modal={false} {...props} data-component="dropdown-menu" />
 }
 
 function DropdownMenuTrigger(props: ParentProps<DropdownMenuTriggerProps>) {


### PR DESCRIPTION
Closes #145.

## Diagnosis

The shared `DropdownMenu` root passed props straight to Kobalte, so its default `modal={true}` applied. A modal menu installs a body scroll-lock that adds `padding-right` to compensate for the removed scrollbar.

When such a menu opens **inside an already-modal `Dialog`** — e.g. the `...` (`dot-grid`) menu in the localhost server settings dialog — two scroll-locks stack. Kobalte captures the *already-padded* body width as its "original" value, so restoring on close doesn't return to the true original: each open/close cycle leaves a little extra `padding-right` behind.

- On macOS the scrollbar is an overlay (width 0), so the compensation is 0 and nothing is visible.
- On Windows 11 the scrollbar is classic (~17px), so the app content narrows a bit more on **every** `...` click — the "GUI shrinking" the reporter saw (and why it only reproduced for them, on Windows).

## Fix

Default the shared `DropdownMenu` to `modal={false}`. A transient dropdown menu doesn't need a body scroll-lock or a focus-trap; it still dismisses on outside-click and Escape. Callers that genuinely need a modal menu can pass `modal={true}`.

This removes the nested scroll-lock across every in-app dropdown (server dialog, settings row menus, terminal-tab menu), not just the one in the report.

## Verification

Typecheck + web build pass. The visual effect is platform-specific (Windows classic scrollbars), and jsdom doesn't compute scrollbar width, so it isn't unit-testable headless — the fix is from the diagnosed scroll-lock stacking above. Reporter is on Windows 11 and can confirm the shrink no longer accumulates.