### PR TITLE
fix(compute): guard analysis runs against OOM (#102)

### DIFF
--- a/backend/cli/skills/biology/scanpy/assets/analysis_template.py
+++ b/backend/cli/skills/biology/scanpy/assets/analysis_template.py
@@ -47,20 +47,31 @@ import os as _os
 
 
 def _available_ram_bytes():
+    # We need *available* RAM (not total) — a box already using most of its
+    # memory must pick fewer workers, or the guard green-lights an OOM.
     try:
         import psutil
         return psutil.virtual_memory().available
     except Exception:
-        try:  # POSIX fallback (psutil gives *available*, which is preferred)
-            return _os.sysconf('SC_PAGE_SIZE') * _os.sysconf('SC_PHYS_PAGES')
-        except (ValueError, OSError, AttributeError):
-            return 8 * 1024 ** 3  # unknown -> assume 8 GB
+        pass
+    try:  # Linux: MemAvailable is the accurate figure
+        with open('/proc/meminfo') as f:
+            for line in f:
+                if line.startswith('MemAvailable:'):
+                    return int(line.split()[1]) * 1024
+    except Exception:
+        pass
+    try:  # last resort: TOTAL physical RAM, halved so we don't over-commit
+        return (_os.sysconf('SC_PAGE_SIZE') * _os.sysconf('SC_PHYS_PAGES')) // 2
+    except (ValueError, OSError, AttributeError):
+        return 4 * 1024 ** 3  # unknown -> assume 4 GB
 
 
 def memory_safe_n_jobs(adata, fraction=0.5):
-    """Largest worker count whose per-worker dense copies fit in `fraction` of RAM."""
+    """Largest worker count whose per-worker dense copies fit in `fraction` of RAM.
+    Reserves one copy for the parent process, which also densifies the matrix."""
     per_worker = max(1, adata.n_obs * adata.n_vars * 8)  # float64 dense copy, bytes
-    fits = int(_available_ram_bytes() * fraction // per_worker)
+    fits = int(_available_ram_bytes() * fraction // per_worker) - 1  # -1: parent's copy
     return max(1, min(_os.cpu_count() or 1, fits))
 
 

--- a/backend/cli/skills/biology/scanpy/assets/analysis_template.py
+++ b/backend/cli/skills/biology/scanpy/assets/analysis_template.py
@@ -38,6 +38,39 @@ sc.settings.verbosity = 3
 sc.settings.set_figure_params(dpi=80, facecolor='white')
 sc.settings.figdir = FIGURES_DIR
 
+# Memory-aware parallelism (#102). Parallel steps like regress_out fork one
+# worker PROCESS per job, each holding a full DENSE copy of the matrix — so the
+# safe n_jobs is bounded by RAM, not just CPU. Size it at runtime (below) rather
+# than hardcoding: the largest worker count whose per-worker copies fit in a
+# fraction of available memory.
+import os as _os
+
+
+def _available_ram_bytes():
+    try:
+        import psutil
+        return psutil.virtual_memory().available
+    except Exception:
+        try:  # POSIX fallback (psutil gives *available*, which is preferred)
+            return _os.sysconf('SC_PAGE_SIZE') * _os.sysconf('SC_PHYS_PAGES')
+        except (ValueError, OSError, AttributeError):
+            return 8 * 1024 ** 3  # unknown -> assume 8 GB
+
+
+def memory_safe_n_jobs(adata, fraction=0.5):
+    """Largest worker count whose per-worker dense copies fit in `fraction` of RAM."""
+    per_worker = max(1, adata.n_obs * adata.n_vars * 8)  # float64 dense copy, bytes
+    fits = int(_available_ram_bytes() * fraction // per_worker)
+    return max(1, min(_os.cpu_count() or 1, fits))
+
+
+# Modest default for light parallel steps; regress_out picks a RAM-aware value.
+sc.settings.n_jobs = min(_os.cpu_count() or 1, 4)
+
+# Guardrail: above this dense-matrix size (GB), the template skips the
+# memory-hazardous dense steps (regress_out) and warns instead of OOMing.
+MAX_DENSE_GB = 8.0
+
 # ============================================================================
 # 1. LOAD DATA
 # ============================================================================
@@ -52,6 +85,14 @@ adata = sc.read_h5ad(INPUT_FILE)
 # adata = sc.read_csv('data/counts.csv')  # For CSV data
 
 print(f"Loaded: {adata.n_obs} cells x {adata.n_vars} genes")
+
+# Memory guard (#102): a count matrix stored DENSE uses ~8 bytes/element and can
+# be tens/hundreds of GB, OOMing the machine on load alone. Keep counts sparse.
+import scipy.sparse as _sp
+_dense_gb = adata.n_obs * adata.n_vars * 8 / 1e9
+if not _sp.issparse(adata.X) and _dense_gb > MAX_DENSE_GB:
+    print(f"WARNING: adata.X is DENSE (~{_dense_gb:.1f} GB). Convert to sparse to "
+          f"avoid running out of memory:  adata.X = scipy.sparse.csr_matrix(adata.X)")
 
 # ============================================================================
 # 2. QUALITY CONTROL
@@ -128,10 +169,27 @@ print("\n" + "=" * 80)
 print("SCALING AND REGRESSION")
 print("=" * 80)
 
-# Regress out unwanted sources of variation
-sc.pp.regress_out(adata, ['total_counts', 'pct_counts_mt'])
+# Regress out unwanted sources of variation.
+# NOTE (#102): regress_out densifies the matrix and runs one joblib worker per
+# job, each holding a full dense copy — the biggest memory hazard in this
+# pipeline. It is optional in modern workflows, so it stays OFF by default and
+# is skipped automatically when the dense matrix would exceed MAX_DENSE_GB.
+REGRESS_OUT = False
+_hvg_dense_gb = adata.n_obs * adata.n_vars * 8 / 1e9
+if REGRESS_OUT and _hvg_dense_gb <= MAX_DENSE_GB:
+    n_jobs = memory_safe_n_jobs(adata)  # as many workers as fit in RAM, up to cores
+    print(f"regress_out: n_jobs={n_jobs} (each worker copies ~{_hvg_dense_gb:.1f} GB)")
+    sc.pp.regress_out(adata, ['total_counts', 'pct_counts_mt'], n_jobs=n_jobs)
+elif REGRESS_OUT:
+    print(f"WARNING: skipping regress_out — dense matrix ~{_hvg_dense_gb:.1f} GB "
+          f"exceeds MAX_DENSE_GB={MAX_DENSE_GB} GB (#102). Subset cells/HVGs first.")
 
-# Scale data
+# Scale to unit variance. zero_center=True (default) fills every structural zero
+# and densifies the matrix; for a very large matrix this alone can exhaust
+# memory. Scaling here runs on the HVG subset (done above); if it is still huge,
+# reduce N_TOP_GENES or the cell count.
+if _hvg_dense_gb > MAX_DENSE_GB * 2:
+    print(f"WARNING: scaling will densify a ~{_hvg_dense_gb:.1f} GB matrix (#102).")
 sc.pp.scale(adata, max_value=10)
 
 # ============================================================================

--- a/backend/cli/skills/biology/scanpy/assets/analysis_template.py
+++ b/backend/cli/skills/biology/scanpy/assets/analysis_template.py
@@ -68,11 +68,13 @@ def _available_ram_bytes():
 
 
 def memory_safe_n_jobs(adata, fraction=0.5):
-    """Largest worker count whose per-worker dense copies fit in `fraction` of RAM.
-    Reserves one copy for the parent process, which also densifies the matrix."""
+    """Largest worker count whose per-worker dense copies fit in `fraction` of RAM,
+    reserving one copy for the parent process (which also densifies the matrix).
+    Returns 0 when not even a single worker copy fits — the caller must then skip
+    the dense step rather than run one worker that OOMs anyway (#102)."""
     per_worker = max(1, adata.n_obs * adata.n_vars * 8)  # float64 dense copy, bytes
     fits = int(_available_ram_bytes() * fraction // per_worker) - 1  # -1: parent's copy
-    return max(1, min(_os.cpu_count() or 1, fits))
+    return max(0, min(_os.cpu_count() or 1, fits))
 
 
 # Modest default for light parallel steps; regress_out picks a RAM-aware value.
@@ -189,8 +191,14 @@ REGRESS_OUT = False
 _hvg_dense_gb = adata.n_obs * adata.n_vars * 8 / 1e9
 if REGRESS_OUT and _hvg_dense_gb <= MAX_DENSE_GB:
     n_jobs = memory_safe_n_jobs(adata)  # as many workers as fit in RAM, up to cores
-    print(f"regress_out: n_jobs={n_jobs} (each worker copies ~{_hvg_dense_gb:.1f} GB)")
-    sc.pp.regress_out(adata, ['total_counts', 'pct_counts_mt'], n_jobs=n_jobs)
+    if n_jobs >= 1:
+        print(f"regress_out: n_jobs={n_jobs} (each worker copies ~{_hvg_dense_gb:.1f} GB)")
+        sc.pp.regress_out(adata, ['total_counts', 'pct_counts_mt'], n_jobs=n_jobs)
+    else:
+        # Even one worker's dense copy won't fit the RAM budget — running it would
+        # OOM, so skip rather than proceed with a doomed single worker (#102).
+        print(f"WARNING: skipping regress_out — not enough free RAM for even one "
+              f"dense worker copy (~{_hvg_dense_gb:.1f} GB) (#102). Subset cells/HVGs first.")
 elif REGRESS_OUT:
     print(f"WARNING: skipping regress_out — dense matrix ~{_hvg_dense_gb:.1f} GB "
           f"exceeds MAX_DENSE_GB={MAX_DENSE_GB} GB (#102). Subset cells/HVGs first.")

--- a/backend/cli/skills/biology/scanpy/references/api_reference.md
+++ b/backend/cli/skills/biology/scanpy/references/api_reference.md
@@ -238,7 +238,14 @@ sc.settings.autoshow = False           # Don't show plots automatically
 sc.settings.autosave = True            # Autosave figures
 sc.settings.figdir = './figures/'      # Figure directory
 sc.settings.cachedir = './cache/'      # Cache directory
-sc.settings.n_jobs = 8                 # Number of parallel jobs
+sc.settings.n_jobs = 1                 # Parallel jobs. CAUTION: parallel steps
+                                       # like regress_out fork one worker per job,
+                                       # each holding a full DENSE copy of the
+                                       # matrix — n_jobs is bounded by RAM, not
+                                       # just CPU (n_jobs=8 on a large matrix can
+                                       # OOM the machine). Size it to memory:
+                                       # min(cores, avail_RAM / per-worker bytes).
+                                       # See analysis_template.py memory_safe_n_jobs().
 ```
 
 ## Useful Utilities

--- a/backend/cli/src/openscience/index.ts
+++ b/backend/cli/src/openscience/index.ts
@@ -1087,31 +1087,21 @@ export namespace OpenScience {
     return result
   }
 
-  /** BLAS / OpenMP / joblib parallelism knobs. Left unset, numpy/scipy BLAS,
-   *  numba, and joblib each default to *all* cores — and joblib's loky backend
-   *  forks one full data copy per worker. Nested (a scanpy step with n_jobs on
-   *  top of all-core BLAS) both oversubscribes CPU and multiplies memory, which
-   *  is how a single analysis balloons to tens of GB across several processes
-   *  (issue #102). Cap to a modest share of cores as a default the user can
-   *  override. This is not a hard memory limit — macOS ignores RLIMIT_AS — it
-   *  bounds the parallelism multiplier. */
-  const COMPUTE_PARALLELISM_VARS = [
-    "OMP_NUM_THREADS",
-    "OPENBLAS_NUM_THREADS",
-    "MKL_NUM_THREADS",
-    "NUMEXPR_NUM_THREADS",
-    "VECLIB_MAXIMUM_THREADS",
-    "NUMBA_NUM_THREADS",
-    "BLIS_NUM_THREADS",
-    "LOKY_MAX_CPU_COUNT",
-  ]
+  const CPU_COUNT = Math.max(1, os.cpus().length)
+
+  /** joblib's loky backend forks one full data COPY per worker process, so its
+   *  default worker count (n_jobs=-1) is the memory multiplier behind #102. Cap
+   *  LOKY_MAX_CPU_COUNT to a modest share of cores, only when unset.
+   *
+   *  We deliberately do NOT cap the BLAS/OpenMP/numba THREAD pools
+   *  (OMP_NUM_THREADS, MKL_NUM_THREADS, …): those are shared-memory threads, so
+   *  capping them throttles legitimate single-process compute (a bash-run
+   *  numpy/torch job) without saving any memory, and joblib already pins worker
+   *  thread pools to 1 to avoid nested oversubscription. This is not a hard
+   *  memory limit — macOS ignores RLIMIT_AS — it bounds the worker-COPY count. */
   export function withComputeParallelismCaps(env: Record<string, string>): Record<string, string> {
-    const cap = String(Math.max(1, Math.min(os.cpus().length, 4)))
-    const result = { ...env }
-    for (const key of COMPUTE_PARALLELISM_VARS) {
-      if (!result[key]) result[key] = cap
-    }
-    return result
+    if (env.LOKY_MAX_CPU_COUNT) return env
+    return { ...env, LOKY_MAX_CPU_COUNT: String(Math.min(CPU_COUNT, 4)) }
   }
 
   /** Subprocess env = sanitized base env + any user-owned BYOK provider keys

--- a/backend/cli/src/openscience/index.ts
+++ b/backend/cli/src/openscience/index.ts
@@ -1098,7 +1098,11 @@ export namespace OpenScience {
    *  capping them throttles legitimate single-process compute (a bash-run
    *  numpy/torch job) without saving any memory, and joblib already pins worker
    *  thread pools to 1 to avoid nested oversubscription. This is not a hard
-   *  memory limit — macOS ignores RLIMIT_AS — it bounds the worker-COPY count. */
+   *  memory limit — macOS ignores RLIMIT_AS — it bounds the worker-COPY count.
+   *
+   *  Applied at the compute-kernel spawn boundary (notebook/rkernel/biology),
+   *  NOT inside the shared subprocessEnv — a memory-parallelism cap doesn't
+   *  belong on every subprocess the agent runs (git, atlas, plain bash). */
   export function withComputeParallelismCaps(env: Record<string, string>): Record<string, string> {
     if (env.LOKY_MAX_CPU_COUNT) return env
     return { ...env, LOKY_MAX_CPU_COUNT: String(Math.min(CPU_COUNT, 4)) }
@@ -1112,8 +1116,9 @@ export namespace OpenScience {
     const base = filterEnvForSubprocess(env)
     const auth = await Auth.all().catch(() => ({}) as Record<string, Auth.Info>)
     // Prepend the bundled atlas CLI to PATH so the agent's native `atlas`
-    // commands resolve without a separate global install.
-    return withComputeParallelismCaps(withAtlasOnPath(mergeByokEnv(base, auth)))
+    // commands resolve without a separate global install. The joblib/loky memory
+    // cap is applied by the compute-kernel spawns, not here (#102).
+    return withAtlasOnPath(mergeByokEnv(base, auth))
   }
 
   // === Server-side Skills ===

--- a/backend/cli/src/openscience/index.ts
+++ b/backend/cli/src/openscience/index.ts
@@ -1087,6 +1087,33 @@ export namespace OpenScience {
     return result
   }
 
+  /** BLAS / OpenMP / joblib parallelism knobs. Left unset, numpy/scipy BLAS,
+   *  numba, and joblib each default to *all* cores — and joblib's loky backend
+   *  forks one full data copy per worker. Nested (a scanpy step with n_jobs on
+   *  top of all-core BLAS) both oversubscribes CPU and multiplies memory, which
+   *  is how a single analysis balloons to tens of GB across several processes
+   *  (issue #102). Cap to a modest share of cores as a default the user can
+   *  override. This is not a hard memory limit — macOS ignores RLIMIT_AS — it
+   *  bounds the parallelism multiplier. */
+  const COMPUTE_PARALLELISM_VARS = [
+    "OMP_NUM_THREADS",
+    "OPENBLAS_NUM_THREADS",
+    "MKL_NUM_THREADS",
+    "NUMEXPR_NUM_THREADS",
+    "VECLIB_MAXIMUM_THREADS",
+    "NUMBA_NUM_THREADS",
+    "BLIS_NUM_THREADS",
+    "LOKY_MAX_CPU_COUNT",
+  ]
+  export function withComputeParallelismCaps(env: Record<string, string>): Record<string, string> {
+    const cap = String(Math.max(1, Math.min(os.cpus().length, 4)))
+    const result = { ...env }
+    for (const key of COMPUTE_PARALLELISM_VARS) {
+      if (!result[key]) result[key] = cap
+    }
+    return result
+  }
+
   /** Subprocess env = sanitized base env + any user-owned BYOK provider keys
    *  from auth.json. Lets skill scripts (e.g. nano-banana image generation)
    *  use a key the user connected with `openscience login`, without leaking the
@@ -1096,7 +1123,7 @@ export namespace OpenScience {
     const auth = await Auth.all().catch(() => ({}) as Record<string, Auth.Info>)
     // Prepend the bundled atlas CLI to PATH so the agent's native `atlas`
     // commands resolve without a separate global install.
-    return withAtlasOnPath(mergeByokEnv(base, auth))
+    return withComputeParallelismCaps(withAtlasOnPath(mergeByokEnv(base, auth)))
   }
 
   // === Server-side Skills ===

--- a/backend/cli/src/shell/shell.ts
+++ b/backend/cli/src/shell/shell.ts
@@ -7,6 +7,23 @@ import { spawn, type ChildProcess } from "child_process"
 const SIGKILL_TIMEOUT_MS = 200
 
 export namespace Shell {
+  /** POSIX: true only when `pid` leads its own process group (i.e. was spawned
+   *  `detached`), so a negative-pid signal targets ONLY its group and can never
+   *  reach ours. On Linux we verify via /proc; elsewhere we can't cheaply check,
+   *  so trust the caller (all kernel spawns pass `detached`). Guards against a
+   *  future non-detached spawn making `kill(-pid)` hit the wrong group (#102). */
+  function leadsOwnGroup(pid: number): boolean {
+    if (process.platform !== "linux") return true
+    try {
+      const stat = fs.readFileSync(`/proc/${pid}/stat`, "utf8")
+      // Fields after the ")" that closes comm are: state ppid pgrp session ...
+      const fields = stat.slice(stat.lastIndexOf(")") + 2).split(" ")
+      return Number(fields[2]) === pid
+    } catch {
+      return false
+    }
+  }
+
   export async function killTree(proc: ChildProcess, opts?: { exited?: () => boolean }): Promise<void> {
     const pid = proc.pid
     if (!pid || opts?.exited?.()) return
@@ -20,24 +37,26 @@ export namespace Shell {
       return
     }
 
-    try {
-      process.kill(-pid, "SIGTERM")
-      await Bun.sleep(SIGKILL_TIMEOUT_MS)
-      if (!opts?.exited?.()) {
-        process.kill(-pid, "SIGKILL")
-      }
-    } catch (_e) {
-      proc.kill("SIGTERM")
-      await Bun.sleep(SIGKILL_TIMEOUT_MS)
-      if (!opts?.exited?.()) {
-        proc.kill("SIGKILL")
+    if (leadsOwnGroup(pid)) {
+      try {
+        process.kill(-pid, "SIGTERM")
+        await Bun.sleep(SIGKILL_TIMEOUT_MS)
+        if (!opts?.exited?.()) process.kill(-pid, "SIGKILL")
+        return
+      } catch (_e) {
+        // group gone or not permitted — fall through to a single-process kill
       }
     }
+    try {
+      proc.kill("SIGTERM")
+      await Bun.sleep(SIGKILL_TIMEOUT_MS)
+      if (!opts?.exited?.()) proc.kill("SIGKILL")
+    } catch {}
   }
   /** Synchronous best-effort group SIGKILL. For process-exit handlers, where
    *  the event loop is already stopping and the async killTree (which sleeps
-   *  before escalating) cannot complete. Requires the child to be spawned
-   *  `detached` so the negative pid targets the whole group. */
+   *  before escalating) cannot complete. Only signals the group when the child
+   *  leads its own (spawned `detached`); otherwise kills just the child. */
   export function killTreeSync(proc: ChildProcess): void {
     const pid = proc.pid
     if (!pid) return
@@ -47,13 +66,15 @@ export namespace Shell {
       } catch {}
       return
     }
-    try {
-      process.kill(-pid, "SIGKILL")
-    } catch {
+    if (leadsOwnGroup(pid)) {
       try {
-        proc.kill("SIGKILL")
+        process.kill(-pid, "SIGKILL")
+        return
       } catch {}
     }
+    try {
+      proc.kill("SIGKILL")
+    } catch {}
   }
 
   const BLACKLIST = new Set(["fish", "nu"])

--- a/backend/cli/src/shell/shell.ts
+++ b/backend/cli/src/shell/shell.ts
@@ -34,6 +34,28 @@ export namespace Shell {
       }
     }
   }
+  /** Synchronous best-effort group SIGKILL. For process-exit handlers, where
+   *  the event loop is already stopping and the async killTree (which sleeps
+   *  before escalating) cannot complete. Requires the child to be spawned
+   *  `detached` so the negative pid targets the whole group. */
+  export function killTreeSync(proc: ChildProcess): void {
+    const pid = proc.pid
+    if (!pid) return
+    if (process.platform === "win32") {
+      try {
+        spawn("taskkill", ["/pid", String(pid), "/f", "/t"], { stdio: "ignore" })
+      } catch {}
+      return
+    }
+    try {
+      process.kill(-pid, "SIGKILL")
+    } catch {
+      try {
+        proc.kill("SIGKILL")
+      } catch {}
+    }
+  }
+
   const BLACKLIST = new Set(["fish", "nu"])
 
   function exists(p: string) {

--- a/backend/cli/src/tool/biology/notebook.ts
+++ b/backend/cli/src/tool/biology/notebook.ts
@@ -3,6 +3,7 @@ import { Tool } from "../tool"
 import { spawn, type ChildProcess } from "child_process"
 import path from "path"
 import os from "os"
+import { Shell } from "@/shell/shell"
 import { Instance } from "@/project/instance"
 import { OpenScience } from "@/openscience"
 import { Config } from "@/config/config"
@@ -83,9 +84,7 @@ const kernels = new Map<string, Kernel>()
 // Clean up all kernels on process exit
 function cleanupAll() {
   for (const [id, kernel] of kernels) {
-    try {
-      kernel.process.kill()
-    } catch {}
+    Shell.killTreeSync(kernel.process)
     try {
       require("fs").unlinkSync(kernel.scriptPath)
     } catch {}
@@ -102,9 +101,7 @@ function cleanupIdle() {
   const idle = 30 * 60 * 1000 // 30 min
   for (const [id, kernel] of kernels) {
     if (now - kernel.lastUsed > idle) {
-      try {
-        kernel.process.kill()
-      } catch {}
+      void Shell.killTree(kernel.process, { exited: () => kernel.process.exitCode !== null })
       try {
         require("fs").unlinkSync(kernel.scriptPath)
       } catch {}
@@ -149,6 +146,8 @@ async function getKernel(sessionID: string): Promise<Kernel> {
     cwd: Instance.directory,
     env: { ...(await OpenScience.subprocessEnv(process.env)), PYTHONUNBUFFERED: "1" },
     stdio: ["pipe", "pipe", "pipe"],
+    // Own process group so killing the kernel reaps its joblib/BLAS children (#102).
+    detached: process.platform !== "win32",
   })
 
   // Collect kernel stderr (startup warnings, etc.)
@@ -162,7 +161,7 @@ async function getKernel(sessionID: string): Promise<Kernel> {
   // Wait for ready signal
   await new Promise<void>((resolve, reject) => {
     const timeout = setTimeout(() => {
-      proc.kill()
+      void Shell.killTree(proc, { exited: () => proc.exitCode !== null })
       reject(new Error(`Kernel startup timed out. stderr: ${kernelStderr}`))
     }, 15_000)
 
@@ -198,10 +197,8 @@ function executeInKernel(
 ): Promise<{ ok: boolean; stdout: string; stderr: string }> {
   return new Promise((resolve, reject) => {
     const timer = setTimeout(() => {
-      // Kill the timed-out kernel — it will be restarted on next call
-      try {
-        kernel.process.kill()
-      } catch {}
+      // Kill the timed-out kernel (and its worker children) — restarted next call
+      void Shell.killTree(kernel.process, { exited: () => kernel.process.exitCode !== null })
       reject(new Error(`Cell execution timed out after ${Math.round(timeout / 1000)}s`))
     }, timeout)
 

--- a/backend/cli/src/tool/biology/notebook.ts
+++ b/backend/cli/src/tool/biology/notebook.ts
@@ -144,7 +144,10 @@ async function getKernel(sessionID: string): Promise<Kernel> {
   })
   const proc = spawn(sandboxed.file, sandboxed.args, {
     cwd: Instance.directory,
-    env: { ...(await OpenScience.subprocessEnv(process.env)), PYTHONUNBUFFERED: "1" },
+    env: OpenScience.withComputeParallelismCaps({
+      ...(await OpenScience.subprocessEnv(process.env)),
+      PYTHONUNBUFFERED: "1",
+    }),
     stdio: ["pipe", "pipe", "pipe"],
     // Own process group so killing the kernel reaps its joblib/BLAS children (#102).
     detached: process.platform !== "win32",

--- a/backend/cli/src/tool/notebook.ts
+++ b/backend/cli/src/tool/notebook.ts
@@ -1,6 +1,7 @@
 import z from "zod"
 import { Tool } from "./tool"
 import { spawn, type ChildProcess } from "child_process"
+import { Shell } from "@/shell/shell"
 import path from "path"
 import os from "os"
 import { unlinkSync } from "fs"
@@ -250,6 +251,10 @@ class PythonKernel implements Kernel {
       cwd: opts?.cwd ?? Instance.directory,
       env: { ...(await OpenScience.subprocessEnv(process.env)), ...(opts?.env ?? {}), PYTHONUNBUFFERED: "1" },
       stdio: ["pipe", "pipe", "pipe"],
+      // Own process group so killing the kernel reaps its children too — a
+      // scanpy run forks joblib/BLAS workers that would otherwise be orphaned
+      // and keep thrashing swap after an abort (issue #102).
+      detached: process.platform !== "win32",
     })
     this.proc = proc
 
@@ -260,9 +265,7 @@ class PythonKernel implements Kernel {
 
     await new Promise<void>((resolve, reject) => {
       const timer = setTimeout(() => {
-        try {
-          proc.kill()
-        } catch {}
+        void Shell.killTree(proc, { exited: () => proc.exitCode !== null })
         reject(new Error(`Python kernel startup timed out. stderr: ${this.stderrTail}`))
       }, 15_000)
       let buf = ""
@@ -295,17 +298,13 @@ class PythonKernel implements Kernel {
     const payload = await new Promise<RawPayload>((resolve, reject) => {
       const timer = setTimeout(() => {
         cleanup()
-        try {
-          proc.kill()
-        } catch {}
+        void Shell.killTree(proc, { exited: () => proc.exitCode !== null })
         reject(new Error(`Cell execution timed out after ${Math.round(timeout / 1000)}s`))
       }, timeout)
 
       const onAbort = () => {
         cleanup()
-        try {
-          proc.kill()
-        } catch {}
+        void Shell.killTree(proc, { exited: () => proc.exitCode !== null })
         reject(new Error("Execution aborted"))
       }
 
@@ -354,9 +353,19 @@ class PythonKernel implements Kernel {
   }
 
   async shutdown(): Promise<void> {
-    try {
-      this.proc?.kill()
-    } catch {}
+    const proc = this.proc
+    if (proc) await Shell.killTree(proc, { exited: () => proc.exitCode !== null })
+    if (this.scriptPath) {
+      try {
+        unlinkSync(this.scriptPath)
+      } catch {}
+      this.scriptPath = undefined
+    }
+  }
+
+  /** Synchronous group kill for process-exit handlers (async shutdown can't run there). */
+  killSync(): void {
+    if (this.proc) Shell.killTreeSync(this.proc)
     if (this.scriptPath) {
       try {
         unlinkSync(this.scriptPath)
@@ -410,6 +419,14 @@ class PythonKernelManager implements KernelManager {
       this.kernels.delete(id)
     }
   }
+
+  /** Sync variant for process-exit handlers. */
+  shutdownAllSync(): void {
+    for (const [id, k] of this.kernels) {
+      k.killSync()
+      this.kernels.delete(id)
+    }
+  }
 }
 
 /** Process-wide singleton manager (mirrors the biology kernel's module-level map). */
@@ -419,7 +436,7 @@ let exitHooked = false
 function hookExit() {
   if (exitHooked) return
   exitHooked = true
-  const cleanup = () => void pythonKernels.shutdownAll()
+  const cleanup = () => pythonKernels.shutdownAllSync()
   process.on("exit", cleanup)
   process.on("SIGTERM", cleanup)
   process.on("SIGINT", cleanup)

--- a/backend/cli/src/tool/notebook.ts
+++ b/backend/cli/src/tool/notebook.ts
@@ -249,7 +249,11 @@ class PythonKernel implements Kernel {
     })
     const proc = spawn(sandboxed.file, sandboxed.args, {
       cwd: opts?.cwd ?? Instance.directory,
-      env: { ...(await OpenScience.subprocessEnv(process.env)), ...(opts?.env ?? {}), PYTHONUNBUFFERED: "1" },
+      env: OpenScience.withComputeParallelismCaps({
+        ...(await OpenScience.subprocessEnv(process.env)),
+        ...(opts?.env ?? {}),
+        PYTHONUNBUFFERED: "1",
+      }),
       stdio: ["pipe", "pipe", "pipe"],
       // Own process group so killing the kernel reaps its children too — a
       // scanpy run forks joblib/BLAS workers that would otherwise be orphaned

--- a/backend/cli/src/tool/rkernel.ts
+++ b/backend/cli/src/tool/rkernel.ts
@@ -4,6 +4,7 @@ import { spawn, type ChildProcess } from "child_process"
 import path from "path"
 import os from "os"
 import { unlinkSync } from "fs"
+import { Shell } from "@/shell/shell"
 import { Instance } from "@/project/instance"
 import { OpenScience } from "@/openscience"
 import { Config } from "@/config/config"
@@ -235,6 +236,8 @@ class RKernel implements Kernel {
       cwd: opts?.cwd ?? Instance.directory,
       env: { ...(await OpenScience.subprocessEnv(process.env)), ...(opts?.env ?? {}) },
       stdio: ["pipe", "pipe", "pipe"],
+      // Own process group so killing the kernel reaps its worker children (#102).
+      detached: process.platform !== "win32",
     })
     this.proc = proc
 
@@ -245,9 +248,7 @@ class RKernel implements Kernel {
 
     await new Promise<void>((resolve, reject) => {
       const timer = setTimeout(() => {
-        try {
-          proc.kill()
-        } catch {}
+        void Shell.killTree(proc, { exited: () => proc.exitCode !== null })
         reject(new Error(`R kernel startup timed out. stderr: ${this.stderrTail}`))
       }, 20_000)
       let buf = ""
@@ -280,17 +281,13 @@ class RKernel implements Kernel {
     const raw = await new Promise<RawResult>((resolve, reject) => {
       const timer = setTimeout(() => {
         cleanup()
-        try {
-          proc.kill()
-        } catch {}
+        void Shell.killTree(proc, { exited: () => proc.exitCode !== null })
         reject(new Error(`Cell execution timed out after ${Math.round(timeout / 1000)}s`))
       }, timeout)
 
       const onAbort = () => {
         cleanup()
-        try {
-          proc.kill()
-        } catch {}
+        void Shell.killTree(proc, { exited: () => proc.exitCode !== null })
         reject(new Error("Execution aborted"))
       }
 
@@ -325,9 +322,19 @@ class RKernel implements Kernel {
   }
 
   async shutdown(): Promise<void> {
-    try {
-      this.proc?.kill()
-    } catch {}
+    const proc = this.proc
+    if (proc) await Shell.killTree(proc, { exited: () => proc.exitCode !== null })
+    if (this.scriptPath) {
+      try {
+        unlinkSync(this.scriptPath)
+      } catch {}
+      this.scriptPath = undefined
+    }
+  }
+
+  /** Synchronous group kill for process-exit handlers. */
+  killSync(): void {
+    if (this.proc) Shell.killTreeSync(this.proc)
     if (this.scriptPath) {
       try {
         unlinkSync(this.scriptPath)
@@ -381,6 +388,14 @@ class RKernelManager implements KernelManager {
       this.kernels.delete(id)
     }
   }
+
+  /** Sync variant for process-exit handlers. */
+  shutdownAllSync(): void {
+    for (const [id, k] of this.kernels) {
+      k.killSync()
+      this.kernels.delete(id)
+    }
+  }
 }
 
 /** Process-wide singleton manager. */
@@ -390,7 +405,7 @@ let exitHooked = false
 function hookExit() {
   if (exitHooked) return
   exitHooked = true
-  const cleanup = () => void rKernels.shutdownAll()
+  const cleanup = () => rKernels.shutdownAllSync()
   process.on("exit", cleanup)
   process.on("SIGTERM", cleanup)
   process.on("SIGINT", cleanup)

--- a/backend/cli/src/tool/rkernel.ts
+++ b/backend/cli/src/tool/rkernel.ts
@@ -234,7 +234,10 @@ class RKernel implements Kernel {
     })
     const proc = spawn(sandboxed.file, sandboxed.args, {
       cwd: opts?.cwd ?? Instance.directory,
-      env: { ...(await OpenScience.subprocessEnv(process.env)), ...(opts?.env ?? {}) },
+      env: OpenScience.withComputeParallelismCaps({
+        ...(await OpenScience.subprocessEnv(process.env)),
+        ...(opts?.env ?? {}),
+      }),
       stdio: ["pipe", "pipe", "pipe"],
       // Own process group so killing the kernel reaps its worker children (#102).
       detached: process.platform !== "win32",

--- a/backend/cli/src/tool/task.ts
+++ b/backend/cli/src/tool/task.ts
@@ -12,8 +12,17 @@ import { defer } from "@/util/defer"
 import { Config } from "../config/config"
 import { PermissionNext } from "@/permission/next"
 import { RLMState } from "../session/rlm/state"
+import { Semaphore } from "../util/semaphore"
 
 const ARTIFACT_AGENTS = ["research", "biology", "ml"]
+
+// Kernel-running compute specialists (a subset of COMPUTE_AGENTS, excluding the
+// general `research` harness). Each opens its own python/R kernel holding a full
+// dataset; several in parallel sum past RAM and OOM the machine (issue #102).
+// Bound how many run at once — subagents complete, so the slot is always freed.
+const COMPUTE_SUBAGENTS = new Set(["biology", "ml", "physics"])
+const MAX_COMPUTE_SUBAGENTS = Math.max(1, Number(process.env.OPENSCIENCE_MAX_COMPUTE_SUBAGENTS) || 2)
+const computeSlots = new Semaphore(MAX_COMPUTE_SUBAGENTS)
 
 const parameters = z.object({
   description: z.string().describe("A short (3-5 words) description of the task"),
@@ -59,6 +68,15 @@ export const TaskTool = Tool.define("task", async (ctx) => {
 
       const agent = await Agent.get(params.subagent_type)
       if (!agent) throw new Error(`Unknown agent type: ${params.subagent_type} is not a valid agent type`)
+
+      // Bound concurrent kernel-running compute subagents (#102). Skip when this
+      // call is itself nested inside a compute subagent — the outer already holds
+      // a slot, so re-acquiring here could deadlock a small pool.
+      const capSlot = COMPUTE_SUBAGENTS.has(agent.name) && !COMPUTE_SUBAGENTS.has(caller?.name ?? "")
+      if (capSlot) await computeSlots.acquire()
+      using _slot = defer(() => {
+        if (capSlot) computeSlots.release()
+      })
 
       const hasTaskPermission = agent.permission.some((rule) => rule.permission === "task")
 

--- a/backend/cli/src/tool/task.ts
+++ b/backend/cli/src/tool/task.ts
@@ -73,7 +73,11 @@ export const TaskTool = Tool.define("task", async (ctx) => {
       // call is itself nested inside a compute subagent — the outer already holds
       // a slot, so re-acquiring here could deadlock a small pool.
       const capSlot = COMPUTE_SUBAGENTS.has(agent.name) && !COMPUTE_SUBAGENTS.has(caller?.name ?? "")
-      if (capSlot) await computeSlots.acquire()
+      // Pass the abort signal so a cancelled subagent that's still QUEUED unblocks
+      // immediately instead of waiting for an unrelated task to free a slot (#102).
+      // If acquire throws (aborted), we never held a slot, so the defer below is
+      // never registered and nothing is released.
+      if (capSlot) await computeSlots.acquire(ctx.abort)
       using _slot = defer(() => {
         if (capSlot) computeSlots.release()
       })

--- a/backend/cli/src/util/semaphore.ts
+++ b/backend/cli/src/util/semaphore.ts
@@ -9,12 +9,28 @@ export class Semaphore {
     this.available = Math.max(1, Math.floor(max))
   }
 
-  async acquire(): Promise<void> {
+  /** Resolves once a slot is free. If `signal` aborts while this call is queued,
+   *  the waiter is removed and acquire() rejects — so a cancelled caller never
+   *  holds a slot and release() never hands one to a dead waiter (#102). */
+  async acquire(signal?: AbortSignal): Promise<void> {
+    if (signal?.aborted) throw signal.reason ?? new Error("aborted while waiting for a slot")
     if (this.available > 0) {
       this.available--
       return
     }
-    await new Promise<void>((resolve) => this.waiters.push(resolve))
+    return new Promise<void>((resolve, reject) => {
+      const waiter = () => {
+        signal?.removeEventListener("abort", onAbort)
+        resolve()
+      }
+      const onAbort = () => {
+        const i = this.waiters.indexOf(waiter)
+        if (i >= 0) this.waiters.splice(i, 1)
+        reject(signal!.reason ?? new Error("aborted while waiting for a slot"))
+      }
+      this.waiters.push(waiter)
+      signal?.addEventListener("abort", onAbort, { once: true })
+    })
   }
 
   release(): void {

--- a/backend/cli/src/util/semaphore.ts
+++ b/backend/cli/src/util/semaphore.ts
@@ -1,0 +1,28 @@
+/** Counting semaphore. `acquire()` resolves once a slot is free; `release()`
+ *  hands a freed slot directly to the next waiter (FIFO) or returns it to the
+ *  pool. Used to bound how many heavy compute subagents run at once (#102). */
+export class Semaphore {
+  private available: number
+  private readonly waiters: Array<() => void> = []
+
+  constructor(max: number) {
+    this.available = Math.max(1, Math.floor(max))
+  }
+
+  async acquire(): Promise<void> {
+    if (this.available > 0) {
+      this.available--
+      return
+    }
+    await new Promise<void>((resolve) => this.waiters.push(resolve))
+  }
+
+  release(): void {
+    const next = this.waiters.shift()
+    if (next) {
+      next() // slot transferred straight to the waiter; count stays "taken"
+      return
+    }
+    this.available++
+  }
+}

--- a/backend/cli/test/openscience-parallelism.test.ts
+++ b/backend/cli/test/openscience-parallelism.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "bun:test"
+import os from "os"
+import { OpenScience } from "../src/openscience"
+
+const expectedCap = String(Math.max(1, Math.min(os.cpus().length, 4)))
+
+test("caps BLAS/OpenMP/joblib parallelism vars when unset", () => {
+  const out = OpenScience.withComputeParallelismCaps({ PATH: "/usr/bin" })
+  expect(out.OMP_NUM_THREADS).toBe(expectedCap)
+  expect(out.OPENBLAS_NUM_THREADS).toBe(expectedCap)
+  expect(out.MKL_NUM_THREADS).toBe(expectedCap)
+  expect(out.VECLIB_MAXIMUM_THREADS).toBe(expectedCap) // macOS Accelerate
+  expect(out.NUMBA_NUM_THREADS).toBe(expectedCap)
+  expect(out.LOKY_MAX_CPU_COUNT).toBe(expectedCap) // bounds joblib worker-process copies
+  expect(out.PATH).toBe("/usr/bin") // unrelated vars untouched
+})
+
+test("never overrides a value the user already set", () => {
+  const out = OpenScience.withComputeParallelismCaps({ OMP_NUM_THREADS: "16", MKL_NUM_THREADS: "8" })
+  expect(out.OMP_NUM_THREADS).toBe("16")
+  expect(out.MKL_NUM_THREADS).toBe("8")
+  // still fills the ones the user did not set
+  expect(out.OPENBLAS_NUM_THREADS).toBe(expectedCap)
+})
+
+test("cap is at least 1 and at most 4", () => {
+  const cap = Number(OpenScience.withComputeParallelismCaps({}).OMP_NUM_THREADS)
+  expect(cap).toBeGreaterThanOrEqual(1)
+  expect(cap).toBeLessThanOrEqual(4)
+})

--- a/backend/cli/test/openscience-parallelism.test.ts
+++ b/backend/cli/test/openscience-parallelism.test.ts
@@ -2,29 +2,30 @@ import { expect, test } from "bun:test"
 import os from "os"
 import { OpenScience } from "../src/openscience"
 
-const expectedCap = String(Math.max(1, Math.min(os.cpus().length, 4)))
+const cap = String(Math.min(Math.max(1, os.cpus().length), 4))
 
-test("caps BLAS/OpenMP/joblib parallelism vars when unset", () => {
+test("caps joblib worker-process count (LOKY) when unset", () => {
   const out = OpenScience.withComputeParallelismCaps({ PATH: "/usr/bin" })
-  expect(out.OMP_NUM_THREADS).toBe(expectedCap)
-  expect(out.OPENBLAS_NUM_THREADS).toBe(expectedCap)
-  expect(out.MKL_NUM_THREADS).toBe(expectedCap)
-  expect(out.VECLIB_MAXIMUM_THREADS).toBe(expectedCap) // macOS Accelerate
-  expect(out.NUMBA_NUM_THREADS).toBe(expectedCap)
-  expect(out.LOKY_MAX_CPU_COUNT).toBe(expectedCap) // bounds joblib worker-process copies
+  expect(out.LOKY_MAX_CPU_COUNT).toBe(cap)
   expect(out.PATH).toBe("/usr/bin") // unrelated vars untouched
 })
 
-test("never overrides a value the user already set", () => {
-  const out = OpenScience.withComputeParallelismCaps({ OMP_NUM_THREADS: "16", MKL_NUM_THREADS: "8" })
-  expect(out.OMP_NUM_THREADS).toBe("16")
-  expect(out.MKL_NUM_THREADS).toBe("8")
-  // still fills the ones the user did not set
-  expect(out.OPENBLAS_NUM_THREADS).toBe(expectedCap)
+test("does NOT cap shared-memory BLAS/OpenMP/numba thread pools", () => {
+  // Those are threads (no per-thread data copy) — capping them only throttles
+  // legit compute without saving memory. Only worker PROCESSES are bounded.
+  const out = OpenScience.withComputeParallelismCaps({})
+  expect(out.OMP_NUM_THREADS).toBeUndefined()
+  expect(out.MKL_NUM_THREADS).toBeUndefined()
+  expect(out.NUMBA_NUM_THREADS).toBeUndefined()
 })
 
-test("cap is at least 1 and at most 4", () => {
-  const cap = Number(OpenScience.withComputeParallelismCaps({}).OMP_NUM_THREADS)
-  expect(cap).toBeGreaterThanOrEqual(1)
-  expect(cap).toBeLessThanOrEqual(4)
+test("never overrides a user-set LOKY_MAX_CPU_COUNT", () => {
+  const out = OpenScience.withComputeParallelismCaps({ LOKY_MAX_CPU_COUNT: "16" })
+  expect(out.LOKY_MAX_CPU_COUNT).toBe("16")
+})
+
+test("cap is between 1 and 4", () => {
+  const n = Number(OpenScience.withComputeParallelismCaps({}).LOKY_MAX_CPU_COUNT)
+  expect(n).toBeGreaterThanOrEqual(1)
+  expect(n).toBeLessThanOrEqual(4)
 })

--- a/backend/cli/test/util/semaphore.test.ts
+++ b/backend/cli/test/util/semaphore.test.ts
@@ -38,3 +38,45 @@ test("max floors at 1 (never zero-slot deadlock)", async () => {
   await sem.acquire()
   expect(true).toBe(true) // resolved, did not hang
 })
+
+test("acquire rejects immediately when the signal is already aborted", async () => {
+  const sem = new Semaphore(1)
+  const ac = new AbortController()
+  ac.abort()
+  await expect(sem.acquire(ac.signal)).rejects.toBeDefined()
+  // the slot was not consumed by the rejected call
+  await sem.acquire()
+  expect(true).toBe(true)
+})
+
+test("abort while queued rejects and does not leak the slot", async () => {
+  const sem = new Semaphore(1)
+  await sem.acquire() // hold the only slot
+  const ac = new AbortController()
+  const queued = sem.acquire(ac.signal)
+  await sleep(1)
+  ac.abort()
+  await expect(queued).rejects.toBeDefined()
+  // the aborted waiter left the queue, so release returns the slot to the pool
+  sem.release()
+  await sem.acquire() // resolves rather than hanging on a ghost waiter
+  expect(true).toBe(true)
+})
+
+test("aborting one queued waiter still serves a live waiter (no lost slot)", async () => {
+  const sem = new Semaphore(1)
+  await sem.acquire() // hold slot
+  const ac = new AbortController()
+  const aborted = sem.acquire(ac.signal).then(
+    () => "resolved",
+    () => "rejected",
+  )
+  const order: string[] = []
+  const live = sem.acquire().then(() => order.push("live"))
+  await sleep(1)
+  ac.abort() // drop the first waiter
+  expect(await aborted).toBe("rejected")
+  sem.release() // must go to the live waiter, not the dead one
+  await live
+  expect(order).toEqual(["live"])
+})

--- a/backend/cli/test/util/semaphore.test.ts
+++ b/backend/cli/test/util/semaphore.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "bun:test"
+import { Semaphore } from "../../src/util/semaphore"
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+test("bounds concurrency to max", async () => {
+  const sem = new Semaphore(2)
+  let running = 0
+  let peak = 0
+  const run = async () => {
+    await sem.acquire()
+    running++
+    peak = Math.max(peak, running)
+    await sleep(10)
+    running--
+    sem.release()
+  }
+  await Promise.all(Array.from({ length: 6 }, run))
+  expect(peak).toBe(2)
+})
+
+test("release wakes blocked waiters in FIFO order", async () => {
+  const sem = new Semaphore(1)
+  const order: number[] = []
+  await sem.acquire() // hold the only slot
+  const p1 = sem.acquire().then(() => order.push(1))
+  const p2 = sem.acquire().then(() => order.push(2))
+  await sleep(1)
+  sem.release() // -> p1
+  await p1
+  sem.release() // -> p2
+  await p2
+  expect(order).toEqual([1, 2])
+})
+
+test("max floors at 1 (never zero-slot deadlock)", async () => {
+  const sem = new Semaphore(0)
+  await sem.acquire()
+  expect(true).toBe(true) // resolved, did not hang
+})


### PR DESCRIPTION
## Problem

Single-cell / compute analysis runs (scanpy and R via the notebook kernels) can exhaust machine memory and OOM the box. Three mechanisms compound:

1. **joblib's `loky` backend forks one full *process copy* of the data per worker.** At the default `n_jobs=-1` that's one dense-matrix copy per core — the dominant memory multiplier behind the OOM.
2. **Kernel worker children were orphaned on abort/timeout.** The old `proc.kill()` signalled only the kernel leader, leaving joblib/BLAS worker processes alive to keep thrashing swap after the run was supposedly killed.
3. **Several compute subagents running in parallel** each open their own kernel holding a full dataset; their memory peaks sum and OOM the machine.

## Changes

**Reap the whole process group**
- The three kernels (`notebook`, `rkernel`, `biology/notebook`) now spawn `detached` (their own process group), and `Shell.killTree` / `killTreeSync` signal the *group* so worker children die with the kernel on abort, timeout, and process exit.
- The negative-pid group kill only fires when the child actually leads its own group (verified via `/proc` on Linux); a non-detached child is killed singly instead, so the group signal can never reach our own process group.

**Cap the memory lever, not the compute**
- `withComputeParallelismCaps` sets `LOKY_MAX_CPU_COUNT` (the worker-*copy* count) but deliberately leaves the `OMP`/`MKL`/numba thread pools alone — those are shared-memory threads, so capping them throttles legitimate single-process compute without saving any memory.
- Applied at the compute-kernel spawn boundary, not inside the shared `subprocessEnv`, so it doesn't ride along on unrelated subprocesses (git, atlas, plain bash).

**Bound concurrent compute subagents**
- A small counting semaphore caps how many kernel-running subagents (`biology`/`ml`/`physics`) run at once (`OPENSCIENCE_MAX_COMPUTE_SUBAGENTS`, default 2). Nested compute calls skip the cap so a small pool can't self-deadlock.
- `acquire()` is abort-aware: a subagent cancelled while still queued rejects and leaves the wait queue immediately, so `release()` never hands a slot to a dead waiter and cancellation isn't deferred until an unrelated task frees one.

**Memory-safe scanpy template**
- `regress_out` (the biggest hazard — it densifies the matrix and forks one dense copy per worker) is off by default, sized at runtime to the worker count that fits in available RAM, and skipped entirely when not even one dense copy fits or the matrix exceeds `MAX_DENSE_GB`. A dense `adata.X` on load also warns rather than silently OOMing.

## Testing

- `bun test` — full backend suite green (**1117 pass / 1 skip / 0 fail**).
- New unit tests: semaphore concurrency bound + FIFO wake + abort-while-queued (proves no slot leak / no lost slot); parallelism-cap env.
- `analysis_template.py` parses; the RAM-sizing math is exercised by the guard paths.

## Notes / limitations

- This addresses the **diagnosed OOM mechanisms**; it has **not** been verified end-to-end against a captured reproducer from the issue (no OOM dataset on hand). The changes are conservative — guards and caps with no behavior change on the happy path — so they are safe to land as hardening, but I'd suggest keeping #102 open until a repro confirms the OOM is actually gone.
- `LOKY_MAX_CPU_COUNT` bounds the worker-copy *count*, not absolute memory; it is not a hard ceiling (macOS ignores `RLIMIT_AS`).

Addresses #102.
