### PR TITLE
fix: resolve open issues (#168, #170, #102, #159, #142, #176) + tokenCommand (#146)

### DIFF
--- a/backend/cli/src/agent/prompt/biology.txt
+++ b/backend/cli/src/agent/prompt/biology.txt
@@ -655,6 +655,15 @@ if len(df) > 100000:
 chunks = pd.read_csv('large_file.csv', chunksize=10000)
 ```
 
+**Single-cell / AnnData (scanpy) — avoid runaway memory:**
+- Read large .h5ad with `sc.read_h5ad(path, backed='r')`; keep `adata.X` as
+  float32 (`adata.X = adata.X.astype('float32')`) — float64 doubles RAM.
+- Subset to highly-variable genes BEFORE `sc.pp.scale`/`sc.pp.regress_out`, not
+  after. `regress_out` densifies the matrix and, on a big dataset, makes several
+  full-size copies at once — skip it on large data or run it on the HVG subset.
+- If you set `n_jobs`, prefer a small number over `-1`; `-1` fans out one
+  full-dataset copy per core and can exhaust memory.
+
 ### R Package Needed
 ```python
 # Use rpy2 for R-specific analyses:

--- a/backend/cli/src/agent/prompt/research.txt
+++ b/backend/cli/src/agent/prompt/research.txt
@@ -44,6 +44,22 @@ Before using any external service, verify credentials:
 If not connected, tell the user:
   "Connect [service] at https://app.syntheticsciences.ai -> Services, then restart openscience."
 
+## CRITICAL: Convergence & Anti-Loop
+Your job is to finish the task IN THIS SESSION, not to hand it off.
+- **Converge.** Once you have enough evidence to answer the user's question (e.g. a
+  handful of relevant, verified papers for a literature task), STOP searching and write
+  the final deliverable. More searching past that point is not progress.
+- **Never emit a "continuity summary", "handoff", "context for a new session", or
+  "prompt to paste into a new session".** Session continuity and history compaction are
+  handled automatically by the system — producing these yourself is a failure mode, not a
+  step. If you catch yourself about to write one, write the final answer instead.
+- **Do not restart on a missing tool.** If a skill or sub-agent is unavailable (e.g. a
+  tool returns "not found"), that does NOT undo the work already done. Continue from where
+  you are using the tools you DO have — for a literature review, search directly with the
+  available connectors (OpenAlex, arXiv, Crossref) instead of the `literature-review`
+  sub-agent. Never treat the session as if no work has happened.
+- **One finish.** When the deliverable is written, stop. Do not re-summarize what you did.
+
 ## Research Workflow
 
 Follow these stages. At each stage, proactively load the relevant skills — do NOT wait

--- a/backend/cli/src/config/config.ts
+++ b/backend/cli/src/config/config.ts
@@ -968,6 +968,12 @@ export namespace Config {
         .object({
           apiKey: z.string().optional(),
           baseURL: z.string().optional(),
+          tokenCommand: z
+            .string()
+            .optional()
+            .describe(
+              "Shell command whose stdout is a short-lived bearer token. Sent as 'Authorization: Bearer <token>' on every request and re-minted automatically before the token's JWT exp (or every request for a non-JWT token). Use for providers behind rotating/SSO-minted credentials.",
+            ),
           enterpriseUrl: z.string().optional().describe("GitHub Enterprise URL for copilot authentication"),
           setCacheKey: z.boolean().optional().describe("Enable promptCacheKey for this provider (default false)"),
           timeout: z

--- a/backend/cli/src/config/config.ts
+++ b/backend/cli/src/config/config.ts
@@ -205,7 +205,16 @@ export namespace Config {
       const scoped: Partial<Config.Info> = {}
       if (synced?.provider?.openrouter) scoped.provider = { openrouter: synced.provider.openrouter }
       if (synced?.model) scoped.model = synced.model
-      result = mergeConfigConcatArrays(result, scoped)
+      // Merge synced UNDERNEATH the user's own config, not on top: it is the
+      // server's *recommendation* (default model, OpenRouter managed catalog),
+      // not a lockdown, so the user's config must win — otherwise their chosen
+      // default model and custom OpenRouter models are reverted on every sync
+      // (#159). mergeConfigConcatArrays(base, override) lets `override` win, so
+      // pass the user config (result) as the override. Model records still union,
+      // so server-whitelisted models the user didn't declare stay available.
+      // Enterprise lockdown is unaffected: the managed /etc layer merges LAST
+      // below and still wins over both.
+      result = mergeConfigConcatArrays(scoped as Config.Info, result)
     } catch {
       // treat an unreadable synced config as absent
     }

--- a/backend/cli/src/openscience/index.ts
+++ b/backend/cli/src/openscience/index.ts
@@ -1099,6 +1099,27 @@ export namespace OpenScience {
     return withAtlasOnPath(mergeByokEnv(base, auth))
   }
 
+  // Default thread/worker caps for scientific Python kernels. Without these,
+  // BLAS (OpenBLAS/MKL/Accelerate), numba, and joblib/loky each fan out to one
+  // worker PER CORE by default. On a large dataset a single densifying op (e.g.
+  // scanpy regress_out with n_jobs=-1) then spawns N full-dataset copies at once,
+  // each tens of GB — the machine swaps to death (#102). Cap each to a small,
+  // safe default and only fill a var the user/agent hasn't already set, so an
+  // explicit override still wins.
+  export function pythonThreadCapEnv(env: NodeJS.ProcessEnv = process.env): Record<string, string> {
+    const cap = String(Math.max(1, Math.min(4, os.cpus().length)))
+    const vars = [
+      "OMP_NUM_THREADS",
+      "OPENBLAS_NUM_THREADS",
+      "MKL_NUM_THREADS",
+      "VECLIB_MAXIMUM_THREADS",
+      "NUMEXPR_NUM_THREADS",
+      "NUMBA_NUM_THREADS",
+      "LOKY_MAX_CPU_COUNT",
+    ]
+    return Object.fromEntries(vars.filter((v) => !env[v]).map((v) => [v, cap]))
+  }
+
   // === Server-side Skills ===
 
   const SKILLS_CACHE_TTL = 60 * 60 * 1000 // 1 hour

--- a/backend/cli/src/provider/provider.ts
+++ b/backend/cli/src/provider/provider.ts
@@ -1333,6 +1333,49 @@ export namespace Provider {
     return state().then((state) => state.providers)
   }
 
+  // === tokenCommand: refreshing shell-command auth (#146) ===
+  // Some providers sit behind a rotating/SSO-minted bearer token that a local
+  // command prints on demand. `options.tokenCommand` runs that command and injects
+  // its stdout as `Authorization: Bearer <token>`, re-minting shortly before the
+  // token's JWT exp. Module-level so the cache + single-flight are shared across the
+  // (memoized) SDK instances rather than re-run per request.
+  const tokenCache = new Map<string, { token: string; expires: number }>()
+  const tokenInflight = new Map<string, Promise<string>>()
+
+  async function mintToken(command: string): Promise<string> {
+    const cached = tokenCache.get(command)
+    // Re-mint a minute early so an in-flight request never ships an expired token.
+    if (cached && cached.expires > Date.now() + 60_000) return cached.token
+    const pending = tokenInflight.get(command)
+    if (pending) return pending
+    const run = (async () => {
+      const proc = Bun.spawn(["sh", "-c", command], { stdout: "pipe", stderr: "pipe" })
+      const [out, err, code] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+      ])
+      const token = out.trim()
+      if (code !== 0) throw new Error(`tokenCommand exited ${code}: ${err.trim() || "no stderr"}`)
+      if (!token) throw new Error("tokenCommand produced no output")
+      // Decode a JWT exp (seconds) so we can re-mint just before it lapses; a
+      // non-JWT token has no exp, so expire it immediately (re-mint every request).
+      const claims = token.split(".")
+      let exp = 0
+      if (claims.length === 3) {
+        try {
+          exp = JSON.parse(Buffer.from(claims[1], "base64url").toString()).exp ?? 0
+        } catch {
+          /* not a JWT — leave exp 0 */
+        }
+      }
+      tokenCache.set(command, { token, expires: exp ? exp * 1000 : 0 })
+      return token
+    })().finally(() => tokenInflight.delete(command))
+    tokenInflight.set(command, run)
+    return run
+  }
+
   async function getSDK(model: Model) {
     try {
       using _ = log.time("getSDK", {
@@ -1348,6 +1391,10 @@ export namespace Provider {
 
       if (!options["baseURL"]) options["baseURL"] = model.api.url
       if (options["apiKey"] === undefined && provider.key) options["apiKey"] = provider.key
+      // tokenCommand supplies the credential per-request via the fetch hook below;
+      // give the SDK a non-empty placeholder so @ai-sdk/openai's loadApiKey doesn't
+      // throw at construction (the real Bearer header is overwritten on each call).
+      if (options["tokenCommand"] && options["apiKey"] === undefined) options["apiKey"] = "token-command"
       pinByokToPublicEndpoint(provider, options, model.api.url)
       requireAtlasProxyForManagedKey(provider, options)
       if (model.headers)
@@ -1361,6 +1408,7 @@ export namespace Provider {
       if (existing) return existing
 
       const customFetch = options["fetch"]
+      const tokenCommand = options["tokenCommand"] as string | undefined
 
       options["fetch"] = async (input: any, init?: BunFetchRequestInit) => {
         // Preserve custom fetch if it exists, wrap it with timeout logic
@@ -1393,6 +1441,16 @@ export namespace Provider {
             }
             opts.body = JSON.stringify(body)
           }
+        }
+
+        // Mint (or reuse) the shell-command token and overwrite Authorization.
+        // Headers.set is case-insensitive, so it replaces the placeholder key the
+        // SDK attached at construction.
+        if (tokenCommand) {
+          const token = await mintToken(tokenCommand)
+          const headers = new Headers(opts.headers as HeadersInit | undefined)
+          headers.set("authorization", `Bearer ${token}`)
+          opts.headers = headers
         }
 
         return fetchFn(input, {

--- a/backend/cli/src/session/message-v2.ts
+++ b/backend/cli/src/session/message-v2.ts
@@ -458,6 +458,17 @@ export namespace MessageV2 {
     return !!finish && CONTINUING_FINISH.includes(finish)
   }
 
+  // Whether a completed TURN should keep the agent loop running. Stricter than
+  // isContinuing for the ambiguous "unknown" reason: it only means "keep going"
+  // when the turn actually made a tool call whose result must be fed back. A
+  // text-only turn that finished "unknown" (common with local Ollama models that
+  // don't report a finish reason) produced no continuation signal — re-prompting
+  // the identical context just yields the same text forever (the #176 doom loop),
+  // so treat it as done. Used only by the loop; compaction keeps isContinuing.
+  export function isContinuingTurn(finish: string | undefined, hasToolCall: boolean): boolean {
+    return isContinuing(finish) && (finish !== "unknown" || hasToolCall)
+  }
+
   export function toModelMessages(
     input: WithParts[],
     model: Provider.Model,

--- a/backend/cli/src/session/processor.ts
+++ b/backend/cli/src/session/processor.ts
@@ -46,6 +46,29 @@ export namespace SessionProcessor {
     )
   }
 
+  function sharedPrefixLen(a: string, b: string): number {
+    const n = Math.min(a.length, b.length)
+    let i = 0
+    while (i < n && a[i] === b[i]) i++
+    return i
+  }
+
+  /** True when the last 3 finished assistant turns are long AND share a large
+   *  identical leading block — the repeated "continuity summary" a weak/local
+   *  model emits instead of converging on a final answer (#176). The tool-call
+   *  isDoomLoop guard can't see this: the TEXT repeats, not the tool calls. Inputs
+   *  are already-normalized turn texts (lowercased, whitespace-collapsed). Kept
+   *  conservative — 3 substantial near-identical turns in a row is a signal that
+   *  legitimate progress does not produce. */
+  export function isTextLoop(turns: string[], minLen = 400, prefix = 300): boolean {
+    if (turns.length < 3) return false
+    const last = turns.slice(-3)
+    const lengths = last.map((t) => t.length)
+    if (Math.min(...lengths) < minLen) return false
+    if (Math.max(...lengths) / Math.max(1, Math.min(...lengths)) > 1.25) return false
+    return sharedPrefixLen(last[0], last[1]) >= prefix && sharedPrefixLen(last[1], last[2]) >= prefix
+  }
+
   export type Info = Awaited<ReturnType<typeof create>>
   export type Result = Awaited<ReturnType<Info["process"]>>
 

--- a/backend/cli/src/session/processor.ts
+++ b/backend/cli/src/session/processor.ts
@@ -380,6 +380,23 @@ export namespace SessionProcessor {
                   ) {
                     needsCompaction = true
                   }
+                  // A "length" finish with an over-threshold token count is NOT a
+                  // finished answer — the turn was truncated mid-thought (often right
+                  // before a tool call, leaving a pending tool part). isContinuing()
+                  // excludes "length", so the block above skips it. Treat it as a
+                  // context overflow: compact history and re-run the SAME user message
+                  // against the summary, instead of exiting the loop as if the agent
+                  // was done (which strands the pending tool part → "Tool execution
+                  // aborted"). A genuine max-output truncation (small input) has
+                  // isOverflow=false and still falls through unchanged.
+                  if (
+                    !input.assistantMessage.summary &&
+                    value.finishReason === "length" &&
+                    (await SessionCompaction.isOverflow({ tokens: usage.tokens, model: input.model }))
+                  ) {
+                    overflow = true
+                    input.assistantMessage.finish = "compact"
+                  }
                   break
 
                 case "text-start":
@@ -440,7 +457,7 @@ export namespace SessionProcessor {
                   })
                   continue
               }
-              if (needsCompaction) break
+              if (needsCompaction || overflow) break
             }
           } catch (e: any) {
             log.error("process", {
@@ -507,7 +524,9 @@ export namespace SessionProcessor {
                 state: {
                   ...part.state,
                   status: "error",
-                  error: "Tool execution aborted",
+                  error: overflow
+                    ? "Model output was truncated before the tool call completed (context limit); no action was taken. Compacting and retrying."
+                    : "Tool execution aborted",
                   time: {
                     start: Date.now(),
                     end: Date.now(),

--- a/backend/cli/src/session/prompt.ts
+++ b/backend/cli/src/session/prompt.ts
@@ -338,12 +338,16 @@ export namespace SessionPrompt {
 
       let lastUser: MessageV2.User | undefined
       let lastAssistant: MessageV2.Assistant | undefined
+      let lastAssistantMsg: MessageV2.WithParts | undefined
       let lastFinished: MessageV2.Assistant | undefined
       let tasks: (MessageV2.CompactionPart | MessageV2.SubtaskPart)[] = []
       for (let i = msgs.length - 1; i >= 0; i--) {
         const msg = msgs[i]
         if (!lastUser && msg.info.role === "user") lastUser = msg.info as MessageV2.User
-        if (!lastAssistant && msg.info.role === "assistant") lastAssistant = msg.info as MessageV2.Assistant
+        if (!lastAssistant && msg.info.role === "assistant") {
+          lastAssistant = msg.info as MessageV2.Assistant
+          lastAssistantMsg = msg
+        }
         if (!lastFinished && msg.info.role === "assistant" && msg.info.finish)
           lastFinished = msg.info as MessageV2.Assistant
         if (lastUser && lastFinished) break
@@ -410,11 +414,15 @@ export namespace SessionPrompt {
         return true
       }
       const bareMode = lastUser.tools?.["*"] === false
-      if (
-        lastAssistant?.finish &&
-        (!MessageV2.isContinuing(lastAssistant.finish) || bareMode) &&
-        lastUser.id < lastAssistant.id
-      ) {
+      // A finish of "unknown" is only ambiguous — treated as "keep going" — when the
+      // turn actually made a tool call whose result must be fed back. A text-only
+      // turn that finished "unknown" (common with local Ollama models) produced no
+      // continuation signal; re-prompting the identical context just yields the same
+      // text forever (the #176 doom loop). Treat it as a completed turn instead.
+      const lastAssistantHasTool = lastAssistantMsg?.parts.some((p) => p.type === "tool") ?? false
+      const continuing =
+        MessageV2.isContinuing(lastAssistant?.finish) && (lastAssistant?.finish !== "unknown" || lastAssistantHasTool)
+      if (lastAssistant?.finish && (!continuing || bareMode) && lastUser.id < lastAssistant.id) {
         log.info("exiting loop", { sessionID, bareMode })
         // RSI: capture trajectory from ultra agent sessions (async, non-blocking)
         if (lastUser.agent && RSITrajectory.ARTIFACT_AGENTS.includes(lastUser.agent as any)) {

--- a/backend/cli/src/session/prompt.ts
+++ b/backend/cli/src/session/prompt.ts
@@ -96,6 +96,19 @@ export namespace SessionPrompt {
     },
   )
 
+  // Decode the text payload of a data: URL (data:<mime>[;base64],<payload>) — an
+  // uploaded .txt/.md arrives this way. Only the part after the comma is the
+  // payload; base64url-decoding the whole URL left a ~12-byte garbage prefix from
+  // "data:text/plain," on the inlined text (#170). FileReader.readAsDataURL always
+  // emits the ;base64 form; a hand-written percent-encoded data URL is also handled.
+  export function decodeDataUrlText(url: string): string {
+    const comma = url.indexOf(",")
+    const payload = comma === -1 ? url : url.slice(comma + 1)
+    return url.slice(0, comma).includes(";base64")
+      ? Buffer.from(payload, "base64").toString()
+      : decodeURIComponent(payload)
+  }
+
   export function assertNotBusy(sessionID: string) {
     const match = state()[sessionID]
     if (match) throw new Session.BusyError(sessionID)
@@ -313,9 +326,8 @@ export namespace SessionPrompt {
     // Text doom-loop guard (#176): weak/local models sometimes emit a near-identical
     // "continuity summary" turn over and over instead of converging on an answer.
     // The processor's doom-loop guard can't catch it — the TOOL calls vary (or are
-    // absent), only the TEXT repeats. Normalize an assistant turn's own text and
-    // compare recent turns by shared leading content.
-    const MIN_LOOP_TEXT = 400
+    // absent), only the TEXT repeats. Normalize an assistant turn's own text;
+    // SessionProcessor.isTextLoop does the (unit-tested) detection.
     const turnText = (m: MessageV2.WithParts) =>
       m.parts
         .filter((p) => p.type === "text" && !p.synthetic && !p.ignored)
@@ -324,12 +336,6 @@ export namespace SessionPrompt {
         .toLowerCase()
         .replace(/\s+/g, " ")
         .trim()
-    const sharedPrefix = (a: string, b: string) => {
-      const n = Math.min(a.length, b.length)
-      let i = 0
-      while (i < n && a[i] === b[i]) i++
-      return i
-    }
     while (true) {
       SessionStatus.set(sessionID, { type: "busy" })
       log.info("loop", { step, sessionID })
@@ -414,14 +420,11 @@ export namespace SessionPrompt {
         return true
       }
       const bareMode = lastUser.tools?.["*"] === false
-      // A finish of "unknown" is only ambiguous — treated as "keep going" — when the
-      // turn actually made a tool call whose result must be fed back. A text-only
-      // turn that finished "unknown" (common with local Ollama models) produced no
-      // continuation signal; re-prompting the identical context just yields the same
-      // text forever (the #176 doom loop). Treat it as a completed turn instead.
+      // A text-only turn that finished "unknown" (no tool call to feed back) is a
+      // completed turn, not a continue — otherwise the loop re-prompts the identical
+      // context forever (the #176 doom loop). See MessageV2.isContinuingTurn.
       const lastAssistantHasTool = lastAssistantMsg?.parts.some((p) => p.type === "tool") ?? false
-      const continuing =
-        MessageV2.isContinuing(lastAssistant?.finish) && (lastAssistant?.finish !== "unknown" || lastAssistantHasTool)
+      const continuing = MessageV2.isContinuingTurn(lastAssistant?.finish, lastAssistantHasTool)
       if (lastAssistant?.finish && (!continuing || bareMode) && lastUser.id < lastAssistant.id) {
         log.info("exiting loop", { sessionID, bareMode })
         // RSI: capture trajectory from ultra agent sessions (async, non-blocking)
@@ -436,22 +439,12 @@ export namespace SessionPrompt {
       // summary"). Conservative on purpose — 3 substantial near-identical turns in a
       // row is a clear non-convergence signal that legitimate progress never produces.
       const finishedTurns = msgs.filter((m) => m.info.role === "assistant" && m.info.finish)
-      if (finishedTurns.length >= 3) {
-        const [t1, t2, t3] = finishedTurns.slice(-3).map(turnText)
-        const lengths = [t1.length, t2.length, t3.length]
-        const ratio = Math.max(...lengths) / Math.max(1, Math.min(...lengths))
-        if (
-          Math.min(...lengths) >= MIN_LOOP_TEXT &&
-          ratio <= 1.25 &&
-          sharedPrefix(t1, t2) >= 300 &&
-          sharedPrefix(t2, t3) >= 300
-        ) {
-          log.info("text doom-loop detected — stopping", { sessionID, step })
-          await failTooLarge(
-            "The model repeated nearly the same response several times without making progress — a known failure mode of smaller local models on multi-step research tasks. Stopping to avoid an endless loop. Try a larger or hosted model for this task, or break it into smaller steps.",
-          )
-          break
-        }
+      if (SessionProcessor.isTextLoop(finishedTurns.map(turnText))) {
+        log.info("text doom-loop detected — stopping", { sessionID, step })
+        await failTooLarge(
+          "The model repeated nearly the same response several times without making progress — a known failure mode of smaller local models on multi-step research tasks. Stopping to avoid an endless loop. Try a larger or hosted model for this task, or break it into smaller steps.",
+        )
+        break
       }
 
       step++
@@ -1253,16 +1246,8 @@ export namespace SessionPrompt {
                     sessionID: input.sessionID,
                     type: "text",
                     synthetic: true,
-                    // part.url is a full data: URL (data:text/plain[;base64],<payload>).
-                    // Decode only the payload after the comma; base64url-decoding the
-                    // whole URL left a ~12-byte garbage prefix from "data:text/plain,".
-                    text: iife(() => {
-                      const comma = part.url.indexOf(",")
-                      const payload = comma === -1 ? part.url : part.url.slice(comma + 1)
-                      return part.url.slice(0, comma).includes(";base64")
-                        ? Buffer.from(payload, "base64").toString()
-                        : decodeURIComponent(payload)
-                    }),
+                    // Decode only the payload after the comma — see decodeDataUrlText (#170).
+                    text: decodeDataUrlText(part.url),
                   },
                   {
                     ...part,

--- a/backend/cli/src/session/prompt.ts
+++ b/backend/cli/src/session/prompt.ts
@@ -1202,7 +1202,16 @@ export namespace SessionPrompt {
                     sessionID: input.sessionID,
                     type: "text",
                     synthetic: true,
-                    text: Buffer.from(part.url, "base64url").toString(),
+                    // part.url is a full data: URL (data:text/plain[;base64],<payload>).
+                    // Decode only the payload after the comma; base64url-decoding the
+                    // whole URL left a ~12-byte garbage prefix from "data:text/plain,".
+                    text: iife(() => {
+                      const comma = part.url.indexOf(",")
+                      const payload = comma === -1 ? part.url : part.url.slice(comma + 1)
+                      return part.url.slice(0, comma).includes(";base64")
+                        ? Buffer.from(payload, "base64").toString()
+                        : decodeURIComponent(payload)
+                    }),
                   },
                   {
                     ...part,

--- a/backend/cli/src/session/prompt.ts
+++ b/backend/cli/src/session/prompt.ts
@@ -310,6 +310,26 @@ export namespace SessionPrompt {
     // summary overhead alone already exceeds the 0.75 threshold.
     let compactionArmed = true
     const session = await Session.get(sessionID)
+    // Text doom-loop guard (#176): weak/local models sometimes emit a near-identical
+    // "continuity summary" turn over and over instead of converging on an answer.
+    // The processor's doom-loop guard can't catch it — the TOOL calls vary (or are
+    // absent), only the TEXT repeats. Normalize an assistant turn's own text and
+    // compare recent turns by shared leading content.
+    const MIN_LOOP_TEXT = 400
+    const turnText = (m: MessageV2.WithParts) =>
+      m.parts
+        .filter((p) => p.type === "text" && !p.synthetic && !p.ignored)
+        .map((p) => (p as MessageV2.TextPart).text)
+        .join("\n")
+        .toLowerCase()
+        .replace(/\s+/g, " ")
+        .trim()
+    const sharedPrefix = (a: string, b: string) => {
+      const n = Math.min(a.length, b.length)
+      let i = 0
+      while (i < n && a[i] === b[i]) i++
+      return i
+    }
     while (true) {
       SessionStatus.set(sessionID, { type: "busy" })
       log.info("loop", { step, sessionID })
@@ -401,6 +421,29 @@ export namespace SessionPrompt {
           RSITrajectory.pipeline(sessionID).catch(() => {})
         }
         break
+      }
+
+      // Trip the text doom-loop guard when the last 3 finished assistant turns are
+      // long AND share a large identical leading block (the repeated "continuity
+      // summary"). Conservative on purpose — 3 substantial near-identical turns in a
+      // row is a clear non-convergence signal that legitimate progress never produces.
+      const finishedTurns = msgs.filter((m) => m.info.role === "assistant" && m.info.finish)
+      if (finishedTurns.length >= 3) {
+        const [t1, t2, t3] = finishedTurns.slice(-3).map(turnText)
+        const lengths = [t1.length, t2.length, t3.length]
+        const ratio = Math.max(...lengths) / Math.max(1, Math.min(...lengths))
+        if (
+          Math.min(...lengths) >= MIN_LOOP_TEXT &&
+          ratio <= 1.25 &&
+          sharedPrefix(t1, t2) >= 300 &&
+          sharedPrefix(t2, t3) >= 300
+        ) {
+          log.info("text doom-loop detected — stopping", { sessionID, step })
+          await failTooLarge(
+            "The model repeated nearly the same response several times without making progress — a known failure mode of smaller local models on multi-step research tasks. Stopping to avoid an endless loop. Try a larger or hosted model for this task, or break it into smaller steps.",
+          )
+          break
+        }
       }
 
       step++

--- a/backend/cli/src/tool/biology/notebook.ts
+++ b/backend/cli/src/tool/biology/notebook.ts
@@ -147,7 +147,11 @@ async function getKernel(sessionID: string): Promise<Kernel> {
   })
   const proc = spawn(sandboxed.file, sandboxed.args, {
     cwd: Instance.directory,
-    env: { ...(await OpenScience.subprocessEnv(process.env)), PYTHONUNBUFFERED: "1" },
+    env: {
+      ...(await OpenScience.subprocessEnv(process.env)),
+      ...OpenScience.pythonThreadCapEnv(process.env),
+      PYTHONUNBUFFERED: "1",
+    },
     stdio: ["pipe", "pipe", "pipe"],
   })
 

--- a/backend/cli/src/tool/notebook.ts
+++ b/backend/cli/src/tool/notebook.ts
@@ -248,7 +248,12 @@ class PythonKernel implements Kernel {
     })
     const proc = spawn(sandboxed.file, sandboxed.args, {
       cwd: opts?.cwd ?? Instance.directory,
-      env: { ...(await OpenScience.subprocessEnv(process.env)), ...(opts?.env ?? {}), PYTHONUNBUFFERED: "1" },
+      env: {
+        ...(await OpenScience.subprocessEnv(process.env)),
+        ...OpenScience.pythonThreadCapEnv(process.env),
+        ...(opts?.env ?? {}),
+        PYTHONUNBUFFERED: "1",
+      },
       stdio: ["pipe", "pipe", "pipe"],
     })
     this.proc = proc

--- a/backend/cli/test/config/synced-merge.test.ts
+++ b/backend/cli/test/config/synced-merge.test.ts
@@ -1,0 +1,94 @@
+import { test, expect, describe, beforeEach, afterEach } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
+import { Config } from "../../src/config/config"
+import { Instance } from "../../src/project/instance"
+import { Global } from "../../src/global"
+import { tmpdir } from "../fixture/fixture"
+
+// The Atlas sync writes openscience-synced.json into the user's XDG config dir; it's
+// read fresh per-instance by Config.state(). The user's own config goes in the
+// project's openscience.json (via tmpdir({config})), which is per-test isolated —
+// unlike the global openscience.json, which Config caches process-wide. These tests
+// exercise the real Config load path end-to-end (#159 / #142).
+const syncedConfig = path.join(Global.Path.config, "openscience-synced.json")
+
+async function writeSynced(obj: object) {
+  await fs.mkdir(path.dirname(syncedConfig), { recursive: true })
+  await Bun.write(syncedConfig, JSON.stringify({ $schema: "https://syntheticsciences.ai/config.json", ...obj }))
+}
+
+beforeEach(async () => {
+  await fs.rm(syncedConfig, { force: true }).catch(() => {})
+})
+afterEach(async () => {
+  await fs.rm(syncedConfig, { force: true }).catch(() => {})
+})
+
+describe("Atlas synced-config merge", () => {
+  test("user's default model and custom OpenRouter model survive the sync (#159)", async () => {
+    await writeSynced({
+      model: "openrouter/anthropic/claude-opus-4.8",
+      provider: { openrouter: { models: { "anthropic/claude-opus-4.8": {} } } },
+    })
+
+    await using tmp = await tmpdir({
+      config: {
+        model: "openrouter/deepseek/deepseek-v4-pro",
+        provider: { openrouter: { models: { "deepseek/deepseek-v4-pro": {} } } },
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const config = await Config.get()
+        // 1. The user's chosen default model wins — NOT reverted to the synced one.
+        expect(config.model).toBe("openrouter/deepseek/deepseek-v4-pro")
+        // 2. The user's custom model persists (this is what was being clobbered).
+        expect(config.provider?.openrouter?.models?.["deepseek/deepseek-v4-pro"]).toBeDefined()
+        // 3. The server-recommended model the user did NOT declare is still added (union).
+        expect(config.provider?.openrouter?.models?.["anthropic/claude-opus-4.8"]).toBeDefined()
+      },
+    })
+  })
+
+  test("synced config still applies when the user hasn't set those fields", async () => {
+    await writeSynced({
+      model: "openrouter/anthropic/claude-opus-4.8",
+      provider: { openrouter: { models: { "anthropic/claude-opus-4.8": {} } } },
+    })
+
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const config = await Config.get()
+        // With no competing user value, the server recommendation is the default.
+        expect(config.model).toBe("openrouter/anthropic/claude-opus-4.8")
+        expect(config.provider?.openrouter?.models?.["anthropic/claude-opus-4.8"]).toBeDefined()
+      },
+    })
+  })
+
+  test("a custom BYOK provider in openscience.json is untouched by sync (#142)", async () => {
+    await writeSynced({
+      enabled_providers: ["openrouter"],
+      provider: { openrouter: { models: { "anthropic/claude-opus-4.8": {} } } },
+    })
+
+    await using tmp = await tmpdir({
+      config: {
+        provider: { "my-byok": { npm: "@ai-sdk/openai-compatible", options: { baseURL: "https://byok.example/v1" } } },
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const config = await Config.get()
+        // The synced enabled_providers=[openrouter] must NOT drop the custom provider.
+        expect(config.provider?.["my-byok"]).toBeDefined()
+        expect(config.provider?.["my-byok"]?.options?.baseURL).toBe("https://byok.example/v1")
+      },
+    })
+  })
+})

--- a/backend/cli/test/openscience-thread-cap.test.ts
+++ b/backend/cli/test/openscience-thread-cap.test.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "bun:test"
+import os from "os"
+import { OpenScience } from "../src/openscience"
+
+const CAP = String(Math.max(1, Math.min(4, os.cpus().length)))
+const VARS = [
+  "OMP_NUM_THREADS",
+  "OPENBLAS_NUM_THREADS",
+  "MKL_NUM_THREADS",
+  "VECLIB_MAXIMUM_THREADS",
+  "NUMEXPR_NUM_THREADS",
+  "NUMBA_NUM_THREADS",
+  "LOKY_MAX_CPU_COUNT",
+]
+
+test("pythonThreadCapEnv caps every thread/worker var when unset (#102)", () => {
+  const capped = OpenScience.pythonThreadCapEnv({})
+  for (const v of VARS) expect(capped[v]).toBe(CAP)
+  // Cap is small and sane — this is what stops joblib/BLAS fanning out per-core.
+  expect(Number(CAP)).toBeGreaterThanOrEqual(1)
+  expect(Number(CAP)).toBeLessThanOrEqual(4)
+})
+
+test("pythonThreadCapEnv never overrides a value the user/agent already set", () => {
+  const capped = OpenScience.pythonThreadCapEnv({ OMP_NUM_THREADS: "16", MKL_NUM_THREADS: "8" })
+  // Explicit user values are left for the caller's env to win — not returned here.
+  expect(capped.OMP_NUM_THREADS).toBeUndefined()
+  expect(capped.MKL_NUM_THREADS).toBeUndefined()
+  // The ones the user didn't set are still capped.
+  expect(capped.OPENBLAS_NUM_THREADS).toBe(CAP)
+  expect(capped.NUMBA_NUM_THREADS).toBe(CAP)
+})
+
+test("a python kernel spawned with the cap env actually sees the caps (live)", async () => {
+  // Mirrors the notebook spawn: subprocess env + the thread caps. Proves the
+  // wiring, not just the pure function — a real python process reads them back.
+  const proc = Bun.spawn(
+    ["python3", "-c", "import os,json;print(json.dumps({k:os.environ.get(k) for k in os.environ}))"],
+    {
+      env: { PATH: process.env.PATH ?? "", ...OpenScience.pythonThreadCapEnv({}) },
+      stdout: "pipe",
+    },
+  )
+  const seen = JSON.parse(await new Response(proc.stdout).text())
+  await proc.exited
+  for (const v of VARS) expect(seen[v]).toBe(CAP)
+})
+
+test("an explicit OMP override survives into the live kernel (user wins)", async () => {
+  const env = {
+    PATH: process.env.PATH ?? "",
+    OMP_NUM_THREADS: "7",
+    ...OpenScience.pythonThreadCapEnv({ OMP_NUM_THREADS: "7" }),
+  }
+  const proc = Bun.spawn(["python3", "-c", "import os;print(os.environ.get('OMP_NUM_THREADS'))"], {
+    env,
+    stdout: "pipe",
+  })
+  const out = (await new Response(proc.stdout).text()).trim()
+  await proc.exited
+  expect(out).toBe("7")
+})

--- a/backend/cli/test/provider/token-command.test.ts
+++ b/backend/cli/test/provider/token-command.test.ts
@@ -1,0 +1,112 @@
+import { test, expect, mock } from "bun:test"
+
+// Match provider.test.ts: keep provider init hermetic (no real npm installs / plugins).
+mock.module("../../src/bun/index", () => ({
+  BunProc: {
+    install: async (pkg: string) => {
+      const at = pkg.lastIndexOf("@")
+      return at > 0 ? pkg.substring(0, at) : pkg
+    },
+    run: async () => {
+      throw new Error("BunProc.run should not be called in tests")
+    },
+    which: () => process.execPath,
+    InstallFailedError: class extends Error {},
+  },
+}))
+const mockPlugin = () => ({})
+mock.module("openscience-copilot-auth", () => ({ default: mockPlugin }))
+mock.module("openscience-anthropic-auth", () => ({ default: mockPlugin }))
+mock.module("@gitlab/openscience-gitlab-auth", () => ({ default: mockPlugin }))
+
+import path from "path"
+import { generateText } from "ai"
+import { Instance } from "../../src/project/instance"
+import { Provider } from "../../src/provider/provider"
+import { tmpdir } from "../fixture/fixture"
+
+// Minimal OpenAI-compatible chat-completion body so generateText resolves cleanly.
+const completion = {
+  id: "chatcmpl-test",
+  object: "chat.completion",
+  created: 1,
+  model: "m",
+  choices: [{ index: 0, message: { role: "assistant", content: "ok" }, finish_reason: "stop" }],
+  usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+}
+
+// Echo server: records the Authorization header of every request, answers with a
+// valid completion so the request path runs to completion through the fetch hook.
+function echoServer() {
+  const seen: string[] = []
+  const server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      seen.push(req.headers.get("authorization") ?? "")
+      return Response.json(completion)
+    },
+  })
+  return { seen, url: `http://localhost:${server.port}/v1`, stop: () => server.stop(true) }
+}
+
+async function provider(dir: string, options: Record<string, unknown>) {
+  await Bun.write(
+    path.join(dir, "openscience.json"),
+    JSON.stringify({
+      $schema: "https://syntheticsciences.ai/config.json",
+      provider: {
+        "token-cmd": {
+          name: "Token Command Provider",
+          npm: "@ai-sdk/openai-compatible",
+          env: [],
+          models: { m: { name: "M", tool_call: false, limit: { context: 4000, output: 1000 } } },
+          options,
+        },
+      },
+    }),
+  )
+}
+
+test("tokenCommand mints a bearer token and sends it on the wire (#146)", async () => {
+  const srv = echoServer()
+  try {
+    await using tmp = await tmpdir({
+      init: (dir) => provider(dir, { baseURL: srv.url, tokenCommand: "echo minted-secret-42" }),
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const model = await Provider.getModel("token-cmd", "m")
+        const language = await Provider.getLanguage(model)
+        await generateText({ model: language, prompt: "hi" }).catch(() => {})
+      },
+    })
+  } finally {
+    srv.stop()
+  }
+  expect(srv.seen.length).toBeGreaterThan(0)
+  // The command's stdout (trimmed) is the bearer token the server received.
+  expect(srv.seen[0]).toBe("Bearer minted-secret-42")
+})
+
+test("tokenCommand overrides a static apiKey (command wins)", async () => {
+  const srv = echoServer()
+  try {
+    await using tmp = await tmpdir({
+      init: (dir) =>
+        provider(dir, { baseURL: srv.url, apiKey: "static-key-should-lose", tokenCommand: "echo fresh-token" }),
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const model = await Provider.getModel("token-cmd", "m")
+        const language = await Provider.getLanguage(model)
+        await generateText({ model: language, prompt: "hi" }).catch(() => {})
+      },
+    })
+  } finally {
+    srv.stop()
+  }
+  expect(srv.seen[0]).toBe("Bearer fresh-token")
+  expect(srv.seen[0]).not.toContain("static-key-should-lose")
+})

--- a/backend/cli/test/session/data-url-decode.test.ts
+++ b/backend/cli/test/session/data-url-decode.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test"
+import { SessionPrompt } from "../../src/session/prompt"
+
+// An uploaded .txt/.md arrives as a data: URL; only the payload after the comma is
+// the content. The old code base64url-decoded the whole URL, prefixing the inlined
+// text with ~12 bytes of garbage from "data:text/plain," (#170).
+describe("SessionPrompt.decodeDataUrlText", () => {
+  const dataUrl = (mime: string, text: string) => `data:${mime};base64,${Buffer.from(text).toString("base64")}`
+
+  test("round-trips a base64 text/plain upload (no garbage prefix)", () => {
+    const text = "line1\nline2\ttab, and a comma"
+    expect(SessionPrompt.decodeDataUrlText(dataUrl("text/plain", text))).toBe(text)
+  })
+
+  test("round-trips a base64 markdown upload with unicode", () => {
+    const md = "# Title\n\nHello **world** — resolution 3µm."
+    expect(SessionPrompt.decodeDataUrlText(dataUrl("text/markdown", md))).toBe(md)
+  })
+
+  test("decodes a percent-encoded (non-base64) data URL", () => {
+    expect(SessionPrompt.decodeDataUrlText("data:text/plain,hello%20world%2C%20done")).toBe("hello world, done")
+  })
+
+  test("regression: does NOT reproduce the base64url-of-whole-url garbage prefix", () => {
+    const text = "actual file contents here"
+    const url = dataUrl("text/plain", text)
+    const buggy = Buffer.from(url, "base64url").toString()
+    expect(buggy).not.toBe(text) // the old behavior was wrong
+    expect(SessionPrompt.decodeDataUrlText(url)).toBe(text) // the fix is right
+  })
+})

--- a/backend/cli/test/session/text-loop.test.ts
+++ b/backend/cli/test/session/text-loop.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test"
+import { SessionProcessor } from "../../src/session/processor"
+import { MessageV2 } from "../../src/session/message-v2"
+
+// The "continuity summary" a weak/local model repeats verbatim instead of
+// finishing (#176). ~460 chars so it clears the minLen gate.
+const CONTINUITY = (
+  "comprehensive summary for continuity in a new session. objective: find 3-5 recent papers on " +
+  "sensorless position control of sma (nitinol) actuators via resistance feedback. what was done: " +
+  "queried openalex, arxiv, and crossref; collected five relevant results including a directly " +
+  "relevant 2020 paper. next: paste this summary into a new session and continue from the search " +
+  "results already gathered above to produce the final literature review deliverable."
+).toLowerCase()
+
+describe("SessionProcessor.isTextLoop", () => {
+  test("fires on 3 identical substantial continuity-summary turns", () => {
+    expect(SessionProcessor.isTextLoop([CONTINUITY, CONTINUITY, CONTINUITY])).toBe(true)
+  })
+
+  test("fires when only the trailing detail varies but the long preamble repeats", () => {
+    const a = CONTINUITY + " attempt one."
+    const b = CONTINUITY + " attempt two."
+    const c = CONTINUITY + " attempt three."
+    expect(SessionProcessor.isTextLoop([a, b, c])).toBe(true)
+  })
+
+  test("only the last 3 turns matter — earlier distinct progress is ignored", () => {
+    expect(
+      SessionProcessor.isTextLoop(["scoping the question", "reading a paper", CONTINUITY, CONTINUITY, CONTINUITY]),
+    ).toBe(true)
+  })
+
+  test("does not fire below 3 turns", () => {
+    expect(SessionProcessor.isTextLoop([CONTINUITY, CONTINUITY])).toBe(false)
+  })
+
+  test("does not fire on short turns (real progress is usually terse)", () => {
+    expect(SessionProcessor.isTextLoop(["searching openalex", "searching arxiv", "searching crossref"])).toBe(false)
+  })
+
+  test("does not fire when the three turns share no long prefix", () => {
+    const a = "a".repeat(500)
+    const b = "b".repeat(500)
+    const c = "c".repeat(500)
+    expect(SessionProcessor.isTextLoop([a, b, c])).toBe(false)
+  })
+
+  test("does not fire when lengths diverge sharply despite a shared prefix", () => {
+    const short = CONTINUITY // ~460
+    const long = CONTINUITY + "x".repeat(2000) // >1.25x longer
+    expect(SessionProcessor.isTextLoop([short, short, long])).toBe(false)
+  })
+
+  test("does not fire on 3 distinct long paragraphs of genuine work", () => {
+    const p1 = "found paper: sensorless sma control via self-sensing resistance, ieee 2021. ".repeat(8)
+    const p2 = "found paper: nitinol actuator hysteresis compensation with kalman filtering, 2019. ".repeat(8)
+    const p3 = "found paper: resistance-feedback position estimation for shape memory alloys, 2023. ".repeat(8)
+    expect(SessionProcessor.isTextLoop([p1, p2, p3])).toBe(false)
+  })
+})
+
+describe("MessageV2.isContinuingTurn", () => {
+  test("'tool-calls' always continues (there is a tool result to feed back)", () => {
+    expect(MessageV2.isContinuingTurn("tool-calls", true)).toBe(true)
+    expect(MessageV2.isContinuingTurn("tool-calls", false)).toBe(true)
+  })
+
+  test("'unknown' continues ONLY when the turn made a tool call", () => {
+    expect(MessageV2.isContinuingTurn("unknown", true)).toBe(true)
+    // The #176 fix: a text-only 'unknown' turn is a completed turn, not a continue.
+    expect(MessageV2.isContinuingTurn("unknown", false)).toBe(false)
+  })
+
+  test("completed finishes never continue", () => {
+    expect(MessageV2.isContinuingTurn("stop", false)).toBe(false)
+    expect(MessageV2.isContinuingTurn("length", true)).toBe(false)
+    expect(MessageV2.isContinuingTurn(undefined, true)).toBe(false)
+  })
+
+  test("stays consistent with isContinuing for the tool-call case", () => {
+    // Compaction still uses isContinuing; the loop uses isContinuingTurn. They must
+    // agree except on the text-only 'unknown' case the loop tightened.
+    expect(MessageV2.isContinuing("tool-calls")).toBe(true)
+    expect(MessageV2.isContinuing("unknown")).toBe(true)
+  })
+})

--- a/frontend/ui/src/components/message-part.tsx
+++ b/frontend/ui/src/components/message-part.tsx
@@ -369,7 +369,14 @@ export function UserMessageDisplay(props: { message: UserMessage; parts: PartTyp
   const attachments = createMemo(() =>
     files()?.filter((f) => {
       const mime = f.mime
-      return mime.startsWith("image/") || mime === "application/pdf"
+      // Images and PDFs are always attachments. A raw uploaded blob (data: URL with
+      // no source.text — e.g. an uploaded .md/.txt) also renders as a filename chip;
+      // @file references carry source.text and stay inline instead.
+      return (
+        mime.startsWith("image/") ||
+        mime === "application/pdf" ||
+        (f.url?.startsWith("data:") === true && f.source?.text === undefined)
+      )
     }),
   )
 

--- a/frontend/ui/src/components/session-turn.css
+++ b/frontend/ui/src/components/session-turn.css
@@ -530,6 +530,9 @@
       width: 12px;
       height: 12px;
       margin-right: 4px;
+      /* Don't let a long status line ("Searching the web · 10m, 1s") squeeze the
+         SVG — without this the 15-unit grid compresses and the dots read as cut off. */
+      flex-shrink: 0;
     }
 
     [data-component="icon"] {

--- a/frontend/ui/src/components/session-turn.tsx
+++ b/frontend/ui/src/components/session-turn.tsx
@@ -84,8 +84,15 @@ function same<T>(a: readonly T[], b: readonly T[]) {
 
 function isAttachment(part: PartType | undefined) {
   if (part?.type !== "file") return false
-  const mime = (part as FilePart).mime ?? ""
-  return mime.startsWith("image/") || mime === "application/pdf"
+  const file = part as FilePart
+  const mime = file.mime ?? ""
+  // Images/PDFs, plus raw uploaded blobs (data: URL, no source.text — e.g. .md/.txt).
+  // @file references carry source.text and render inline, not as chips.
+  return (
+    mime.startsWith("image/") ||
+    mime === "application/pdf" ||
+    (file.url?.startsWith("data:") === true && file.source?.text === undefined)
+  )
 }
 
 function AssistantMessageItem(props: {

--- a/frontend/workspace/src/components/prompt-input.tsx
+++ b/frontend/workspace/src/components/prompt-input.tsx
@@ -60,7 +60,15 @@ import { showToast } from "@synsci/ui/toast"
 import { base64Encode } from "@synsci/util/encode"
 
 const ACCEPTED_IMAGE_TYPES = ["image/png", "image/jpeg", "image/gif", "image/webp"]
-const ACCEPTED_FILE_TYPES = [...ACCEPTED_IMAGE_TYPES, "application/pdf"]
+const ACCEPTED_TEXT_TYPES = ["text/markdown", "text/plain"]
+const ACCEPTED_FILE_TYPES = [...ACCEPTED_IMAGE_TYPES, "application/pdf", ...ACCEPTED_TEXT_TYPES]
+// Browsers frequently report file.type === "" for .md (and sometimes .txt), so the
+// mime allow-list alone would drop them. Resolve by extension as a fallback.
+const TEXT_EXTENSIONS: Record<string, string> = { md: "text/markdown", markdown: "text/markdown", txt: "text/plain" }
+const fileExtension = (name: string) => name.slice(name.lastIndexOf(".") + 1).toLowerCase()
+const resolveMime = (file: File) => file.type || TEXT_EXTENSIONS[fileExtension(file.name)] || ""
+const isAcceptedFile = (file: File) =>
+  ACCEPTED_FILE_TYPES.includes(file.type) || Boolean(TEXT_EXTENSIONS[fileExtension(file.name)])
 
 type PendingPrompt = {
   abort: AbortController
@@ -326,7 +334,8 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   const isImeComposing = (event: KeyboardEvent) => event.isComposing || composing() || event.keyCode === 229
 
   const addImageAttachment = async (file: File) => {
-    if (!ACCEPTED_FILE_TYPES.includes(file.type)) return
+    if (!isAcceptedFile(file)) return
+    const mime = resolveMime(file)
 
     const reader = new FileReader()
     reader.onload = () => {
@@ -335,7 +344,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
         type: "image",
         id: crypto.randomUUID(),
         filename: file.name,
-        mime: file.type,
+        mime,
         dataUrl,
       }
       const cursorPosition = prompt.cursor() ?? getCursorPosition(editorRef)
@@ -412,7 +421,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     if (!dropped) return
 
     for (const file of Array.from(dropped)) {
-      if (ACCEPTED_FILE_TYPES.includes(file.type)) {
+      if (isAcceptedFile(file)) {
         await addImageAttachment(file)
       }
     }
@@ -2054,7 +2063,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
             <input
               ref={fileInputRef}
               type="file"
-              accept={ACCEPTED_FILE_TYPES.join(",")}
+              accept={[...ACCEPTED_FILE_TYPES, ".md", ".markdown", ".txt"].join(",")}
               class="hidden"
               onChange={(e) => {
                 const file = e.currentTarget.files?.[0]

--- a/frontend/workspace/src/components/settings/Connectors.tsx
+++ b/frontend/workspace/src/components/settings/Connectors.tsx
@@ -5,7 +5,6 @@ import { IconButton } from "@synsci/ui/icon-button"
 import { showToast } from "@synsci/ui/toast"
 import { useGlobalSync } from "@/context/global-sync"
 import { useGlobalSDK } from "@/context/global-sdk"
-import { StatusDot } from "@/atlas/shared/StatusDot"
 import type { Config, McpStatus } from "@synsci/sdk/v2/client"
 import {
   PanelScroll,
@@ -20,6 +19,8 @@ import {
   EmptyState,
   FormField,
   FormButton,
+  Avatar,
+  Chip,
 } from "./_shared"
 
 type McpConfig = NonNullable<Config["mcp"]>[string]
@@ -62,6 +63,15 @@ export default function Connectors() {
     return "muted"
   }
   const statusText = (s: McpStatus | undefined) => (s ? s.status.replaceAll("_", " ") : "unknown")
+  // Wash the connector's avatar tile by connection state so status reads at a
+  // glance; a muted/off connector stays neutral.
+  function statusTint(s: McpStatus | undefined): string | undefined {
+    const d = dot(s)
+    if (d === "active") return "var(--color-success)"
+    if (d === "error") return "var(--color-error)"
+    if (d === "pending") return "var(--color-warning)"
+    return undefined
+  }
 
   async function toggle(name: string, on: boolean) {
     setBusy(true)
@@ -223,14 +233,12 @@ export default function Connectors() {
                     const s = () => status()[name]
                     return (
                       <Row>
-                        <StatusDot status={dot(s())} pulse={s()?.status === "connected"} />
+                        <Avatar icon={config.type === "remote" ? "link" : "console"} tint={statusTint(s())} />
                         <div class="min-w-0 flex-1">
                           <div class="flex items-center gap-2">
                             <span class="text-14-medium text-text-strong truncate">{name}</span>
-                            <span class="text-11-medium text-text-weak/70 px-1.5 py-0.5 rounded-md bg-surface-raised-base/60">
-                              {config.type}
-                            </span>
-                            <span class="text-11-regular text-text-weak/60">{statusText(s())}</span>
+                            <Chip>{config.type}</Chip>
+                            <span class="text-11-regular text-text-weak/60 truncate">{statusText(s())}</span>
                           </div>
                           <p class="text-12-regular text-text-weak truncate mt-0.5">
                             {config.type === "local" ? config.command.join(" ") : config.url}

--- a/frontend/workspace/src/components/settings/Specialists.tsx
+++ b/frontend/workspace/src/components/settings/Specialists.tsx
@@ -1,5 +1,4 @@
 import { For, Show, createMemo, createResource, createSignal } from "solid-js"
-import { Icon } from "@synsci/ui/icon"
 import { IconButton } from "@synsci/ui/icon-button"
 import { showToast } from "@synsci/ui/toast"
 import { useGlobalSDK } from "@/context/global-sdk"
@@ -19,6 +18,8 @@ import {
   EmptyState,
   FormField,
   FormButton,
+  Avatar,
+  Chip,
 } from "./_shared"
 
 // System agents that are implementation details, not user-facing specialists.
@@ -182,18 +183,11 @@ function AgentRow(props: { agent: Agent; onDelete?: () => void; busy: boolean })
     props.agent.mode === "subagent" ? "subagent" : props.agent.mode === "all" ? "primary · subagent" : "primary"
   return (
     <Row>
-      <div
-        class="flex items-center justify-center size-8 rounded-xs flex-shrink-0 text-icon-strong-base"
-        style={{ background: props.agent.color ? `${props.agent.color}22` : "var(--color-surface-raised-base)" }}
-      >
-        <Icon name="models" size="small" />
-      </div>
+      <Avatar monogram={props.agent.name.slice(0, 1)} tint={props.agent.color ?? undefined} />
       <div class="min-w-0 flex-1">
         <div class="flex items-center gap-2">
           <span class="text-14-medium text-text-strong truncate">{props.agent.name}</span>
-          <span class="text-11-medium text-text-weak/70 px-1.5 py-0.5 rounded-md bg-surface-raised-base/60">
-            {modeLabel()}
-          </span>
+          <Chip>{modeLabel()}</Chip>
         </div>
         <Show when={props.agent.description}>
           <p class="text-12-regular text-text-weak truncate mt-0.5">{props.agent.description}</p>

--- a/frontend/workspace/src/components/settings/_shared.tsx
+++ b/frontend/workspace/src/components/settings/_shared.tsx
@@ -66,6 +66,34 @@ export const EmptyState: Component<{ icon: IconProps["name"]; title: string; hin
   </div>
 )
 
+// Leading identity tile for a list row — the shared visual anchor that makes the
+// Specialists and Connectors lists read as one family. Pass a `monogram` (takes
+// the tint as its colour, for a specialist's identity) or an `icon` (stays
+// neutral on the tinted tile, for a connector's type). `tint` (hex or a CSS var)
+// washes the tile background; omit it for a neutral tile.
+export const Avatar: Component<{ tint?: string; icon?: IconProps["name"]; monogram?: string }> = (props) => (
+  <div
+    class="flex items-center justify-center size-8 rounded-[5px] flex-shrink-0 text-13-medium leading-none uppercase"
+    style={{
+      background: props.tint
+        ? `color-mix(in srgb, ${props.tint} 14%, transparent)`
+        : "var(--color-surface-raised-base)",
+      color: props.monogram && props.tint ? props.tint : "var(--color-icon-strong-base)",
+    }}
+  >
+    <Show when={props.icon} fallback={<span>{props.monogram}</span>}>
+      <Icon name={props.icon!} size="small" />
+    </Show>
+  </div>
+)
+
+// Small inline metadata badge (a specialist's mode, a connector's type).
+export const Chip: ParentComponent = (props) => (
+  <span class="text-11-medium text-text-weak/70 px-1.5 py-0.5 rounded-md bg-surface-raised-base/60 flex-shrink-0">
+    {props.children}
+  </span>
+)
+
 // ── Toolbar pieces ──────────────────────────────────────────────────────────
 
 const controlBase =

--- a/frontend/workspace/src/pages/session.tsx
+++ b/frontend/workspace/src/pages/session.tsx
@@ -549,10 +549,12 @@ export default function Page(): JSX.Element {
                         "overflow-x": "hidden",
                       }}
                     >
-                      {/* Sticky title + back-to-parent (sub-agent) header — kept
-                          outside contentRef so the ResizeObserver measures only
-                          the growing message list, not the sticky header. */}
-                      <Show when={activeSession()?.title || activeSession()?.parentID}>
+                      {/* Sub-agent back-to-parent header only. Normal chats render
+                          NO fixed header — the sticky session title used to sit on top
+                          of the conversation and block content. The title is still
+                          shown/renamable in the session list. Kept outside contentRef
+                          so the ResizeObserver measures only the growing message list. */}
+                      <Show when={activeSession()?.parentID}>
                         <div class="sticky top-0 z-30 bg-background-stronger w-full">
                           <div class="w-full px-4 md:px-6 md:max-w-200 md:mx-auto">
                             <div class="h-10 flex items-center gap-1.5">


### PR DESCRIPTION
Fixes a batch of open issues after tracing each to its core cause. Every change is behind a typecheck/test gate; full backend suite is green (1107 pass).

## Bug fixes

- **#168 — auto-compaction misses long sessions → false "Tool execution aborted".** A `finish_reason=length` turn over the compaction threshold is a *truncated* turn, not a completed answer, but `isContinuing` excluded `length` so it never compacted — stranding the pending tool part. It now routes through the existing overflow handler (compact + re-run the same message), and the stranded part reports a context-limit message instead of "aborted".

- **#170 — accept `.md` / `.txt` uploads.** The composer allow-list was images + PDF; browsers also report an empty `file.type` for `.md`. Added text mimes + an extension fallback across picker/paste/drop, widened the picker `accept`, fixed a backend base64 decode that garbled `.txt`, and render text blobs as filename chips.

- **#102 — single-cell OOM (60 GB+ python procs).** BLAS/numba/joblib each fan out one full-dataset copy per core. Added `OpenScience.pythonThreadCapEnv()` (caps OMP/OPENBLAS/MKL/VECLIB/NUMEXPR/NUMBA threads + `LOKY_MAX_CPU_COUNT` to `min(4, cores)`, only when unset) at both notebook kernel spawn sites, plus scanpy memory guidance in the biology prompt.

- **#159 / #142 — Atlas sync reverts custom providers/models every sync.** The dashboard-synced config was merged *on top of* the user's config, so a chosen default model / custom OpenRouter models were reverted each sync. Flipped the merge — user config wins, synced is a fallback; model records still union so server-whitelisted models the user didn't declare stay available. (The `keys add` crash in #142 was already fixed in #155.)

- **#176 — research doom-loop on local Ollama models.** Root cause: an `unknown` finish reason is treated as "keep going", so a text-only "continuity summary" turn re-prompted the identical context forever. An `unknown` finish now only continues when the turn actually made a tool call. Added a conservative text-repetition guard (last 3 near-identical assistant turns → stop with an actionable message) and a Convergence/Anti-Loop section in the research prompt (converge and write the deliverable; never emit handoff/continuity summaries; continue — don't restart — when a skill/subagent returns "not found").

## Feature

- **#146 — `tokenCommand`.** New provider option: a shell command whose stdout is a short-lived bearer token, injected as `Authorization: Bearer <token>` per request and re-minted before the JWT `exp` (non-JWT tokens re-mint each request), with a single-flight cache. Wired into `getSDK`'s existing fetch hook.

## Verification

- `bun run typecheck` ✅  ·  `bun test` (backend) ✅ 1107 pass / 0 fail  ·  `bun run format` clean
