### PR TITLE
Tighten permission and snapshot file guards

### DIFF
--- a/backend/cli/src/permission/next.ts
+++ b/backend/cli/src/permission/next.ts
@@ -131,27 +131,27 @@ export namespace PermissionNext {
     async (input) => {
       const s = await state()
       const { ruleset, ...request } = input
-      for (const pattern of request.patterns ?? []) {
+      const evaluated = (request.patterns ?? []).map((pattern) => {
         const rule = evaluate(request.permission, pattern, ruleset, s.approved)
         log.info("evaluated", { permission: request.permission, pattern, action: rule })
-        if (rule.action === "deny")
-          throw new DeniedError(ruleset.filter((r) => Wildcard.match(request.permission, r.permission)))
-        if (rule.action === "ask") {
-          const id = input.id ?? Identifier.ascending("permission")
-          return new Promise<void>((resolve, reject) => {
-            const info: Request = {
-              id,
-              ...request,
-            }
-            s.pending[id] = {
-              info,
-              resolve,
-              reject,
-            }
-            Bus.publish(Event.Asked, info)
-          })
-        }
-        if (rule.action === "allow") continue
+        return rule
+      })
+      const denied = evaluated.find((rule) => rule.action === "deny")
+      if (denied) throw new DeniedError(ruleset.filter((r) => Wildcard.match(request.permission, r.permission)))
+      if (evaluated.some((rule) => rule.action === "ask")) {
+        const id = input.id ?? Identifier.ascending("permission")
+        return new Promise<void>((resolve, reject) => {
+          const info: Request = {
+            id,
+            ...request,
+          }
+          s.pending[id] = {
+            info,
+            resolve,
+            reject,
+          }
+          Bus.publish(Event.Asked, info)
+        })
       }
     },
   )

--- a/backend/cli/src/session/prompt.ts
+++ b/backend/cli/src/session/prompt.ts
@@ -58,6 +58,7 @@ import { correctImageMime } from "@/util/image"
 import { Shell } from "@/shell/shell"
 import { Truncate } from "@/tool/truncation"
 import { Memory } from "@/settings/memory"
+import { assertExternalDirectory } from "@/tool/external-directory"
 
 // @ts-ignore
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -1134,6 +1135,15 @@ export namespace SessionPrompt {
 
   async function createUserMessage(input: PromptInput) {
     const agent = await Agent.get(input.agent ?? (await Agent.defaultAgent()))
+    const session = await Session.get(input.sessionID)
+    const ruleset = PermissionNext.merge(agent.permission, session.permission ?? [])
+    const ask = async (req: Omit<PermissionNext.Request, "id" | "sessionID" | "tool">) => {
+      await PermissionNext.ask({
+        ...req,
+        sessionID: input.sessionID,
+        ruleset,
+      })
+    }
     // Regenerate ID if client-provided one would sort before existing messages
     // (48-bit Identifier timestamp field wraps every ~2.2y; cross-clock drift
     // in pre-existing sessions can cause new IDs to sort below old ones).
@@ -1325,12 +1335,12 @@ export namespace SessionPrompt {
                     const readCtx: Tool.Context = {
                       sessionID: input.sessionID,
                       abort: new AbortController().signal,
-                      agent: input.agent!,
+                      agent: agent.name,
                       messageID: info.id,
-                      extra: { bypassCwdCheck: true, model },
+                      extra: { model },
                       messages: [],
                       metadata: async () => {},
-                      ask: async () => {},
+                      ask,
                     }
                     const result = await t.execute(args, readCtx)
                     pieces.push({
@@ -1387,12 +1397,12 @@ export namespace SessionPrompt {
                 const listCtx: Tool.Context = {
                   sessionID: input.sessionID,
                   abort: new AbortController().signal,
-                  agent: input.agent!,
+                  agent: agent.name,
                   messageID: info.id,
-                  extra: { bypassCwdCheck: true },
+                  extra: {},
                   messages: [],
                   metadata: async () => {},
-                  ask: async () => {},
+                  ask,
                 }
                 const result = await ListTool.init().then((t) => t.execute(args, listCtx))
                 return [
@@ -1422,6 +1432,23 @@ export namespace SessionPrompt {
               }
 
               const file = Bun.file(filepath)
+              const readCtx: Tool.Context = {
+                sessionID: input.sessionID,
+                abort: new AbortController().signal,
+                agent: agent.name,
+                messageID: info.id,
+                extra: {},
+                messages: [],
+                metadata: async () => {},
+                ask,
+              }
+              await assertExternalDirectory(readCtx, filepath)
+              await readCtx.ask({
+                permission: "read",
+                patterns: [filepath],
+                always: ["*"],
+                metadata: {},
+              })
               FileTime.read(input.sessionID, filepath)
               const bytes = await file.bytes()
               const mime = correctImageMime(part.mime, bytes)

--- a/backend/cli/src/snapshot/index.ts
+++ b/backend/cli/src/snapshot/index.ts
@@ -7,6 +7,7 @@ import z from "zod"
 import { Config } from "../config/config"
 import { Instance } from "../project/instance"
 import { Scheduler } from "../scheduler"
+import { Filesystem } from "../util/filesystem"
 
 export namespace Snapshot {
   const log = Log.create({ service: "snapshot" })
@@ -157,6 +158,7 @@ export namespace Snapshot {
   export async function revert(patches: Patch[]) {
     const files = new Set<string>()
     const git = gitdir()
+    const root = await fs.realpath(Instance.worktree).catch(() => path.resolve(Instance.worktree))
     for (const item of patches) {
       // Restore never builds a per-file git pathspec: `git checkout <tree> --
       // <path>` proved unreliable for unusual filenames depending on platform.
@@ -186,42 +188,60 @@ export namespace Snapshot {
         entries.set(path.join(Instance.worktree, line.slice(tab + 1)), { mode, sha })
       }
       for (const file of item.files) {
-        if (files.has(file)) continue
-        files.add(file)
-        log.info("reverting", { file, hash: item.hash })
-        const entry = entries.get(file)
+        const target = path.resolve(file)
+        if (files.has(target)) continue
+        files.add(target)
+        if (!Filesystem.contains(Instance.worktree, target)) {
+          log.warn("skipping snapshot revert outside worktree", { file, hash: item.hash })
+          continue
+        }
+        const parent = await realExistingParent(path.dirname(target))
+        if (!parent || !Filesystem.contains(root, parent)) {
+          log.warn("skipping snapshot revert through external parent", { file, parent, hash: item.hash })
+          continue
+        }
+        log.info("reverting", { file: target, hash: item.hash })
+        const entry = entries.get(target)
         if (!entry) {
-          log.info("file did not exist in snapshot, deleting", { file })
-          await fs.rm(file, { force: true }).catch(() => {})
+          log.info("file did not exist in snapshot, deleting", { file: target })
+          await fs.rm(target, { force: true }).catch(() => {})
           continue
         }
         if (entry.mode === "160000") {
-          log.info("skipping submodule entry", { file })
+          log.info("skipping submodule entry", { file: target })
           continue
         }
         const blob = await $`git --git-dir ${git} cat-file blob ${entry.sha}`.quiet().cwd(Instance.worktree).nothrow()
         if (blob.exitCode !== 0) {
           log.warn("could not read blob, keeping file", {
-            file,
+            file: target,
             sha: entry.sha,
             stderr: blob.stderr.toString(),
           })
           continue
         }
-        await fs.mkdir(path.dirname(file), { recursive: true }).catch(() => {})
+        await fs.mkdir(path.dirname(target), { recursive: true }).catch(() => {})
         // remove the current entry first: it may be a symlink (writing through
         // it would clobber the target) or have the wrong file type
-        await fs.rm(file, { force: true }).catch(() => {})
+        await fs.rm(target, { force: true }).catch(() => {})
         if (entry.mode === "120000") {
           await fs
-            .symlink(blob.text(), file)
-            .catch((e) => log.warn("could not restore symlink", { file, error: String(e) }))
+            .symlink(blob.text(), target)
+            .catch((e) => log.warn("could not restore symlink", { file: target, error: String(e) }))
           continue
         }
-        await fs.writeFile(file, blob.bytes())
-        await fs.chmod(file, entry.mode === "100755" ? 0o755 : 0o644).catch(() => {})
+        await fs.writeFile(target, blob.bytes())
+        await fs.chmod(target, entry.mode === "100755" ? 0o755 : 0o644).catch(() => {})
       }
     }
+  }
+
+  async function realExistingParent(dir: string): Promise<string | undefined> {
+    const real = await fs.realpath(dir).catch(() => undefined)
+    if (real) return real
+    const parent = path.dirname(dir)
+    if (parent === dir) return
+    return realExistingParent(parent)
   }
 
   export async function diff(hash: string) {

--- a/backend/cli/src/util/filesystem.ts
+++ b/backend/cli/src/util/filesystem.ts
@@ -1,5 +1,5 @@
 import { realpathSync } from "fs"
-import { dirname, join, relative } from "path"
+import { dirname, isAbsolute, join, relative } from "path"
 
 export namespace Filesystem {
   export const exists = (p: string) =>
@@ -33,7 +33,8 @@ export namespace Filesystem {
   }
 
   export function contains(parent: string, child: string) {
-    return !relative(parent, child).startsWith("..")
+    const rel = relative(parent, child)
+    return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel))
   }
 
   export async function findUp(target: string, start: string, stop?: string) {

--- a/backend/cli/test/snapshot/snapshot.test.ts
+++ b/backend/cli/test/snapshot/snapshot.test.ts
@@ -595,6 +595,52 @@ test("revert only removes files in invoking worktree", async () => {
   }
 })
 
+test("revert ignores malformed patch files outside the worktree", async () => {
+  await using tmp = await bootstrap()
+  const outside = `${tmp.path}-outside.txt`
+  await Bun.write(outside, "keep")
+
+  try {
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const before = await Snapshot.track()
+        expect(before).toBeTruthy()
+
+        await Snapshot.revert([{ hash: before!, files: [outside] }])
+
+        expect(await Bun.file(outside).text()).toBe("keep")
+      },
+    })
+  } finally {
+    await $`rm -f ${outside}`.quiet()
+  }
+})
+
+test("revert ignores malformed patch files through a symlinked parent", async () => {
+  await using tmp = await bootstrap()
+  const outside = `${tmp.path}-outside`
+  await $`mkdir -p ${outside}`.quiet()
+  await Bun.write(`${outside}/owned.txt`, "keep")
+
+  try {
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const before = await Snapshot.track()
+        expect(before).toBeTruthy()
+
+        await $`ln -s ${outside} ${tmp.path}/linked`.quiet()
+        await Snapshot.revert([{ hash: before!, files: [`${tmp.path}/linked/owned.txt`] }])
+
+        expect(await Bun.file(`${outside}/owned.txt`).text()).toBe("keep")
+      },
+    })
+  } finally {
+    await $`rm -rf ${outside}`.quiet()
+  }
+})
+
 test("diff reports worktree-only/shared edits and ignores primary-only", async () => {
   await using tmp = await bootstrap()
   const worktreePath = `${tmp.path}-worktree`


### PR DESCRIPTION
Summary:
- evaluate all requested permission patterns before resolving a permission request
- route file attachments through normal read/list and external-directory permission checks
- guard snapshot revert against malformed outside-worktree paths and symlink-parent escapes

Tests:
- bun test ./test/permission/next.test.ts
- bun test ./test/snapshot/snapshot.test.ts
- bun test ./test/file/path-traversal.test.ts