### PR TITLE
fix(skills): load bundled Ray skills

### DIFF
--- a/backend/cli/skills/data-engineering/ray-data/SKILL.md
+++ b/backend/cli/skills/data-engineering/ray-data/SKILL.md
@@ -6,7 +6,7 @@ version: 1.0.0
 author: Synthetic Sciences
 license: MIT
 tags: [Data Processing, Ray Data, Distributed Computing, ML Pipelines, Batch Inference, ETL, Scalable, Ray, PyTorch, TensorFlow]
-dependencies: [ray[data], pyarrow, pandas]
+dependencies: ["ray[data]", pyarrow, pandas]
 ---
 
 # Ray Data - Scalable ML Data Processing
@@ -322,6 +322,5 @@ for features, labels in tf_ds:
 - **GitHub**: https://github.com/ray-project/ray ⭐ 36,000+
 - **Version**: Ray 2.40.0+
 - **Examples**: https://docs.ray.io/en/latest/data/examples/overview.html
-
 
 

--- a/backend/cli/skills/ml-training/ray-train/SKILL.md
+++ b/backend/cli/skills/ml-training/ray-train/SKILL.md
@@ -6,7 +6,7 @@ version: 1.0.0
 author: Synthetic Sciences
 license: MIT
 tags: [Ray Train, Distributed Training, Synthetic Sciencestion, Ray, Hyperparameter Tuning, Fault Tolerance, Elastic Scaling, Multi-Node, PyTorch, TensorFlow]
-dependencies: [ray[train], torch, transformers]
+dependencies: ["ray[train]", torch, transformers]
 ---
 
 # Ray Train - Distributed Training Synthetic Sciencestion
@@ -403,5 +403,4 @@ dataloader = DataLoader(dataset, num_workers=8)
 - Examples: https://docs.ray.io/en/latest/train/examples.html
 - Slack: https://forms.gle/9TSdDYUgxYs8SA9e8
 - Used by: OpenAI, Uber, Spotify, Shopify, Instacart
-
 

--- a/backend/cli/test/skill/bundled-skills.test.ts
+++ b/backend/cli/test/skill/bundled-skills.test.ts
@@ -1,0 +1,28 @@
+import { test, expect } from "bun:test"
+import path from "path"
+import { ConfigMarkdown } from "../../src/config/markdown"
+import { Skill } from "../../src/skill"
+
+const Frontmatter = Skill.Info.pick({ name: true, description: true, category: true, tags: true, entry: true })
+const root = path.join(import.meta.dir, "..", "..", "skills")
+const files = await Array.fromAsync(new Bun.Glob("**/SKILL.md").scan({ cwd: root, absolute: true }))
+
+test("every bundled skill with frontmatter parses and validates", async () => {
+  expect(files.length).toBeGreaterThan(0)
+  const broken = await Promise.all(
+    files.map(async (file) => {
+      const raw = await Bun.file(file).text()
+      if (!raw.startsWith("---")) return undefined
+      const parsed = await ConfigMarkdown.parse(file)
+      return Frontmatter.safeParse(parsed.data).success ? undefined : path.relative(root, file)
+    }),
+  )
+  expect(broken.filter(Boolean)).toEqual([])
+})
+
+test("Ray extras remain scalar dependency names", async () => {
+  const train = await ConfigMarkdown.parse(path.join(root, "ml-training", "ray-train", "SKILL.md"))
+  const data = await ConfigMarkdown.parse(path.join(root, "data-engineering", "ray-data", "SKILL.md"))
+  expect(train.data.dependencies[0]).toBe("ray[train]")
+  expect(data.data.dependencies[0]).toBe("ray[data]")
+})


### PR DESCRIPTION
## Summary
- quote the `ray[data]` and `ray[train]` extras so both bundled skill frontmatters are valid YAML
- add a CI invariant that every bundled `SKILL.md` with frontmatter parses and satisfies the loader schema
- assert both Ray extras remain scalar dependency names

Closes #187

## Verification
- `bun test --timeout 15000` (1,163 passed, 1 scheduled live test skipped)
- `bun run typecheck`
- `bun run format:check`