### PR TITLE
feat(workspace): support Markdown and text attachments

### DIFF
--- a/backend/cli/src/session/message-v2.ts
+++ b/backend/cli/src/session/message-v2.ts
@@ -552,8 +552,8 @@ export namespace MessageV2 {
               type: "text",
               text: part.text,
             })
-          // text/plain and directory files are converted into text parts, ignore them
-          if (part.type === "file" && part.mime !== "text/plain" && part.mime !== "application/x-directory") {
+          // Text and directory files are converted into text parts, ignore them
+          if (part.type === "file" && !part.mime.startsWith("text/") && part.mime !== "application/x-directory") {
             const dropped = dropImage(part.mime, part.url, part.filename)
             if (dropped) {
               userMessage.parts.push({ type: "text", text: dropped })

--- a/backend/cli/src/session/prompt.ts
+++ b/backend/cli/src/session/prompt.ts
@@ -1186,7 +1186,8 @@ export namespace SessionPrompt {
           const url = new URL(part.url)
           switch (url.protocol) {
             case "data:":
-              if (part.mime === "text/plain") {
+              if (part.mime.startsWith("text/")) {
+                const text = await fetch(part.url).then((response) => response.text())
                 return [
                   {
                     id: Identifier.ascending("part"),
@@ -1202,7 +1203,7 @@ export namespace SessionPrompt {
                     sessionID: input.sessionID,
                     type: "text",
                     synthetic: true,
-                    text: Buffer.from(part.url, "base64url").toString(),
+                    text,
                   },
                   {
                     ...part,
@@ -1224,7 +1225,7 @@ export namespace SessionPrompt {
                 part.mime = "application/x-directory"
               }
 
-              if (part.mime === "text/plain") {
+              if (part.mime.startsWith("text/")) {
                 let offset: number | undefined = undefined
                 let limit: number | undefined = undefined
                 const range = {

--- a/backend/cli/test/session/message-v2.test.ts
+++ b/backend/cli/test/session/message-v2.test.ts
@@ -279,17 +279,24 @@ describe("session.message-v2.toModelMessage", () => {
           {
             ...basePart(messageID, "p5"),
             type: "file",
+            mime: "text/markdown",
+            filename: "notes.md",
+            url: "https://example.com/notes.md",
+          },
+          {
+            ...basePart(messageID, "p6"),
+            type: "file",
             mime: "application/x-directory",
             filename: "dir",
             url: "https://example.com/dir",
           },
           {
-            ...basePart(messageID, "p6"),
+            ...basePart(messageID, "p7"),
             type: "compaction",
             auto: true,
           },
           {
-            ...basePart(messageID, "p7"),
+            ...basePart(messageID, "p8"),
             type: "subtask",
             prompt: "prompt",
             description: "desc",

--- a/backend/cli/test/session/prompt-attachments.test.ts
+++ b/backend/cli/test/session/prompt-attachments.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test"
+import { Instance } from "../../src/project/instance"
+import { Session } from "../../src/session"
+import { SessionPrompt } from "../../src/session/prompt"
+import { tmpdir } from "../fixture/fixture"
+
+describe("session prompt text attachments", () => {
+  test.each([
+    ["text/plain", "notes.txt", "plain text"],
+    ["text/markdown", "notes.md", "# Markdown\n\nResearch notes"],
+  ])(
+    "decodes %s data URLs into model text",
+    async (mime, filename, content) => {
+      await using tmp = await tmpdir()
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const session = await Session.create({})
+          const result = await SessionPrompt.prompt({
+            sessionID: session.id,
+            noReply: true,
+            agent: "research",
+            model: { providerID: "test", modelID: "test" },
+            parts: [
+              {
+                type: "file",
+                mime,
+                filename,
+                url: `data:${mime};base64,${Buffer.from(content).toString("base64")}`,
+              },
+            ],
+          })
+
+          expect(result.parts).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({ type: "text", synthetic: true, text: content }),
+              expect.objectContaining({ type: "file", mime, filename }),
+            ]),
+          )
+        },
+      })
+    },
+    15_000,
+  )
+})

--- a/frontend/workspace/e2e/prompt-attachments.spec.ts
+++ b/frontend/workspace/e2e/prompt-attachments.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from "./fixtures"
+
+test("attaches Markdown and text files", async ({ page, gotoSession }) => {
+  await gotoSession()
+
+  const input = page.locator('input[type="file"][accept*=".md"]')
+  await expect(input).toHaveCount(1)
+
+  await input.setInputFiles({
+    name: "research-notes.md",
+    mimeType: "application/octet-stream",
+    buffer: Buffer.from("# Research notes"),
+  })
+  await expect(page.getByText("research-notes.md", { exact: true })).toBeVisible()
+
+  await input.setInputFiles({
+    name: "observations.txt",
+    mimeType: "text/plain",
+    buffer: Buffer.from("Observation one"),
+  })
+  await expect(page.getByText("observations.txt", { exact: true })).toBeVisible()
+})

--- a/frontend/workspace/src/components/prompt-input.tsx
+++ b/frontend/workspace/src/components/prompt-input.tsx
@@ -60,7 +60,15 @@ import { showToast } from "@synsci/ui/toast"
 import { base64Encode } from "@synsci/util/encode"
 
 const ACCEPTED_IMAGE_TYPES = ["image/png", "image/jpeg", "image/gif", "image/webp"]
-const ACCEPTED_FILE_TYPES = [...ACCEPTED_IMAGE_TYPES, "application/pdf"]
+const ACCEPTED_FILE_TYPES = [...ACCEPTED_IMAGE_TYPES, "application/pdf", "text/markdown", "text/plain"]
+const ACCEPTED_FILE_EXTENSIONS = [".md", ".markdown", ".txt"]
+
+function attachmentMime(file: File) {
+  const extension = file.name.slice(file.name.lastIndexOf(".")).toLowerCase()
+  if (extension === ".md" || extension === ".markdown") return "text/markdown"
+  if (extension === ".txt") return "text/plain"
+  if (ACCEPTED_FILE_TYPES.includes(file.type)) return file.type
+}
 
 type PendingPrompt = {
   abort: AbortController
@@ -228,7 +236,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       },
   )
   const working = createMemo(() => status()?.type !== "idle")
-  const imageAttachments = createMemo(
+  const uploadAttachments = createMemo(
     () => prompt.current().filter((part) => part.type === "image") as ImageAttachmentPart[],
   )
 
@@ -325,8 +333,9 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   const [composing, setComposing] = createSignal(false)
   const isImeComposing = (event: KeyboardEvent) => event.isComposing || composing() || event.keyCode === 229
 
-  const addImageAttachment = async (file: File) => {
-    if (!ACCEPTED_FILE_TYPES.includes(file.type)) return
+  const addUploadAttachment = async (file: File) => {
+    const mime = attachmentMime(file)
+    if (!mime) return
 
     const reader = new FileReader()
     reader.onload = () => {
@@ -335,7 +344,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
         type: "image",
         id: crypto.randomUUID(),
         filename: file.name,
-        mime: file.type,
+        mime,
         dataUrl,
       }
       const cursorPosition = prompt.cursor() ?? getCursorPosition(editorRef)
@@ -344,7 +353,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     reader.readAsDataURL(file)
   }
 
-  const removeImageAttachment = (id: string) => {
+  const removeUploadAttachment = (id: string) => {
     const current = prompt.current()
     const next = current.filter((part) => part.type !== "image" || part.id !== id)
     prompt.set(next, prompt.cursor())
@@ -360,12 +369,15 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
 
     const items = Array.from(clipboardData.items)
     const fileItems = items.filter((item) => item.kind === "file")
-    const imageItems = fileItems.filter((item) => ACCEPTED_FILE_TYPES.includes(item.type))
+    const attachmentItems = fileItems.filter((item) => {
+      const file = item.getAsFile()
+      return file && attachmentMime(file)
+    })
 
-    if (imageItems.length > 0) {
-      for (const item of imageItems) {
+    if (attachmentItems.length > 0) {
+      for (const item of attachmentItems) {
         const file = item.getAsFile()
-        if (file) await addImageAttachment(file)
+        if (file) await addUploadAttachment(file)
       }
       return
     }
@@ -412,9 +424,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     if (!dropped) return
 
     for (const file of Array.from(dropped)) {
-      if (ACCEPTED_FILE_TYPES.includes(file.type)) {
-        await addImageAttachment(file)
-      }
+      if (attachmentMime(file)) await addUploadAttachment(file)
     }
   }
 
@@ -796,7 +806,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
 
   const handleInput = () => {
     const rawParts = parseFromDOM()
-    const images = imageAttachments()
+    const images = uploadAttachments()
     const cursorPosition = getCursorPosition(editorRef)
     const rawText = rawParts.map((p) => ("content" in p ? p.content : "")).join("")
     const trimmed = rawText.replace(/\u200B/g, "").trim()
@@ -1152,7 +1162,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
 
     const currentPrompt = prompt.current()
     const text = currentPrompt.map((part) => ("content" in part ? part.content : "")).join("")
-    const images = imageAttachments().slice()
+    const images = uploadAttachments().slice()
     const mode = store.mode
 
     if (text.trim().length === 0 && images.length === 0) {
@@ -1833,16 +1843,16 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
             </For>
           </div>
         </Show>
-        <Show when={imageAttachments().length > 0}>
+        <Show when={uploadAttachments().length > 0}>
           <div class="flex flex-wrap gap-2 px-3 pt-3">
-            <For each={imageAttachments()}>
+            <For each={uploadAttachments()}>
               {(attachment) => (
                 <div class="relative group">
                   <Show
                     when={attachment.mime.startsWith("image/")}
                     fallback={
                       <div class="size-16 rounded-md bg-surface-base flex items-center justify-center border border-border-base">
-                        <Icon name="folder" class="size-6 text-text-weak" />
+                        <FileIcon node={{ path: attachment.filename, type: "file" }} class="size-6 text-text-weak" />
                       </div>
                     }
                   >
@@ -1857,7 +1867,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                   </Show>
                   <button
                     type="button"
-                    onClick={() => removeImageAttachment(attachment.id)}
+                    onClick={() => removeUploadAttachment(attachment.id)}
                     class="absolute -top-1.5 -right-1.5 size-5 rounded-full bg-surface-raised-stronger-non-alpha border border-border-base flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity hover:bg-surface-raised-base-hover"
                     aria-label={language.t("prompt.attachment.remove")}
                   >
@@ -2054,11 +2064,11 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
             <input
               ref={fileInputRef}
               type="file"
-              accept={ACCEPTED_FILE_TYPES.join(",")}
+              accept={[...ACCEPTED_FILE_TYPES, ...ACCEPTED_FILE_EXTENSIONS].join(",")}
               class="hidden"
               onChange={(e) => {
                 const file = e.currentTarget.files?.[0]
-                if (file) addImageAttachment(file)
+                if (file) addUploadAttachment(file)
                 e.currentTarget.value = ""
               }}
             />


### PR DESCRIPTION
Closes #170

## Summary
- accept `.md`, `.markdown`, and `.txt` files from the composer picker, paste, and drag-and-drop paths
- infer Markdown/text MIME types from file extensions and render them as file attachment cards
- decode `text/*` data URLs into message text so every model can consume the contents without native file support

## Verification
- `bun test test/session/message-v2.test.ts test/session/prompt-attachments.test.ts` (25 pass)
- `bun typecheck` (7 workspace packages pass)
- `playwright test e2e/prompt-attachments.spec.ts --project=chromium` (1 pass)
- `prettier --check` on changed files