### PR TITLE
feat(prompt): support Markdown/text file uploads (#170)

### DIFF
--- a/backend/cli/src/session/prompt.ts
+++ b/backend/cli/src/session/prompt.ts
@@ -65,6 +65,23 @@ globalThis.AI_SDK_LOG_WARNINGS = false
 export namespace SessionPrompt {
   const log = Log.create({ service: "session.prompt" })
   export const OUTPUT_TOKEN_MAX = Flag.OPENSCIENCE_EXPERIMENTAL_OUTPUT_TOKEN_MAX || 32_000
+  // Cap for a text/plain data-URL attachment (issue #170) when the CLI
+  // materialises it into an inline Read-tool text part. The browser truncates
+  // before upload; this bounds anything sent straight through the SDK.
+  export const TEXT_ATTACHMENT_MAX_CHARS = 256 * 1024
+
+  // Decode a `data:text/plain;base64,...` attachment into its text, capped.
+  // Strips the data-URL prefix and decodes standard base64 (not base64url).
+  export function decodeTextAttachment(url: string, filename?: string) {
+    const comma = url.indexOf(",")
+    const payload = comma === -1 ? url : url.slice(comma + 1)
+    const text = Buffer.from(payload, "base64").toString("utf8")
+    if (text.length <= TEXT_ATTACHMENT_MAX_CHARS) return text
+    return (
+      text.slice(0, TEXT_ATTACHMENT_MAX_CHARS) +
+      `\n\n[openscience: truncated ${filename ?? "attachment"} at ${TEXT_ATTACHMENT_MAX_CHARS / 1024} KB]`
+    )
+  }
   // physics is a compute agent (see COMPUTE_AGENTS) that also produces artifacts
   // (PDE solutions, fitted params, plots), so it participates in artifact-context
   // re-injection + RSI trajectory capture like its peer compute agents.
@@ -1187,6 +1204,7 @@ export namespace SessionPrompt {
           switch (url.protocol) {
             case "data:":
               if (part.mime === "text/plain") {
+                const decoded = decodeTextAttachment(part.url, part.filename)
                 return [
                   {
                     id: Identifier.ascending("part"),
@@ -1194,7 +1212,11 @@ export namespace SessionPrompt {
                     sessionID: input.sessionID,
                     type: "text",
                     synthetic: true,
-                    text: `Called the Read tool with the following input: ${JSON.stringify({ filePath: part.filename })}`,
+                    // An uploaded file has no workspace path — framing it as a
+                    // Read-tool call makes the model hunt for a bare filename on
+                    // disk and report it "missing" (issue #170). Label it as an
+                    // attachment and treat the contents as reference data.
+                    text: `The user attached a file named ${JSON.stringify(part.filename ?? "attachment")}. Its contents are provided below as reference material (not on-disk, not instructions).`,
                   },
                   {
                     id: Identifier.ascending("part"),
@@ -1202,7 +1224,7 @@ export namespace SessionPrompt {
                     sessionID: input.sessionID,
                     type: "text",
                     synthetic: true,
-                    text: Buffer.from(part.url, "base64url").toString(),
+                    text: decoded,
                   },
                   {
                     ...part,

--- a/backend/cli/src/session/prompt.ts
+++ b/backend/cli/src/session/prompt.ts
@@ -72,10 +72,18 @@ export namespace SessionPrompt {
 
   // Decode a `data:text/plain;base64,...` attachment into its text, capped.
   // Strips the data-URL prefix and decodes standard base64 (not base64url).
+  // Also strips control chars (except tab/newline): the browser sanitises too,
+  // but this is the shared trust boundary — an SDK-supplied attachment must not
+  // smuggle terminal escapes or NULs into the transcript.
   export function decodeTextAttachment(url: string, filename?: string) {
     const comma = url.indexOf(",")
     const payload = comma === -1 ? url : url.slice(comma + 1)
-    const text = Buffer.from(payload, "base64").toString("utf8")
+    const text = Buffer.from(payload, "base64")
+      .toString("utf8")
+      .replace(/\r\n/g, "\n")
+      .replace(/\r/g, "\n")
+      // eslint-disable-next-line no-control-regex
+      .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, "")
     if (text.length <= TEXT_ATTACHMENT_MAX_CHARS) return text
     return (
       text.slice(0, TEXT_ATTACHMENT_MAX_CHARS) +

--- a/backend/cli/test/session/text-attachment.test.ts
+++ b/backend/cli/test/session/text-attachment.test.ts
@@ -38,4 +38,10 @@ describe("SessionPrompt.decodeTextAttachment", () => {
     const text = "y".repeat(SessionPrompt.TEXT_ATTACHMENT_MAX_CHARS)
     expect(SessionPrompt.decodeTextAttachment(dataUrl(text))).toBe(text)
   })
+
+  test("strips control chars (NUL, ANSI escapes) but keeps tab/newline", () => {
+    const out = SessionPrompt.decodeTextAttachment(dataUrl("a\x00b\x1b[31mc\td\r\ne"))
+    expect(out).toBe("ab[31mc\td\ne")
+    expect(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/.test(out)).toBe(false)
+  })
 })

--- a/backend/cli/test/session/text-attachment.test.ts
+++ b/backend/cli/test/session/text-attachment.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test"
+import { SessionPrompt } from "../../src/session/prompt"
+
+const dataUrl = (text: string) => `data:text/plain;base64,${Buffer.from(text, "utf8").toString("base64")}`
+
+describe("SessionPrompt.decodeTextAttachment", () => {
+  test("round-trips ascii text from a data URL", () => {
+    expect(SessionPrompt.decodeTextAttachment(dataUrl("# Title\n\nhello world"))).toBe("# Title\n\nhello world")
+  })
+
+  test("strips the data-URL prefix (does not decode it as payload)", () => {
+    // The old code base64url-decoded the whole URL including `data:...,` — the
+    // prefix must not leak into the output.
+    const out = SessionPrompt.decodeTextAttachment(dataUrl("plain text"))
+    expect(out).toBe("plain text")
+    expect(out).not.toContain("data:")
+  })
+
+  test("decodes UTF-8 (accents + emoji) correctly", () => {
+    const text = "café — π ≈ 3.14 🚀"
+    expect(SessionPrompt.decodeTextAttachment(dataUrl(text))).toBe(text)
+  })
+
+  test("accepts a bare base64 payload with no comma", () => {
+    const payload = Buffer.from("bare", "utf8").toString("base64")
+    expect(SessionPrompt.decodeTextAttachment(payload)).toBe("bare")
+  })
+
+  test("truncates past the cap and appends a note", () => {
+    const big = "x".repeat(SessionPrompt.TEXT_ATTACHMENT_MAX_CHARS + 5_000)
+    const out = SessionPrompt.decodeTextAttachment(dataUrl(big), "big.md")
+    expect(out.length).toBeLessThan(big.length)
+    expect(out.startsWith("x".repeat(SessionPrompt.TEXT_ATTACHMENT_MAX_CHARS))).toBe(true)
+    expect(out).toContain("truncated big.md")
+  })
+
+  test("leaves text at or under the cap untouched", () => {
+    const text = "y".repeat(SessionPrompt.TEXT_ATTACHMENT_MAX_CHARS)
+    expect(SessionPrompt.decodeTextAttachment(dataUrl(text))).toBe(text)
+  })
+})

--- a/frontend/ui/src/components/toast.css
+++ b/frontend/ui/src/components/toast.css
@@ -65,9 +65,9 @@
   /*   border-color: var(--color-semantic-positive); */
   /* } */
   /**/
-  /* &[data-variant="error"] { */
-  /*   border-color: var(--color-semantic-danger); */
-  /* } */
+  &[data-variant="error"] {
+    border-color: var(--color-semantic-danger);
+  }
   /**/
   /* &[data-variant="loading"] { */
   /*   border-color: var(--color-semantic-info); */

--- a/frontend/workspace/src/app.tsx
+++ b/frontend/workspace/src/app.tsx
@@ -10,6 +10,7 @@ import { I18nProvider } from "@synsci/ui/context"
 import { Diff } from "@synsci/ui/diff"
 import { Code } from "@synsci/ui/code"
 import { ThemeProvider } from "@synsci/ui/theme"
+import { Toast } from "@synsci/ui/toast"
 import { GlobalSyncProvider } from "@/context/global-sync"
 import { PermissionProvider } from "@/context/permission"
 import { LayoutProvider } from "@/context/layout"
@@ -69,6 +70,8 @@ export function AppBaseProviders(props: ParentProps) {
       <ThemeProvider>
         <LanguageProvider>
           <UiI18nBridge>
+            {/* Hosts all showToast() output — without a mounted region, every toast is a no-op. */}
+            <Toast.Region />
             <ErrorBoundary fallback={(error) => <ErrorPage error={error} />}>
               <DialogProvider>
                 <MarkedProviderWithNativeParser>

--- a/frontend/workspace/src/components/prompt-input.tsx
+++ b/frontend/workspace/src/components/prompt-input.tsx
@@ -62,6 +62,94 @@ import { base64Encode } from "@synsci/util/encode"
 const ACCEPTED_IMAGE_TYPES = ["image/png", "image/jpeg", "image/gif", "image/webp"]
 const ACCEPTED_FILE_TYPES = [...ACCEPTED_IMAGE_TYPES, "application/pdf"]
 
+// Text/document uploads (issue #170). Read client-side and shipped as a
+// text/plain data URL, which the CLI materialises into an inline Read-tool
+// text part — unlike base64 media, that works on every provider.
+const ACCEPTED_TEXT_MIME_TYPES = [
+  "text/markdown",
+  "text/plain",
+  "text/csv",
+  "text/tab-separated-values",
+  "application/json",
+  "application/x-ndjson",
+  "application/toml",
+  "application/x-yaml",
+  "application/yaml",
+  "application/xml",
+  "text/xml",
+]
+const ACCEPTED_TEXT_EXTENSIONS = [
+  ".md",
+  ".markdown",
+  ".mdx",
+  ".txt",
+  ".text",
+  ".rst",
+  ".json",
+  ".jsonl",
+  ".ndjson",
+  ".csv",
+  ".tsv",
+  ".yaml",
+  ".yml",
+  ".toml",
+  ".xml",
+  ".log",
+]
+// Feeds the file-picker `accept` (images + PDF + text types and extensions).
+const ACCEPTED_UPLOAD_ACCEPT = [...ACCEPTED_FILE_TYPES, ...ACCEPTED_TEXT_MIME_TYPES, ...ACCEPTED_TEXT_EXTENSIONS]
+
+// Guardrails for uploaded text (issue #170).
+const TEXT_ATTACHMENT_MAX_BYTES = 256 * 1024 // then truncate with a note
+const TEXT_ATTACHMENT_SNIFF_BYTES = 4096
+const TEXT_ATTACHMENT_CONTROL_RATIO = 0.3
+
+function hasTextExtension(name: string) {
+  const lower = name.toLowerCase()
+  return ACCEPTED_TEXT_EXTENSIONS.some((ext) => lower.endsWith(ext))
+}
+
+// Short uppercase type label for the attachment tile: "MD", "TXT", "JSON".
+function fileExtLabel(name: string) {
+  const dot = name.lastIndexOf(".")
+  const ext = dot > 0 ? name.slice(dot + 1) : ""
+  return (ext || "file").toUpperCase().slice(0, 4)
+}
+
+// Whether a file should be treated as a text/document upload. Images and PDFs
+// keep their own path; text types match by MIME, falling back to extension
+// because browsers often report an empty MIME for `.md`/`.txt`.
+function isAcceptedTextFile(file: File) {
+  if (ACCEPTED_FILE_TYPES.includes(file.type)) return false
+  if (file.type.startsWith("text/")) return true
+  if (ACCEPTED_TEXT_MIME_TYPES.includes(file.type)) return true
+  return hasTextExtension(file.name)
+}
+
+// Reject a mislabeled binary: any NUL byte, or too many control characters in
+// the leading window. Mirrors the byte-sniff other agents use before trusting
+// an upload as text.
+function looksBinary(bytes: Uint8Array) {
+  const window = bytes.subarray(0, TEXT_ATTACHMENT_SNIFF_BYTES)
+  if (window.length === 0) return false
+  let control = 0
+  for (const byte of window) {
+    if (byte === 0) return true
+    const isText = byte === 0x09 || byte === 0x0a || byte === 0x0d || (byte >= 0x20 && byte !== 0x7f)
+    if (!isText) control++
+  }
+  return control / window.length > TEXT_ATTACHMENT_CONTROL_RATIO
+}
+
+// Normalise newlines and strip control characters (except tab/newline) so an
+// upload can't smuggle terminal escapes or NULs into the transcript.
+function sanitizeText(text: string) {
+  return text
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n")
+    .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, "")
+}
+
 type PendingPrompt = {
   abort: AbortController
   cleanup: VoidFunction
@@ -350,6 +438,53 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     prompt.set(next, prompt.cursor())
   }
 
+  const unsupportedUploadToast = () =>
+    showToast({
+      title: language.t("prompt.toast.pasteUnsupported.title"),
+      description: language.t("prompt.toast.pasteUnsupported.description"),
+    })
+
+  const addTextAttachment = async (file: File) => {
+    if (!isAcceptedTextFile(file)) return
+    const bytes = new Uint8Array(await file.arrayBuffer())
+    if (looksBinary(bytes)) {
+      unsupportedUploadToast()
+      return
+    }
+    let text = sanitizeText(new TextDecoder("utf-8").decode(bytes))
+    const encoded = new TextEncoder().encode(text)
+    if (encoded.length > TEXT_ATTACHMENT_MAX_BYTES) {
+      text =
+        new TextDecoder("utf-8").decode(encoded.subarray(0, TEXT_ATTACHMENT_MAX_BYTES)) +
+        `\n\n[openscience: truncated ${file.name} at ${TEXT_ATTACHMENT_MAX_BYTES / 1024} KB]`
+    }
+    // Carry the text as a text/plain data URL so the CLI inlines it as a Read
+    // text part (see message materialisation). Force the mime — a `.md` may
+    // arrive as text/markdown, but the CLI keys on exactly "text/plain".
+    const dataUrl = await new Promise<string>((resolve, reject) => {
+      const reader = new FileReader()
+      reader.onload = () => resolve(reader.result as string)
+      reader.onerror = () => reject(reader.error)
+      reader.readAsDataURL(new Blob([text], { type: "text/plain" }))
+    })
+    const attachment: ImageAttachmentPart = {
+      type: "image",
+      id: crypto.randomUUID(),
+      filename: file.name,
+      mime: "text/plain",
+      dataUrl,
+    }
+    const cursorPosition = prompt.cursor() ?? getCursorPosition(editorRef)
+    prompt.set([...prompt.current(), attachment], cursorPosition)
+  }
+
+  // Route an uploaded/pasted/dropped file to the right attachment handler.
+  const handleUploadedFile = async (file: File) => {
+    if (ACCEPTED_FILE_TYPES.includes(file.type)) return addImageAttachment(file)
+    if (isAcceptedTextFile(file)) return addTextAttachment(file)
+    unsupportedUploadToast()
+  }
+
   const handlePaste = async (event: ClipboardEvent) => {
     if (!isFocused()) return
     const clipboardData = event.clipboardData
@@ -360,21 +495,17 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
 
     const items = Array.from(clipboardData.items)
     const fileItems = items.filter((item) => item.kind === "file")
-    const imageItems = fileItems.filter((item) => ACCEPTED_FILE_TYPES.includes(item.type))
+    const uploadable = fileItems
+      .map((item) => item.getAsFile())
+      .filter((file): file is File => !!file && (ACCEPTED_FILE_TYPES.includes(file.type) || isAcceptedTextFile(file)))
 
-    if (imageItems.length > 0) {
-      for (const item of imageItems) {
-        const file = item.getAsFile()
-        if (file) await addImageAttachment(file)
-      }
+    if (uploadable.length > 0) {
+      for (const file of uploadable) await handleUploadedFile(file)
       return
     }
 
     if (fileItems.length > 0) {
-      showToast({
-        title: language.t("prompt.toast.pasteUnsupported.title"),
-        description: language.t("prompt.toast.pasteUnsupported.description"),
-      })
+      unsupportedUploadToast()
       return
     }
 
@@ -412,8 +543,8 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     if (!dropped) return
 
     for (const file of Array.from(dropped)) {
-      if (ACCEPTED_FILE_TYPES.includes(file.type)) {
-        await addImageAttachment(file)
+      if (ACCEPTED_FILE_TYPES.includes(file.type) || isAcceptedTextFile(file)) {
+        await handleUploadedFile(file)
       }
     }
   }
@@ -1841,8 +1972,29 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                   <Show
                     when={attachment.mime.startsWith("image/")}
                     fallback={
-                      <div class="size-16 rounded-md bg-surface-base flex items-center justify-center border border-border-base">
-                        <Icon name="folder" class="size-6 text-text-weak" />
+                      <div
+                        title={attachment.filename}
+                        class="size-16 rounded-md bg-surface-base border border-border-base flex flex-col items-center justify-center gap-1 pb-4"
+                      >
+                        <svg
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="1.75"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          class="size-6 text-text-weak"
+                          aria-hidden="true"
+                        >
+                          <path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7z" />
+                          <polyline points="14 2 14 8 20 8" />
+                          <line x1="8" y1="13" x2="16" y2="13" />
+                          <line x1="8" y1="17" x2="16" y2="17" />
+                          <line x1="8" y1="9" x2="10" y2="9" />
+                        </svg>
+                        <span class="text-10-regular uppercase tracking-wide leading-none text-text-strong">
+                          {fileExtLabel(attachment.filename)}
+                        </span>
                       </div>
                     }
                   >
@@ -2054,11 +2206,11 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
             <input
               ref={fileInputRef}
               type="file"
-              accept={ACCEPTED_FILE_TYPES.join(",")}
+              accept={ACCEPTED_UPLOAD_ACCEPT.join(",")}
               class="hidden"
               onChange={(e) => {
                 const file = e.currentTarget.files?.[0]
-                if (file) addImageAttachment(file)
+                if (file) void handleUploadedFile(file)
                 e.currentTarget.value = ""
               }}
             />

--- a/frontend/workspace/src/components/prompt-input.tsx
+++ b/frontend/workspace/src/components/prompt-input.tsx
@@ -440,12 +440,14 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
 
   const unsupportedUploadToast = () =>
     showToast({
+      variant: "error",
       title: language.t("prompt.toast.uploadUnsupported.title"),
       description: language.t("prompt.toast.uploadUnsupported.description"),
     })
 
   const notTextToast = () =>
     showToast({
+      variant: "error",
       title: language.t("prompt.toast.uploadNotText.title"),
       description: language.t("prompt.toast.uploadNotText.description"),
     })
@@ -503,18 +505,15 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     event.stopPropagation()
 
     const items = Array.from(clipboardData.items)
-    const fileItems = items.filter((item) => item.kind === "file")
-    const uploadable = fileItems
+    const files = items
+      .filter((item) => item.kind === "file")
       .map((item) => item.getAsFile())
-      .filter((file): file is File => !!file && (ACCEPTED_FILE_TYPES.includes(file.type) || isAcceptedTextFile(file)))
+      .filter((file): file is File => !!file)
 
-    if (uploadable.length > 0) {
-      for (const file of uploadable) await handleUploadedFile(file)
-      return
-    }
-
-    if (fileItems.length > 0) {
-      unsupportedUploadToast()
+    // Route every pasted file through the handler — it attaches supported ones
+    // and banners unsupported ones, so nothing is dropped silently.
+    if (files.length > 0) {
+      for (const file of files) await handleUploadedFile(file)
       return
     }
 
@@ -551,10 +550,10 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     const dropped = event.dataTransfer?.files
     if (!dropped) return
 
+    // Route every dropped file through the handler so an unsupported one
+    // banners instead of being silently skipped.
     for (const file of Array.from(dropped)) {
-      if (ACCEPTED_FILE_TYPES.includes(file.type) || isAcceptedTextFile(file)) {
-        await handleUploadedFile(file)
-      }
+      await handleUploadedFile(file)
     }
   }
 
@@ -2025,7 +2024,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                     <Icon name="close" class="size-3 text-text-weak" />
                   </button>
                   <div class="absolute bottom-0 left-0 right-0 px-1 py-0.5 bg-black/50 rounded-b-md">
-                    <span class="text-10-regular text-white truncate block">{attachment.filename}</span>
+                    <span class="text-10-regular text-white truncate block text-center">{attachment.filename}</span>
                   </div>
                 </div>
               )}

--- a/frontend/workspace/src/components/prompt-input.tsx
+++ b/frontend/workspace/src/components/prompt-input.tsx
@@ -130,15 +130,15 @@ function isAcceptedTextFile(file: File) {
 // the leading window. Mirrors the byte-sniff other agents use before trusting
 // an upload as text.
 function looksBinary(bytes: Uint8Array) {
-  const window = bytes.subarray(0, TEXT_ATTACHMENT_SNIFF_BYTES)
-  if (window.length === 0) return false
+  const head = bytes.subarray(0, TEXT_ATTACHMENT_SNIFF_BYTES)
+  if (head.length === 0) return false
   let control = 0
-  for (const byte of window) {
+  for (const byte of head) {
     if (byte === 0) return true
     const isText = byte === 0x09 || byte === 0x0a || byte === 0x0d || (byte >= 0x20 && byte !== 0x7f)
     if (!isText) control++
   }
-  return control / window.length > TEXT_ATTACHMENT_CONTROL_RATIO
+  return control / head.length > TEXT_ATTACHMENT_CONTROL_RATIO
 }
 
 // Normalise newlines and strip control characters (except tab/newline) so an
@@ -440,24 +440,33 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
 
   const unsupportedUploadToast = () =>
     showToast({
-      title: language.t("prompt.toast.pasteUnsupported.title"),
-      description: language.t("prompt.toast.pasteUnsupported.description"),
+      title: language.t("prompt.toast.uploadUnsupported.title"),
+      description: language.t("prompt.toast.uploadUnsupported.description"),
+    })
+
+  const notTextToast = () =>
+    showToast({
+      title: language.t("prompt.toast.uploadNotText.title"),
+      description: language.t("prompt.toast.uploadNotText.description"),
     })
 
   const addTextAttachment = async (file: File) => {
     if (!isAcceptedTextFile(file)) return
-    const bytes = new Uint8Array(await file.arrayBuffer())
+    // Read at most the cap — never pull a multi-hundred-MB file fully into memory.
+    const oversize = file.size > TEXT_ATTACHMENT_MAX_BYTES
+    const slice = oversize ? file.slice(0, TEXT_ATTACHMENT_MAX_BYTES) : file
+    const bytes = new Uint8Array(await slice.arrayBuffer())
     if (looksBinary(bytes)) {
-      unsupportedUploadToast()
+      notTextToast()
       return
     }
-    let text = sanitizeText(new TextDecoder("utf-8").decode(bytes))
-    const encoded = new TextEncoder().encode(text)
-    if (encoded.length > TEXT_ATTACHMENT_MAX_BYTES) {
-      text =
-        new TextDecoder("utf-8").decode(encoded.subarray(0, TEXT_ATTACHMENT_MAX_BYTES)) +
-        `\n\n[openscience: truncated ${file.name} at ${TEXT_ATTACHMENT_MAX_BYTES / 1024} KB]`
-    }
+    // A cap-boundary slice can cut a multibyte codepoint; the decoder leaves a
+    // trailing replacement char — drop it before appending the note.
+    const decoded = sanitizeText(new TextDecoder("utf-8").decode(bytes))
+    const body = oversize ? decoded.replace(/�+$/, "") : decoded
+    const text = oversize
+      ? `${body}\n\n[openscience: truncated ${file.name} at ${TEXT_ATTACHMENT_MAX_BYTES / 1024} KB]`
+      : body
     // Carry the text as a text/plain data URL so the CLI inlines it as a Read
     // text part (see message materialisation). Force the mime — a `.md` may
     // arrive as text/markdown, but the CLI keys on exactly "text/plain".

--- a/frontend/workspace/src/i18n/en.ts
+++ b/frontend/workspace/src/i18n/en.ts
@@ -227,6 +227,10 @@ export const dict = {
 
   "prompt.toast.pasteUnsupported.title": "unsupported paste",
   "prompt.toast.pasteUnsupported.description": "only images or PDFs can be pasted here.",
+  "prompt.toast.uploadUnsupported.title": "unsupported file",
+  "prompt.toast.uploadUnsupported.description": "only images, PDFs, and text files can be attached.",
+  "prompt.toast.uploadNotText.title": "couldn't attach file",
+  "prompt.toast.uploadNotText.description": "this file looks binary, not text.",
   "prompt.toast.modelAgentRequired.title": "select an agent and model",
   "prompt.toast.modelAgentRequired.description": "choose an agent and model before sending a prompt.",
   "prompt.toast.worktreeCreateFailed.title": "failed to create worktree",


### PR DESCRIPTION
Closes #170.

## What
Users could previously only upload images and PDFs. This enables uploading **Markdown, plain text, and common text/data files** (`.md`, `.txt`, `.json`, `.yaml`, `.csv`, `.xml`, …) via **all three ingest paths** — the attach button, drag-drop, and paste.

Text is read client-side and shipped as a `text/plain` data URL, which the CLI materialises into an **inline text part**. This deliberately avoids the base64-media route (Anthropic/OpenAI reject non-image media), so it works on **every provider**.

## Guardrails
Derived from how claude-code / opencode / hermes handle the same concern:
- **Type gate** — MIME match + extension fallback (browsers report empty MIME for `.md`/`.txt`)
- **Binary sniff** — reject on NUL byte or >30% control chars in the first 4 KB (catches a mislabeled binary)
- **Sanitize** — CRLF→LF, strip control chars except tab/newline
- **Size cap** — 256 KB, truncate with a note; enforced on the client **and** re-enforced on decode (defense-in-depth)
- **Injection framing** — content is presented as *reference material, not instructions*

## Backend fixes
- Fixed the `text/plain` data-URL decode — it was decoding the whole data URL (prefix included) as `base64url`; now strips the prefix and decodes standard base64, capped.
- Reframed the synthetic part from `Called the Read tool …{filePath}` to an **attachment** label. An uploaded out-of-workspace file was being reported as "missing on disk" because the framing implied a real workspace path; now it doesn't.

## UI
Text attachments render as a **document tile** (file-text icon + type label, e.g. `MD`) instead of the image-thumbnail path.

## Testing
- New unit tests for the decoder (round-trip, prefix-strip, UTF-8, truncation, cap boundary) — 6/6 pass
- Backend + frontend typecheck clean, prettier clean
- Manually verified end-to-end: attach an out-of-workspace `.md`, agent reads the contents correctly, no phantom-file confusion