### PR TITLE
fix(skills): route only to available skills

### DIFF
--- a/backend/cli/src/session/prompt.ts
+++ b/backend/cli/src/session/prompt.ts
@@ -71,6 +71,7 @@ export namespace SessionPrompt {
   const ARTIFACT_AGENTS = ["research", "biology", "physics", "ml"]
   // Science agents that dispatch GPU/compute work and should honor billing.compute.
   const COMPUTE_AGENTS = new Set(["research", "biology", "physics", "ml"])
+  const SKILL_ROUTING_AGENTS = new Set(["research", "biology", "physics", "ml"])
 
   const state = Instance.state(
     () => {
@@ -855,6 +856,7 @@ export namespace SessionPrompt {
         ...(await SystemPrompt.environment(model)),
         ...(await InstructionPrompt.system()),
         ...(await Memory.recall()),
+        ...(SKILL_ROUTING_AGENTS.has(agent.name) ? [await SystemPrompt.availableSkills(agent.permission)] : []),
         ...artifactContext,
       ]
 

--- a/backend/cli/src/session/system.ts
+++ b/backend/cli/src/session/system.ts
@@ -10,6 +10,8 @@ import PROMPT_GEMINI from "./prompt/gemini.txt"
 import PROMPT_CODEX from "./prompt/codex_header.txt"
 import type { Provider } from "@/provider/provider"
 import { Config } from "../config/config"
+import { Skill } from "../skill"
+import { PermissionNext } from "../permission/next"
 
 export namespace SystemPrompt {
   export function instructions() {
@@ -58,6 +60,41 @@ If <name> is NOT a known skill, treat the / as literal text and respond
 normally.
 </slash-skill-invocation>`,
     ]
+  }
+
+  export async function availableSkills(permission: PermissionNext.Ruleset) {
+    const skills = (await Skill.all()).filter(
+      (skill) => PermissionNext.evaluate("skill", skill.name, permission).action !== "deny",
+    )
+    if (skills.length === 0) {
+      return [
+        "<available-skills>",
+        "No skills are currently available. Static skill routing tables are guidance only.",
+        "Do not call the skill tool because no skill name will resolve.",
+        "</available-skills>",
+      ].join("\n")
+    }
+
+    const groups = new Map<string, string[]>()
+    for (const skill of skills) {
+      const category = skill.category ?? "other"
+      groups.set(category, [...(groups.get(category) ?? []), skill.name])
+    }
+
+    const list = [...groups.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .flatMap(([category, names]) => [
+        `### ${category}`,
+        ...names.sort((a, b) => a.localeCompare(b)).map((name) => `- ${name}`),
+      ])
+
+    return [
+      "<available-skills>",
+      "Only the skill names below are currently loaded and callable.",
+      "Static skill routing tables are guidance only. Never call a skill absent from this list.",
+      ...list,
+      "</available-skills>",
+    ].join("\n")
   }
 
   export async function planModeInstructions(): Promise<string[]> {

--- a/backend/cli/test/session/system-skills.test.ts
+++ b/backend/cli/test/session/system-skills.test.ts
@@ -1,0 +1,77 @@
+import { expect, test } from "bun:test"
+import path from "path"
+import { SystemPrompt } from "../../src/session/system"
+import { Instance } from "../../src/project/instance"
+import { tmpdir } from "../fixture/fixture"
+
+async function writeSkill(dir: string, name: string, category: string) {
+  await Bun.write(
+    path.join(dir, ".openscience", "skill", name, "SKILL.md"),
+    `---
+name: ${name}
+description: ${name} test skill.
+category: ${category}
+---
+
+# ${name}
+`,
+  )
+}
+
+test("availableSkills lists loaded skills instead of static prompt entries", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      await writeSkill(dir, "scanpy", "biology")
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const section = await SystemPrompt.availableSkills([])
+      expect(section).toContain("<available-skills>")
+      expect(section).toContain("### biology")
+      expect(section).toContain("- scanpy")
+      expect(section).not.toContain("peft")
+    },
+  })
+})
+
+test("availableSkills excludes permission-denied skills", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      await writeSkill(dir, "scanpy", "biology")
+      await writeSkill(dir, "private-analysis", "biology")
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const section = await SystemPrompt.availableSkills([
+        {
+          permission: "skill",
+          pattern: "private-analysis",
+          action: "deny",
+        },
+      ])
+      expect(section).toContain("- scanpy")
+      expect(section).not.toContain("private-analysis")
+    },
+  })
+})
+
+test("availableSkills blocks skill calls when the registry is empty", async () => {
+  await using tmp = await tmpdir({ git: true })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const section = await SystemPrompt.availableSkills([])
+      expect(section).toContain("No skills are currently available")
+      expect(section).toContain("Do not call the skill tool")
+    },
+  })
+})


### PR DESCRIPTION
## Summary
- give research, biology, physics, and ML agents an authoritative runtime list of callable skills
- filter the list through the active agent permission rules
- prevent skill calls when the current registry is empty
- cover installed-only, permission-denied, and empty-registry behavior with real loader tests

Supersedes #98.

## Verification
- `bun test --timeout 15000 --only-failures` in `backend/cli` (1169 pass, 1 scheduled live-catalog test skipped)
- `bun run typecheck`
- `bun run format:check`
- focused skill loader and routing tests (9 pass)