### PR TITLE
Harden linux arm64 release builds

### DIFF
--- a/backend/cli/script/build.ts
+++ b/backend/cli/script/build.ts
@@ -14,6 +14,7 @@ process.chdir(dir)
 
 import pkg from "../package.json"
 import { Script } from "@synsci/script"
+import { assertLinuxArm64PageSize } from "./linux-arm64-page-size"
 
 // Fetch and generate models.dev snapshot. Runtime refreshes stale snapshots
 // when current frontier IDs are missing, so avoid inventing model aliases here.
@@ -179,6 +180,11 @@ for (const item of targets) {
       OPENSCIENCE_LIBC: item.os === "linux" ? `'${item.abi ?? "glibc"}'` : "",
     },
   })
+
+  if (item.os === "linux" && item.arch === "arm64") {
+    const report = await assertLinuxArm64PageSize(`dist/${name}/bin/openscience`)
+    console.log(`verified ${name} has ${report.loads} ELF load segments compatible with 64KB-page kernels`)
+  }
 
   // Skills are served via API — no longer copied into dist
 

--- a/backend/cli/script/linux-arm64-page-size.ts
+++ b/backend/cli/script/linux-arm64-page-size.ts
@@ -1,0 +1,72 @@
+const PAGE = 65_536n
+const ELF = [0x7f, 0x45, 0x4c, 0x46]
+const AARCH64 = 183
+const LOAD = 1
+
+type Segment = {
+  index: number
+  offset: bigint
+  vaddr: bigint
+  align: bigint
+}
+
+function hex(value: bigint) {
+  return `0x${value.toString(16)}`
+}
+
+export async function assertLinuxArm64PageSize(file: string): Promise<{ loads: number }> {
+  const bytes = new Uint8Array(await Bun.file(file).arrayBuffer())
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+  const valid =
+    bytes.length >= 64 &&
+    ELF.every((byte, index) => bytes[index] === byte) &&
+    bytes[4] === 2 &&
+    (bytes[5] === 1 || bytes[5] === 2)
+
+  if (!valid) {
+    throw new Error(`Expected ${file} to be an ELF64 executable`)
+  }
+
+  const little = bytes[5] === 1
+  const machine = view.getUint16(18, little)
+  if (machine !== AARCH64) {
+    throw new Error(`Expected ${file} to be an AArch64 ELF executable, found e_machine=${machine}`)
+  }
+
+  const phoff = Number(view.getBigUint64(32, little))
+  const size = view.getUint16(54, little)
+  const count = view.getUint16(56, little)
+  const segments = Array.from({ length: count }, (_, index): Segment | undefined => {
+    const base = phoff + index * size
+    if (base + size > bytes.length) return undefined
+    if (view.getUint32(base, little) !== LOAD) return undefined
+    return {
+      index,
+      offset: view.getBigUint64(base + 8, little),
+      vaddr: view.getBigUint64(base + 16, little),
+      align: view.getBigUint64(base + 48, little),
+    }
+  }).filter((segment): segment is Segment => segment !== undefined)
+  const bad = segments.filter((segment) => segment.align < PAGE || segment.offset % PAGE !== segment.vaddr % PAGE)
+
+  if (segments.length === 0) {
+    throw new Error(`Expected ${file} to contain ELF PT_LOAD segments`)
+  }
+
+  if (bad.length > 0) {
+    const details = bad
+      .map(
+        (segment) =>
+          `PT_LOAD[${segment.index}] align=${hex(segment.align)} offset=${hex(segment.offset)} vaddr=${hex(
+            segment.vaddr,
+          )}`,
+      )
+      .join("; ")
+    throw new Error(
+      `Linux ARM64 binary is not compatible with 64KB-page kernels. ` +
+        `Build with a Bun runtime linked using -z max-page-size=65536. ${details}`,
+    )
+  }
+
+  return { loads: segments.length }
+}

--- a/backend/cli/test/installation/linux-arm64-page-size.test.ts
+++ b/backend/cli/test/installation/linux-arm64-page-size.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test"
+import os from "node:os"
+import path from "node:path"
+import { mkdtemp, rm } from "node:fs/promises"
+import { assertLinuxArm64PageSize } from "../../script/linux-arm64-page-size"
+
+function elf(loads: { offset: bigint; vaddr: bigint; align: bigint }[]) {
+  const bytes = new Uint8Array(64 + loads.length * 56)
+  const view = new DataView(bytes.buffer)
+
+  bytes.set([0x7f, 0x45, 0x4c, 0x46], 0)
+  bytes[4] = 2
+  bytes[5] = 1
+  bytes[6] = 1
+
+  view.setUint16(16, 2, true)
+  view.setUint16(18, 183, true)
+  view.setUint32(20, 1, true)
+  view.setBigUint64(32, 64n, true)
+  view.setUint16(52, 64, true)
+  view.setUint16(54, 56, true)
+  view.setUint16(56, loads.length, true)
+
+  for (const [index, load] of loads.entries()) {
+    const base = 64 + index * 56
+    view.setUint32(base, 1, true)
+    view.setUint32(base + 4, 5, true)
+    view.setBigUint64(base + 8, load.offset, true)
+    view.setBigUint64(base + 16, load.vaddr, true)
+    view.setBigUint64(base + 32, 0x1000n, true)
+    view.setBigUint64(base + 40, 0x1000n, true)
+    view.setBigUint64(base + 48, load.align, true)
+  }
+
+  return bytes
+}
+
+describe("linux-arm64 release page-size guard", () => {
+  test("accepts load segments aligned for 64KB-page kernels", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "openscience-arm64-page-ok-"))
+    const file = path.join(dir, "openscience")
+
+    await Bun.write(file, elf([{ offset: 0x10000n, vaddr: 0x210000n, align: 0x10000n }]))
+
+    try {
+      await expect(assertLinuxArm64PageSize(file)).resolves.toEqual({
+        loads: 1,
+      })
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("rejects 4KB-aligned load segments before publishing linux-arm64 binaries", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "openscience-arm64-page-bad-"))
+    const file = path.join(dir, "openscience")
+
+    await Bun.write(file, elf([{ offset: 0x1000n, vaddr: 0x201000n, align: 0x1000n }]))
+
+    try {
+      await expect(assertLinuxArm64PageSize(file)).rejects.toThrow("-z max-page-size=65536")
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/bun.lock
+++ b/bun.lock
@@ -320,7 +320,7 @@
     "@tailwindcss/vite": "4.1.11",
     "@tsconfig/bun": "1.0.9",
     "@tsconfig/node22": "22.0.2",
-    "@types/bun": "1.3.5",
+    "@types/bun": "1.3.14",
     "@types/luxon": "3.7.1",
     "@types/node": "22.13.9",
     "@types/semver": "7.7.1",
@@ -935,7 +935,7 @@
 
     "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
 
-    "@types/bun": ["@types/bun@1.3.5", "", { "dependencies": { "bun-types": "1.3.5" } }, "sha512-RnygCqNrd3srIPEWBd5LFeUYG7plCoH2Yw9WaZGyNmdTEei+gWaHqydbaIRkIkcbXwhBT94q78QljxN0Sk838w=="],
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/compression": ["@types/compression@1.8.1", "", { "dependencies": { "@types/express": "*", "@types/node": "*" } }, "sha512-kCFuWS0ebDbmxs0AXYn6e2r2nrGAb5KwQhknjSPSPgJcGd8+HVSILlUyFhGqML2gk39HcG7D1ydW9/qpYkN00Q=="],
 
@@ -1079,7 +1079,7 @@
 
     "bun-pty": ["bun-pty@0.4.4", "", {}, "sha512-WK4G6uWsZgu1v4hKIlw6G1q2AOf8Rbga2Yr7RnxArVjjyb+mtVa/CFc9GOJf+OYSJSH8k7LonAtQOVeNAddRyg=="],
 
-    "bun-types": ["bun-types@1.3.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw=="],
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "AI-powered CLI for ML research and development workflows",
   "private": true,
   "type": "module",
-  "packageManager": "bun@1.3.5",
+  "packageManager": "bun@1.3.14",
   "scripts": {
     "dev": "bun run --cwd backend/cli --conditions=browser src/index.ts",
     "dev:local": "SYNSC_API_BASE=http://localhost:8001 SYNSC_AUTH_URL=http://localhost:8001/auth/cli bun run --cwd backend/cli --conditions=browser src/index.ts",
@@ -26,7 +26,7 @@
       "tooling/sdk/js"
     ],
     "catalog": {
-      "@types/bun": "1.3.5",
+      "@types/bun": "1.3.14",
       "@octokit/rest": "22.0.0",
       "@hono/zod-validator": "0.4.2",
       "ulid": "3.0.1",


### PR DESCRIPTION
## Summary

- bump the release Bun toolchain from 1.3.5 to 1.3.14 so standalone Linux ARM64 binaries are built with the newer runtime that includes upstream non-4KB page-size work
- add a release-build guard for `linux-arm64` and `linux-arm64-musl` outputs that fails if ELF `PT_LOAD` segments are not compatible with 64KB-page kernels
- cover the guard with minimal AArch64 ELF regression tests

## Analysis

#201 fixed the silent launcher exit when a native binary dies by signal, but it did not change how the native Linux ARM64 binaries are produced.

I inspected the current published `@synsci/openscience-linux-arm64@1.3.4` artifact and its `PT_LOAD` segments already use `0x10000` alignment, so `-z max-page-size=65536` alone does not explain the remaining report. The more likely release-side gap is that this repo still pins Bun 1.3.5 for CI/release builds, while upstream Bun's ARM64 64KB-page work landed after that pin. This PR updates that build toolchain and adds a static artifact guard so future release builds cannot silently ship a 4KB-aligned Linux ARM64 ELF.

Refs #190.

## Validation

- `bun test ./test/installation/linux-arm64-page-size.test.ts`
- compiled a tiny `bun-linux-arm64` standalone binary with Bun 1.3.14 and validated it with `assertLinuxArm64PageSize` (`{"loads":3}`)
- `bun run typecheck`
- `bun prettier --check package.json backend/cli/script/build.ts backend/cli/script/linux-arm64-page-size.ts backend/cli/test/installation/linux-arm64-page-size.test.ts`
- `git diff --check`
- `bun run --cwd frontend/workspace build`
- `bun run --cwd backend/cli script/generate-web-assets.ts`
- `bun test` from `backend/cli`: 1184 pass, 1 skip, 0 fail

## Remaining verification

I do not have a real Oracle/Ampere ARM64 host with `getconf PAGESIZE = 65536` in this workspace. Before closing #190, this draft should be smoke-tested on that host class with the PR-built `@synsci/openscience-linux-arm64` artifact.
