### PR TITLE
Sanitize helper subprocess environments

### DIFF
--- a/backend/cli/src/format/index.ts
+++ b/backend/cli/src/format/index.ts
@@ -8,6 +8,7 @@ import * as Formatter from "./formatter"
 import { Config } from "../config/config"
 import { mergeDeep } from "remeda"
 import { Instance } from "../project/instance"
+import { OpenScience } from "@/openscience"
 
 export namespace Format {
   const log = Log.create({ service: "format" })
@@ -113,7 +114,7 @@ export namespace Format {
           const proc = Bun.spawn({
             cmd: item.command.map((x) => x.replace("$FILE", file)),
             cwd: Instance.directory,
-            env: { ...process.env, ...item.environment },
+            env: { ...(await OpenScience.subprocessEnv(process.env)), ...item.environment },
             stdout: "ignore",
             stderr: "ignore",
           })

--- a/backend/cli/src/lsp/index.ts
+++ b/backend/cli/src/lsp/index.ts
@@ -10,6 +10,7 @@ import { Config } from "../config/config"
 import { spawn } from "child_process"
 import { Instance } from "../project/instance"
 import { Flag } from "@/flag/flag"
+import { OpenScience } from "@/openscience"
 
 export namespace LSP {
   const log = Log.create({ service: "lsp" })
@@ -114,10 +115,7 @@ export namespace LSP {
             return {
               process: spawn(item.command[0], item.command.slice(1), {
                 cwd: root,
-                env: {
-                  ...process.env,
-                  ...item.env,
-                },
+                env: { ...(await OpenScience.subprocessEnv(process.env)), ...item.env },
               }),
               initialization: item.initialization,
             }

--- a/backend/cli/src/mcp/index.ts
+++ b/backend/cli/src/mcp/index.ts
@@ -22,6 +22,7 @@ import { McpAuth } from "./auth"
 import { BusEvent } from "../bus/bus-event"
 import { Bus } from "@/bus"
 import open from "open"
+import { OpenScience } from "@/openscience"
 
 export namespace MCP {
   const log = Log.create({ service: "mcp" })
@@ -157,6 +158,18 @@ export namespace MCP {
   type McpEntry = NonNullable<Config.Info["mcp"]>[string]
   function isMcpConfigured(entry: McpEntry): entry is Config.Mcp {
     return typeof entry === "object" && entry !== null && "type" in entry
+  }
+
+  export function localEnv(
+    base: Record<string, string>,
+    command: string,
+    environment?: Record<string, string>,
+  ): Record<string, string> {
+    return {
+      ...base,
+      ...(command === "openscience" ? { BUN_BE_BUN: "1" } : {}),
+      ...environment,
+    }
   }
 
   const state = Instance.state(
@@ -395,16 +408,13 @@ export namespace MCP {
     if (mcp.type === "local") {
       const [cmd, ...args] = mcp.command
       const cwd = Instance.directory
+      const env = localEnv(await OpenScience.subprocessEnv(process.env), cmd, mcp.environment)
       const transport = new StdioClientTransport({
         stderr: "pipe",
         command: cmd,
         args,
         cwd,
-        env: {
-          ...process.env,
-          ...(cmd === "openscience" ? { BUN_BE_BUN: "1" } : {}),
-          ...mcp.environment,
-        },
+        env,
       })
       transport.stderr?.on("data", (chunk: Buffer) => {
         log.info(`mcp stderr: ${chunk.toString()}`, { key })

--- a/backend/cli/src/session/prompt.ts
+++ b/backend/cli/src/session/prompt.ts
@@ -58,6 +58,7 @@ import { correctImageMime } from "@/util/image"
 import { Shell } from "@/shell/shell"
 import { Truncate } from "@/tool/truncation"
 import { Memory } from "@/settings/memory"
+import { OpenScience } from "@/openscience"
 
 // @ts-ignore
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -1923,7 +1924,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       detached: process.platform !== "win32",
       stdio: ["ignore", "pipe", "pipe"],
       env: {
-        ...process.env,
+        ...(await OpenScience.subprocessEnv(process.env)),
         TERM: "dumb",
       },
     })

--- a/backend/cli/test/mcp/env.test.ts
+++ b/backend/cli/test/mcp/env.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "bun:test"
+import { MCP } from "../../src/mcp"
+import { OpenScience } from "../../src/openscience"
+
+test("local MCP env composes sanitized subprocess env with explicit server env", () => {
+  const base = OpenScience.filterEnvForSubprocess({
+    PATH: "/usr/bin",
+    OPENAI_API_KEY: "thk_managed_openai",
+    OPENROUTER_API_KEY: "sk-or-user-owned",
+  })
+  const env = MCP.localEnv(base, "openscience", {
+    MCP_SERVER_TOKEN: "server-secret",
+    OPENROUTER_API_KEY: "server-specific-key",
+  })
+
+  expect(env.PATH).toBe("/usr/bin")
+  expect(env.OPENAI_API_KEY).toBeUndefined()
+  expect(env.OPENROUTER_API_KEY).toBe("server-specific-key")
+  expect(env.MCP_SERVER_TOKEN).toBe("server-secret")
+  expect(env.BUN_BE_BUN).toBe("1")
+})


### PR DESCRIPTION
Summary:
- run local MCP servers with sanitized subprocess environment variables
- apply the same sanitized environment to custom LSP, formatter, and noninteractive shell spawns
- preserve explicit server/config environment overrides while stripping ambient managed keys

Tests:
- bun test ./test/openscience-env.test.ts ./test/mcp/env.test.ts
- bun run typecheck