### PR TITLE
fix(skills): load ray-data and ray-train by quoting YAML extras

### DIFF
--- a/backend/cli/skills/data-engineering/ray-data/SKILL.md
+++ b/backend/cli/skills/data-engineering/ray-data/SKILL.md
@@ -6,7 +6,7 @@ version: 1.0.0
 author: Synthetic Sciences
 license: MIT
 tags: [Data Processing, Ray Data, Distributed Computing, ML Pipelines, Batch Inference, ETL, Scalable, Ray, PyTorch, TensorFlow]
-dependencies: [ray[data], pyarrow, pandas]
+dependencies: ["ray[data]", pyarrow, pandas]
 ---
 
 # Ray Data - Scalable ML Data Processing

--- a/backend/cli/skills/ml-training/ray-train/SKILL.md
+++ b/backend/cli/skills/ml-training/ray-train/SKILL.md
@@ -6,7 +6,7 @@ version: 1.0.0
 author: Synthetic Sciences
 license: MIT
 tags: [Ray Train, Distributed Training, Synthetic Sciencestion, Ray, Hyperparameter Tuning, Fault Tolerance, Elastic Scaling, Multi-Node, PyTorch, TensorFlow]
-dependencies: [ray[train], torch, transformers]
+dependencies: ["ray[train]", torch, transformers]
 ---
 
 # Ray Train - Distributed Training Synthetic Sciencestion

--- a/backend/cli/test/skill/bundled-skills.test.ts
+++ b/backend/cli/test/skill/bundled-skills.test.ts
@@ -1,0 +1,40 @@
+import { test, expect } from "bun:test"
+import { ConfigMarkdown } from "../../src/config/markdown"
+import { Skill } from "../../src/skill"
+import path from "path"
+
+// Same fields the loader validates in Skill.compute() before accepting a skill.
+const Frontmatter = Skill.Info.pick({ name: true, description: true, category: true, tags: true, entry: true })
+
+const root = path.join(import.meta.dir, "..", "..", "skills")
+const files = await Array.fromAsync(new Bun.Glob("**/SKILL.md").scan({ cwd: root, absolute: true }))
+
+// Every bundled SKILL.md that declares a frontmatter block must produce a
+// loadable skill. Malformed YAML (e.g. the unquoted `ray[train]` extras in
+// issue #187) leaves the parser with empty data, so the loader silently drops
+// the skill and it never appears in `skill list`. Category READMEs carry no
+// frontmatter block and are intentionally skipped.
+test("every bundled skill with frontmatter loads", async () => {
+  expect(files.length).toBeGreaterThan(0)
+  const broken = await Promise.all(
+    files.map(async (file) => {
+      const raw = await Bun.file(file).text()
+      if (!raw.startsWith("---")) return undefined
+      const parsed = await ConfigMarkdown.parse(file)
+      return Frontmatter.safeParse(parsed.data).success ? undefined : path.relative(root, file)
+    }),
+  )
+  expect(broken.filter(Boolean)).toEqual([])
+})
+
+test("ray-train frontmatter parses with quoted extras", async () => {
+  const parsed = await ConfigMarkdown.parse(path.join(root, "ml-training", "ray-train", "SKILL.md"))
+  expect(parsed.data.name).toBe("ray-train")
+  expect(parsed.data.dependencies[0]).toBe("ray[train]")
+})
+
+test("ray-data frontmatter parses with quoted extras", async () => {
+  const parsed = await ConfigMarkdown.parse(path.join(root, "data-engineering", "ray-data", "SKILL.md"))
+  expect(parsed.data.name).toBe("ray-data")
+  expect(parsed.data.dependencies[0]).toBe("ray[data]")
+})


### PR DESCRIPTION
### What does this PR do?

Fixes two bundled skills, `ray-data` and `ray-train`, that never load.

Their frontmatter declared dependencies as `[ray[data], ...]` and `[ray[train], ...]`. Inside a YAML flow sequence the `[` in `ray[data]` opens a nested sequence, so `gray-matter`/`js-yaml` cannot parse the frontmatter. `Skill.compute()` catches the parse error and drops the skill, so both were missing from `skill list`, the `/` picker, and the Skills panel with no user-visible error. Quoting the extras makes each entry a plain scalar and both skills load again.

I also added a test that parses every bundled `SKILL.md` and validates its frontmatter, so a malformed block fails the suite instead of silently dropping a skill.

Fixes #187

### How did you verify your code works?

- Added `test/skill/bundled-skills.test.ts`. It fails on the two files before the quoting change and passes after.
- `bun test` in `backend/cli`: the new tests pass and there are no new failures versus the base branch.
- `openscience skill list --all` now lists `ray-data` and `ray-train`.

### Checklist

- [x] `bun run typecheck` passes
- [x] `bun test` (in `backend/cli`) passes
- [x] `bunx prettier --check .` is clean
- [x] Linked an issue (`Fixes #187`)
- [ ] Screenshots or a short video for UI changes (not a UI change)
