### PR TITLE
fix(research): abort intra-turn text repetition (#176)

### DIFF
--- a/backend/cli/src/session/loop-guard.ts
+++ b/backend/cli/src/session/loop-guard.ts
@@ -1,0 +1,33 @@
+// A stuck weak model can degenerate WITHIN a single turn: it re-emits the same
+// block back-to-back until it exhausts its output budget. The cross-turn text
+// doom-loop guard (in prompt.ts) can't see that — it's one turn — so detect a
+// repeated tail as the text streams in and abort the generation before it burns
+// minutes spinning (#176).
+export const INTRA_REPEAT_MIN_BLOCK = 120
+export const INTRA_REPEAT_COUNT = 3
+const INTRA_REPEAT_MAX_WINDOW = 8000
+
+/** True when the tail of `text` is a substantial block (≥ minBlock chars) repeated
+ *  back-to-back at least `repeats` times. Bounded to the last INTRA_REPEAT_MAX_WINDOW
+ *  chars and O(window) so it stays cheap enough to run on each streamed chunk. */
+export function hasRepeatedTail(
+  text: string,
+  minBlock = INTRA_REPEAT_MIN_BLOCK,
+  repeats = INTRA_REPEAT_COUNT,
+): boolean {
+  if (text.length < minBlock * repeats) return false
+  const window = text.slice(-INTRA_REPEAT_MAX_WINDOW)
+  const w = window.length
+  const anchor = window.slice(-Math.min(64, w))
+  // Estimate the repeat period from where the final chunk last recurred before
+  // the end. For a tail of ...[block][block][block] this lands one period back.
+  const prev = window.lastIndexOf(anchor, w - anchor.length - 1)
+  if (prev < 0) return false
+  const period = w - anchor.length - prev
+  if (period < minBlock || w < period * repeats) return false
+  const block = window.slice(w - period)
+  for (let k = 2; k <= repeats; k++) {
+    if (window.slice(w - period * k, w - period * (k - 1)) !== block) return false
+  }
+  return true
+}

--- a/backend/cli/src/session/processor.ts
+++ b/backend/cli/src/session/processor.ts
@@ -13,6 +13,7 @@ import type { Provider } from "@/provider/provider"
 import { LLM } from "./llm"
 import { Config } from "@/config/config"
 import { SessionCompaction } from "./compaction"
+import { hasRepeatedTail } from "./loop-guard"
 import { PermissionNext } from "@/permission/next"
 import { Question } from "@/question"
 import { OpenScience, InsufficientCreditsError } from "@/openscience"
@@ -87,6 +88,9 @@ export namespace SessionProcessor {
     let attempt = 0
     let needsCompaction = false
     let overflow = false
+    // Set when the model degenerates into repeating the same block within one
+    // turn; breaks the stream loop and finalizes the turn as "stop" (#176).
+    let repeatAbort = false
 
     const result = {
       get message() {
@@ -143,6 +147,9 @@ export namespace SessionProcessor {
 
             let currentText: MessageV2.TextPart | undefined
             let reasoningMap: Record<string, MessageV2.ReasoningPart> = {}
+            // Reset per stream attempt (retries re-enter this block).
+            repeatAbort = false
+            let lastRepeatCheck = 0
             const stream = await LLM.stream(streamInput)
 
             for await (const value of stream.fullStream) {
@@ -445,6 +452,19 @@ export namespace SessionProcessor {
                         part: currentText,
                         delta: value.text,
                       })
+                    // Intra-turn degeneration guard (#176): once the model is just
+                    // re-emitting the same block, stop consuming so it can't spin
+                    // for minutes. Throttled to every ~1.5KB of new text.
+                    if (currentText.text.length - lastRepeatCheck >= 1500) {
+                      lastRepeatCheck = currentText.text.length
+                      if (hasRepeatedTail(currentText.text)) {
+                        repeatAbort = true
+                        log.warn("intra-turn text repetition — aborting generation", {
+                          sessionID: input.sessionID,
+                          length: currentText.text.length,
+                        })
+                      }
+                    }
                   }
                   break
 
@@ -481,6 +501,9 @@ export namespace SessionProcessor {
                   continue
               }
               if (needsCompaction || overflow) break
+              // Breaking the for-await disposes the iterator, which aborts the
+              // underlying request so the model stops generating (#176).
+              if (repeatAbort) break
             }
           } catch (e: any) {
             log.error("process", {
@@ -558,6 +581,10 @@ export namespace SessionProcessor {
               })
             }
           }
+          // A repetition-aborted turn never received a finish-step event, so
+          // stamp a terminal reason — otherwise the outer loop treats the blank
+          // finish as "continuing" and keeps going (#176).
+          if (repeatAbort && !input.assistantMessage.finish) input.assistantMessage.finish = "stop"
           input.assistantMessage.time.completed = Date.now()
           await Session.updateMessage(input.assistantMessage)
           if (overflow) return "overflow"

--- a/backend/cli/test/session/loop-guard.test.ts
+++ b/backend/cli/test/session/loop-guard.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "bun:test"
+import { hasRepeatedTail } from "../../src/session/loop-guard"
+
+const STATE_BLOCK =
+  "# Research State: placeholder topic here\n## Current Stage\nSCOPE\n## Research Question\nplaceholder question line\n## Artifacts\n- literature-review.md: missing\n- reasoning.md: missing\n"
+
+test("hasRepeatedTail: trips when a substantial block repeats back-to-back", () => {
+  expect(hasRepeatedTail(STATE_BLOCK.repeat(3))).toBe(true)
+  expect(hasRepeatedTail("intro paragraph. " + STATE_BLOCK.repeat(4))).toBe(true)
+})
+
+test("hasRepeatedTail: does NOT trip on varied text or too-few repeats", () => {
+  expect(hasRepeatedTail(STATE_BLOCK)).toBe(false) // one copy
+  expect(hasRepeatedTail(STATE_BLOCK.repeat(2))).toBe(false) // only two copies
+  expect(
+    hasRepeatedTail(
+      "A genuinely varied paragraph about sensorless SMA control that never repeats any substantial block of text and keeps introducing new clauses and ideas throughout its length.",
+    ),
+  ).toBe(false)
+})
+
+test("hasRepeatedTail: ignores short-period repeats (below the block minimum)", () => {
+  expect(hasRepeatedTail("ab".repeat(300))).toBe(false) // period 2 « min block
+  expect(hasRepeatedTail("\n".repeat(500))).toBe(false)
+})


### PR DESCRIPTION
## Context

`main`'s #176 guard (#178, `2594b9c`) catches **cross-turn** repetition — it trips when the last 3 *finished* assistant turns are long and share a large identical leading block. It can't see a model that repeats the same block **within a single turn**: only one finished turn exists, so the 3-turn window never fills.

## What

Detect a repeated tail as the assistant text streams and abort the generation. Observed live this session: a local `qwen3:4b` on the research agent re-printed the same `research-state.md` block ~7× inside **one** generation before stopping — burning the whole output budget while the cross-turn guard sat blind (one turn). This closes that gap.

## How

- `hasRepeatedTail(text)`: is the tail a substantial block (≥120 chars) repeated back-to-back ≥3×? O(window), bounded to the last 8KB, so it's cheap to run as text streams. Throttled to every ~1.5KB of new text.
- On detection: break the stream loop — disposing the async iterator aborts the underlying request so the model stops generating — and finalize the turn as `stop` so the outer session loop ends cleanly (a repetition-aborted turn never gets a finish-step event, so the reason is stamped explicitly).

## Testing

- `bun test` — full suite green (**1135 pass / 1 skip / 0 fail**).
- New `hasRepeatedTail` unit tests: trips on a block repeated 3–4×; does not trip on one/two copies, varied prose, or short-period repeats (whitespace runs, `ab`×N).

## Notes

- Purely complementary to main's cross-turn guard — different failure shape, no overlap.
- Conservative on purpose (exact block match, ≥3 back-to-back repeats, ≥120-char period) so legitimately repetitive structure — markdown tables, boilerplate headers — doesn't trip it.

Addresses #176 (complements #178's cross-turn guard).
