### PR TITLE
fix(ui): readable terminal-disconnect toast on WebKit

### DIFF
--- a/frontend/workspace/src/components/terminal-error.test.ts
+++ b/frontend/workspace/src/components/terminal-error.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test"
+import { connectionError } from "./terminal-error"
+
+describe("connectionError", () => {
+  test("passes an Error through untouched", () => {
+    const cause = new Error("Session not found")
+    expect(connectionError(cause)).toBe(cause)
+  })
+
+  test("wraps the bare error Event WebKit fires when a socket drops", () => {
+    const wrapped = connectionError(new Event("error"))
+    expect(wrapped).toBeInstanceOf(Error)
+    expect(wrapped.message).toBe("connection to the server was lost")
+  })
+
+  test("wraps any other non-Error rejection", () => {
+    expect(connectionError(undefined).message).toBe("connection to the server was lost")
+    expect(connectionError("boom").message).toBe("connection to the server was lost")
+  })
+})

--- a/frontend/workspace/src/components/terminal-error.ts
+++ b/frontend/workspace/src/components/terminal-error.ts
@@ -1,0 +1,6 @@
+// When a pty socket dies, WebKit dispatches a bare `error` Event (no detail)
+// before the close event, while Blink goes straight to close. Stringifying
+// that Event put "[object Event]" in the disconnect toast — normalize anything
+// non-Error into a readable fallback instead.
+export const connectionError = (cause: unknown) =>
+  cause instanceof Error ? cause : new Error("connection to the server was lost")

--- a/frontend/workspace/src/components/terminal.tsx
+++ b/frontend/workspace/src/components/terminal.tsx
@@ -4,6 +4,7 @@ import { useSDK } from "@/context/sdk"
 import { monoFontFamily, useSettings } from "@/context/settings"
 import { SerializeAddon } from "@/addons/serialize"
 import { LocalPTY } from "@/context/terminal"
+import { connectionError } from "./terminal-error"
 import { resolveThemeVariant, useTheme, withAlpha, type HexColor } from "@synsci/ui/theme"
 import { useLanguage } from "@/context/language"
 import { showToast } from "@synsci/ui/toast"
@@ -13,7 +14,7 @@ export interface TerminalProps extends ComponentProps<"div"> {
   onSubmit?: () => void
   onCleanup?: (pty: LocalPTY) => void
   onConnect?: () => void
-  onConnectError?: (error: unknown) => void
+  onConnectError?: (error: Error) => void
 }
 
 let shared: Promise<{ mod: typeof import("ghostty-web"); ghostty: Ghostty }> | undefined
@@ -321,7 +322,7 @@ export const Terminal = (props: TerminalProps) => {
         if (once.value) return
         once.value = true
         console.error("WebSocket error:", error)
-        local.onConnectError?.(error)
+        local.onConnectError?.(connectionError(error))
       }
       socket.addEventListener("error", handleError)
       cleanups.push(() => socket.removeEventListener("error", handleError))
@@ -347,7 +348,7 @@ export const Terminal = (props: TerminalProps) => {
         title: language.t("terminal.connectionLost.title"),
         description: err instanceof Error ? err.message : language.t("terminal.connectionLost.description"),
       })
-      local.onConnectError?.(err)
+      local.onConnectError?.(connectionError(err))
     })
   })
 

--- a/frontend/workspace/src/thesis/RightPane.tsx
+++ b/frontend/workspace/src/thesis/RightPane.tsx
@@ -398,9 +398,7 @@ function TerminalTab(): JSX.Element {
                   <Terminal
                     pty={pty}
                     onCleanup={(next) => terminal.update(next)}
-                    onConnectError={(e) =>
-                      toast.error("terminal disconnected", e instanceof Error ? e.message : String(e))
-                    }
+                    onConnectError={(e) => toast.error("terminal disconnected", e.message)}
                   />
                 </div>
               )}


### PR DESCRIPTION
## Problem

With the workspace open in Safari, a dropped terminal session shows:

> **terminal disconnected**
> [object Event]

## Root cause

When a pty WebSocket dies (server restart/update, network loss), the two engines report it differently:

- **Blink/Chrome** fires only `close` (code 1006) → the close handler builds a readable `Error`.
- **WebKit/Safari** fires a bare `error` **Event first**, then `close`. The `once` gate in `terminal.tsx` means the error path wins, and it passed the raw `Event` to `onConnectError`, which the right-pane toast rendered via `String(e)` → `[object Event]`.

Confirmed against the real `/pty/:id/connect` endpoint in Safari and Chrome side by side: killing the server produced `error → [object Event]` in Safari and `close 1006` in Chrome. Connection setup itself is healthy in Safari (CSP, ws scheme, IPv6, and idle-timeout scenarios all tested clean) — this is purely an error-reporting bug.

## Fix

- `terminal-error.ts`: normalize any non-`Error` failure (the WebKit error `Event`, string rejections, `undefined`) into `Error("connection to the server was lost")`.
- `terminal.tsx`: route both failure paths (`error` event handler and the setup `catch`) through it, and tighten `onConnectError` from `(error: unknown)` to `(error: Error)` so a non-Error can never reach the toast again.
- `RightPane.tsx`: with the contract guaranteed, render `e.message` directly.

## Verification

- Unit tests for the normalization helper (`bun test`), workspace typecheck clean.
- End-to-end in Playwright **WebKit** against the fixed frontend: opened a terminal, SIGKILLed the backend — toast now reads **"terminal disconnected — connection to the server was lost"**.