### PR TITLE
fix: propagate signal exit code from the npm bin wrapper

### DIFF
--- a/backend/cli/bin/openscience
+++ b/backend/cli/bin/openscience
@@ -31,8 +31,15 @@ function run(target) {
     console.error(result.error.message)
     process.exit(1)
   }
-  const code = typeof result.status === "number" ? result.status : 0
-  process.exit(code)
+  if (typeof result.status === "number") {
+    process.exit(result.status)
+  }
+  // Killed by a signal (status is null): report failure using the shell
+  // convention 128 + signal number, instead of masking it as a success exit 0.
+  if (result.signal) {
+    process.exit(128 + (os.constants.signals[result.signal] || 0))
+  }
+  process.exit(1)
 }
 
 // Helper: check if a path points to a real binary (not this wrapper script)


### PR DESCRIPTION
## Problem

`backend/cli/bin/openscience` ran the real binary via `spawnSync` and did:

```js
const code = typeof result.status === "number" ? result.status : 0
process.exit(code)
```

When the child is killed by a signal, `spawnSync` sets `status` to `null` (and `signal` to the signal name). The wrapper mapped that to exit **0**, so a subprocess killed by SIGINT/SIGTERM/SIGKILL looked *successful* to callers, scripts, and CI.

## Fix

Exit with the numeric status when present; otherwise, if the child was signalled, exit with the shell convention `128 + signal number`; otherwise exit 1. `os` is already required at the top of the file.

Verified the wrapper still parses (`node --check`, the same check the Smoke CI job runs).

Re-lands the fix reported in #101 as a first-party commit.