### PR TITLE
Enforce network routing boundaries

### DIFF
--- a/backend/cli/src/provider/provider.ts
+++ b/backend/cli/src/provider/provider.ts
@@ -13,7 +13,7 @@ import { Env } from "../env"
 import { Instance } from "../project/instance"
 import { Flag } from "../flag/flag"
 import { iife } from "@/util/iife"
-import { OpenScience } from "../openscience"
+import { API_BASE, OpenScience } from "../openscience"
 
 // Direct imports for bundled providers
 import { createAmazonBedrock, type AmazonBedrockProviderSettings } from "@ai-sdk/amazon-bedrock"
@@ -104,8 +104,25 @@ export namespace Provider {
     return typeof key === "string" && key.startsWith("thk_")
   }
 
-  function isAtlasProxyBaseURL(baseURL: unknown): baseURL is string {
-    return typeof baseURL === "string" && baseURL.includes("/api/llm/proxy/")
+  export function isManagedProxyBaseURL(baseURL: unknown): baseURL is string {
+    if (typeof baseURL !== "string") return false
+    try {
+      const url = new URL(baseURL)
+      return url.pathname.startsWith("/api/llm/proxy/") && !url.search && !url.hash
+    } catch {
+      return false
+    }
+  }
+
+  export function isAtlasProxyBaseURL(baseURL: unknown): baseURL is string {
+    if (typeof baseURL !== "string") return false
+    try {
+      const url = new URL(baseURL)
+      const proxy = new URL(`${API_BASE}/api/llm/proxy/`)
+      return url.origin === proxy.origin && url.pathname.startsWith(proxy.pathname) && !url.search && !url.hash
+    } catch {
+      return false
+    }
   }
 
   // Explicit apiKey for a provider routed through the Atlas managed proxy: force
@@ -491,7 +508,7 @@ export namespace Provider {
         // OPENROUTER_BASE_URL); only the Atlas proxy is swapped for the public
         // endpoint, since a BYOK key must never be sent to the managed proxy.
         const envBase = Env.get("OPENROUTER_BASE_URL")
-        const baseURL = envBase && !isAtlasProxyBaseURL(envBase) ? envBase : "https://openrouter.ai/api/v1"
+        const baseURL = envBase && !isManagedProxyBaseURL(envBase) ? envBase : "https://openrouter.ai/api/v1"
         return { autoload: false, options: { apiKey: ownKey, baseURL, headers } }
       }
 

--- a/backend/cli/src/science/connectors/http.ts
+++ b/backend/cli/src/science/connectors/http.ts
@@ -13,6 +13,7 @@
  */
 
 import type { RateLimit } from "./types"
+import { Network } from "@/settings/network"
 
 const USER_AGENT = "openscience-science/1.0 (+https://syntheticsciences.ai)"
 const DEFAULT_TIMEOUT = 30_000
@@ -154,6 +155,7 @@ async function throttle(url: string, limit?: RateLimit): Promise<() => void> {
  * Returns a normalized response object with `json()` / `text()` helpers.
  */
 export async function request(url: string, opts: HttpOptions = {}) {
+  await Network.assertAllowed(url)
   const method = (opts.method ?? "GET").toUpperCase()
   const timeout = opts.timeout ?? DEFAULT_TIMEOUT
   const retries = opts.retries ?? DEFAULT_RETRIES

--- a/backend/cli/src/settings/network.ts
+++ b/backend/cli/src/settings/network.ts
@@ -118,11 +118,7 @@ export namespace Network {
   }
 
   function normalize(domain: string): string {
-    return domain
-      .trim()
-      .toLowerCase()
-      .replace(/^\*\./, "")
-      .replace(/\.$/, "")
+    return domain.trim().toLowerCase().replace(/^\*\./, "").replace(/\.$/, "")
   }
 
   function domains(state: State): string[] {

--- a/backend/cli/src/settings/network.ts
+++ b/backend/cli/src/settings/network.ts
@@ -117,6 +117,28 @@ export namespace Network {
     return { allowlistEnabled: false, enabled: ["package-management"], custom: [] }
   }
 
+  function normalize(domain: string): string {
+    return domain
+      .trim()
+      .toLowerCase()
+      .replace(/^\*\./, "")
+      .replace(/\.$/, "")
+  }
+
+  function domains(state: State): string[] {
+    const result = new Set<string>(state.custom.map(normalize).filter(Boolean))
+    for (const group of CATALOG) {
+      if (!state.enabled.includes(group.id)) continue
+      for (const domain of group.domains) result.add(normalize(domain))
+    }
+    return [...result].sort()
+  }
+
+  export function domainAllowed(hostname: string, allowlist: string[]): boolean {
+    const host = normalize(hostname)
+    return allowlist.map(normalize).some((domain) => host === domain || host.endsWith(`.${domain}`))
+  }
+
   export async function get(): Promise<State> {
     const text = await Bun.file(file)
       .text()
@@ -140,12 +162,23 @@ export namespace Network {
   // Effective flat list of allowed domains (enabled groups ∪ custom). Readable
   // by any backend caller that wants to gate outbound access.
   export async function allowlist(): Promise<string[]> {
+    return domains(await get())
+  }
+
+  export async function assertAllowed(raw: string): Promise<void> {
     const state = await get()
-    const domains = new Set<string>(state.custom.map((d) => d.trim()).filter(Boolean))
-    for (const group of CATALOG) {
-      if (!state.enabled.includes(group.id)) continue
-      for (const domain of group.domains) domains.add(domain)
+    if (!state.allowlistEnabled) return
+    let url: URL
+    try {
+      url = new URL(raw)
+    } catch {
+      throw new Error(`Invalid network URL: ${raw}`)
     }
-    return [...domains].sort()
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      throw new Error(`Network URL must use http or https: ${raw}`)
+    }
+    const allowed = domains(state)
+    if (domainAllowed(url.hostname, allowed)) return
+    throw new Error(`Network access to ${url.hostname} is not in the configured allow-list`)
   }
 }

--- a/backend/cli/src/tool/webfetch.ts
+++ b/backend/cli/src/tool/webfetch.ts
@@ -2,6 +2,7 @@ import z from "zod"
 import { Tool } from "./tool"
 import TurndownService from "turndown"
 import DESCRIPTION from "./webfetch.txt"
+import { Network } from "@/settings/network"
 
 const MAX_RESPONSE_SIZE = 5 * 1024 * 1024 // 5MB
 const DEFAULT_TIMEOUT = 30 * 1000 // 30 seconds
@@ -22,6 +23,7 @@ export const WebFetchTool = Tool.define("webfetch", {
     if (!params.url.startsWith("http://") && !params.url.startsWith("https://")) {
       throw new Error("URL must start with http:// or https://")
     }
+    await Network.assertAllowed(params.url)
 
     await ctx.ask({
       permission: "webfetch",

--- a/backend/cli/test/provider/managed-routing.test.ts
+++ b/backend/cli/test/provider/managed-routing.test.ts
@@ -24,6 +24,7 @@ import { tmpdir } from "../fixture/fixture"
 import { Instance } from "../../src/project/instance"
 import { Provider } from "../../src/provider/provider"
 import { Env } from "../../src/env"
+import { API_BASE } from "../../src/openscience"
 
 function clearManagedLLMEnv() {
   for (const key of [
@@ -42,7 +43,7 @@ function clearManagedLLMEnv() {
   }
 }
 
-const PROXY = "https://atlas.test/api/llm/proxy"
+const PROXY = `${API_BASE}/api/llm/proxy`
 
 // ── Pure decision helpers ────────────────────────────────────────────────────
 
@@ -70,6 +71,29 @@ describe("Provider.managedProviderAllowed (pure)", () => {
     for (const id of ["anthropic", "openai", "google", "openai-codex", "github-copilot", "gateway", "azure"]) {
       expect(Provider.managedProviderAllowed(id)).toBe(false)
     }
+  })
+})
+
+describe("Provider.isAtlasProxyBaseURL (pure)", () => {
+  test("accepts only current first-party proxy routes", () => {
+    expect(Provider.isAtlasProxyBaseURL(`${PROXY}/openrouter/v1`)).toBe(true)
+    expect(Provider.isAtlasProxyBaseURL(`${PROXY}/openrouter/v1/chat/completions`)).toBe(true)
+  })
+
+  test("rejects lookalike origins and path/query tricks", () => {
+    expect(Provider.isAtlasProxyBaseURL("https://evil.test/api/llm/proxy/openrouter/v1")).toBe(false)
+    expect(Provider.isAtlasProxyBaseURL(`${API_BASE}/not-api/llm/proxy/openrouter/v1`)).toBe(false)
+    expect(Provider.isAtlasProxyBaseURL(`${PROXY}/openrouter/v1?next=https://evil.test`)).toBe(false)
+    expect(Provider.isAtlasProxyBaseURL(`not a url`)).toBe(false)
+  })
+})
+
+describe("Provider.isManagedProxyBaseURL (pure)", () => {
+  test("detects proxy-shaped routes for BYOK leak prevention", () => {
+    expect(Provider.isManagedProxyBaseURL(`${PROXY}/openrouter/v1`)).toBe(true)
+    expect(Provider.isManagedProxyBaseURL("https://legacy.example/api/llm/proxy/openrouter/v1")).toBe(true)
+    expect(Provider.isManagedProxyBaseURL("https://openrouter.ai/api/v1")).toBe(false)
+    expect(Provider.isManagedProxyBaseURL(`${PROXY}/openrouter/v1?key=value`)).toBe(false)
   })
 })
 

--- a/backend/cli/test/provider/provider.test.ts
+++ b/backend/cli/test/provider/provider.test.ts
@@ -27,6 +27,7 @@ import { Instance } from "../../src/project/instance"
 import { Provider } from "../../src/provider/provider"
 import { Env } from "../../src/env"
 import { Auth } from "../../src/auth"
+import { API_BASE } from "../../src/openscience"
 
 /* Keep this list aligned with live-catalog.test.ts. The committed fixture makes
    PR CI deterministic; the scheduled live check catches upstream delistings. */
@@ -1242,6 +1243,7 @@ test("multiple providers can be configured simultaneously", async () => {
 })
 
 test("managed atlas proxy base URLs are forwarded for managed LLM providers", async () => {
+  const proxy = `${API_BASE}/api/llm/proxy`
   await using tmp = await tmpdir({
     init: async (dir) => {
       await Bun.write(
@@ -1257,21 +1259,21 @@ test("managed atlas proxy base URLs are forwarded for managed LLM providers", as
     init: async () => {
       clearManagedLLMEnv()
       Env.set("ANTHROPIC_API_KEY", "thk_anthropic")
-      Env.set("ANTHROPIC_BASE_URL", "https://atlas.test/api/llm/proxy/anthropic/v1")
+      Env.set("ANTHROPIC_BASE_URL", `${proxy}/anthropic/v1`)
       Env.set("OPENAI_API_KEY", "thk_openai")
-      Env.set("OPENAI_BASE_URL", "https://atlas.test/api/llm/proxy/openai/v1")
+      Env.set("OPENAI_BASE_URL", `${proxy}/openai/v1`)
       Env.set("GOOGLE_GENERATIVE_AI_API_KEY", "thk_google")
-      Env.set("GOOGLE_GENERATIVE_AI_BASE_URL", "https://atlas.test/api/llm/proxy/gemini/v1beta")
+      Env.set("GOOGLE_GENERATIVE_AI_BASE_URL", `${proxy}/gemini/v1beta`)
       Env.set("OPENROUTER_API_KEY", "thk_openrouter")
-      Env.set("OPENROUTER_BASE_URL", "https://atlas.test/api/llm/proxy/openrouter/v1")
+      Env.set("OPENROUTER_BASE_URL", `${proxy}/openrouter/v1`)
       Provider.invalidate()
     },
     fn: async () => {
       const providers = await Provider.list()
-      expect(providers["anthropic"].options.baseURL).toBe("https://atlas.test/api/llm/proxy/anthropic/v1")
-      expect(providers["openai"].options.baseURL).toBe("https://atlas.test/api/llm/proxy/openai/v1")
-      expect(providers["google"].options.baseURL).toBe("https://atlas.test/api/llm/proxy/gemini/v1beta")
-      expect(providers["openrouter"].options.baseURL).toBe("https://atlas.test/api/llm/proxy/openrouter/v1")
+      expect(providers["anthropic"].options.baseURL).toBe(`${proxy}/anthropic/v1`)
+      expect(providers["openai"].options.baseURL).toBe(`${proxy}/openai/v1`)
+      expect(providers["google"].options.baseURL).toBe(`${proxy}/gemini/v1beta`)
+      expect(providers["openrouter"].options.baseURL).toBe(`${proxy}/openrouter/v1`)
     },
   })
 })

--- a/backend/cli/test/science/http.test.ts
+++ b/backend/cli/test/science/http.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
 import { getJSON, getText, request, clearCache, resetRateLimits, orFallback } from "../../src/science/connectors/http"
+import { Network } from "../../src/settings/network"
 
 // The shared http helper is the ONLY reliability layer under science/connectors,
 // yet had zero tests. These stub globalThis.fetch to exercise retry/backoff, the
@@ -12,8 +13,9 @@ beforeEach(() => {
   resetRateLimits()
 })
 
-afterEach(() => {
+afterEach(async () => {
   globalThis.fetch = realFetch
+  await Network.set({ allowlistEnabled: false, enabled: ["package-management"], custom: [] })
 })
 
 describe("http retry / backoff", () => {
@@ -108,6 +110,21 @@ describe("http content negotiation", () => {
 
     await getJSON("https://accept.test/json")
     expect(seen.accept).toBe("application/json")
+  })
+})
+
+describe("http network allow-list", () => {
+  test("blocks disallowed hosts before fetch", async () => {
+    let calls = 0
+    globalThis.fetch = (async () => {
+      calls++
+      return new Response("ok", { status: 200 })
+    }) as unknown as typeof fetch
+
+    await Network.set({ allowlistEnabled: true, enabled: [], custom: ["allowed.test"] })
+
+    await expect(getText("https://blocked.test/a")).rejects.toThrow("allow-list")
+    expect(calls).toBe(0)
   })
 })
 

--- a/backend/cli/test/settings/network.test.ts
+++ b/backend/cli/test/settings/network.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, expect, test } from "bun:test"
+import { Network } from "../../src/settings/network"
+
+afterEach(async () => {
+  await Network.set({ allowlistEnabled: false, enabled: ["package-management"], custom: [] })
+})
+
+test("domainAllowed accepts exact domains and subdomains only", () => {
+  expect(Network.domainAllowed("example.com", ["example.com"])).toBe(true)
+  expect(Network.domainAllowed("api.example.com", ["example.com"])).toBe(true)
+  expect(Network.domainAllowed("badexample.com", ["example.com"])).toBe(false)
+})
+
+test("assertAllowed is advisory when the allow-list is disabled", async () => {
+  await Network.set({ allowlistEnabled: false, enabled: [], custom: [] })
+  await expect(Network.assertAllowed("https://blocked.test/resource")).resolves.toBeUndefined()
+})
+
+test("assertAllowed blocks hosts outside the effective allow-list", async () => {
+  await Network.set({ allowlistEnabled: true, enabled: [], custom: ["example.com"] })
+
+  await expect(Network.assertAllowed("https://api.example.com/resource")).resolves.toBeUndefined()
+  await expect(Network.assertAllowed("https://blocked.test/resource")).rejects.toThrow("allow-list")
+})

--- a/backend/cli/test/tool/webfetch-network.test.ts
+++ b/backend/cli/test/tool/webfetch-network.test.ts
@@ -22,7 +22,5 @@ test("webfetch blocks disallowed hosts before permission prompts", async () => {
   await Network.set({ allowlistEnabled: true, enabled: [], custom: ["allowed.test"] })
   const webfetch = await WebFetchTool.init()
 
-  await expect(webfetch.execute({ url: "https://blocked.test", format: "markdown" }, ctx)).rejects.toThrow(
-    "allow-list",
-  )
+  await expect(webfetch.execute({ url: "https://blocked.test", format: "markdown" }, ctx)).rejects.toThrow("allow-list")
 })

--- a/backend/cli/test/tool/webfetch-network.test.ts
+++ b/backend/cli/test/tool/webfetch-network.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, expect, test } from "bun:test"
+import { Network } from "../../src/settings/network"
+import { WebFetchTool } from "../../src/tool/webfetch"
+
+const ctx = {
+  sessionID: "session_test",
+  messageID: "message_test",
+  agent: "research",
+  abort: new AbortController().signal,
+  messages: [],
+  metadata: () => {},
+  ask: async () => {
+    throw new Error("permission should not be requested for blocked network hosts")
+  },
+}
+
+afterEach(async () => {
+  await Network.set({ allowlistEnabled: false, enabled: ["package-management"], custom: [] })
+})
+
+test("webfetch blocks disallowed hosts before permission prompts", async () => {
+  await Network.set({ allowlistEnabled: true, enabled: [], custom: ["allowed.test"] })
+  const webfetch = await WebFetchTool.init()
+
+  await expect(webfetch.execute({ url: "https://blocked.test", format: "markdown" }, ctx)).rejects.toThrow(
+    "allow-list",
+  )
+})


### PR DESCRIPTION
Summary:
- require managed proxy URLs to match the current first-party API base before managed routing is used
- keep BYOK OpenRouter keys off any proxy-shaped base URL, including legacy synced proxy URLs
- enforce the network allow-list in webfetch and science connector HTTP requests

Tests:
- bun test ./test/provider/managed-routing.test.ts ./test/provider/provider.test.ts
- bun test ./test/settings/network.test.ts ./test/tool/webfetch-network.test.ts ./test/science/http.test.ts
- bun run typecheck