### PR TITLE
docs(models): document Eden AI as an EU OpenAI-compatible gateway

### DIFF
--- a/frontend/docs/src/content/openscience/models.mdx
+++ b/frontend/docs/src/content/openscience/models.mdx
@@ -28,6 +28,34 @@ openscience run --model ollama/llama3.1 "hello"
 
 Local models are free and never metered. See **[Local models](/openscience/local-models)** for the full guide.
 
+## Hosted OpenAI-compatible gateways (EU data residency)
+
+Any hosted OpenAI-compatible gateway works the same way — add it as a provider block in `openscience.json`. For example, [Eden AI](https://www.edenai.co/) is a French, EU-based gateway that reaches many upstream vendors through one key:
+
+```jsonc
+{
+  "provider": {
+    "edenai": {
+      "name": "Eden AI",
+      "npm": "@ai-sdk/openai-compatible",
+      "options": {
+        "baseURL": "https://api.edenai.run/v3",
+        "apiKey": "your-edenai-key"
+      },
+      "models": {
+        "openai/gpt-4o-mini": {},
+        "anthropic/claude-sonnet-4-5": {},
+        "mistral/mistral-small-latest": {}
+      }
+    }
+  }
+}
+```
+
+Model ids are vendor-prefixed (`<vendor>/<model>`), so you run them as `edenai/openai/gpt-4o-mini`, `edenai/anthropic/claude-sonnet-4-5`, and so on.
+
+For teams under EU data-protection requirements, Eden AI also exposes a dedicated EU endpoint (`https://api.eu.edenai.run/v3`) that processes and routes prompts and outputs within the European Union, with zero data retention by default (SOC 2 / ISO 27001, DPA as standard). Point `baseURL` at it to keep traffic in-region. See [Eden AI data compliance](https://www.edenai.co/data-compliancy).
+
 ## List what is configured
 
 ```bash


### PR DESCRIPTION
## What

Documents Eden AI as a hosted OpenAI-compatible gateway in the Models & providers guide. No code change is needed: OpenScience already loads any OpenAI-compatible provider from a `config.provider` block (same mechanism as the local-models guide), so this adds a worked example plus the EU data-residency angle.

Eden AI is a French, EU-based OpenAI-compatible gateway. Example `openscience.json`:

```jsonc
{
  "provider": {
    "edenai": {
      "name": "Eden AI",
      "npm": "@ai-sdk/openai-compatible",
      "options": { "baseURL": "https://api.edenai.run/v3", "apiKey": "your-edenai-key" },
      "models": {
        "openai/gpt-4o-mini": {},
        "anthropic/claude-sonnet-4-5": {},
        "mistral/mistral-small-latest": {}
      }
    }
  }
}
```

Model ids are vendor-prefixed, so they run as `edenai/openai/gpt-4o-mini`, `edenai/anthropic/claude-sonnet-4-5`, etc.

## Why Eden AI (EU / GDPR / data residency)

- **EU data residency**: a dedicated EU endpoint (`https://api.eu.edenai.run/v3`) that processes and routes prompts and outputs within the European Union (non-EU models are rejected).
- **Zero data retention**: prompts and outputs are not stored by default and are removed within 24 hours.
- **Compliance**: SOC 2 and ISO 27001, DPA as standard, designed around GDPR and the EU AI Act.

Refs: https://www.edenai.co/post/eu-ai-endpoint-how-to-keep-ai-requests-and-data-in-europe and https://www.edenai.co/data-compliancy

## Changes

- `frontend/docs/src/content/openscience/models.mdx`: a "Hosted OpenAI-compatible gateways (EU data residency)" section with the Eden AI config block, mirroring the existing local-models config style.

## Testing

- The documented mechanism is verified: OpenScience loads OpenAI-compatible providers through `@ai-sdk/openai-compatible` with the block's `baseURL`. I confirmed against the real Eden AI API with a real key using that exact adapter (`createOpenAICompatible({ baseURL: "https://api.edenai.run/v3", apiKey })`), which returns completions for `openai/gpt-4o-mini`, `anthropic/claude-sonnet-4-5`, and `mistral/mistral-small-latest` (the vendor-prefixed id is sent verbatim, so no double prefix is needed here).

I saw CONTRIBUTING asks to open an issue/discussion before larger changes; happy to convert this to an issue first, or to adjust the wording/placement.
