### PR TITLE
fix(codex): apply subscription request shaping

### DIFF
--- a/backend/cli/src/session/llm.ts
+++ b/backend/cli/src/session/llm.ts
@@ -62,7 +62,7 @@ export namespace LLM {
       Provider.getProvider(input.model.providerID),
       Auth.get(input.model.providerID),
     ])
-    const isCodex = provider.id === "openai" && auth?.type === "oauth"
+    const isCodex = isCodexSubscriptionModel(input.model, auth)
 
     const system = []
     system.push(
@@ -302,5 +302,12 @@ export namespace LLM {
       }
     }
     return false
+  }
+
+  export function isCodexSubscriptionModel(
+    model: Pick<Provider.Model, "providerID">,
+    auth?: Pick<Auth.Info, "type">,
+  ): boolean {
+    return model.providerID === "openai-codex" && auth?.type === "oauth"
   }
 }

--- a/backend/cli/test/session/llm.test.ts
+++ b/backend/cli/test/session/llm.test.ts
@@ -88,3 +88,49 @@ describe("session.llm.hasToolCalls", () => {
     expect(LLM.hasToolCalls(messages)).toBe(true)
   })
 })
+
+describe("session.llm.isCodexSubscriptionModel", () => {
+  test("recognizes the synthesized Codex OAuth provider", () => {
+    expect(
+      LLM.isCodexSubscriptionModel(
+        {
+          providerID: "openai-codex",
+        },
+        {
+          type: "oauth",
+        },
+      ),
+    ).toBe(true)
+  })
+
+  test("does not treat plain OpenAI OAuth as a Codex subscription", () => {
+    expect(
+      LLM.isCodexSubscriptionModel(
+        {
+          providerID: "openai",
+        },
+        {
+          type: "oauth",
+        },
+      ),
+    ).toBe(false)
+  })
+
+  test("requires OAuth credentials for the Codex provider", () => {
+    expect(
+      LLM.isCodexSubscriptionModel(
+        {
+          providerID: "openai-codex",
+        },
+        {
+          type: "api",
+        },
+      ),
+    ).toBe(false)
+    expect(
+      LLM.isCodexSubscriptionModel({
+        providerID: "openai-codex",
+      }),
+    ).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- detect Codex subscription sessions from the synthesized `openai-codex` model provider and OAuth credentials
- apply the existing Codex request path for instructions, system messages, and output-token handling
- keep plain OpenAI OAuth sessions on the normal OpenAI path
- add focused regression coverage for provider/auth classification

Supersedes #150.

## Verification
- `bun test --timeout 15000` in `backend/cli` (1166 pass, 1 scheduled live-catalog test skipped)
- `bun run typecheck`
- `bun run format:check`
- focused Codex refresh, retry, billing, and LLM tests (23 pass)