### PR TITLE
feat(agents): Agents tab — subagent visibility in the right pane

### DIFF
--- a/frontend/workspace/src/pages/session.tsx
+++ b/frontend/workspace/src/pages/session.tsx
@@ -553,53 +553,58 @@ export default function Page(): JSX.Element {
                 </Match>
               </Switch>
 
-              {/* Prompt dock — gradient fade + centered PromptInput (v1.1.116) */}
-              <div class="absolute inset-x-0 bottom-0 pt-12 pb-4 flex flex-col justify-center items-center z-50 px-4 md:px-0 bg-gradient-to-t from-background-base via-background-base to-transparent pointer-events-none">
-                <div class="w-full px-4 pointer-events-auto md:max-w-200 md:mx-auto">
-                  <Show when={revertInfo()}>
-                    <div
-                      class="mb-3"
-                      style={{
-                        display: "flex",
-                        "align-items": "center",
-                        gap: "12px",
-                        padding: "8px 12px",
-                        border: "1px solid var(--color-border)",
-                        "border-radius": "8px",
-                        "font-size": "12px",
-                        "font-family": FONT_SANS,
-                        color: "var(--color-text-muted)",
-                        background: "var(--color-bg)",
-                      }}
-                    >
-                      <span style={{ flex: 1, "min-width": 0 }}>
-                        Conversation reverted. {revertedCount()} turn{revertedCount() === 1 ? "" : "s"} hidden and file
-                        changes rolled back. Sending a new message makes this permanent.
-                      </span>
-                      <button
-                        type="button"
-                        onClick={() => void restoreRevert()}
+              {/* Prompt dock — gradient fade + centered PromptInput (v1.1.116). Hidden on
+                subagent (child) transcripts: those are read-only inspection views, and typing
+                here would spawn an independent turn on the worker session, disconnected from the
+                parent that owns it. Use "back to parent session" to continue. */}
+              <Show when={!activeSession()?.parentID}>
+                <div class="absolute inset-x-0 bottom-0 pt-12 pb-4 flex flex-col justify-center items-center z-50 px-4 md:px-0 bg-gradient-to-t from-background-base via-background-base to-transparent pointer-events-none">
+                  <div class="w-full px-4 pointer-events-auto md:max-w-200 md:mx-auto">
+                    <Show when={revertInfo()}>
+                      <div
+                        class="mb-3"
                         style={{
+                          display: "flex",
+                          "align-items": "center",
+                          gap: "12px",
+                          padding: "8px 12px",
                           border: "1px solid var(--color-border)",
-                          background: "transparent",
-                          color: "inherit",
-                          padding: "4px 10px",
                           "border-radius": "8px",
                           "font-size": "12px",
-                          cursor: "pointer",
-                          "white-space": "nowrap",
+                          "font-family": FONT_SANS,
+                          color: "var(--color-text-muted)",
+                          background: "var(--color-bg)",
                         }}
                       >
-                        restore
-                      </button>
-                    </div>
-                  </Show>
-                  <PromptInput
-                    newSessionWorktree={newSessionWorktree()}
-                    onNewSessionWorktreeReset={() => setNewSessionWorktree("main")}
-                  />
+                        <span style={{ flex: 1, "min-width": 0 }}>
+                          Conversation reverted. {revertedCount()} turn{revertedCount() === 1 ? "" : "s"} hidden and
+                          file changes rolled back. Sending a new message makes this permanent.
+                        </span>
+                        <button
+                          type="button"
+                          onClick={() => void restoreRevert()}
+                          style={{
+                            border: "1px solid var(--color-border)",
+                            background: "transparent",
+                            color: "inherit",
+                            padding: "4px 10px",
+                            "border-radius": "8px",
+                            "font-size": "12px",
+                            cursor: "pointer",
+                            "white-space": "nowrap",
+                          }}
+                        >
+                          restore
+                        </button>
+                      </div>
+                    </Show>
+                    <PromptInput
+                      newSessionWorktree={newSessionWorktree()}
+                      onNewSessionWorktreeReset={() => setNewSessionWorktree("main")}
+                    />
+                  </div>
                 </div>
-              </div>
+              </Show>
             </div>
 
             {/* files — the host explorer, mounted on first visit */}

--- a/frontend/workspace/src/thesis/AgentsTab.tsx
+++ b/frontend/workspace/src/thesis/AgentsTab.tsx
@@ -1,0 +1,63 @@
+import { createMemo, For, Show, type JSX } from "solid-js"
+import { useNavigate, useParams } from "@solidjs/router"
+import { useSync } from "@/context/sync"
+import { activeSubagents } from "@/thesis/store/subagents"
+import { StatusDot } from "@/thesis/shared/StatusDot"
+import { AgentIcon } from "@/thesis/shared/AgentIcon"
+import { FONT_MONO, FONT_SANS } from "@/styles/tokens"
+
+export function AgentsTab(): JSX.Element {
+  const sync = useSync()
+  const params = useParams()
+  const navigate = useNavigate()
+
+  const rows = createMemo(() => {
+    const id = params.id
+    if (!id || id === "new") return []
+    return activeSubagents(sync.data.session as any, sync.data.session_status ?? {}, id)
+  })
+
+  return (
+    <div style={{ flex: 1, "min-height": 0, overflow: "auto", padding: "8px 10px" }} class="thesis-scroll">
+      <Show
+        when={rows().length > 0}
+        fallback={
+          <div style={{ padding: "24px 12px", "font-family": FONT_SANS, "font-size": "12px", color: "var(--color-text-faint)", "text-align": "center" }}>
+            No subagents running in this session.
+          </div>
+        }
+      >
+        <For each={rows()}>
+          {(row) => (
+            <button
+              type="button"
+              onClick={() => navigate(`/${params.dir}/session/${row.sessionId}`)}
+              style={{
+                all: "unset",
+                cursor: "pointer",
+                display: "flex",
+                "align-items": "center",
+                gap: "8px",
+                width: "100%",
+                "box-sizing": "border-box",
+                padding: "8px 8px",
+                "border-radius": "4px",
+                "border-bottom": "1px solid var(--color-border)",
+                "font-family": FONT_MONO,
+                "font-size": "11px",
+              }}
+              onMouseEnter={(e) => (e.currentTarget.style.background = "var(--color-accent-subtle)")}
+              onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
+            >
+              <StatusDot status={row.status} pulse={row.status === "active"} />
+              <AgentIcon size={14} animated={row.status === "active"} />
+              <span style={{ flex: 1, "min-width": 0, overflow: "hidden", "text-overflow": "ellipsis", "white-space": "nowrap", color: "var(--color-text)" }}>
+                {row.title}
+              </span>
+            </button>
+          )}
+        </For>
+      </Show>
+    </div>
+  )
+}

--- a/frontend/workspace/src/thesis/AgentsTab.tsx
+++ b/frontend/workspace/src/thesis/AgentsTab.tsx
@@ -4,12 +4,22 @@ import { useSync } from "@/context/sync"
 import { activeSubagents } from "@/thesis/store/subagents"
 import { StatusDot } from "@/thesis/shared/StatusDot"
 import { AgentIcon } from "@/thesis/shared/AgentIcon"
+import { IconChevronLeft } from "@/thesis/shared/Icon"
 import { FONT_MONO, FONT_SANS } from "@/styles/tokens"
 
 export function AgentsTab(): JSX.Element {
   const sync = useSync()
   const params = useParams()
   const navigate = useNavigate()
+
+  // When viewing a subagent (child) session, surface a way back to the
+  // orchestrator here too — the chat header's back arrow is icon-only and easy
+  // to miss, and a child session has no subagents of its own to list.
+  const parentId = createMemo(() => {
+    const id = params.id
+    if (!id || id === "new") return undefined
+    return sync.session.get(id)?.parentID
+  })
 
   const rows = createMemo(() => {
     const id = params.id
@@ -19,12 +29,60 @@ export function AgentsTab(): JSX.Element {
 
   return (
     <div style={{ flex: 1, "min-height": 0, overflow: "auto", padding: "8px 10px" }} class="thesis-scroll">
+      <Show when={parentId()}>
+        {(pid) => (
+          <button
+            type="button"
+            onClick={() => navigate(`/${params.dir}/session/${pid()}`)}
+            style={{
+              all: "unset",
+              cursor: "pointer",
+              display: "flex",
+              "align-items": "center",
+              gap: "8px",
+              width: "100%",
+              "box-sizing": "border-box",
+              padding: "8px 8px",
+              "border-radius": "4px",
+              "border-bottom": "1px solid var(--color-border)",
+              "font-family": FONT_MONO,
+              "font-size": "11px",
+              color: "var(--color-text-muted)",
+            }}
+            onMouseEnter={(e) => (e.currentTarget.style.background = "var(--color-accent-subtle)")}
+            onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
+          >
+            <IconChevronLeft size={13} strokeWidth={1.6} />
+            <span
+              style={{
+                flex: 1,
+                "min-width": 0,
+                overflow: "hidden",
+                "text-overflow": "ellipsis",
+                "white-space": "nowrap",
+              }}
+            >
+              back to main agent
+            </span>
+          </button>
+        )}
+      </Show>
       <Show
         when={rows().length > 0}
         fallback={
-          <div style={{ padding: "24px 12px", "font-family": FONT_SANS, "font-size": "12px", color: "var(--color-text-faint)", "text-align": "center" }}>
-            No subagents running in this session.
-          </div>
+          <Show when={!parentId()}>
+            <div
+              style={{
+                padding: "24px 12px",
+                "font-family": FONT_SANS,
+                "font-size": "12px",
+                color: "var(--color-text-faint)",
+                "text-align": "center",
+              }}
+            >
+              No subagents running in this session.
+            </div>
+          </Show>
         }
       >
         <For each={rows()}>
@@ -51,7 +109,16 @@ export function AgentsTab(): JSX.Element {
             >
               <StatusDot status={row.status} pulse={row.status === "active"} />
               <AgentIcon size={14} animated={row.status === "active"} />
-              <span style={{ flex: 1, "min-width": 0, overflow: "hidden", "text-overflow": "ellipsis", "white-space": "nowrap", color: "var(--color-text)" }}>
+              <span
+                style={{
+                  flex: 1,
+                  "min-width": 0,
+                  overflow: "hidden",
+                  "text-overflow": "ellipsis",
+                  "white-space": "nowrap",
+                  color: "var(--color-text)",
+                }}
+              >
                 {row.title}
               </span>
             </button>

--- a/frontend/workspace/src/thesis/RightPane.tsx
+++ b/frontend/workspace/src/thesis/RightPane.tsx
@@ -22,6 +22,8 @@ import { Terminal } from "@/components/terminal"
 import { confirmDialog } from "@/thesis/dialogs"
 import { URLS } from "@/config/urls"
 import { uiStore, type RightPaneTab } from "@/thesis/store/ui"
+import { activeSubagents, activeCount } from "@/thesis/store/subagents"
+import { AgentsTab } from "@/thesis/AgentsTab"
 import { OpenScienceFileTree } from "@/thesis/OpenScienceFileTree"
 import { FilePreview } from "@/thesis/FilePreview"
 import { SkillLibraryDialog } from "@/thesis/SkillsBrowser"
@@ -71,6 +73,14 @@ function readSavedWidth(): number {
 export function RightPane(): JSX.Element {
   const tab = uiStore.rightPaneTab
   const setTab = uiStore.setRightPaneTab
+  const sync = useSync()
+  const routeParams = useParams()
+  const agentCount = createMemo(() => {
+    const id = routeParams.id
+    if (!id || id === "new") return 0
+    const rows = activeSubagents(sync.data.session as any, sync.data.session_status ?? {}, id)
+    return activeCount(rows)
+  })
   // Keep-alive: once a tab has been opened it stays mounted (hidden via CSS),
   // so switching tabs never re-mounts/re-fetches/re-animates — no flash.
   const [visited, setVisited] = createSignal<Set<RightPaneTab>>(new Set([tab()]))
@@ -86,6 +96,7 @@ export function RightPane(): JSX.Element {
   const TABS: { k: RightPaneTab; label?: string; Icon: (p: { size?: number; strokeWidth?: number }) => JSX.Element }[] =
     [
       { k: "canvas", label: "atlas", Icon: IconLayoutGrid },
+      { k: "agents", label: "agents", Icon: IconCpu },
       { k: "terminal", Icon: IconTerminal },
     ]
   const visibleTabs = createMemo(() => TABS.filter((t) => !uiStore.isTabHidden(t.k)))
@@ -191,7 +202,14 @@ export function RightPane(): JSX.Element {
           >
             <For each={visibleTabs()}>
               {(t) => (
-                <TabBtn k={t.k} label={t.label} Icon={t.Icon} active={tab() === t.k} onClick={() => setTab(t.k)} />
+                <TabBtn
+                  k={t.k}
+                  label={t.label}
+                  Icon={t.Icon}
+                  active={tab() === t.k}
+                  onClick={() => setTab(t.k)}
+                  badge={t.k === "agents" ? agentCount() : undefined}
+                />
               )}
             </For>
           </div>
@@ -258,6 +276,9 @@ export function RightPane(): JSX.Element {
         <div style={{ flex: 1, "min-height": 0, position: "relative", display: "flex", "flex-direction": "column" }}>
           <KeepAlive show={tab() === "canvas"} mounted={visited().has("canvas")}>
             <CanvasTab />
+          </KeepAlive>
+          <KeepAlive show={tab() === "agents"} mounted={visited().has("agents")}>
+            <AgentsTab />
           </KeepAlive>
           <KeepAlive show={tab() === "terminal"} mounted={visited().has("terminal")}>
             <TerminalTab />

--- a/frontend/workspace/src/thesis/store/subagents.test.ts
+++ b/frontend/workspace/src/thesis/store/subagents.test.ts
@@ -1,7 +1,12 @@
 import { describe, test, expect } from "bun:test"
 import { activeSubagents, subagentStatusKind, activeCount } from "./subagents"
 
-const s = (id: string, parentID: string | undefined, updated: number, title = id) => ({ id, parentID, title, time: { updated } })
+const s = (id: string, parentID: string | undefined, updated: number, title = id) => ({
+  id,
+  parentID,
+  title,
+  time: { updated },
+})
 
 describe("subagentStatusKind", () => {
   test("busy → active, retry → pending, idle/missing → done", () => {

--- a/frontend/workspace/src/thesis/store/subagents.test.ts
+++ b/frontend/workspace/src/thesis/store/subagents.test.ts
@@ -1,0 +1,24 @@
+import { describe, test, expect } from "bun:test"
+import { activeSubagents, subagentStatusKind, activeCount } from "./subagents"
+
+const s = (id: string, parentID: string | undefined, updated: number, title = id) => ({ id, parentID, title, time: { updated } })
+
+describe("subagentStatusKind", () => {
+  test("busy → active, retry → pending, idle/missing → done", () => {
+    expect(subagentStatusKind({ type: "busy" })).toBe("active")
+    expect(subagentStatusKind({ type: "retry" })).toBe("pending")
+    expect(subagentStatusKind({ type: "idle" })).toBe("done")
+    expect(subagentStatusKind(undefined)).toBe("done")
+  })
+})
+
+describe("activeSubagents", () => {
+  test("filters by parent, joins status, sorts recent first", () => {
+    const sessions = [s("c1", "p", 10), s("c2", "p", 30), s("root", undefined, 99), s("other", "q", 50)]
+    const statuses = { c1: { type: "busy" }, c2: { type: "idle" } }
+    const rows = activeSubagents(sessions as any, statuses as any, "p")
+    expect(rows.map((r) => r.sessionId)).toEqual(["c2", "c1"])
+    expect(rows.find((r) => r.sessionId === "c1")!.status).toBe("active")
+    expect(activeCount(rows)).toBe(1)
+  })
+})

--- a/frontend/workspace/src/thesis/store/subagents.ts
+++ b/frontend/workspace/src/thesis/store/subagents.ts
@@ -1,0 +1,29 @@
+import type { Session } from "@synsci/sdk/v2/client"
+
+type StatusKind = "active" | "pending" | "done" | "error"
+type Status = { type: string } | undefined
+
+export type SubagentRow = { sessionId: string; title: string; status: StatusKind; updated: number }
+
+export function subagentStatusKind(status: Status): StatusKind {
+  if (!status) return "done"
+  if (status.type === "busy") return "active"
+  if (status.type === "retry") return "pending"
+  return "done"
+}
+
+export function activeSubagents(sessions: Session[], statuses: Record<string, Status>, parentId: string): SubagentRow[] {
+  return sessions
+    .filter((session) => session.parentID === parentId)
+    .map((session) => ({
+      sessionId: session.id,
+      title: session.title,
+      status: subagentStatusKind(statuses[session.id]),
+      updated: session.time?.updated ?? 0,
+    }))
+    .sort((a, b) => b.updated - a.updated)
+}
+
+export function activeCount(rows: SubagentRow[]): number {
+  return rows.filter((r) => r.status === "active").length
+}

--- a/frontend/workspace/src/thesis/store/subagents.ts
+++ b/frontend/workspace/src/thesis/store/subagents.ts
@@ -12,7 +12,11 @@ export function subagentStatusKind(status: Status): StatusKind {
   return "done"
 }
 
-export function activeSubagents(sessions: Session[], statuses: Record<string, Status>, parentId: string): SubagentRow[] {
+export function activeSubagents(
+  sessions: Session[],
+  statuses: Record<string, Status>,
+  parentId: string,
+): SubagentRow[] {
   return sessions
     .filter((session) => session.parentID === parentId)
     .map((session) => ({

--- a/frontend/workspace/src/thesis/store/ui.ts
+++ b/frontend/workspace/src/thesis/store/ui.ts
@@ -1,6 +1,6 @@
 import { createSignal } from "solid-js"
 
-export type RightPaneTab = "canvas" | "terminal"
+export type RightPaneTab = "canvas" | "agents" | "terminal"
 
 const PANE_OPEN_KEY = "thesis-rightpane-open-v1"
 const HIDDEN_TABS_KEY = "thesis-rightpane-hidden-tabs-v1"


### PR DESCRIPTION
## Agents tab — subagent visibility in the right pane

Adds an **agents** tab to the workspace right pane that lists the active session's subagents (status dot + agent icon + title, with a live active-count badge on the tab). Clicking a row opens that child session's transcript in the chat area. All data comes from the existing sync store — **no backend changes**.

This is the self-contained slice of the earlier `chat-ui-quality` effort's subagent-visibility work, rebased cleanly onto current `main` (the Agents-tab surface touches files `main` didn't).

### What's included
- **Pure selectors** (`store/subagents.ts` + test): `activeSubagents`, `subagentStatusKind` (busy→active, retry→pending, idle/missing→done), `activeCount`.
- **`AgentsTab.tsx`** — lists the active session's subagents; row-click navigates to the child session.
- **Right-pane registration** (`RightPane.tsx` / `store/ui.ts`) — the tab (`atlas | agents | terminal`) with the active-subagent count badge.
- **Composer hidden on subagent transcripts** (`session.tsx`) — a child session is a delegated worker; typing into it would spawn an independent turn disconnected from its parent, so the prompt dock is gated on `activeSession().parentID`. Child transcripts are read-only inspection views.
- **"back to main agent" entry** (`AgentsTab.tsx`) — when viewing a child, the Agents tab shows a labelled row back to the orchestrator (the header's back arrow is icon-only and easy to miss), and the "No subagents" empty-state is suppressed there.

### Intentionally NOT included
`main` already provides these via its own session UI, so they were dropped to avoid duplication:
- back-to-parent button in the chat header (main's `feat(session): … editable title`).
- child-session title in the chat tab (main's `EditableTitle`).

### Verification (built on `main`)
- `bun test src/thesis/store/subagents.test.ts` → 2 pass / 7 assertions.
- `frontend/workspace` typecheck → exit 0; pre-push checks pass.
- Single binary builds; `openscience web` launched and driven live:
  - Agents tab lists a real research session's 5 `@literature-review` subagents; row-click opens the child transcript; **0 console errors**.
  - On a child: composer hidden, "back to main agent" shown → returns to parent. On the parent: composer present, subagent list shown, no back entry.
- Note: the live **active/pulsing** dot + rising badge was verified by tracing the data path (task tool sets the child session busy → `session.status` event → workspace global store → `activeSubagents` → `StatusDot`), not frozen-frame in a screenshot — subagents finish quickly in the test environment.

### Not covered here
The rest of the `chat-ui-quality` chat-rendering work (streaming/typewriter, reasoning collapsible, chronological turns, rich tool/skill cards) overlaps `main`'s parallel v1.1.116 chat reskin and is being triaged separately — **not** part of this PR.
