### PR TITLE
add npm test publish workflow

### DIFF
--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -1,0 +1,364 @@
+name: npm test publish
+run-name: "npm test ${{ inputs.version || github.run_number }}"
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Override test version, e.g. 1.3.5-test.1"
+        required: false
+        type: string
+      run_packaged_e2e:
+        description: "Install @synsci/openscience@test and run packaged browser e2e"
+        required: false
+        type: boolean
+        default: true
+      run_os_smoke:
+        description: "Install @synsci/openscience@test on Linux, macOS, and Windows"
+        required: false
+        type: boolean
+        default: true
+
+concurrency: npm-test-publish
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  version:
+    if: github.repository == 'synthetic-sciences/OpenScience'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -n "${{ inputs.version }}" ]; then
+            version="${{ inputs.version }}"
+          else
+            latest="$(npm view @synsci/openscience@latest version)"
+            IFS=. read -r major minor patch <<< "$latest"
+            version="${major}.${minor}.$((patch + 1))-test.${GITHUB_RUN_NUMBER}.${GITHUB_RUN_ATTEMPT}"
+          fi
+
+          if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+-test\.[0-9A-Za-z.-]+$ ]]; then
+            echo "::error::Test publish versions must look like 1.3.5-test.1, received '$version'"
+            exit 1
+          fi
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Publishing npm test version $version"
+
+  build-cli:
+    needs: version
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: ./.github/actions/setup-bun
+      - name: Build all npm CLI packages
+        run: ./backend/cli/script/build.ts
+        env:
+          OPENSCIENCE_CHANNEL: test
+          OPENSCIENCE_VERSION: ${{ needs.version.outputs.version }}
+          GH_TOKEN: ${{ github.token }}
+      - name: Cache CLI build
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: backend/cli/dist
+          key: npm-test-cli-build-${{ github.run_id }}-${{ github.run_attempt }}
+
+  publish-test:
+    needs:
+      - version
+      - build-cli
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    outputs:
+      version: ${{ needs.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/setup-bun
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+      - name: Restore CLI build
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: backend/cli/dist
+          key: npm-test-cli-build-${{ github.run_id }}-${{ github.run_attempt }}
+          fail-on-cache-miss: true
+      - name: Publish npm test packages
+        run: ./tooling/repo/publish.ts
+        env:
+          HUSKY: "0"
+          OPENSCIENCE_CHANNEL: test
+          OPENSCIENCE_VERSION: ${{ needs.version.outputs.version }}
+          OPENSCIENCE_REQUIRE_LAUNCHER_PUBLISH: "true"
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: "true"
+
+  packaged-e2e:
+    needs: publish-test
+    if: inputs.run_packaged_e2e
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: ./.github/actions/setup-bun
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+      - name: Install Playwright browsers
+        working-directory: frontend/workspace
+        run: bunx playwright install --with-deps
+      - name: Install published OpenScience test package
+        run: |
+          set -euo pipefail
+          prefix="$RUNNER_TEMP/openscience-npm-test-prefix"
+          home="$RUNNER_TEMP/openscience-npm-test-home"
+          mkdir -p "$prefix" "$home"
+          npm install --global --prefix "$prefix" @synsci/openscience@test
+          echo "$prefix/bin" >> "$GITHUB_PATH"
+          "$prefix/bin/openscience" --version | tee "$RUNNER_TEMP/openscience-version.txt"
+          grep -Fx "${{ needs.publish-test.outputs.version }}" "$RUNNER_TEMP/openscience-version.txt"
+          wrapper_dir="$prefix/lib/node_modules/@synsci/openscience"
+          WRAPPER_DIR="$wrapper_dir" node - <<'NODE'
+          const path = require("node:path")
+          const { execFileSync } = require("node:child_process")
+          const pkg = require.resolve("@synsci/atlas/package.json", { paths: [process.env.WRAPPER_DIR] })
+          const atlas = require(pkg)
+          if (!atlas.version) throw new Error("@synsci/atlas resolved without a version")
+          console.log(`resolved @synsci/atlas ${atlas.version} from ${path.dirname(pkg)}`)
+          const rel = typeof atlas.bin === "string" ? atlas.bin : atlas.bin?.atlas
+          if (!rel) throw new Error("@synsci/atlas package does not expose an atlas bin")
+          const bin = path.join(path.dirname(pkg), rel)
+          console.log(execFileSync(bin, ["--version"], { encoding: "utf8" }).trim())
+          NODE
+
+          launcher_prefix="$RUNNER_TEMP/synsci-npm-test-prefix"
+          npm install --global --prefix "$launcher_prefix" synsci@test
+          node --check "$launcher_prefix/lib/node_modules/synsci/bin/synsci.mjs"
+          LAUNCHER_DIR="$launcher_prefix/lib/node_modules/synsci" node --input-type=module - <<'NODE'
+          const mod = await import(`file://${process.env.LAUNCHER_DIR}/lib/channel.mjs`)
+          const spec = mod.opensciencePackageSpec(process.env.OPENSCIENCE_VERSION)
+          if (spec !== "@synsci/openscience@test") throw new Error(`synsci@test resolves ${spec}`)
+          console.log(`synsci@test resolves ${spec}`)
+          NODE
+        env:
+          HOME: ${{ runner.temp }}/openscience-npm-test-home
+          OPENSCIENCE_VERSION: ${{ needs.publish-test.outputs.version }}
+      - name: Run optional authenticated Atlas smoke
+        run: |
+          set -euo pipefail
+          if [ -z "${ATLAS_TEST_API_KEY:-}" ]; then
+            echo "ATLAS_TEST_API_KEY is not set; skipping authenticated Atlas smoke."
+            exit 0
+          fi
+          wrapper_dir="$RUNNER_TEMP/openscience-npm-test-prefix/lib/node_modules/@synsci/openscience"
+          WRAPPER_DIR="$wrapper_dir" node - <<'NODE'
+          const path = require("node:path")
+          const { execFileSync } = require("node:child_process")
+          const pkg = require.resolve("@synsci/atlas/package.json", { paths: [process.env.WRAPPER_DIR] })
+          const atlas = require(pkg)
+          const rel = typeof atlas.bin === "string" ? atlas.bin : atlas.bin?.atlas
+          if (!rel) throw new Error("@synsci/atlas package does not expose an atlas bin")
+          const bin = path.join(path.dirname(pkg), rel)
+          execFileSync(bin, ["doctor", "--format=json"], {
+            env: { ...process.env, ATLAS_API_KEY: process.env.ATLAS_TEST_API_KEY },
+            stdio: "inherit",
+          })
+          NODE
+        env:
+          ATLAS_TEST_API_KEY: ${{ secrets.ATLAS_TEST_API_KEY }}
+      - name: Set isolated OpenScience paths
+        run: |
+          PASS="ci-$(openssl rand -hex 16)"
+          {
+            echo "OPENSCIENCE_SERVER_PASSWORD=$PASS"
+            echo "VITE_OPENSCIENCE_SERVER_PASSWORD=$PASS"
+            echo "OPENSCIENCE_E2E_ROOT=$RUNNER_TEMP/openscience-e2e"
+            echo "OPENSCIENCE_TEST_HOME=$RUNNER_TEMP/openscience-e2e/home"
+            echo "XDG_DATA_HOME=$RUNNER_TEMP/openscience-e2e/share"
+            echo "XDG_CACHE_HOME=$RUNNER_TEMP/openscience-e2e/cache"
+            echo "XDG_CONFIG_HOME=$RUNNER_TEMP/openscience-e2e/config"
+            echo "XDG_STATE_HOME=$RUNNER_TEMP/openscience-e2e/state"
+          } >> "$GITHUB_ENV"
+          cat > frontend/workspace/.env.local <<ENV
+          VITE_OPENSCIENCE_SERVER_HOST=127.0.0.1
+          VITE_OPENSCIENCE_SERVER_PORT=4096
+          VITE_OPENSCIENCE_SERVER_USERNAME=openscience
+          VITE_OPENSCIENCE_SERVER_PASSWORD=$PASS
+          ENV
+      - name: Start deterministic E2E model
+        run: |
+          CONFIG=$(bun frontend/workspace/script/e2e-fake-model.ts --port 4097 --print-config)
+          {
+            printf '%s\n' "OPENSCIENCE_CONFIG_CONTENT=$CONFIG"
+            printf '%s\n' "OPENSCIENCE_E2E_MODEL=e2e/echo"
+            printf '%s\n' "OPENSCIENCE_E2E_FAKE_MODEL=1"
+          } >> "$GITHUB_ENV"
+          bun frontend/workspace/script/e2e-fake-model.ts --port 4097 > "$RUNNER_TEMP/openscience-fake-model.log" 2>&1 &
+          for _ in $(seq 1 30); do
+            curl -fsS "http://127.0.0.1:4097/health" > /dev/null && exit 0
+            sleep 1
+          done
+          echo "::error::deterministic E2E model never became healthy on 127.0.0.1:4097"
+          exit 1
+      - name: Seed OpenScience data
+        working-directory: backend/cli
+        run: bun script/seed-e2e.ts
+        env:
+          OPENSCIENCE_DISABLE_SHARE: "true"
+          OPENSCIENCE_DISABLE_LSP_DOWNLOAD: "true"
+          OPENSCIENCE_DISABLE_DEFAULT_PLUGINS: "true"
+          OPENSCIENCE_EXPERIMENTAL_DISABLE_FILEWATCHER: "true"
+          OPENSCIENCE_TEST_HOME: ${{ env.OPENSCIENCE_TEST_HOME }}
+          XDG_DATA_HOME: ${{ env.XDG_DATA_HOME }}
+          XDG_CACHE_HOME: ${{ env.XDG_CACHE_HOME }}
+          XDG_CONFIG_HOME: ${{ env.XDG_CONFIG_HOME }}
+          XDG_STATE_HOME: ${{ env.XDG_STATE_HOME }}
+          OPENSCIENCE_E2E_PROJECT_DIR: ${{ github.workspace }}
+          OPENSCIENCE_E2E_SESSION_TITLE: "E2E Session"
+          OPENSCIENCE_E2E_MESSAGE: "Seeded for UI e2e"
+          OPENSCIENCE_E2E_MODEL: "e2e/echo"
+      - name: Run published OpenScience server
+        run: openscience --print-logs --log-level WARN serve --port 4096 > "$RUNNER_TEMP/openscience-server.log" 2>&1 &
+        env:
+          OPENSCIENCE_DISABLE_SHARE: "true"
+          OPENSCIENCE_DISABLE_LSP_DOWNLOAD: "true"
+          OPENSCIENCE_DISABLE_DEFAULT_PLUGINS: "true"
+          OPENSCIENCE_EXPERIMENTAL_DISABLE_FILEWATCHER: "true"
+          OPENSCIENCE_TEST_HOME: ${{ env.OPENSCIENCE_TEST_HOME }}
+          XDG_DATA_HOME: ${{ env.XDG_DATA_HOME }}
+          XDG_CACHE_HOME: ${{ env.XDG_CACHE_HOME }}
+          XDG_CONFIG_HOME: ${{ env.XDG_CONFIG_HOME }}
+          XDG_STATE_HOME: ${{ env.XDG_STATE_HOME }}
+          OPENSCIENCE_CLIENT: "app"
+      - name: Wait for published OpenScience server
+        run: |
+          for _ in $(seq 1 120); do
+            curl -fsS "http://127.0.0.1:4096/global/health" > /dev/null && exit 0
+            sleep 1
+          done
+          echo "::error::published openscience server never became healthy on 127.0.0.1:4096"
+          exit 1
+      - name: Run packaged E2E
+        working-directory: frontend/workspace
+        run: bun run test:e2e:packaged
+        env:
+          CI: true
+          PLAYWRIGHT_BASE_URL: "http://127.0.0.1:4096"
+          PLAYWRIGHT_SERVER_HOST: "127.0.0.1"
+          PLAYWRIGHT_SERVER_PORT: "4096"
+          VITE_OPENSCIENCE_SERVER_HOST: "127.0.0.1"
+          VITE_OPENSCIENCE_SERVER_PORT: "4096"
+          OPENSCIENCE_CLIENT: "app"
+      - name: Print server logs
+        if: failure()
+        run: |
+          cat "$RUNNER_TEMP/openscience-server.log" || true
+          cat "$RUNNER_TEMP/openscience-fake-model.log" || true
+      - name: Upload packaged E2E artifacts
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: npm-test-packaged-e2e-${{ github.run_attempt }}
+          if-no-files-found: ignore
+          retention-days: 7
+          path: |
+            frontend/workspace/e2e/test-results
+            frontend/workspace/e2e/playwright-report
+            ${{ runner.temp }}/openscience-server.log
+            ${{ runner.temp }}/openscience-fake-model.log
+
+  os-smoke:
+    needs: publish-test
+    if: inputs.run_os_smoke
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux-x64
+            runner: ubuntu-latest
+          - name: linux-arm64
+            runner: ubuntu-24.04-arm
+          - name: macos
+            runner: macos-latest
+          - name: windows
+            runner: windows-latest
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 25
+    steps:
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+      - name: Install and smoke OpenScience test package
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          prefix="$RUNNER_TEMP/openscience-prefix"
+          mkdir -p "$prefix"
+          export OPENSCIENCE_DISABLE_SHARE=true
+          export OPENSCIENCE_DISABLE_LSP_DOWNLOAD=true
+          export OPENSCIENCE_DISABLE_DEFAULT_PLUGINS=true
+          export OPENSCIENCE_EXPERIMENTAL_DISABLE_FILEWATCHER=true
+          npm install --global --prefix "$prefix" @synsci/openscience@test
+          bin="$prefix/bin/openscience"
+          "$bin" --version | tee "$RUNNER_TEMP/openscience-version.txt"
+          grep -Fx "${{ needs.publish-test.outputs.version }}" "$RUNNER_TEMP/openscience-version.txt"
+          "$bin" serve --port 4096 > "$RUNNER_TEMP/openscience-smoke.log" 2>&1 &
+          pid=$!
+          trap 'kill "$pid" 2>/dev/null || true' EXIT
+          for _ in $(seq 1 90); do
+            curl -fsS "http://127.0.0.1:4096/global/health" > /dev/null && exit 0
+            sleep 1
+          done
+          echo "::error::openscience server never became healthy"
+          cat "$RUNNER_TEMP/openscience-smoke.log" || true
+          exit 1
+      - name: Install and smoke OpenScience test package
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $prefix = Join-Path $env:RUNNER_TEMP "openscience-prefix"
+          $env:OPENSCIENCE_DISABLE_SHARE = "true"
+          $env:OPENSCIENCE_DISABLE_LSP_DOWNLOAD = "true"
+          $env:OPENSCIENCE_DISABLE_DEFAULT_PLUGINS = "true"
+          $env:OPENSCIENCE_EXPERIMENTAL_DISABLE_FILEWATCHER = "true"
+          npm install --global --prefix $prefix "@synsci/openscience@test"
+          $bin = Join-Path $prefix "openscience.cmd"
+          & $bin --version | Tee-Object -FilePath (Join-Path $env:RUNNER_TEMP "openscience-version.txt")
+          $actual = Get-Content (Join-Path $env:RUNNER_TEMP "openscience-version.txt")
+          if ($actual -ne "${{ needs.publish-test.outputs.version }}") {
+            throw "expected version ${{ needs.publish-test.outputs.version }}, got $actual"
+          }
+          $stdout = Join-Path $env:RUNNER_TEMP "openscience-smoke.out.log"
+          $stderr = Join-Path $env:RUNNER_TEMP "openscience-smoke.err.log"
+          $proc = Start-Process -FilePath $bin -ArgumentList @("serve", "--port", "4096") -RedirectStandardOutput $stdout -RedirectStandardError $stderr -PassThru
+          try {
+            foreach ($i in 1..90) {
+              try {
+                Invoke-WebRequest -UseBasicParsing "http://127.0.0.1:4096/global/health" | Out-Null
+                exit 0
+              } catch {
+                Start-Sleep -Seconds 1
+              }
+            }
+            Get-Content $stdout -ErrorAction SilentlyContinue
+            Get-Content $stderr -ErrorAction SilentlyContinue
+            throw "openscience server never became healthy"
+          } finally {
+            Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+          }

--- a/backend/cli/src/installation/index.ts
+++ b/backend/cli/src/installation/index.ts
@@ -210,6 +210,11 @@ export namespace Installation {
     return `https://community.chocolatey.org/api/v2/Packages?$filter=${filter}&$select=Version`
   }
 
+  export function npmReleaseChannel(channel: string = CHANNEL) {
+    const knownTags = new Set(["latest", "ci", "dev", "beta", "test"])
+    return knownTags.has(channel) ? channel : "latest"
+  }
+
   export async function latest(installMethod?: Method) {
     const detectedMethod = installMethod || (await method())
 
@@ -236,8 +241,7 @@ export namespace Installation {
         const reg = r || "https://registry.npmjs.org"
         return reg.endsWith("/") ? reg.slice(0, -1) : reg
       })
-      const knownTags = new Set(["latest", "ci", "dev", "beta"])
-      const channel = knownTags.has(CHANNEL) ? CHANNEL : "latest"
+      const channel = npmReleaseChannel()
       return fetch(`${registry}/@synsci/openscience/${channel}`)
         .then((res) => {
           if (!res.ok) throw new Error(res.statusText)

--- a/backend/cli/test/installation/launcher-channel.test.ts
+++ b/backend/cli/test/installation/launcher-channel.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test"
+import { npmDistTag, opensciencePackageSpec } from "../../../../tooling/launcher/lib/channel.mjs"
+
+describe("synsci launcher npm channel", () => {
+  test("installs OpenScience from the test dist-tag for test launcher builds", () => {
+    expect(npmDistTag("1.3.5-test.42")).toBe("test")
+    expect(npmDistTag("0.0.0-test-202607260856")).toBe("test")
+    expect(opensciencePackageSpec("1.3.5-test.42")).toBe("@synsci/openscience@test")
+  })
+
+  test("keeps stable launcher builds on latest", () => {
+    expect(npmDistTag("1.3.5")).toBe("latest")
+    expect(opensciencePackageSpec("1.3.5")).toBe("@synsci/openscience@latest")
+  })
+})

--- a/backend/cli/test/installation/npm-channel.test.ts
+++ b/backend/cli/test/installation/npm-channel.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test"
+import { Installation } from "../../src/installation"
+
+describe("Installation.npmReleaseChannel", () => {
+  test("keeps public prerelease channels on their matching npm dist-tag", () => {
+    expect(Installation.npmReleaseChannel("test")).toBe("test")
+    expect(Installation.npmReleaseChannel("beta")).toBe("beta")
+    expect(Installation.npmReleaseChannel("dev")).toBe("dev")
+    expect(Installation.npmReleaseChannel("ci")).toBe("ci")
+    expect(Installation.npmReleaseChannel("latest")).toBe("latest")
+  })
+
+  test("falls back unknown local branch channels to latest", () => {
+    expect(Installation.npmReleaseChannel("codex/npm-test-workflow")).toBe("latest")
+    expect(Installation.npmReleaseChannel("feature-branch")).toBe("latest")
+  })
+})

--- a/backend/cli/test/server/atlas-bridge.test.ts
+++ b/backend/cli/test/server/atlas-bridge.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { $ } from "bun"
 import fs from "node:fs/promises"
 import path from "node:path"
 import { Global } from "../../src/global"
@@ -10,6 +11,7 @@ import {
   parseStageNodeInput,
   pinMatchesKey,
 } from "../../src/server/routes/atlas-bridge"
+import { tmpdir } from "../fixture/fixture"
 
 const realFetch = globalThis.fetch
 const sessionPath = path.join(Global.Path.data, "openscience-session.json")
@@ -124,6 +126,10 @@ describe("stage node bridge", () => {
   test("creates a staged child with repository context", async () => {
     await fs.mkdir(Global.Path.data, { recursive: true })
     await Bun.write(sessionPath, JSON.stringify({ api_key: "thk_test", user_id: "user-1" }))
+    await using tmp = await tmpdir({ git: true })
+    await $`git remote add origin https://github.com/synthetic-sciences/openscience.git`.cwd(tmp.path).quiet()
+    const branch = (await $`git branch --show-current`.cwd(tmp.path).quiet().text()).trim()
+    const head = (await $`git rev-parse HEAD`.cwd(tmp.path).quiet().text()).trim()
 
     let requestURL = ""
     let requestBody: any
@@ -144,14 +150,16 @@ describe("stage node bridge", () => {
     const response = await AtlasBridgeRoutes().request("/nodes", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ title: "result", directory: process.cwd(), parent_id: "parent-1" }),
+      body: JSON.stringify({ title: "result", directory: tmp.path, parent_id: "parent-1" }),
     })
 
     expect(response.status).toBe(201)
     expect(requestURL).toEndWith("/api/nodes/stage-create")
     expect(requestBody.parent_ids).toEqual(["parent-1"])
     expect(requestBody.title).toBe("result")
-    expect(requestBody.branch_name).toBeTruthy()
+    expect(requestBody.repo_url).toBe("https://github.com/synthetic-sciences/openscience")
+    expect(requestBody.branch_name).toBe(branch)
+    expect(requestBody.head_commit_sha).toBe(head)
     expect(await response.json()).toMatchObject({
       node_id: "staged-1",
       lifecycle: "staged",

--- a/tooling/launcher/bin/synsci.mjs
+++ b/tooling/launcher/bin/synsci.mjs
@@ -23,6 +23,7 @@ import { homedir } from "node:os"
 import { join } from "node:path"
 import { createInterface } from "node:readline"
 import { fileURLToPath } from "node:url"
+import { npmDistTag, opensciencePackageSpec } from "../lib/channel.mjs"
 
 const SELF_PATH = (() => {
   try {
@@ -31,6 +32,15 @@ const SELF_PATH = (() => {
     return ""
   }
 })()
+const LAUNCHER_VERSION = (() => {
+  try {
+    return JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf-8")).version || "0.0.0"
+  } catch {
+    return "0.0.0"
+  }
+})()
+const OPENSCIENCE_NPM_TAG = npmDistTag(LAUNCHER_VERSION)
+const OPENSCIENCE_NPM_SPEC = opensciencePackageSpec(LAUNCHER_VERSION)
 
 const BOLD = "\x1b[1m"
 const DIM = "\x1b[2m"
@@ -278,13 +288,13 @@ async function main() {
     } else {
       const s = spinner("Checking for updates...")
       const current = raw.replace(/[^0-9.]/g, "")
-      const latest = runQuiet("npm view @synsci/openscience version")
+      const latest = runQuiet(`npm view @synsci/openscience@${OPENSCIENCE_NPM_TAG} version`)
       if (!latest || current === latest) {
         s.ok(`openscience ${current} ${DIM}(up to date)${RESET}`)
       } else {
         s.update(`Upgrading ${current} → ${latest}...`)
         try {
-          execCli(cliPath, ["upgrade"], { stdio: "pipe" })
+          execCli(cliPath, ["upgrade", latest], { stdio: "pipe" })
           s.ok(`Upgraded to ${latest}`)
         } catch {
           s.warn(`Upgrade failed, continuing with ${current}`)
@@ -295,7 +305,7 @@ async function main() {
     const s = spinner("Installing OpenScience...")
     try {
       try {
-        execSync("npm i -g @synsci/openscience@latest", { stdio: "pipe" })
+        execSync(`npm i -g ${OPENSCIENCE_NPM_SPEC}`, { stdio: "pipe" })
       } catch (e) {
         // npm refuses to overwrite a bin file owned by another package
         // (EEXIST). If the conflict is the deprecated @synsci/cli, remove it
@@ -306,7 +316,7 @@ async function main() {
         s.update("Removing the deprecated @synsci/cli so it can't shadow the openscience command...")
         runQuiet("npm rm -g @synsci/cli")
         s.update("Retrying the OpenScience install...")
-        execSync("npm i -g @synsci/openscience@latest", { stdio: "pipe" })
+        execSync(`npm i -g ${OPENSCIENCE_NPM_SPEC}`, { stdio: "pipe" })
       }
       cliPath = resolveCli()
       if (!cliPath) throw new Error("openscience not on PATH after install")
@@ -316,7 +326,7 @@ async function main() {
       // no bash to pipe it into, so don't suggest a fallback that can't run.
       if (process.platform === "win32") {
         s.fail("Install failed")
-        console.log(`\n  Try manually: ${CYAN}npm i -g @synsci/openscience${RESET}\n`)
+        console.log(`\n  Try manually: ${CYAN}npm i -g ${OPENSCIENCE_NPM_SPEC}${RESET}\n`)
         process.exit(1)
       }
       // Global npm installs commonly fail on permissions. Fall back to the
@@ -330,7 +340,7 @@ async function main() {
         s.ok("Installed OpenScience")
       } catch (e2) {
         s.fail(`Install failed${e2 && e2.message ? ": " + e2.message : ""}`)
-        console.log(`\n  Try manually: ${CYAN}npm i -g @synsci/openscience${RESET}`)
+        console.log(`\n  Try manually: ${CYAN}npm i -g ${OPENSCIENCE_NPM_SPEC}${RESET}`)
         console.log(`  or:           ${CYAN}curl -fsSL https://openscience.sh/install | bash${RESET}\n`)
         process.exit(1)
       }

--- a/tooling/launcher/lib/channel.mjs
+++ b/tooling/launcher/lib/channel.mjs
@@ -1,0 +1,12 @@
+const known = new Set(["latest", "ci", "dev", "beta", "test"])
+
+export function npmDistTag(version) {
+  const value = String(version || "")
+  const match = value.match(/^\d+\.\d+\.\d+-([0-9A-Za-z]+)(?:[.-]|$)/)
+  const tag = match?.[1] || "latest"
+  return known.has(tag) ? tag : "latest"
+}
+
+export function opensciencePackageSpec(version) {
+  return `@synsci/openscience@${npmDistTag(version)}`
+}

--- a/tooling/launcher/package.json
+++ b/tooling/launcher/package.json
@@ -8,7 +8,8 @@
     "synsci": "bin/synsci.mjs"
   },
   "files": [
-    "bin"
+    "bin",
+    "lib"
   ],
   "keywords": [
     "openscience",

--- a/tooling/repo/publish.ts
+++ b/tooling/repo/publish.ts
@@ -110,10 +110,6 @@ try {
 console.log("\n=== launcher (openscience) ===\n")
 try {
   const launcherDir = new URL("../launcher", import.meta.url).pathname
-  // Pin @synsci/openscience dependency to the version being published.
-  // Defensive: initialize `dependencies` if the launcher's package.json
-  // was authored without it — happened on the v1.1.117 publish (broken
-  // launcher step). Empty object is fine since we only need the pin.
   const launcherPkg = await Bun.file(`${launcherDir}/package.json`).json()
   // Keep the launcher version in lockstep with the just-released @synsci/openscience.
   // Without this, each subsequent publish would npm-error with "cannot
@@ -141,6 +137,11 @@ try {
     // chase (`npm owner add <token-user> synsci`), not a broken release —
     // every other package shipped, so warn loudly instead of failing.
     if (stderr.includes("E403") || stderr.includes("do not have permission")) {
+      if (process.env.OPENSCIENCE_REQUIRE_LAUNCHER_PUBLISH === "true") {
+        throw new Error(
+          "npm token's account is not an owner of the 'synsci' package; refusing to pass the test publish without launcher coverage",
+        )
+      }
       // A GitHub Actions annotation, so this shows on the run summary
       // instead of being a log line nobody reads on a green run.
       console.warn(


### PR DESCRIPTION
## Summary
- add a manual npm test-publish workflow that builds and publishes the OpenScience test lane under the `test` dist-tag
- verify installed `@synsci/openscience@test`, bundled Atlas resolution, optional Atlas doctor, packaged e2e, and OS smoke installs
- teach the `synsci@test` launcher and OpenScience upgrade checker to follow the `test` dist-tag instead of production `latest`

## Validation
- `bun run format:check`
- `bun run typecheck`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/npm-test.yml"); puts "workflow yaml parses"' && node --check tooling/launcher/bin/synsci.mjs`\n- `cd backend/cli && bun test --timeout 15000`