### PR TITLE
fix(compute): reap kernel workers + cap compute subagents (follow-up to #102 thread-cap)

### DIFF
--- a/backend/cli/skills/biology/scanpy/assets/analysis_template.py
+++ b/backend/cli/skills/biology/scanpy/assets/analysis_template.py
@@ -39,6 +39,49 @@ sc.settings.set_figure_params(dpi=80, facecolor='white')
 sc.settings.figdir = FIGURES_DIR
 
 # ============================================================================
+# MEMORY GUARDS (#102)
+# ============================================================================
+# Parallel steps like regress_out fork one worker PROCESS per job, each holding a
+# full DENSE copy of the matrix — so the safe worker count is bounded by RAM, not
+# just CPU. Size it at runtime rather than hardcoding n_jobs=-1.
+import os as _os
+
+
+def _available_ram_bytes():
+    # *available* RAM (not total): a box already using most of its memory must
+    # pick fewer workers, or the guard green-lights an OOM.
+    try:
+        import psutil
+        return psutil.virtual_memory().available
+    except Exception:
+        pass
+    try:  # Linux: MemAvailable is the accurate figure
+        with open('/proc/meminfo') as f:
+            for line in f:
+                if line.startswith('MemAvailable:'):
+                    return int(line.split()[1]) * 1024
+    except Exception:
+        pass
+    try:  # last resort: TOTAL physical RAM, halved so we don't over-commit
+        return (_os.sysconf('SC_PAGE_SIZE') * _os.sysconf('SC_PHYS_PAGES')) // 2
+    except (ValueError, OSError, AttributeError):
+        return 4 * 1024 ** 3  # unknown -> assume 4 GB
+
+
+def memory_safe_n_jobs(adata, fraction=0.5):
+    """Largest worker count whose per-worker dense copies fit in `fraction` of RAM,
+    reserving one copy for the parent process (which also densifies the matrix).
+    Returns 0 when not even one worker copy fits — the caller must then skip the
+    dense step rather than run one worker that OOMs anyway."""
+    per_worker = max(1, adata.n_obs * adata.n_vars * 8)  # float64 dense copy, bytes
+    fits = int(_available_ram_bytes() * fraction // per_worker) - 1  # -1: parent's copy
+    return max(0, min(_os.cpu_count() or 1, fits))
+
+
+# Above this dense-matrix size (GB), skip the memory-hazardous dense step and warn.
+MAX_DENSE_GB = 8.0
+
+# ============================================================================
 # 1. LOAD DATA
 # ============================================================================
 
@@ -52,6 +95,14 @@ adata = sc.read_h5ad(INPUT_FILE)
 # adata = sc.read_csv('data/counts.csv')  # For CSV data
 
 print(f"Loaded: {adata.n_obs} cells x {adata.n_vars} genes")
+
+# Memory guard (#102): a count matrix stored DENSE uses ~8 bytes/element and can
+# be tens/hundreds of GB, OOMing the machine on load alone. Keep counts sparse.
+import scipy.sparse as _sp
+_load_gb = adata.n_obs * adata.n_vars * 8 / 1e9
+if not _sp.issparse(adata.X) and _load_gb > MAX_DENSE_GB:
+    print(f"WARNING: adata.X is DENSE (~{_load_gb:.1f} GB). Convert to sparse to "
+          f"avoid running out of memory:  adata.X = scipy.sparse.csr_matrix(adata.X)")
 
 # ============================================================================
 # 2. QUALITY CONTROL
@@ -128,8 +179,20 @@ print("\n" + "=" * 80)
 print("SCALING AND REGRESSION")
 print("=" * 80)
 
-# Regress out unwanted sources of variation
-sc.pp.regress_out(adata, ['total_counts', 'pct_counts_mt'])
+# Regress out unwanted sources of variation.
+# Memory guard (#102): regress_out densifies the matrix and forks one joblib
+# worker (a full dense copy) per job — the biggest memory hazard here. Size the
+# worker count to available RAM, and skip only when even one dense copy won't fit
+# (running it anyway would just OOM). regress_out stays ON by default.
+_dense_gb = adata.n_obs * adata.n_vars * 8 / 1e9
+_n_jobs = memory_safe_n_jobs(adata)
+if _n_jobs >= 1 and _dense_gb <= MAX_DENSE_GB:
+    print(f"regress_out: n_jobs={_n_jobs} (each worker copies ~{_dense_gb:.1f} GB)")
+    sc.pp.regress_out(adata, ['total_counts', 'pct_counts_mt'], n_jobs=_n_jobs)
+else:
+    print(f"WARNING: skipping regress_out — dense matrix ~{_dense_gb:.1f} GB would "
+          f"exhaust RAM (fits={_n_jobs}, MAX_DENSE_GB={MAX_DENSE_GB}). Subset cells "
+          f"or reduce N_TOP_GENES first, then re-run this step (#102).")
 
 # Scale data
 sc.pp.scale(adata, max_value=10)

--- a/backend/cli/src/shell/shell.ts
+++ b/backend/cli/src/shell/shell.ts
@@ -7,6 +7,23 @@ import { spawn, type ChildProcess } from "child_process"
 const SIGKILL_TIMEOUT_MS = 200
 
 export namespace Shell {
+  /** POSIX: true only when `pid` leads its own process group (i.e. was spawned
+   *  `detached`), so a negative-pid signal targets ONLY its group and can never
+   *  reach ours. On Linux we verify via /proc; elsewhere we can't cheaply check,
+   *  so trust the caller. Guards a negative-pid kill against a non-detached child
+   *  whose group is our own (#102). */
+  function leadsOwnGroup(pid: number): boolean {
+    if (process.platform !== "linux") return true
+    try {
+      const stat = fs.readFileSync(`/proc/${pid}/stat`, "utf8")
+      // Fields after the ")" that closes comm are: state ppid pgrp session ...
+      const fields = stat.slice(stat.lastIndexOf(")") + 2).split(" ")
+      return Number(fields[2]) === pid
+    } catch {
+      return false
+    }
+  }
+
   export async function killTree(proc: ChildProcess, opts?: { exited?: () => boolean }): Promise<void> {
     const pid = proc.pid
     if (!pid || opts?.exited?.()) return
@@ -20,19 +37,45 @@ export namespace Shell {
       return
     }
 
-    try {
-      process.kill(-pid, "SIGTERM")
-      await Bun.sleep(SIGKILL_TIMEOUT_MS)
-      if (!opts?.exited?.()) {
-        process.kill(-pid, "SIGKILL")
-      }
-    } catch (_e) {
-      proc.kill("SIGTERM")
-      await Bun.sleep(SIGKILL_TIMEOUT_MS)
-      if (!opts?.exited?.()) {
-        proc.kill("SIGKILL")
+    if (leadsOwnGroup(pid)) {
+      try {
+        process.kill(-pid, "SIGTERM")
+        await Bun.sleep(SIGKILL_TIMEOUT_MS)
+        if (!opts?.exited?.()) process.kill(-pid, "SIGKILL")
+        return
+      } catch (_e) {
+        // group gone or not permitted — fall through to a single-process kill
       }
     }
+    try {
+      proc.kill("SIGTERM")
+      await Bun.sleep(SIGKILL_TIMEOUT_MS)
+      if (!opts?.exited?.()) proc.kill("SIGKILL")
+    } catch {}
+  }
+
+  /** Synchronous best-effort group SIGKILL. For process-exit handlers, where the
+   *  event loop is already stopping and the async killTree (which sleeps before
+   *  escalating) cannot complete. Only signals the group when the child leads its
+   *  own (spawned `detached`); otherwise kills just the child (#102). */
+  export function killTreeSync(proc: ChildProcess): void {
+    const pid = proc.pid
+    if (!pid) return
+    if (process.platform === "win32") {
+      try {
+        spawn("taskkill", ["/pid", String(pid), "/f", "/t"], { stdio: "ignore" })
+      } catch {}
+      return
+    }
+    if (leadsOwnGroup(pid)) {
+      try {
+        process.kill(-pid, "SIGKILL")
+        return
+      } catch {}
+    }
+    try {
+      proc.kill("SIGKILL")
+    } catch {}
   }
   const BLACKLIST = new Set(["fish", "nu"])
 

--- a/backend/cli/src/tool/biology/notebook.ts
+++ b/backend/cli/src/tool/biology/notebook.ts
@@ -3,6 +3,7 @@ import { Tool } from "../tool"
 import { spawn, type ChildProcess } from "child_process"
 import path from "path"
 import os from "os"
+import { Shell } from "@/shell/shell"
 import { Instance } from "@/project/instance"
 import { OpenScience } from "@/openscience"
 import { Config } from "@/config/config"
@@ -83,9 +84,7 @@ const kernels = new Map<string, Kernel>()
 // Clean up all kernels on process exit
 function cleanupAll() {
   for (const [id, kernel] of kernels) {
-    try {
-      kernel.process.kill()
-    } catch {}
+    Shell.killTreeSync(kernel.process)
     try {
       require("fs").unlinkSync(kernel.scriptPath)
     } catch {}
@@ -102,9 +101,7 @@ function cleanupIdle() {
   const idle = 30 * 60 * 1000 // 30 min
   for (const [id, kernel] of kernels) {
     if (now - kernel.lastUsed > idle) {
-      try {
-        kernel.process.kill()
-      } catch {}
+      void Shell.killTree(kernel.process, { exited: () => kernel.process.exitCode !== null })
       try {
         require("fs").unlinkSync(kernel.scriptPath)
       } catch {}
@@ -153,6 +150,8 @@ async function getKernel(sessionID: string): Promise<Kernel> {
       PYTHONUNBUFFERED: "1",
     },
     stdio: ["pipe", "pipe", "pipe"],
+    // Own process group so killing the kernel reaps its joblib/BLAS children (#102).
+    detached: process.platform !== "win32",
   })
 
   // Collect kernel stderr (startup warnings, etc.)
@@ -166,7 +165,7 @@ async function getKernel(sessionID: string): Promise<Kernel> {
   // Wait for ready signal
   await new Promise<void>((resolve, reject) => {
     const timeout = setTimeout(() => {
-      proc.kill()
+      void Shell.killTree(proc, { exited: () => proc.exitCode !== null })
       reject(new Error(`Kernel startup timed out. stderr: ${kernelStderr}`))
     }, 15_000)
 
@@ -202,10 +201,8 @@ function executeInKernel(
 ): Promise<{ ok: boolean; stdout: string; stderr: string }> {
   return new Promise((resolve, reject) => {
     const timer = setTimeout(() => {
-      // Kill the timed-out kernel — it will be restarted on next call
-      try {
-        kernel.process.kill()
-      } catch {}
+      // Kill the timed-out kernel (and its worker children) — restarted next call
+      void Shell.killTree(kernel.process, { exited: () => kernel.process.exitCode !== null })
       reject(new Error(`Cell execution timed out after ${Math.round(timeout / 1000)}s`))
     }, timeout)
 

--- a/backend/cli/src/tool/notebook.ts
+++ b/backend/cli/src/tool/notebook.ts
@@ -4,6 +4,7 @@ import { spawn, type ChildProcess } from "child_process"
 import path from "path"
 import os from "os"
 import { unlinkSync } from "fs"
+import { Shell } from "@/shell/shell"
 import { Instance } from "@/project/instance"
 import { OpenScience } from "@/openscience"
 import { Config } from "@/config/config"
@@ -255,6 +256,10 @@ class PythonKernel implements Kernel {
         PYTHONUNBUFFERED: "1",
       },
       stdio: ["pipe", "pipe", "pipe"],
+      // Own process group so killing the kernel reaps its children too — a scanpy
+      // run forks joblib/BLAS workers that would otherwise be orphaned and keep
+      // thrashing swap after an abort (#102).
+      detached: process.platform !== "win32",
     })
     this.proc = proc
 
@@ -265,9 +270,7 @@ class PythonKernel implements Kernel {
 
     await new Promise<void>((resolve, reject) => {
       const timer = setTimeout(() => {
-        try {
-          proc.kill()
-        } catch {}
+        void Shell.killTree(proc, { exited: () => proc.exitCode !== null })
         reject(new Error(`Python kernel startup timed out. stderr: ${this.stderrTail}`))
       }, 15_000)
       let buf = ""
@@ -300,17 +303,13 @@ class PythonKernel implements Kernel {
     const payload = await new Promise<RawPayload>((resolve, reject) => {
       const timer = setTimeout(() => {
         cleanup()
-        try {
-          proc.kill()
-        } catch {}
+        void Shell.killTree(proc, { exited: () => proc.exitCode !== null })
         reject(new Error(`Cell execution timed out after ${Math.round(timeout / 1000)}s`))
       }, timeout)
 
       const onAbort = () => {
         cleanup()
-        try {
-          proc.kill()
-        } catch {}
+        void Shell.killTree(proc, { exited: () => proc.exitCode !== null })
         reject(new Error("Execution aborted"))
       }
 
@@ -359,9 +358,18 @@ class PythonKernel implements Kernel {
   }
 
   async shutdown(): Promise<void> {
-    try {
-      this.proc?.kill()
-    } catch {}
+    const proc = this.proc
+    if (proc) await Shell.killTree(proc, { exited: () => proc.exitCode !== null })
+    this.cleanupScript()
+  }
+
+  /** Synchronous group kill for process-exit handlers (async shutdown can't run there). */
+  killSync(): void {
+    if (this.proc) Shell.killTreeSync(this.proc)
+    this.cleanupScript()
+  }
+
+  private cleanupScript(): void {
     if (this.scriptPath) {
       try {
         unlinkSync(this.scriptPath)
@@ -415,6 +423,14 @@ class PythonKernelManager implements KernelManager {
       this.kernels.delete(id)
     }
   }
+
+  /** Sync variant for process-exit handlers. */
+  shutdownAllSync(): void {
+    for (const [id, k] of this.kernels) {
+      k.killSync()
+      this.kernels.delete(id)
+    }
+  }
 }
 
 /** Process-wide singleton manager (mirrors the biology kernel's module-level map). */
@@ -424,7 +440,7 @@ let exitHooked = false
 function hookExit() {
   if (exitHooked) return
   exitHooked = true
-  const cleanup = () => void pythonKernels.shutdownAll()
+  const cleanup = () => pythonKernels.shutdownAllSync()
   process.on("exit", cleanup)
   process.on("SIGTERM", cleanup)
   process.on("SIGINT", cleanup)

--- a/backend/cli/src/tool/rkernel.ts
+++ b/backend/cli/src/tool/rkernel.ts
@@ -4,6 +4,7 @@ import { spawn, type ChildProcess } from "child_process"
 import path from "path"
 import os from "os"
 import { unlinkSync } from "fs"
+import { Shell } from "@/shell/shell"
 import { Instance } from "@/project/instance"
 import { OpenScience } from "@/openscience"
 import { Config } from "@/config/config"
@@ -235,6 +236,8 @@ class RKernel implements Kernel {
       cwd: opts?.cwd ?? Instance.directory,
       env: { ...(await OpenScience.subprocessEnv(process.env)), ...(opts?.env ?? {}) },
       stdio: ["pipe", "pipe", "pipe"],
+      // Own process group so killing the kernel reaps its worker children (#102).
+      detached: process.platform !== "win32",
     })
     this.proc = proc
 
@@ -245,9 +248,7 @@ class RKernel implements Kernel {
 
     await new Promise<void>((resolve, reject) => {
       const timer = setTimeout(() => {
-        try {
-          proc.kill()
-        } catch {}
+        void Shell.killTree(proc, { exited: () => proc.exitCode !== null })
         reject(new Error(`R kernel startup timed out. stderr: ${this.stderrTail}`))
       }, 20_000)
       let buf = ""
@@ -280,17 +281,13 @@ class RKernel implements Kernel {
     const raw = await new Promise<RawResult>((resolve, reject) => {
       const timer = setTimeout(() => {
         cleanup()
-        try {
-          proc.kill()
-        } catch {}
+        void Shell.killTree(proc, { exited: () => proc.exitCode !== null })
         reject(new Error(`Cell execution timed out after ${Math.round(timeout / 1000)}s`))
       }, timeout)
 
       const onAbort = () => {
         cleanup()
-        try {
-          proc.kill()
-        } catch {}
+        void Shell.killTree(proc, { exited: () => proc.exitCode !== null })
         reject(new Error("Execution aborted"))
       }
 
@@ -325,9 +322,18 @@ class RKernel implements Kernel {
   }
 
   async shutdown(): Promise<void> {
-    try {
-      this.proc?.kill()
-    } catch {}
+    const proc = this.proc
+    if (proc) await Shell.killTree(proc, { exited: () => proc.exitCode !== null })
+    this.cleanupScript()
+  }
+
+  /** Synchronous group kill for process-exit handlers (async shutdown can't run there). */
+  killSync(): void {
+    if (this.proc) Shell.killTreeSync(this.proc)
+    this.cleanupScript()
+  }
+
+  private cleanupScript(): void {
     if (this.scriptPath) {
       try {
         unlinkSync(this.scriptPath)
@@ -381,6 +387,14 @@ class RKernelManager implements KernelManager {
       this.kernels.delete(id)
     }
   }
+
+  /** Sync variant for process-exit handlers. */
+  shutdownAllSync(): void {
+    for (const [id, k] of this.kernels) {
+      k.killSync()
+      this.kernels.delete(id)
+    }
+  }
 }
 
 /** Process-wide singleton manager. */
@@ -390,7 +404,7 @@ let exitHooked = false
 function hookExit() {
   if (exitHooked) return
   exitHooked = true
-  const cleanup = () => void rKernels.shutdownAll()
+  const cleanup = () => rKernels.shutdownAllSync()
   process.on("exit", cleanup)
   process.on("SIGTERM", cleanup)
   process.on("SIGINT", cleanup)

--- a/backend/cli/src/tool/task.ts
+++ b/backend/cli/src/tool/task.ts
@@ -12,8 +12,17 @@ import { defer } from "@/util/defer"
 import { Config } from "../config/config"
 import { PermissionNext } from "@/permission/next"
 import { RLMState } from "../session/rlm/state"
+import { Semaphore } from "../util/semaphore"
 
 const ARTIFACT_AGENTS = ["research", "biology", "ml"]
+
+// Kernel-running compute specialists (a subset of the agents, excluding the
+// general `research` harness). Each opens its own python/R kernel holding a full
+// dataset; several in parallel sum past RAM and OOM the machine (#102). Bound how
+// many run at once — subagents complete, so the slot is always freed.
+const COMPUTE_SUBAGENTS = new Set(["biology", "ml", "physics"])
+const MAX_COMPUTE_SUBAGENTS = Math.max(1, Number(process.env.OPENSCIENCE_MAX_COMPUTE_SUBAGENTS) || 2)
+const computeSlots = new Semaphore(MAX_COMPUTE_SUBAGENTS)
 
 const parameters = z.object({
   description: z.string().describe("A short (3-5 words) description of the task"),
@@ -59,6 +68,16 @@ export const TaskTool = Tool.define("task", async (ctx) => {
 
       const agent = await Agent.get(params.subagent_type)
       if (!agent) throw new Error(`Unknown agent type: ${params.subagent_type} is not a valid agent type`)
+
+      // Bound concurrent kernel-running compute subagents (#102). Skip when this
+      // call is itself nested inside a compute subagent — the outer already holds a
+      // slot, so re-acquiring here could deadlock a small pool. Abort-aware: a
+      // cancelled subagent still queued unblocks immediately and frees no slot.
+      const capSlot = COMPUTE_SUBAGENTS.has(agent.name) && !COMPUTE_SUBAGENTS.has(caller?.name ?? "")
+      if (capSlot) await computeSlots.acquire(ctx.abort)
+      using _slot = defer(() => {
+        if (capSlot) computeSlots.release()
+      })
 
       const hasTaskPermission = agent.permission.some((rule) => rule.permission === "task")
 

--- a/backend/cli/src/util/semaphore.ts
+++ b/backend/cli/src/util/semaphore.ts
@@ -1,0 +1,44 @@
+/** Counting semaphore. `acquire()` resolves once a slot is free; `release()`
+ *  hands a freed slot directly to the next waiter (FIFO) or returns it to the
+ *  pool. Used to bound how many heavy compute subagents run at once (#102). */
+export class Semaphore {
+  private available: number
+  private readonly waiters: Array<() => void> = []
+
+  constructor(max: number) {
+    this.available = Math.max(1, Math.floor(max))
+  }
+
+  /** Resolves once a slot is free. If `signal` aborts while this call is queued,
+   *  the waiter is removed and acquire() rejects — so a cancelled caller never
+   *  holds a slot and release() never hands one to a dead waiter (#102). */
+  async acquire(signal?: AbortSignal): Promise<void> {
+    if (signal?.aborted) throw signal.reason ?? new Error("aborted while waiting for a slot")
+    if (this.available > 0) {
+      this.available--
+      return
+    }
+    return new Promise<void>((resolve, reject) => {
+      const waiter = () => {
+        signal?.removeEventListener("abort", onAbort)
+        resolve()
+      }
+      const onAbort = () => {
+        const i = this.waiters.indexOf(waiter)
+        if (i >= 0) this.waiters.splice(i, 1)
+        reject(signal!.reason ?? new Error("aborted while waiting for a slot"))
+      }
+      this.waiters.push(waiter)
+      signal?.addEventListener("abort", onAbort, { once: true })
+    })
+  }
+
+  release(): void {
+    const next = this.waiters.shift()
+    if (next) {
+      next() // slot transferred straight to the waiter; count stays "taken"
+      return
+    }
+    this.available++
+  }
+}

--- a/backend/cli/test/util/semaphore.test.ts
+++ b/backend/cli/test/util/semaphore.test.ts
@@ -1,0 +1,82 @@
+import { expect, test } from "bun:test"
+import { Semaphore } from "../../src/util/semaphore"
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+test("bounds concurrency to max", async () => {
+  const sem = new Semaphore(2)
+  let running = 0
+  let peak = 0
+  const run = async () => {
+    await sem.acquire()
+    running++
+    peak = Math.max(peak, running)
+    await sleep(10)
+    running--
+    sem.release()
+  }
+  await Promise.all(Array.from({ length: 6 }, run))
+  expect(peak).toBe(2)
+})
+
+test("release wakes blocked waiters in FIFO order", async () => {
+  const sem = new Semaphore(1)
+  const order: number[] = []
+  await sem.acquire() // hold the only slot
+  const p1 = sem.acquire().then(() => order.push(1))
+  const p2 = sem.acquire().then(() => order.push(2))
+  await sleep(1)
+  sem.release() // -> p1
+  await p1
+  sem.release() // -> p2
+  await p2
+  expect(order).toEqual([1, 2])
+})
+
+test("max floors at 1 (never zero-slot deadlock)", async () => {
+  const sem = new Semaphore(0)
+  await sem.acquire()
+  expect(true).toBe(true) // resolved, did not hang
+})
+
+test("acquire rejects immediately when the signal is already aborted", async () => {
+  const sem = new Semaphore(1)
+  const ac = new AbortController()
+  ac.abort()
+  await expect(sem.acquire(ac.signal)).rejects.toBeDefined()
+  // the slot was not consumed by the rejected call
+  await sem.acquire()
+  expect(true).toBe(true)
+})
+
+test("abort while queued rejects and does not leak the slot", async () => {
+  const sem = new Semaphore(1)
+  await sem.acquire() // hold the only slot
+  const ac = new AbortController()
+  const queued = sem.acquire(ac.signal)
+  await sleep(1)
+  ac.abort()
+  await expect(queued).rejects.toBeDefined()
+  // the aborted waiter left the queue, so release returns the slot to the pool
+  sem.release()
+  await sem.acquire() // resolves rather than hanging on a ghost waiter
+  expect(true).toBe(true)
+})
+
+test("aborting one queued waiter still serves a live waiter (no lost slot)", async () => {
+  const sem = new Semaphore(1)
+  await sem.acquire() // hold slot
+  const ac = new AbortController()
+  const aborted = sem.acquire(ac.signal).then(
+    () => "resolved",
+    () => "rejected",
+  )
+  const order: string[] = []
+  const live = sem.acquire().then(() => order.push("live"))
+  await sleep(1)
+  ac.abort() // drop the first waiter
+  expect(await aborted).toBe("rejected")
+  sem.release() // must go to the live waiter, not the dead one
+  await live
+  expect(order).toEqual(["live"])
+})


### PR DESCRIPTION
## Context

**Follow-up hardening on top of the #102 fix already merged in `main`.** #102 is closed — `060e1dd` (#178) added `pythonThreadCapEnv`, which caps thread/worker fan-out *inside* one kernel. This PR does **not** re-open or re-litigate that; it keeps `pythonThreadCapEnv` and adds the OOM axes that cap doesn't cover (orphaned workers, parallel-kernel concurrency) plus a code-level scanpy guard where main currently relies on prompt advice.

## Changes

**Reap orphaned workers**
- The python and R kernels now spawn `detached` (own process group), and every kill path — startup timeout, cell timeout, abort, idle-reap, `shutdown`, and process-exit — routes through `Shell.killTree` / `killTreeSync`. So joblib/BLAS worker children die *with* the kernel instead of lingering.
- The negative-pid group kill only fires when the child actually leads its own group (verified via `/proc` on Linux); a non-detached child is killed singly, so the group signal can never reach our own process group.

**Bound concurrent compute subagents**
- A small counting semaphore caps how many kernel-running subagents (`biology`/`ml`/`physics`) run at once (`OPENSCIENCE_MAX_COMPUTE_SUBAGENTS`, default 2). Nested compute calls skip the cap so a small pool can't self-deadlock.
- `acquire(signal)` is abort-aware: a subagent cancelled while still queued rejects and leaves the wait queue, so `release()` never hands a slot to a dead waiter.

**Scanpy template guard**
- `regress_out` (densifies + forks one dense copy per worker) now sizes `n_jobs` to the worker copies that fit in available RAM and skips (with guidance) only when even one won't fit. Warns on a dense `adata.X`. `regress_out` stays **enabled by default** — this is pure sizing/skip safety, not a behavior change.

## Why each helps beyond the merged thread-cap

- **Reaping:** the thread-cap limits workers *per kernel* but never kills them on abort/timeout — a cancelled scanpy run leaves N tens-of-GB worker procs thrashing swap. Group-kill reaps them.
- **Semaphore:** the thread-cap does nothing about the *number* of concurrent kernels. N parallel `biology`/`ml` subagents each holding a dataset copy still sum to an OOM — this was the subagent-multiplication mechanism diagnosed for #102. The semaphore serializes them.
- **Template guard:** prompt advice ("avoid `n_jobs=-1`") relies on the model complying; code enforcement doesn't — which matters for exactly the weak models that OOM.

## Testing

- `bun test` — full suite green (**1138 pass / 1 skip / 0 fail**).
- New: semaphore concurrency bound + FIFO wake + abort-while-queued (proves no slot leak / no lost slot).

## Notes

- Not verified end-to-end against a captured OOM dataset; the changes are conservative (guards + reaping, no happy-path change), safe to land as hardening.
- `killTreeSync`/group-kill are best-effort; the group signal is guarded so it can't hit the wrong group.

Follow-up to the merged #102 thread-cap (#178) — #102 is already closed; this hardens the axes that fix didn't cover. Not intended to re-open the issue.
