### PR TITLE
fix: add GPT-5.6 to Codex OAuth models

### DIFF
--- a/backend/cli/src/provider/provider.ts
+++ b/backend/cli/src/provider/provider.ts
@@ -42,6 +42,31 @@ import { ProviderTransform } from "./transform"
 export namespace Provider {
   const log = Log.create({ service: "provider" })
 
+  const CODEX_MODEL_IDS = new Set<string>([
+    "gpt-5.6",
+    "gpt-5-6",
+    "gpt-5.6-sol",
+    "gpt-5-6-sol",
+    "gpt-5.6-terra",
+    "gpt-5-6-terra",
+    "gpt-5.6-luna",
+    "gpt-5-6-luna",
+    "gpt-5.5",
+    "gpt-5-5",
+    "gpt-5.4",
+    "gpt-5-4",
+    "gpt-5.4-mini",
+    "gpt-5-4-mini",
+    "gpt-5.3-codex",
+    "gpt-5-3-codex",
+    "gpt-5.2",
+    "gpt-5-2",
+  ])
+
+  export function isCodexModel(modelID: string): boolean {
+    return CODEX_MODEL_IDS.has(modelID)
+  }
+
   function isGpt5OrLater(modelID: string): boolean {
     const match = /^gpt-(\d+)/.exec(modelID)
     if (!match) {
@@ -1095,22 +1120,10 @@ export namespace Provider {
       // snapshot normalizes dots to dashes (e.g. `gpt-5-5`) while the
       // OpenAI API expects dots (`gpt-5.5`). We pick up whichever the
       // snapshot ships and route it through the codex provider.
-      const codexModelIds = new Set<string>([
-        "gpt-5.5",
-        "gpt-5-5",
-        "gpt-5.4",
-        "gpt-5-4",
-        "gpt-5.4-mini",
-        "gpt-5-4-mini",
-        "gpt-5.3-codex",
-        "gpt-5-3-codex",
-        "gpt-5.2",
-        "gpt-5-2",
-      ])
       const baseOpenai = database["openai"]
       const codexModels: Record<string, (typeof baseOpenai.models)[string]> = {}
       for (const [id, model] of Object.entries(baseOpenai.models)) {
-        if (codexModelIds.has(id)) {
+        if (isCodexModel(id)) {
           codexModels[id] = {
             ...model,
             providerID: "openai-codex",

--- a/backend/cli/test/provider/provider.test.ts
+++ b/backend/cli/test/provider/provider.test.ts
@@ -35,6 +35,21 @@ import { Env } from "../../src/env"
 const SONNET = "claude-sonnet-4-6"
 const OPUS = "claude-opus-4-5"
 
+test("Codex OAuth allowlist includes the GPT-5.6 family", () => {
+  for (const id of [
+    "gpt-5.6",
+    "gpt-5-6",
+    "gpt-5.6-sol",
+    "gpt-5-6-sol",
+    "gpt-5.6-terra",
+    "gpt-5-6-terra",
+    "gpt-5.6-luna",
+    "gpt-5-6-luna",
+  ]) {
+    expect(Provider.isCodexModel(id)).toBe(true)
+  }
+})
+
 test("pinned catalog models are present in the seeded test fixture", async () => {
   await using tmp = await tmpdir({})
   await Instance.provide({


### PR DESCRIPTION
Fixes #184

Adds GPT-5.6, Sol, Terra, and Luna to the Codex OAuth allowlist, including normalized model IDs.

Verified with provider tests, typecheck, a local build, and live Codex OAuth text and tool-call smoke tests.
