### PR TITLE
fix: Local Models settings crash — trailing-slash routing miss (#180 #197 #189)

### DIFF
--- a/backend/cli/src/server/server.ts
+++ b/backend/cli/src/server/server.ts
@@ -5,7 +5,7 @@ import { describeRoute, generateSpecs, validator, resolver, openAPIRouteHandler 
 import { Hono } from "hono"
 import { cors } from "hono/cors"
 import { streamSSE } from "hono/streaming"
-import { serveWebAsset } from "../web/serve"
+import { serveWebAsset, wantsJson } from "../web/serve"
 import { isAllowedHost, isAllowedOrigin, isCrossOrigin } from "./host-guard"
 import { timingSafeEqual } from "../util/timing-safe"
 import { FolderResolveRoutes } from "./routes/folder-resolve"
@@ -639,6 +639,11 @@ export namespace Server {
           // Unmatched /api/* must 404 — never SPA-fallback (the SPA would
           // try to JSON.parse `<!doctype`) and never proxy upstream.
           if (c.req.path.startsWith("/api/")) return c.notFound()
+
+          if (wantsJson(c.req.header("accept") ?? null, c.req.header("content-type") ?? null)) {
+            log.warn("unmatched API-shaped request", { method: c.req.method, path: c.req.path })
+            return c.json({ error: "not_found", path: c.req.path }, 404)
+          }
 
           const local = await serveWebAsset(c)
           if (local) {

--- a/backend/cli/src/server/server.ts
+++ b/backend/cli/src/server/server.ts
@@ -80,7 +80,7 @@ export namespace Server {
     return _server?.requestIP(req)?.address
   }
 
-  const app = new Hono()
+  const app = new Hono({ strict: false })
   export const App: () => Hono = lazy(
     () =>
       // TODO: Break server.ts into smaller route files to fix type inference

--- a/backend/cli/src/web/serve.ts
+++ b/backend/cli/src/web/serve.ts
@@ -33,6 +33,18 @@ function contentType(reqPath: string): string {
   return MIME[reqPath.slice(dot).toLowerCase()] ?? "application/octet-stream"
 }
 
+/**
+ * True when a request is an API/data call (expects JSON), not a browser
+ * navigation (expects an HTML page). The catch-all uses this to choose a JSON
+ * 404 over the SPA index.html fallback — SPA-falling-back a data call makes the
+ * client JSON.parse `<!doctype html>` and crash (#180/#197/#189).
+ */
+export function wantsJson(accept: string | null, contentType: string | null): boolean {
+  if (contentType?.includes("application/json")) return true
+  const a = accept ?? ""
+  return a.includes("application/json") && !a.includes("text/html")
+}
+
 export async function serveWebAsset(c: Context): Promise<Response | undefined> {
   if (!WEB_INDEX) return undefined
 

--- a/backend/cli/src/web/serve.ts
+++ b/backend/cli/src/web/serve.ts
@@ -39,8 +39,8 @@ function contentType(reqPath: string): string {
  * 404 over the SPA index.html fallback — SPA-falling-back a data call makes the
  * client JSON.parse `<!doctype html>` and crash (#180/#197/#189).
  */
-export function wantsJson(accept: string | null, contentType: string | null): boolean {
-  if (contentType?.includes("application/json")) return true
+export function wantsJson(accept: string | null, contentTypeHeader: string | null): boolean {
+  if (contentTypeHeader?.includes("application/json")) return true
   const a = accept ?? ""
   return a.includes("application/json") && !a.includes("text/html")
 }

--- a/backend/cli/test/server/spa-fallback.test.ts
+++ b/backend/cli/test/server/spa-fallback.test.ts
@@ -38,6 +38,7 @@ describe("spa fallback", () => {
 
         expect(response.status).toBe(200)
         expect(response.headers.get("content-type")).toContain("text/html")
+        expect(response.headers.get("content-security-policy")).toContain("default-src 'self'")
 
         const text = await response.text()
         expect(text.toLowerCase().startsWith("<!doctype")).toBe(true)

--- a/backend/cli/test/server/spa-fallback.test.ts
+++ b/backend/cli/test/server/spa-fallback.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import { Instance } from "../../src/project/instance"
+import { Server } from "../../src/server/server"
+import { Log } from "../../src/util/log"
+
+const projectRoot = path.join(__dirname, "../..")
+Log.init({ print: false })
+
+describe("spa fallback", () => {
+  test("unmatched API-shaped request under /settings gets a JSON 404, not SPA HTML", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const fetch = Server.internalFetch()
+        const response = await fetch("http://openscience.internal/settings/nonexistent", {
+          headers: { "content-type": "application/json" },
+        })
+
+        expect(response.status).toBe(404)
+        expect(response.headers.get("content-type")).toContain("application/json")
+
+        const text = await response.text()
+        expect(text.startsWith("<")).toBe(false)
+        expect(JSON.parse(text)).toEqual({ error: "not_found", path: "/settings/nonexistent" })
+      },
+    })
+  })
+
+  test("browser navigation to an unmatched route still gets the SPA index.html", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const fetch = Server.internalFetch()
+        const response = await fetch("http://openscience.internal/definitely/not/a/route", {
+          headers: { accept: "text/html" },
+        })
+
+        expect(response.status).toBe(200)
+        expect(response.headers.get("content-type")).toContain("text/html")
+
+        const text = await response.text()
+        expect(text.toLowerCase().startsWith("<!doctype")).toBe(true)
+      },
+    })
+  })
+
+  test("unmatched /api/* request still 404s (regression)", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const fetch = Server.internalFetch()
+        const response = await fetch("http://openscience.internal/api/also-nonexistent")
+
+        expect(response.status).toBe(404)
+      },
+    })
+  })
+})

--- a/backend/cli/test/server/spa-fallback.test.ts
+++ b/backend/cli/test/server/spa-fallback.test.ts
@@ -57,4 +57,22 @@ describe("spa fallback", () => {
       },
     })
   })
+
+  test("GET /settings/local/ (trailing slash) resolves to the real route, not the catch-all", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const fetch = Server.internalFetch()
+        const response = await fetch("http://openscience.internal/settings/local/", {
+          headers: { "content-type": "application/json" },
+        })
+
+        expect(response.status).toBe(200)
+        expect(response.headers.get("content-type")).toContain("application/json")
+
+        const body = await response.json()
+        expect(Array.isArray(body.presets)).toBe(true)
+      },
+    })
+  })
 })

--- a/backend/cli/test/web/serve.test.ts
+++ b/backend/cli/test/web/serve.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test"
+import { wantsJson } from "../../src/web/serve"
+
+describe("wantsJson", () => {
+  test("content-type application/json → true", () => {
+    expect(wantsJson(null, "application/json")).toBe(true)
+  })
+
+  test("accept includes application/json, no text/html → true", () => {
+    expect(wantsJson("application/json, text/plain", null)).toBe(true)
+  })
+
+  test("browser navigation accept header → false", () => {
+    expect(wantsJson("text/html,application/xhtml+xml,*/*", null)).toBe(false)
+  })
+
+  test("text/html present alongside application/json → treated as navigation, false", () => {
+    expect(wantsJson("text/html,application/json", null)).toBe(false)
+  })
+
+  test("wildcard accept → false", () => {
+    expect(wantsJson("*/*", null)).toBe(false)
+  })
+
+  test("both null → false", () => {
+    expect(wantsJson(null, null)).toBe(false)
+  })
+})

--- a/frontend/workspace/src/components/settings/LocalModels.tsx
+++ b/frontend/workspace/src/components/settings/LocalModels.tsx
@@ -54,7 +54,7 @@ const LocalModels: Component = () => {
     call<{ detected: Detected[] }>("/detect").then((r) => r.detected),
   )
   const [configured, { refetch: refetchConfigured }] = createResource(() =>
-    call<{ providers: Configured[] }>("/").then((r) => r.providers),
+    call<{ providers: Configured[] }>("").then((r) => r.providers),
   )
   const [status, { refetch: refetchStatus }] = createResource(() =>
     call<{ runtimes: Runtime[] }>("/status").then((r) => r.runtimes),
@@ -80,7 +80,7 @@ const LocalModels: Component = () => {
   const addRuntime = (d: Detected) =>
     guard(
       () =>
-        call("/", {
+        call("", {
           method: "POST",
           body: JSON.stringify({ url: d.baseURL, id: d.id, name: `${d.name} (local)`, models: d.models }),
         }),

--- a/frontend/workspace/src/components/settings/LocalModels.tsx
+++ b/frontend/workspace/src/components/settings/LocalModels.tsx
@@ -106,7 +106,7 @@ const LocalModels: Component = () => {
         showToast({ title: `${rt.name} isn't installed`, description: `Install it, then start it here.` })
         window.open(r.install ?? rt.install, "_blank", "noopener")
       } else if (r.running && r.models?.length) {
-        await call("/", {
+        await call("", {
           method: "POST",
           body: JSON.stringify({ url: rt.baseURL, id: rt.id, name: `${rt.name} (local)`, models: r.models }),
         })
@@ -126,7 +126,7 @@ const LocalModels: Component = () => {
   const addRunning = (rt: Runtime) =>
     guard(
       () =>
-        call("/", {
+        call("", {
           method: "POST",
           body: JSON.stringify({ url: rt.baseURL, id: rt.id, name: `${rt.name} (local)`, models: rt.models }),
         }),
@@ -172,7 +172,7 @@ const LocalModels: Component = () => {
     guard(async () => {
       const models = [...selected()]
       if (!models.length) throw new Error("Select at least one model.")
-      await call("/", {
+      await call("", {
         method: "POST",
         body: JSON.stringify({ url: url().trim(), key: key().trim() || undefined, models }),
       })

--- a/frontend/workspace/src/components/settings/api.test.ts
+++ b/frontend/workspace/src/components/settings/api.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test"
+import { settingsApi } from "./api"
+
+const base = "http://x"
+const path = "/settings/local"
+
+describe("settingsApi", () => {
+  test("throws a descriptive error when a 200 response is not JSON", async () => {
+    const fetchFn = (async () =>
+      new Response("<!doctype html><html></html>", {
+        status: 200,
+        headers: { "content-type": "text/html; charset=utf-8" },
+      })) as unknown as typeof fetch
+
+    const error = await settingsApi<never>(base, fetchFn, path).catch((e: Error) => e)
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error.message).toContain("/settings/local")
+    expect(error.message).toContain("Expected JSON")
+    expect(error.message).not.toContain("Unexpected token")
+  })
+
+  test("resolves with parsed JSON on a normal 200 response", async () => {
+    const fetchFn = (async () => Response.json({ ok: true }, { status: 200 })) as unknown as typeof fetch
+
+    expect(await settingsApi<{ ok: boolean }>(base, fetchFn, path)).toEqual({ ok: true })
+  })
+
+  test("resolves with undefined on 204", async () => {
+    const fetchFn = (async () => new Response(null, { status: 204 })) as unknown as typeof fetch
+
+    expect(await settingsApi(base, fetchFn, path)).toBeUndefined()
+  })
+
+  test("preserves the existing non-ok error path", async () => {
+    const fetchFn = (async () => new Response("boom", { status: 500 })) as unknown as typeof fetch
+
+    await expect(settingsApi(base, fetchFn, path)).rejects.toThrow(/boom|500/)
+  })
+})

--- a/frontend/workspace/src/components/settings/api.ts
+++ b/frontend/workspace/src/components/settings/api.ts
@@ -17,5 +17,9 @@ export async function settingsApi<T>(
     throw new Error(text || `${res.status} ${res.statusText}`)
   }
   if (res.status === 204) return undefined as T
+  const contentType = res.headers.get("content-type") ?? ""
+  if (!contentType.includes("application/json")) {
+    throw new Error(`Expected JSON from ${path}, but got ${res.status} (${contentType || "no content-type"})`)
+  }
   return (await res.json()) as T
 }


### PR DESCRIPTION
## Summary

Fixes the Local Models settings page crashing with `SyntaxError: Unexpected token '<', "<!doctype "... is not valid JSON`, which also wedged the rest of Settings.

Closes #180
Closes #197
Closes #189

## Root cause

Deterministic and cross-platform (not environment-specific). The Local Models panel fetched its route **root with a trailing slash** — `call("/")` → `GET`/`POST /settings/local/` — but the server mounts `LocalModelsRoutes` such that Hono's `.get("/")` / `.post("/")` match `/settings/local` but **not** `/settings/local/`. The trailing-slash request matched no route, fell through to the catch-all `.all("/*")`, which returned the SPA `index.html` with **HTTP 200 + `text/html`**. The frontend's `settingsApi` then ran `res.json()` on `<!doctype html>` → the crash. Because the panel threw mid-load, the surrounding Settings UI wedged ("can't save settings", #197).

It only ever hit Local Models because that was the **only** panel fetching its route root with a trailing slash; every other settings panel uses the generated SDK or sub-paths. (#189 is the same bug on the add-provider `POST /settings/local/`.)

Verified live: `GET /settings/local` → 200 JSON, but `GET /settings/local/` → miss → (on `main`) 200 HTML.

## The fix (functional fix + two defense-in-depth nets)

**Functional fix — make the trailing-slash form resolve:**
- `server.ts`: main app is now `new Hono({ strict: false })`, so `/x/` ≡ `/x` for all routes (propagates through `.route()` to mounted sub-apps).
- `LocalModels.tsx`: all root call sites `call("/")` → `call("")`, so the panel sends the canonical `/settings/local` path (0 `call("/")` remain).

**Defense-in-depth (so any future routing miss fails gracefully, never crashes):**
- `server.ts` catch-all: unmatched **API-shaped** requests (detected by a pure `wantsJson(accept, contentType)` predicate) now return a JSON `404 {"error":"not_found","path":…}` instead of 200 SPA HTML. Browser navigations still get `index.html` + CSP unchanged; `/api/*` misses still 404.
- `settingsApi`: throws a descriptive error if a 2xx response isn't JSON, instead of the opaque `res.json()` `SyntaxError`.

## Tests

- `test/web/serve.test.ts` — `wantsJson` truth table (6 cases).
- `test/server/spa-fallback.test.ts` — end-to-end via `Server.internalFetch()`: `/settings/nonexistent` → JSON 404; navigation → 200 HTML **+ CSP header**; `/api/*` → 404; and `/settings/local/` (trailing slash) → **200 with a `presets` array** (proves it reached the real handler, not the catch-all or the 404 net).
- `settings/api.test.ts` — non-JSON-200 → descriptive error (not `Unexpected token`); happy-path, 204, and non-ok cases.

## Verification

- Backend suite: **1142 pass / 0 fail** (1 pre-existing env-gated skip). Frontend settings test **4/4**. Typecheck clean.
- Live on the branch: replaying the panel's three load requests (`/settings/local`, `/detect`, `/status`) all return JSON, no crash; `/settings/local/` and `/settings/local` both → 200 JSON.

## Notes / optional follow-ups (non-blocking)

- The `/api/*` miss still returns `text/plain` "404 Not Found" (pre-existing) rather than the structured JSON 404; could be unified for a consistent API-404 contract.
- A now-redundant `/api/` short-circuit remains inside `serveWebAsset` (the catch-all handles `/api/` first).
