### PR TITLE
fix(wallet): show the CLI wallet balance, not the unified pool

### DIFF
--- a/backend/cli/src/openscience/index.ts
+++ b/backend/cli/src/openscience/index.ts
@@ -1621,6 +1621,25 @@ export namespace OpenScience {
     lifetimeSpentCents: number
   }
 
+  /**
+   * The wallet balance the CLI can actually spend, in cents.
+   *
+   * Atlas `/api/credits` also returns `unified_balance_cents` — the sum of every
+   * pool: the CLI wallet + the Atlas-web wallet + the subscription cycle pool +
+   * gifted credits. But OpenScience managed mode debits ONLY the CLI wallet
+   * (Atlas `cli.py`: `category="cli"`; an Atlas plan grants BYOK + library quota,
+   * not CLI spending credits). Showing the unified pool made the wallet read
+   * e.g. $160 when the CLI could actually spend far less. Prefer the CLI wallet;
+   * fall back to the older aggregate fields only if a backend omits it.
+   */
+  export function cliSpendableCents(d: {
+    cli_balance_cents?: number
+    unified_balance_cents?: number
+    balance_cents?: number
+  }): number {
+    return d.cli_balance_cents ?? d.unified_balance_cents ?? d.balance_cents ?? 0
+  }
+
   export async function getCredits(): Promise<Credits | null> {
     const session = await getSession()
     if (!session) return null
@@ -1636,7 +1655,7 @@ export namespace OpenScience {
         cycle_credits_remaining_cents?: number
         lifetime_spent_cents?: number
       }
-      const cents = d.unified_balance_cents ?? d.balance_cents ?? 0
+      const cents = cliSpendableCents(d)
       return {
         balanceUsd: cents / 100,
         cliBalanceCents: d.cli_balance_cents ?? d.balance_cents ?? 0,

--- a/backend/cli/test/openscience/wallet-balance.test.ts
+++ b/backend/cli/test/openscience/wallet-balance.test.ts
@@ -1,0 +1,24 @@
+import { test, expect, describe } from "bun:test"
+import { OpenScience } from "../../src/openscience"
+
+// Wallet balance bug: the panel showed Atlas's unified balance (CLI wallet +
+// Atlas-web wallet + subscription + gifted, e.g. $160) but OpenScience managed
+// mode can only spend the CLI wallet. cliSpendableCents must report the CLI
+// wallet, so the number reflects what the CLI can actually spend.
+
+describe("cliSpendableCents", () => {
+  test("prefers the CLI wallet over the unified pool", () => {
+    // Unified $160 (mostly Atlas-web + gifted), CLI wallet $2.50 — show $2.50.
+    expect(OpenScience.cliSpendableCents({ cli_balance_cents: 250, unified_balance_cents: 16000 })).toBe(250)
+  })
+
+  test("shows an empty CLI wallet as 0, not the unified pool", () => {
+    expect(OpenScience.cliSpendableCents({ cli_balance_cents: 0, unified_balance_cents: 16000 })).toBe(0)
+  })
+
+  test("falls back to unified, then aggregate, when the CLI field is absent", () => {
+    expect(OpenScience.cliSpendableCents({ unified_balance_cents: 500 })).toBe(500)
+    expect(OpenScience.cliSpendableCents({ balance_cents: 300 })).toBe(300)
+    expect(OpenScience.cliSpendableCents({})).toBe(0)
+  })
+})


### PR DESCRIPTION
## Where the number came from

The wallet panel read Atlas `GET /api/credits` → `unified_balance_cents`. On the Atlas side that field is the **sum of every pool**: the CLI wallet + the Atlas-web wallet + the subscription cycle pool + gifted credits (`credits.py`: "the unified spendable balance so /billing, /agent, and /cli all speak about the same pool").

But OpenScience managed mode can only spend the **CLI wallet**. Atlas `cli.py` is explicit:

> CLI managed mode spends ONLY the CLI wallet (`category='cli'`, funded by top-ups). An Atlas plan grants BYOK + better library quotas, not CLI spending credits, so we deliberately do NOT include the Atlas sub pool / Atlas top-ups here.

So a user with, say, a gifted/subscription grant saw a large headline "Balance" (the $160 in the report) that the CLI could never actually spend — while the rest of the same panel (lifetime spent, ledger) was already CLI-scoped and small. That mismatch is the bug.

## Fix

`getCredits` now reports the CLI wallet (`cli_balance_cents`) via a small `cliSpendableCents` helper, which is exactly what `/api/cli/billing-mode` already returns as the spendable balance. Falls back to `unified_balance_cents` / `balance_cents` only if an older backend omits the CLI field. Unit tests cover the preference order.

## Not changed

The Atlas backend deliberately exposes the unified balance on `/api/credits` for its web surfaces — that's fine for the dashboard. This change only affects what the **CLI** wallet panel shows. No Atlas change needed.