### PR TITLE
Harden rendered HTML surfaces

### DIFF
--- a/backend/cli/src/mcp/oauth-callback.ts
+++ b/backend/cli/src/mcp/oauth-callback.ts
@@ -1,4 +1,5 @@
 import { Log } from "../util/log"
+import { escapeHtml, htmlResponse } from "../util/html"
 import { OAUTH_CALLBACK_PORT, OAUTH_CALLBACK_PATH } from "./oauth-provider"
 
 const log = Log.create({ service: "mcp.oauth-callback" })
@@ -19,7 +20,6 @@ const HTML_SUCCESS = `<!DOCTYPE html>
     <h1>Authorization Successful</h1>
     <p>You can close this window and return to OpenScience.</p>
   </div>
-  <script>setTimeout(() => window.close(), 2000);</script>
 </body>
 </html>`
 
@@ -39,7 +39,7 @@ const HTML_ERROR = (error: string) => `<!DOCTYPE html>
   <div class="container">
     <h1>Authorization Failed</h1>
     <p>An error occurred during authorization.</p>
-    <div class="error">${error}</div>
+    <div class="error">${escapeHtml(error)}</div>
   </div>
 </body>
 </html>`
@@ -67,6 +67,7 @@ export namespace McpOAuthCallback {
 
     server = Bun.serve({
       port: OAUTH_CALLBACK_PORT,
+      hostname: "127.0.0.1",
       fetch(req) {
         const url = new URL(req.url)
 
@@ -85,9 +86,8 @@ export namespace McpOAuthCallback {
         if (!state) {
           const errorMsg = "Missing required state parameter - potential CSRF attack"
           log.error("oauth callback missing state parameter", { url: url.toString() })
-          return new Response(HTML_ERROR(errorMsg), {
+          return htmlResponse(HTML_ERROR(errorMsg), {
             status: 400,
-            headers: { "Content-Type": "text/html" },
           })
         }
 
@@ -99,15 +99,12 @@ export namespace McpOAuthCallback {
             pendingAuths.delete(state)
             pending.reject(new Error(errorMsg))
           }
-          return new Response(HTML_ERROR(errorMsg), {
-            headers: { "Content-Type": "text/html" },
-          })
+          return htmlResponse(HTML_ERROR(errorMsg))
         }
 
         if (!code) {
-          return new Response(HTML_ERROR("No authorization code provided"), {
+          return htmlResponse(HTML_ERROR("No authorization code provided"), {
             status: 400,
-            headers: { "Content-Type": "text/html" },
           })
         }
 
@@ -115,9 +112,8 @@ export namespace McpOAuthCallback {
         if (!pendingAuths.has(state)) {
           const errorMsg = "Invalid or expired state parameter - potential CSRF attack"
           log.error("oauth callback with invalid state", { state, pendingStates: Array.from(pendingAuths.keys()) })
-          return new Response(HTML_ERROR(errorMsg), {
+          return htmlResponse(HTML_ERROR(errorMsg), {
             status: 400,
-            headers: { "Content-Type": "text/html" },
           })
         }
 
@@ -127,9 +123,7 @@ export namespace McpOAuthCallback {
         pendingAuths.delete(state)
         pending.resolve(code)
 
-        return new Response(HTML_SUCCESS, {
-          headers: { "Content-Type": "text/html" },
-        })
+        return htmlResponse(HTML_SUCCESS)
       },
     })
 

--- a/backend/cli/src/plugin/codex.ts
+++ b/backend/cli/src/plugin/codex.ts
@@ -1,5 +1,6 @@
 import type { Hooks, PluginInput } from "@synsci/plugin"
 import { Log } from "../util/log"
+import { escapeHtml, htmlResponse } from "../util/html"
 import { Installation } from "../installation"
 import { OAUTH_DUMMY_KEY } from "../auth"
 import { OpenScience } from "../openscience"
@@ -293,9 +294,6 @@ const HTML_SUCCESS = `<!doctype html>
       <h1>Authorization Successful</h1>
       <p>You can close this window and return to OpenScience.</p>
     </div>
-    <script>
-      setTimeout(() => window.close(), 2000)
-    </script>
   </body>
 </html>`
 
@@ -342,7 +340,7 @@ const HTML_ERROR = (error: string) => `<!doctype html>
     <div class="container">
       <h1>Authorization Failed</h1>
       <p>An error occurred during authorization.</p>
-      <div class="error">${error}</div>
+      <div class="error">${escapeHtml(error)}</div>
     </div>
   </body>
 </html>`
@@ -378,6 +376,7 @@ async function startOAuthServer(): Promise<{ port: number; redirectUri: string }
 
   oauthServer = Bun.serve({
     port: OAUTH_PORT,
+    hostname: "127.0.0.1",
     fetch(req) {
       const url = new URL(req.url)
 
@@ -391,18 +390,15 @@ async function startOAuthServer(): Promise<{ port: number; redirectUri: string }
           const errorMsg = errorDescription || error
           pendingOAuth?.reject(new Error(errorMsg))
           pendingOAuth = undefined
-          return new Response(HTML_ERROR(errorMsg), {
-            headers: { "Content-Type": "text/html" },
-          })
+          return htmlResponse(HTML_ERROR(errorMsg))
         }
 
         if (!code) {
           const errorMsg = "Missing authorization code"
           pendingOAuth?.reject(new Error(errorMsg))
           pendingOAuth = undefined
-          return new Response(HTML_ERROR(errorMsg), {
+          return htmlResponse(HTML_ERROR(errorMsg), {
             status: 400,
-            headers: { "Content-Type": "text/html" },
           })
         }
 
@@ -410,9 +406,8 @@ async function startOAuthServer(): Promise<{ port: number; redirectUri: string }
           const errorMsg = "Invalid state - potential CSRF attack"
           pendingOAuth?.reject(new Error(errorMsg))
           pendingOAuth = undefined
-          return new Response(HTML_ERROR(errorMsg), {
+          return htmlResponse(HTML_ERROR(errorMsg), {
             status: 400,
-            headers: { "Content-Type": "text/html" },
           })
         }
 
@@ -423,9 +418,7 @@ async function startOAuthServer(): Promise<{ port: number; redirectUri: string }
           .then((tokens) => current.resolve(tokens))
           .catch((err) => current.reject(err))
 
-        return new Response(HTML_SUCCESS, {
-          headers: { "Content-Type": "text/html" },
-        })
+        return htmlResponse(HTML_SUCCESS)
       }
 
       if (url.pathname === "/cancel") {

--- a/backend/cli/src/util/html.ts
+++ b/backend/cli/src/util/html.ts
@@ -1,0 +1,19 @@
+export function escapeHtml(value: string) {
+  return value.replace(/[&<>"']/g, (char) => {
+    if (char === "&") return "&amp;"
+    if (char === "<") return "&lt;"
+    if (char === ">") return "&gt;"
+    if (char === '"') return "&quot;"
+    return "&#39;"
+  })
+}
+
+export function htmlResponse(body: string, init: ResponseInit = {}) {
+  const headers = new Headers(init.headers)
+  headers.set("Content-Type", "text/html; charset=utf-8")
+  headers.set("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline'; script-src 'none'")
+  return new Response(body, {
+    ...init,
+    headers,
+  })
+}

--- a/backend/cli/test/util/html.test.ts
+++ b/backend/cli/test/util/html.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from "bun:test"
+import { escapeHtml, htmlResponse } from "../../src/util/html"
+
+test("escapeHtml escapes active HTML payloads", () => {
+  expect(escapeHtml(`<img src=x onerror="alert(1)">`)).toBe("&lt;img src=x onerror=&quot;alert(1)&quot;&gt;")
+})
+
+test("htmlResponse blocks script execution with CSP", () => {
+  const res = htmlResponse("<p>hello</p>")
+  expect(res.headers.get("Content-Type")).toBe("text/html; charset=utf-8")
+  expect(res.headers.get("Content-Security-Policy")).toContain("script-src 'none'")
+})

--- a/frontend/ui/src/components/notebook-cell.test.tsx
+++ b/frontend/ui/src/components/notebook-cell.test.tsx
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test"
+import { sanitizeNotebookHtml } from "./notebook-cell"
+
+describe("NotebookCell", () => {
+  test("sanitizes text/html outputs before rendering", () => {
+    const html = sanitizeNotebookHtml(
+      '<img src="x" onerror="alert(1)"><script>alert(2)</script><strong>ok</strong>',
+    )
+
+    expect(html).toContain("<strong>ok</strong>")
+    expect(html).not.toContain("onerror")
+    expect(html).not.toContain("<script")
+  })
+})

--- a/frontend/ui/src/components/notebook-cell.test.tsx
+++ b/frontend/ui/src/components/notebook-cell.test.tsx
@@ -3,9 +3,7 @@ import { sanitizeNotebookHtml } from "./notebook-cell"
 
 describe("NotebookCell", () => {
   test("sanitizes text/html outputs before rendering", () => {
-    const html = sanitizeNotebookHtml(
-      '<img src="x" onerror="alert(1)"><script>alert(2)</script><strong>ok</strong>',
-    )
+    const html = sanitizeNotebookHtml('<img src="x" onerror="alert(1)"><script>alert(2)</script><strong>ok</strong>')
 
     expect(html).toContain("<strong>ok</strong>")
     expect(html).not.toContain("onerror")

--- a/frontend/ui/src/components/notebook-cell.tsx
+++ b/frontend/ui/src/components/notebook-cell.tsx
@@ -1,5 +1,6 @@
 import { createSignal, For, Show, type JSX } from "solid-js"
 import { Icon } from "./icon"
+import { sanitize } from "./markdown"
 
 export interface NotebookCellProps {
   cellType: "code" | "markdown"
@@ -76,7 +77,7 @@ function NotebookOutputView(props: { output: NotebookOutput }): JSX.Element {
             />
           </Show>
           <Show when={output().data?.["text/html"]}>
-            <div data-slot="notebook-output-html" innerHTML={output().data!["text/html"]} />
+            <div data-slot="notebook-output-html" innerHTML={sanitizeNotebookHtml(output().data!["text/html"])} />
           </Show>
           <Show when={output().data?.["text/plain"] && !output().data?.["image/png"] && !output().data?.["text/html"]}>
             <pre data-slot="notebook-output-text">{output().data!["text/plain"]}</pre>
@@ -120,4 +121,8 @@ export function NotebookView(props: { cells: NotebookCellProps[]; title?: string
       </For>
     </div>
   )
+}
+
+export function sanitizeNotebookHtml(value: string) {
+  return sanitize(value)
 }


### PR DESCRIPTION
Summary:
- sanitize notebook text/html outputs before rendering
- escape OAuth callback error HTML and apply a restrictive CSP
- bind local OAuth callback servers to loopback

Tests:
- bun test ./src/components/notebook-cell.test.tsx ./src/components/markdown.test.ts
- bun test ./test/util/html.test.ts