### PR TITLE
fix npm test workflow Playwright cache

### DIFF
--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -119,6 +119,8 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
+      - name: Set Playwright browser path
+        run: echo "PLAYWRIGHT_BROWSERS_PATH=$RUNNER_TEMP/ms-playwright" >> "$GITHUB_ENV"
       - name: Install Playwright browsers
         working-directory: frontend/workspace
         run: bunx playwright install --with-deps


### PR DESCRIPTION
## Summary
- pin packaged-e2e Playwright browsers to a stable runner temp path
- keeps browser install and browser launch from disagreeing after the workflow isolates XDG cache paths

## Validation
- `bun run format:check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/npm-test.yml"); puts "workflow yaml parses"'`