### PR TITLE
fix(wallet): report the unified spendable balance managed mode debits

### DIFF
--- a/backend/cli/src/cli/cmd/billing.ts
+++ b/backend/cli/src/cli/cmd/billing.ts
@@ -14,7 +14,7 @@ export const WalletCommand = cmd({
 
 const BillingShowCommand = cmd({
   command: ["show", "$0"],
-  describe: "show CLI wallet balance and key routing",
+  describe: "show Atlas wallet balance and key routing",
   async handler() {
     UI.empty()
     prompts.intro("openscience billing")
@@ -26,14 +26,21 @@ const BillingShowCommand = cmd({
       return
     }
 
-    const mode = await OpenScience.getBillingMode()
+    const [mode, balanceUsd] = await Promise.all([
+      OpenScience.getBillingMode(),
+      OpenScience.getBalance().catch(() => null),
+    ])
     if (!mode) {
       prompts.log.error("Couldn't fetch billing state. Check your connection or visit " + PLAN_URL)
       prompts.outro("Done")
       return
     }
-    prompts.log.info(`CLI wallet  : $${mode.balance_usd.toFixed(2)}`)
-    prompts.log.info("Key routing : per-provider (auto). BYOK key if set, else Atlas managed (debits wallet).")
+    // Managed mode spends the unified wallet (subscription + Atlas ledger + CLI
+    // ledger), so show that spendable balance. Fall back to billing-mode's
+    // CLI-only figure only when /api/credits is briefly unavailable.
+    const walletUsd = balanceUsd ?? mode.balance_usd
+    prompts.log.info(`Atlas wallet : $${walletUsd.toFixed(2)}`)
+    prompts.log.info("Key routing  : per-provider (auto). BYOK key if set, else Atlas managed (debits wallet).")
     if (!mode.managed_supported) {
       prompts.log.warn(
         "Atlas managed fallback is not provisioned on this deployment — set a BYOK key for each provider.",

--- a/backend/cli/src/openscience/index.ts
+++ b/backend/cli/src/openscience/index.ts
@@ -1232,18 +1232,28 @@ export namespace OpenScience {
     const session = await getSession()
     if (!session) return null
     try {
-      const res = await atlasFetch(`${API_BASE}/api/cli/balance`, {
+      // Managed mode spends the UNIFIED wallet (Atlas charges category="unified"),
+      // so the spendable balance is /api/credits' unified figure — not the
+      // CLI-only /api/cli/balance, which stays flat while the Atlas ledger drains
+      // and made managed spend look like it debited nothing. See cliSpendableCents.
+      const res = await atlasFetch(`${API_BASE}/api/credits`, {
         headers: { Authorization: `Bearer ${session.api_key}` },
       })
       if (!res.ok) return null
-      const data = await res.json()
-      const usd =
-        typeof data.balance_usd === "number"
-          ? data.balance_usd
-          : typeof data.balance_cents === "number"
-            ? data.balance_cents / 100
-            : null
-      if (usd === null) return null
+      const data = (await res.json()) as {
+        unified_balance_cents?: number
+        balance_cents?: number
+        cli_balance_cents?: number
+      }
+      // Distinguish "couldn't determine" (null) from a real zero balance: only
+      // trust the figure when the response actually carried a balance field.
+      if (
+        typeof data.unified_balance_cents !== "number" &&
+        typeof data.balance_cents !== "number" &&
+        typeof data.cli_balance_cents !== "number"
+      )
+        return null
+      const usd = cliSpendableCents(data) / 100
       cachedBalance = { value: usd, at: Date.now() }
       return usd
     } catch {
@@ -1625,20 +1635,25 @@ export namespace OpenScience {
   /**
    * The wallet balance the CLI can actually spend, in cents.
    *
-   * Atlas `/api/credits` also returns `unified_balance_cents` — the sum of every
-   * pool: the CLI wallet + the Atlas-web wallet + the subscription cycle pool +
-   * gifted credits. But OpenScience managed mode debits ONLY the CLI wallet
-   * (Atlas `cli.py`: `category="cli"`; an Atlas plan grants BYOK + library quota,
-   * not CLI spending credits). Showing the unified pool made the wallet read
-   * e.g. $160 when the CLI could actually spend far less. Prefer the CLI wallet;
-   * fall back to the older aggregate fields only if a backend omits it.
+   * Managed mode debits the UNIFIED wallet: Atlas charges every managed LLM call
+   * with `category="unified"`, draining the subscription cycle pool, then the
+   * Atlas-web ledger, then the CLI ledger — one spendable balance across web and
+   * CLI (Atlas `usage_service.charge`; `llm_proxy_service` passes
+   * `category="unified"`). So the spendable figure is `unified_balance_cents`,
+   * NOT the CLI-only ledger.
+   *
+   * Reporting only the CLI ledger (the earlier behaviour) froze the number: a
+   * user with any Atlas-ledger balance saw managed calls drain that pool first
+   * while the displayed CLI wallet never moved — the "my credits aren't being
+   * deducted" report. Prefer the unified balance; fall back to the aggregate,
+   * then the CLI ledger, only if a backend omits it.
    */
   export function cliSpendableCents(d: {
     cli_balance_cents?: number
     unified_balance_cents?: number
     balance_cents?: number
   }): number {
-    return d.cli_balance_cents ?? d.unified_balance_cents ?? d.balance_cents ?? 0
+    return d.unified_balance_cents ?? d.balance_cents ?? d.cli_balance_cents ?? 0
   }
 
   export async function getCredits(): Promise<Credits | null> {

--- a/backend/cli/test/openscience/wallet-balance.test.ts
+++ b/backend/cli/test/openscience/wallet-balance.test.ts
@@ -1,24 +1,27 @@
 import { test, expect, describe } from "bun:test"
 import { OpenScience } from "../../src/openscience"
 
-// Wallet balance bug: the panel showed Atlas's unified balance (CLI wallet +
-// Atlas-web wallet + subscription + gifted, e.g. $160) but OpenScience managed
-// mode can only spend the CLI wallet. cliSpendableCents must report the CLI
-// wallet, so the number reflects what the CLI can actually spend.
+// Wallet balance bug: the CLI showed the CLI-only ledger, but managed mode
+// debits the UNIFIED wallet (Atlas charges category="unified" — subscription
+// pool, then the Atlas-web ledger, then the CLI ledger). A user with any
+// Atlas-ledger balance saw managed calls drain that pool first while the
+// displayed CLI wallet never moved ("my credits aren't being deducted").
+// cliSpendableCents must report the unified spendable balance.
 
 describe("cliSpendableCents", () => {
-  test("prefers the CLI wallet over the unified pool", () => {
-    // Unified $160 (mostly Atlas-web + gifted), CLI wallet $2.50 — show $2.50.
-    expect(OpenScience.cliSpendableCents({ cli_balance_cents: 250, unified_balance_cents: 16000 })).toBe(250)
+  test("prefers the unified spendable balance over the CLI-only ledger", () => {
+    // Unified $156.34 (Atlas ledger $101.79 + CLI ledger $54.55). Managed spend
+    // drains the Atlas ledger first, so the spendable figure is the unified one.
+    expect(OpenScience.cliSpendableCents({ cli_balance_cents: 5455, unified_balance_cents: 15634 })).toBe(15634)
   })
 
-  test("shows an empty CLI wallet as 0, not the unified pool", () => {
-    expect(OpenScience.cliSpendableCents({ cli_balance_cents: 0, unified_balance_cents: 16000 })).toBe(0)
+  test("shows an empty unified balance as 0, even with a stale CLI-ledger figure", () => {
+    expect(OpenScience.cliSpendableCents({ cli_balance_cents: 5455, unified_balance_cents: 0 })).toBe(0)
   })
 
-  test("falls back to unified, then aggregate, when the CLI field is absent", () => {
-    expect(OpenScience.cliSpendableCents({ unified_balance_cents: 500 })).toBe(500)
+  test("falls back to the aggregate, then the CLI ledger, when unified is absent", () => {
     expect(OpenScience.cliSpendableCents({ balance_cents: 300 })).toBe(300)
+    expect(OpenScience.cliSpendableCents({ cli_balance_cents: 250 })).toBe(250)
     expect(OpenScience.cliSpendableCents({})).toBe(0)
   })
 })


### PR DESCRIPTION
## Symptom

Managed mode "isn't deducting my credits." The wallet balance in `openscience billing` and the Settings → Wallet panel sat frozen at **$54.55** across a whole session of managed `openrouter/claude-opus-4.8` calls.

## Root cause

The gateway and billing are actually working — the freeze is a **display bug**. The CLI reported the **CLI-only ledger** (`cli_balance_cents`), but managed mode debits the **unified wallet**:

- `llm_proxy_service` charges every managed call with `category="unified"`.
- `usage_service.charge` (unified) drains **subscription pool → Atlas-web ledger → CLI ledger**, in that order.

So a user who holds any Atlas-ledger balance has every managed call absorbed by the Atlas ledger first — the CLI ledger (the number we displayed) never moves, even though the spendable balance is dropping normally.

Confirmed against the live wallet for the affected account:

| field | value |
|---|---|
| `atlas_balance_cents` | $101.79 |
| `cli_balance_cents` | **$54.55** ← what the CLI showed (frozen) |
| `unified_balance_cents` | **$156.34** ← what managed mode actually spends |
| `lifetime_spent_cents` | $3.99 (all `managed_llm:openrouter` holds, settled) |

The recent session's 6 managed calls settled cleanly (`pending_managed_debits` → `settled`) and posted `-$3.28` to `credit_transactions`, every cent drawn from `atlas_topup_share` — i.e. the money left the unified balance exactly as designed; only the displayed pool was wrong.

This supersedes the premise of #157 ("managed debits only the CLI wallet, `category=cli`"). That was true when written, but the backend has since moved managed spend onto the unified wallet, which is why the CLI-only display went stale.

## Fix

Report the **unified spendable balance** everywhere the CLI answers "what can this call spend":

- `cliSpendableCents()` prefers `unified_balance_cents` (then the aggregate, then the CLI ledger as a last-resort fallback).
- `getBalance()` reads `/api/credits` — `/api/cli/balance` only exposes the CLI ledger, so it can never reflect Atlas-ledger spend. Preserves the null-vs-zero distinction.
- `openscience billing` shows that figure, labelled **Atlas wallet**.

## Verification

- `bun test test/openscience` — 35 pass (wallet-balance test updated to assert the unified preference + fallbacks).
- `bun run typecheck` — clean.
- Ran the built subcommand against the live backend: `openscience billing` now prints `Atlas wallet : $156.34` (was `$54.55`) and tracks real spend.

## Follow-ups (backend, not in this PR)

Client-side display is fixed; for full consistency the Atlas side still wants:

1. `/api/cli/balance` and `/api/cli/billing-mode` should return the unified spendable balance (today they return CLI-only), so any client reading them agrees without special-casing.
2. `require_managed_unlocked` / `require_cli_access` gate on `balances["cli"] > 0`; that gate should move to the unified balance, or a user with Atlas-ledger-only credit gets blocked from managed mode despite having spendable funds.
3. The managed OpenRouter hold/settle path doesn't write an `llm_usage` audit row, so the web dashboard's usage history shows nothing for these calls (only `credit_transactions` records them). `record_managed_usage` already writes one on the non-hold path — the hold path should too.
