### PR TITLE
fix(reasoning): don't request reasoning for Claude via OpenRouter

### DIFF
--- a/backend/cli/src/provider/transform.ts
+++ b/backend/cli/src/provider/transform.ts
@@ -39,6 +39,17 @@ export namespace ProviderTransform {
     return undefined
   }
 
+  // Whether a model is Anthropic/Claude on ANY route (native, Bedrock, Vertex, or
+  // OpenRouter). Checks the display id AND the wire api.id, lowercased, plus the
+  // provider/npm — so a config alias, mixed-case slug, or id/api.id divergence
+  // can't slip past a caller's guard. Mirrors the canonical detection in message().
+  function isAnthropic(model: Provider.Model): boolean {
+    if (model.providerID === "anthropic") return true
+    if (model.api.npm === "@ai-sdk/anthropic" || model.api.npm === "@ai-sdk/amazon-bedrock") return true
+    const ids = `${model.id} ${model.api.id}`.toLowerCase()
+    return ids.includes("claude") || ids.includes("anthropic")
+  }
+
   function normalizeMessages(
     msgs: ModelMessage[],
     model: Provider.Model,
@@ -452,11 +463,22 @@ export namespace ProviderTransform {
 
     switch (model.api.npm) {
       case "@openrouter/ai-sdk-provider":
+        // Claude via OpenRouter cannot round-trip reasoning. Anthropic requires the
+        // signed thinking block to be replayed unmodified on the next step of a
+        // tool-use turn, but OpenRouter strips that signature on these routes — so
+        // the moment Claude produces a thinking block and the turn continues (tool
+        // call → result), the replay is rejected with 400 "Invalid `signature`…" /
+        // "…blocks cannot be modified", surfaced as the generic "Provider returned
+        // error" that stalls the loop. Offer NO reasoning-effort variants for it, so
+        // no thinking block is ever generated to fail — matching the last-known-good
+        // release (1.2.5). Native-Anthropic BYOK is a different npm (@ai-sdk/anthropic)
+        // and keeps its reasoning, since it carries a valid signature. Uses the SAME
+        // predicate as options() above so the two guards can't disagree and leak.
+        if (isAnthropic(model)) return {}
         // OpenRouter accepts a unified `reasoning.effort` for ANY reasoning-capable
-        // model (Claude, DeepSeek, GLM, Kimi, Gemini, OpenAI), normalizing effort
-        // to a token budget where the native API is on/off only. gpt keeps its
-        // wider ladder (none/minimal/xhigh); everything else uses the universal
-        // low/medium/high floor.
+        // model (DeepSeek, GLM, Kimi, Gemini, OpenAI), normalizing effort to a token
+        // budget where the native API is on/off only. gpt keeps its wider ladder
+        // (none/minimal/xhigh); everything else uses the universal low/medium/high floor.
         if (model.id.includes("gpt")) {
           return Object.fromEntries(
             (id.includes("gpt-5.5") ? OPENAI_GPT55_EFFORTS : OPENAI_EFFORTS).map((effort) => [
@@ -769,7 +791,31 @@ export namespace ProviderTransform {
       // by default for every reasoning-capable model (a selected effort variant
       // overrides this via mergeDeep in llm.ts). This is the single normalized
       // reasoning path that all managed wallet inference now flows through.
-      if (input.model.capabilities.reasoning) {
+      //
+      // EXCEPT Claude via OpenRouter: Anthropic requires the signed thinking block
+      // to be replayed unmodified on the next step of a tool-use turn, but OpenRouter
+      // strips that signature on these routes — so any multi-step turn that produced
+      // thinking is rejected with 400 "Invalid `signature`…" / "…cannot be modified",
+      // surfaced as the generic "Provider returned error" that stalls the loop. Don't
+      // request reasoning for it, so no unreplayable thinking block is ever generated
+      // (1.2.5 requested reasoning for gemini-3 only). Native-Anthropic BYOK is a
+      // different npm (@ai-sdk/anthropic) and keeps its properly-signed reasoning.
+      //
+      // This is a workaround, not the ceiling. The corruption lives in
+      // @openrouter/ai-sdk-provider@1.5.x: it emits per-`reasoning-delta`
+      // reasoning_details fragments with no signature and duplicates them across the
+      // message on replay, so the signed block can never be reconstructed intact
+      // (see Kilo-Org/kilo#303). Re-enabling Claude-OR reasoning requires the fix in
+      // @openrouter/ai-sdk-provider@2.x, which needs ai@^6 — a breaking upgrade
+      // tracked separately. When that lands, drop this guard AND the one in variants().
+      //
+      // Explicitly DISABLE rather than merely omit: adaptive-thinking Claude (Opus
+      // 4.7+/Claude 5) defaults thinking ON on the wire, and llm.ts merges
+      // model/agent `options.reasoning` AFTER this base — `{ enabled: false }` (the
+      // same shape smallOptions() uses) survives both, where an omission would not.
+      const claude = isAnthropic(input.model)
+      if (claude) result["reasoning"] = { enabled: false }
+      if (!claude && input.model.capabilities.reasoning) {
         result["reasoning"] = { effort: input.model.api.id.includes("gemini-3") ? "high" : "medium" }
       }
     }

--- a/backend/cli/test/provider/transform-reasoning.test.ts
+++ b/backend/cli/test/provider/transform-reasoning.test.ts
@@ -39,7 +39,7 @@ const orModel = (id: string, apiId: string, extra: Partial<any> = {}) =>
 describe("ProviderTransform.options — managed OpenRouter reasoning", () => {
   test("reasoning-capable OR model requests unified reasoning + usage, no OpenAI keys", () => {
     const result = ProviderTransform.options({
-      model: orModel("openrouter/anthropic/claude-sonnet-4", "anthropic/claude-sonnet-4"),
+      model: orModel("openrouter/deepseek/deepseek-r1", "deepseek/deepseek-r1"),
       sessionID,
       providerOptions: { baseURL: PROXY_OR },
     })
@@ -48,6 +48,57 @@ describe("ProviderTransform.options — managed OpenRouter reasoning", () => {
     expect(result.reasoningEffort).toBeUndefined()
     expect(result.reasoningSummary).toBeUndefined()
     expect(result.include).toBeUndefined()
+  })
+
+  test("Claude via OpenRouter explicitly DISABLES reasoning (unreplayable signed thinking → 400)", () => {
+    const result = ProviderTransform.options({
+      model: orModel("openrouter/anthropic/claude-sonnet-4", "anthropic/claude-sonnet-4"),
+      sessionID,
+      providerOptions: { baseURL: PROXY_OR },
+    })
+    // usage tracking still on, reasoning explicitly off → no thinking blocks, even
+    // for adaptive-thinking models that default on and past a config effort merge.
+    expect(result.usage).toEqual({ include: true })
+    expect(result.reasoning).toEqual({ enabled: false })
+  })
+
+  test("Claude-OR reasoning is disabled even when only api.id (mixed-case) carries the token", () => {
+    // options() and variants() must key off the SAME both-field, lowercased predicate,
+    // or an uppercase/aliased Claude id slips options() and re-triggers the 400.
+    const upper = ProviderTransform.options({
+      model: orModel("openrouter/some-alias", "Anthropic/Claude-Sonnet-4"),
+      sessionID,
+      providerOptions: { baseURL: PROXY_OR },
+    })
+    expect(upper.reasoning).toEqual({ enabled: false })
+    // model.id carries the token, api.id does not → still caught (both fields checked).
+    const aliased = ProviderTransform.options({
+      model: orModel("openrouter/anthropic/claude-x", "vendor/opaque-slug"),
+      sessionID,
+      providerOptions: { baseURL: PROXY_OR },
+    })
+    expect(aliased.reasoning).toEqual({ enabled: false })
+  })
+
+  test("Claude via OpenRouter offers no reasoning-effort variants (same predicate as options)", () => {
+    expect(
+      ProviderTransform.variants(orModel("openrouter/anthropic/claude-sonnet-4", "anthropic/claude-sonnet-4")),
+    ).toEqual({})
+    // mixed-case api.id must also yield no picker, matching options() above.
+    expect(ProviderTransform.variants(orModel("openrouter/some-alias", "Anthropic/Claude-Sonnet-4"))).toEqual({})
+  })
+
+  test("a non-Claude OR model whose id merely contains a vendor token is unaffected", () => {
+    // deepseek model, id has no claude/anthropic → keeps reasoning + effort variants.
+    const opts = ProviderTransform.options({
+      model: orModel("openrouter/deepseek/deepseek-r1", "deepseek/deepseek-r1"),
+      sessionID,
+      providerOptions: { baseURL: PROXY_OR },
+    })
+    expect(opts.reasoning).toEqual({ effort: "medium" })
+    expect(
+      Object.keys(ProviderTransform.variants(orModel("openrouter/deepseek/deepseek-r1", "deepseek/deepseek-r1"))),
+    ).toContain("medium")
   })
 
   test("OR-routed gpt-5 uses reasoning.effort (not the OpenAI keys), even via the managed proxy", () => {


### PR DESCRIPTION
## Problem

Claude models via OpenRouter throw **"Provider returned error"** the moment a turn goes multi-step (tool call → tool result). The underlying error is an OpenRouter 400: `Invalid \`signature\` in \`thinking\` block` / `\`thinking\` blocks in the latest assistant message cannot be modified`. It hits the main research agent, sub-agents, and compaction alike, stalling the loop. **Native Anthropic BYOK is unaffected** — it returns valid signatures.

## Root cause

`transform.ts` `options()` requests `reasoning: { effort }` for **every** reasoning-capable OpenRouter model — including Claude. Claude then emits thinking blocks, but `@openrouter/ai-sdk-provider@1.5.x` corrupts them on replay: per-`reasoning-delta` `reasoning_details` fragments arrive with no signature and get duplicated across the message (see [Kilo-Org/kilo#303](https://github.com/Kilo-Org/kilo/issues/303)). Anthropic requires the *signed* thinking block to be replayed unmodified on the next step of a tool-use turn, so the corrupt/unsigned block is rejected.

The `v1.2.5` release requested reasoning for `gemini-3` only on OpenRouter and ran these workflows clean; a later refactor turned it on for all OR reasoning models, which is what regressed it. `v1.2.5` has byte-identical reasoning capture and replay code — proving the bug is that we *request* the thinking blocks, not how we replay them.

## Fix

- Add a shared `isAnthropic(model)` predicate (checks both `model.id` **and** `api.id`, lowercased, plus provider/npm) and use it in `options()` and `variants()` so the two guards can't disagree — an uppercase or config-aliased Claude id could otherwise slip `options()` while `variants()` caught it.
- `options()` now explicitly sets `reasoning: { enabled: false }` (the shape `smallOptions()` already uses) for Claude-via-OpenRouter — instead of merely omitting the object. This also covers adaptive-thinking Claude (Opus 4.7+/Claude 5, which defaults thinking on the wire) and survives a config `options.reasoning` merge in `llm.ts`.
- `variants()` offers no reasoning-effort picker for Claude-OR, so a manual variant selection can't re-enable it.

Native-Anthropic BYOK (`@ai-sdk/anthropic`, valid signatures) and other OpenRouter reasoning models (DeepSeek, GLM, Gemini, gpt-5) are unaffected.

## Verification

- **Live:** an `openrouter/anthropic/claude-sonnet-5` multi-step tool-use turn now completes — 0 reasoning requests, 0 `reasoning_details`, 0 errors.
- Unit tests for the guard divergence, mixed-case `api.id`, and the non-Claude carve-out.
- Backend typecheck + full provider suite green.

## Re-enable path (separate, tracked)

Enabling Claude reasoning on OpenRouter *properly* requires upgrading `@openrouter/ai-sdk-provider` to `2.x` + `ai@^6` (the v2.x line fixes the `reasoning_details` corruption) — a breaking AI-SDK-v6 migration. When that lands, drop both `isAnthropic` guards (each is commented with this note).
