### PR TITLE
Route managed models through OpenRouter

### DIFF
--- a/backend/cli/src/config/config.ts
+++ b/backend/cli/src/config/config.ts
@@ -194,8 +194,8 @@ export namespace Config {
     try {
       // Atlas writes model-lockdown config (enabled_providers, per-provider
       // whitelists, default model) for the hosted web agents. On the CLI the
-      // managed routes are OpenRouter plus the narrow Meta/Muse proxy. Honour
-      // those managed catalogs and the recommended model; drop the rest
+      // managed route is OpenRouter. Honour that managed catalog and the
+      // recommended model; drop the rest
       // UNCONDITIONALLY — the
       // synced enabled_providers must never hide a locally-configured BYOK
       // provider, regardless of the billing toggle. An open-source CLI shouldn't
@@ -206,10 +206,9 @@ export namespace Config {
       const scoped: Partial<Config.Info> = {}
       const managedProviders = {
         ...(synced?.provider?.openrouter ? { openrouter: synced.provider.openrouter } : {}),
-        ...(synced?.provider?.meta ? { meta: synced.provider.meta } : {}),
       }
       if (Object.keys(managedProviders).length) scoped.provider = managedProviders
-      if (synced?.model) scoped.model = synced.model
+      if (typeof synced?.model === "string" && synced.model.startsWith("openrouter/")) scoped.model = synced.model
       // Merge synced UNDERNEATH the user's own config, not on top: it is the
       // server's *recommendation* (default model, OpenRouter managed catalog),
       // not a lockdown, so the user's config must win — otherwise their chosen

--- a/backend/cli/src/openscience/index.ts
+++ b/backend/cli/src/openscience/index.ts
@@ -89,6 +89,7 @@ const SHARED_PROVIDER_KEYS = new Set([
   "GOOGLE_GENERATIVE_AI_API_KEY",
   "GEMINI_API_KEY",
   "META_MODEL_API_KEY",
+  "META_MODEL_BASE_URL",
   "XAI_API_KEY",
 ])
 
@@ -824,8 +825,8 @@ export namespace OpenScience {
         }
       }
 
-      // OpenScience honours only the narrow OpenRouter + Meta managed routes,
-      // plus compute / ML-service credentials from Atlas sync; every other
+      // OpenScience honours only the narrow OpenRouter managed route, plus
+      // compute / ML-service credentials from Atlas sync; every other
       // model provider is BYOK-local-only. Drop the rest before they are applied or
       // persisted — and the unset pass below removes any a previous sync wrote,
       // so this doubles as the migration for existing installs. See

--- a/backend/cli/src/openscience/synced-env-policy.ts
+++ b/backend/cli/src/openscience/synced-env-policy.ts
@@ -1,11 +1,11 @@
 /**
  * Which Atlas-synced env vars the CLI is allowed to apply.
  *
- * OpenScience routes managed LLM calls through two explicit seams: OpenRouter
- * for the aggregated catalog, and Meta for Muse Spark. Both receive only an
- * Atlas `thk_*` token plus their Atlas proxy URL. Every other model provider
- * (Anthropic, OpenAI, Gemini, Together, Groq, Fireworks, xAI, Mistral,
- * DeepSeek, Cerebras, and Codex) is BYOK-only, configured locally with a shell `export`,
+ * OpenScience routes managed LLM calls through one explicit seam: OpenRouter
+ * for the aggregated catalog. It receives only an Atlas `thk_*` token plus
+ * the Atlas proxy URL. Every other model provider (Anthropic, OpenAI, Gemini,
+ * Meta, Together, Groq, Fireworks, xAI, Mistral, DeepSeek, Cerebras, and Codex)
+ * is BYOK-only, configured locally with a shell `export`,
  * `openscience keys add`, or Codex OAuth.
  *
  * Atlas still emits per-provider LLM credentials over `/api/cli/sync` for the
@@ -24,7 +24,7 @@ import { managedApiBase } from "../endpoints"
  *  credential. Single source of truth — openscience/index.ts imports this for
  *  its subprocess-redaction set, and the sync blocklist below derives from it,
  *  so the two can never drift. OpenRouter is included (its own key is BYOK too)
- *  but the two managed-capable credentials are kept OUT of the blocklist. */
+ *  but the managed OpenRouter credential is kept OUT of the blocklist. */
 export const BYOK_LLM_ENV_KEYS = [
   "ANTHROPIC_API_KEY",
   "OPENAI_API_KEY",
@@ -42,10 +42,9 @@ export const BYOK_LLM_ENV_KEYS = [
   "CEREBRAS_API_KEY",
 ]
 
-const MANAGED_SYNCED_LLM_KEYS = new Set(["OPENROUTER_API_KEY", "META_MODEL_API_KEY"])
+const MANAGED_SYNCED_LLM_KEYS = new Set(["OPENROUTER_API_KEY"])
 const MANAGED_SYNCED_BASE_URLS: Record<string, string> = {
   OPENROUTER_BASE_URL: "/api/llm/proxy/openrouter/",
-  META_MODEL_BASE_URL: "/api/llm/proxy/meta/",
 }
 
 /** Match a proxy URL to the configured Atlas origin and an exact route prefix.
@@ -75,7 +74,7 @@ export function isAtlasProxyURL(
 }
 
 /** Env vars the CLI drops from Atlas sync: every BYOK model provider EXCEPT
- *  OpenRouter and Meta, each with its `*_BASE_URL` companion. Derived from
+ *  OpenRouter, each with its `*_BASE_URL` companion. Derived from
  *  BYOK_LLM_ENV_KEYS so a newly-added provider is covered automatically. */
 export const BLOCKED_SYNCED_ENV = new Set<string>(
   BYOK_LLM_ENV_KEYS.filter((key) => !MANAGED_SYNCED_LLM_KEYS.has(key)).flatMap((key) => [
@@ -85,7 +84,7 @@ export const BLOCKED_SYNCED_ENV = new Set<string>(
 )
 
 /** True when an Atlas-synced env var may be applied to the CLI process.
- *  OpenRouter + Meta managed routing vars and all compute / ML-service keys pass
+ *  OpenRouter managed routing vars and all compute / ML-service keys pass
  *  through; every other model-provider LLM credential is dropped because that
  *  provider is BYOK-local-only. */
 export function isSyncedEnvAllowed(key: string, value?: string, atlasBase = managedApiBase()): boolean {

--- a/backend/cli/src/provider/provider.ts
+++ b/backend/cli/src/provider/provider.ts
@@ -172,11 +172,11 @@ export namespace Provider {
     const managed =
       isAtlasProxyBaseURL(baseURL) && (await Config.get().catch(() => undefined))?.billing?.llm === "managed"
     if (!managed) return {}
-    // Managed wallet routes are deliberately narrow: OpenRouter for its
-    // aggregated catalog and Meta for Muse Spark. Never attach the wallet's
-    // thk_ token to any other first-party proxy (anthropic / openai / google /
-    // xAI). Those providers are also dropped from availability below, so this
-    // is belt-and-suspenders.
+    // Managed wallet routes are deliberately narrow: OpenRouter for the
+    // aggregated catalog. Never attach the wallet's thk_ token to any other
+    // first-party proxy (anthropic / openai / google / xAI / Meta). Those
+    // providers are also dropped from availability below, so this is
+    // belt-and-suspenders.
     if (!managedProviderAllowed(providerID)) return {}
     const session = await OpenScience.getSession().catch(() => null)
     return session?.api_key ? { apiKey: session.api_key } : {}
@@ -223,9 +223,9 @@ export namespace Provider {
   /** Managed wallet ⇒ curated managed-provider routing.
    *
    *  When the LLM spend toggle is explicitly "managed", every wallet inference
-   *  call flows through OpenRouter, except Muse Spark which uses Atlas's narrow
-   *  Meta proxy. The other first-party managed proxies (anthropic / openai /
-   *  google / xAI) are taken out of the managed path entirely; the hosted
+   *  call flows through OpenRouter. The other first-party managed proxies
+   *  (anthropic / openai / google / xAI / Meta) are taken out of the managed
+   *  path entirely; the hosted
    *  zero-cost `synsci` demo provider is kept. BYOK and the legacy
    *  auto-detect path (`billing.llm` unset / null / "byok") are UNTOUCHED —
    *  this only fires on an explicit managed-wallet opt-in. Pure + sync. */
@@ -234,9 +234,32 @@ export namespace Provider {
   }
 
   /** Providers a managed wallet session may load: OpenRouter for aggregated
-   *  inference, Meta for Muse Spark, plus the hosted `synsci` demo. Pure. */
+   *  inference, plus the hosted `synsci` demo. Pure. */
   export function managedProviderAllowed(providerID: string): boolean {
-    return providerID === "openrouter" || providerID === "meta" || providerID.startsWith("synsci")
+    return providerID === "openrouter" || providerID.startsWith("synsci")
+  }
+
+  const OPENROUTER_VENDOR_PREFIX: Record<string, string> = {
+    gemini: "google",
+    google: "google",
+    xai: "x-ai",
+    meta: "meta",
+    zai: "z-ai",
+    zhipuai: "z-ai",
+  }
+
+  const ANTHROPIC_DASHED_VERSION = /^(claude-(?:opus|sonnet|haiku)-\d+)-(\d+)(?:-\d{8})?$/
+
+  function openrouterAliasCandidates(providerID: string, modelID: string) {
+    if (providerID === "openrouter") return []
+    const vendor = OPENROUTER_VENDOR_PREFIX[providerID] ?? providerID
+    const base = modelID.replace(/^~/, "")
+    if (!vendor || !base) return []
+    const direct = `${vendor}/${base}`
+    const normalized =
+      vendor === "anthropic" ? `${vendor}/${base.replace(ANTHROPIC_DASHED_VERSION, "$1.$2")}` : direct
+    const aliased = providerID === "openai" && base === "gpt-5.6" ? ["openai/gpt-5.6-sol"] : []
+    return Array.from(new Set([direct, normalized, ...aliased]))
   }
 
   /** True when a base URL points at the local machine (localhost / loopback).
@@ -587,11 +610,9 @@ export namespace Provider {
       return { autoload: false, options: { headers } }
     },
     meta: async () => {
-      // Meta has the same dual-route contract as OpenRouter, but only for the
-      // Muse catalog: a user-owned key always goes directly to Meta (or their
-      // explicitly configured non-Atlas compatible gateway); otherwise an
-      // Atlas session may route with its thk_* token through the Meta proxy.
-      // The upstream/shared Meta credential never exists in the client.
+      // Meta is BYOK-only in the client. Managed Muse Spark now routes through
+      // OpenRouter's `meta/muse-spark-1.1` slug, so stale Atlas Meta proxy env
+      // from older syncs must not create a managed Meta provider.
       const auth = await Auth.get("meta").catch(() => undefined)
       const authKey = auth?.type === "api" ? auth.key : undefined
       const envKey = Env.get("META_MODEL_API_KEY")
@@ -603,19 +624,6 @@ export namespace Provider {
           autoload: false,
           options: { apiKey: ownKey, baseURL },
           getModel: async (sdk, modelID) => sdk.responses(modelID),
-        }
-      }
-
-      const proxyBase = Env.get("META_MODEL_BASE_URL")
-      if (isAtlasProxyBaseURL(proxyBase)) {
-        const session = await OpenScience.getSession().catch(() => null)
-        const managedKey = session?.api_key ?? (isAtlasApiKey(envKey) ? envKey : undefined)
-        if (managedKey) {
-          return {
-            autoload: false,
-            options: { apiKey: managedKey, baseURL: proxyBase },
-            getModel: async (sdk, modelID) => sdk.responses(modelID),
-          }
         }
       }
 
@@ -1076,8 +1084,8 @@ export namespace Provider {
     const disabled = new Set(config.disabled_providers ?? [])
     const enabled = config.enabled_providers ? new Set(config.enabled_providers) : null
     // Managed wallet ⇒ curated routes only. OpenRouter handles the aggregated
-    // catalog, while Muse Spark uses the narrow Meta proxy. Every other
-    // first-party managed proxy is dropped. Gated on the explicit toggle, so
+    // catalog. Every other first-party managed proxy is dropped. Gated on the
+    // explicit toggle, so
     // BYOK and legacy auto-detect sessions see every provider as before. This is
     // the single seam that makes defaultModel()/getSmallModel() managed-safe.
     const managedCuratedProvidersOnly = managedRoutesCuratedProvidersOnly(config)
@@ -1475,6 +1483,20 @@ export namespace Provider {
     _stateCacheDirectory = undefined
   }
 
+  function resolveOpenRouterAlias(s: Awaited<ReturnType<typeof state>>, providerID: string, modelID: string) {
+    const openrouter = s.providers["openrouter"]
+    if (!openrouter) return undefined
+    for (const alias of openrouterAliasCandidates(providerID, modelID)) {
+      const model = openrouter.models[alias]
+      if (model) return model
+    }
+  }
+
+  function resolveAvailableModel(s: Awaited<ReturnType<typeof state>>, providerID: string, modelID: string) {
+    const exact = s.providers[providerID]?.models[modelID]
+    return exact ?? resolveOpenRouterAlias(s, providerID, modelID)
+  }
+
   export async function list() {
     return state().then((state) => state.providers)
   }
@@ -1648,6 +1670,9 @@ export namespace Provider {
 
   export async function getModel(providerID: string, modelID: string) {
     const s = await state()
+    const resolved = resolveAvailableModel(s, providerID, modelID)
+    if (resolved) return resolved
+
     const provider = s.providers[providerID]
     if (!provider) {
       const availableProviders = Object.keys(s.providers)
@@ -1656,14 +1681,10 @@ export namespace Provider {
       throw new ModelNotFoundError({ providerID, modelID, suggestions })
     }
 
-    const info = provider.models[modelID]
-    if (!info) {
-      const availableModels = Object.keys(provider.models)
-      const matches = fuzzysort.go(modelID, availableModels, { limit: 3, threshold: -10000 })
-      const suggestions = matches.map((m) => m.target)
-      throw new ModelNotFoundError({ providerID, modelID, suggestions })
-    }
-    return info
+    const availableModels = Object.keys(provider.models)
+    const matches = fuzzysort.go(modelID, availableModels, { limit: 3, threshold: -10000 })
+    const suggestions = matches.map((m) => m.target)
+    throw new ModelNotFoundError({ providerID, modelID, suggestions })
   }
 
   export async function getLanguage(model: Model): Promise<LanguageModelV2> {
@@ -1794,7 +1815,8 @@ export namespace Provider {
       // (e.g. a saved `anthropic/...` model with no API key must not be returned)
       // — otherwise fall through to the priority-based selection below.
       const parsed = parseModel(cfg.model)
-      if (available[parsed.providerID]?.models[parsed.modelID]) return parsed
+      const resolved = resolveAvailableModel(await state(), parsed.providerID, parsed.modelID)
+      if (resolved) return { providerID: resolved.providerID, modelID: resolved.id }
       log.warn("configured model is not available, falling back to default selection", parsed)
     }
 

--- a/backend/cli/src/session/prompt.ts
+++ b/backend/cli/src/session/prompt.ts
@@ -940,8 +940,11 @@ export namespace SessionPrompt {
       // A historical model can reference a provider that is no longer available
       // (e.g. its API key was removed) — validate before reusing it.
       const model = item.info.model
-      const provider = await Provider.getProvider(model.providerID)
-      if (provider?.models[model.modelID]) return model
+      const resolved = await Provider.getModel(model.providerID, model.modelID).catch((e) => {
+        if (Provider.ModelNotFoundError.isInstance(e)) return undefined
+        throw e
+      })
+      if (resolved) return { providerID: resolved.providerID, modelID: resolved.id }
       log.warn("last used model is no longer available, falling back to default", model)
       break
     }

--- a/backend/cli/test/config/synced-merge.test.ts
+++ b/backend/cli/test/config/synced-merge.test.ts
@@ -70,7 +70,7 @@ describe("Atlas synced-config merge", () => {
     })
   })
 
-  test("synced Meta whitelist is retained for the managed Muse route", async () => {
+  test("stale synced Meta model config is ignored because managed Muse routes through OpenRouter", async () => {
     await writeSynced({
       model: "meta/muse-spark-1.1",
       provider: { meta: { whitelist: ["muse-spark-1.1"] } },
@@ -81,8 +81,8 @@ describe("Atlas synced-config merge", () => {
       directory: tmp.path,
       fn: async () => {
         const config = await Config.get()
-        expect(config.model).toBe("meta/muse-spark-1.1")
-        expect(config.provider?.meta?.whitelist).toEqual(["muse-spark-1.1"])
+        expect(config.model).toBeUndefined()
+        expect(config.provider?.meta).toBeUndefined()
       },
     })
   })

--- a/backend/cli/test/openscience-env.test.ts
+++ b/backend/cli/test/openscience-env.test.ts
@@ -18,7 +18,7 @@ test("subprocess env filtering never passes managed Atlas provider keys", () => 
   expect(filtered.META_MODEL_API_KEY).toBeUndefined()
   expect(filtered.XAI_API_KEY).toBeUndefined()
   expect(filtered.OPENROUTER_BASE_URL).toBe("https://atlas.test/api/llm/proxy/openrouter/v1")
-  expect(filtered.META_MODEL_BASE_URL).toBe("https://atlas.test/api/llm/proxy/meta/v1")
+  expect(filtered.META_MODEL_BASE_URL).toBeUndefined()
 })
 
 test("subprocess env filtering still passes BYOK OpenRouter keys", () => {

--- a/backend/cli/test/openscience/sync-precedence.test.ts
+++ b/backend/cli/test/openscience/sync-precedence.test.ts
@@ -9,8 +9,8 @@ import { managedApiBase } from "../../src/endpoints"
 // with a managed thk_ value, which would silently turn a free BYOK call into a
 // billed managed one (the "billing flip" bug).
 //
-// OpenRouter and Meta are the only providers Atlas sync may deliver a managed
-// credential for; every other model provider is BYOK-local-only, so its synced credential is dropped
+// OpenRouter is the only provider Atlas sync may deliver a managed credential
+// for; every other model provider is BYOK-local-only, so its synced credential is dropped
 // (see synced-env-policy.ts) — Atlas still emits them for the hosted web agents.
 
 const realFetch = globalThis.fetch
@@ -60,7 +60,7 @@ test("a synced managed OpenRouter key IS applied when the slot is empty", async 
   expect(process.env["OPENROUTER_API_KEY"]).toBe("thk_managed.value")
 })
 
-test("Meta sync applies only a scoped thk token plus the matching Atlas proxy", async () => {
+test("Meta sync is dropped even when it looks like an old managed route", async () => {
   await seedSession()
   const proxyURL = `${managedApiBase()}/api/llm/proxy/meta/v1`
   stubSync({
@@ -70,8 +70,8 @@ test("Meta sync applies only a scoped thk token plus the matching Atlas proxy", 
     },
   })
   await OpenScience.syncServices()
-  expect(process.env["META_MODEL_API_KEY"]).toBe("thk_managed.value")
-  expect(process.env["META_MODEL_BASE_URL"]).toBe(proxyURL)
+  expect(process.env["META_MODEL_API_KEY"]).toBeUndefined()
+  expect(process.env["META_MODEL_BASE_URL"]).toBeUndefined()
 })
 
 test("Meta sync rejects an upstream shared key or public endpoint", async () => {

--- a/backend/cli/test/openscience/synced-env-policy.test.ts
+++ b/backend/cli/test/openscience/synced-env-policy.test.ts
@@ -16,6 +16,8 @@ test("blocks every non-managed model-provider LLM credential (key + *_BASE_URL)"
     "GROQ_API_KEY",
     "FIREWORKS_API_KEY",
     "XAI_API_KEY",
+    "META_MODEL_API_KEY",
+    "META_MODEL_BASE_URL",
     // Derived from BYOK_LLM_ENV_KEYS — these three used to be missing from the
     // hand-maintained blocklist; deriving keeps them covered automatically.
     "MISTRAL_API_KEY",
@@ -29,12 +31,10 @@ test("blocks every non-managed model-provider LLM credential (key + *_BASE_URL)"
   }
 })
 
-test("allows the OpenRouter + Meta managed routes and compute / ML-service keys", () => {
+test("allows the OpenRouter managed route and compute / ML-service keys", () => {
   const allowed = [
     "OPENROUTER_API_KEY",
     "OPENROUTER_BASE_URL",
-    "META_MODEL_API_KEY",
-    "META_MODEL_BASE_URL",
     "TINKER_API_KEY",
     "WANDB_API_KEY",
     "HF_TOKEN",
@@ -50,20 +50,27 @@ test("allows the OpenRouter + Meta managed routes and compute / ML-service keys"
 
 test("managed provider sync accepts only thk tokens and matching Atlas proxy urls", () => {
   const atlasBase = "https://atlas.test"
-  expect(isSyncedEnvAllowed("META_MODEL_API_KEY", "thk_user.scoped")).toBe(true)
-  expect(isSyncedEnvAllowed("META_MODEL_API_KEY", "meta-shared-secret")).toBe(false)
-  expect(isSyncedEnvAllowed("META_MODEL_BASE_URL", "https://atlas.test/api/llm/proxy/meta/v1", atlasBase)).toBe(true)
-  expect(isSyncedEnvAllowed("META_MODEL_BASE_URL", "https://api.meta.ai/v1", atlasBase)).toBe(false)
-  expect(isSyncedEnvAllowed("META_MODEL_BASE_URL", "https://atlas.test/api/llm/proxy/openrouter/v1", atlasBase)).toBe(
-    false,
+  expect(isSyncedEnvAllowed("OPENROUTER_API_KEY", "thk_user.scoped")).toBe(true)
+  expect(isSyncedEnvAllowed("OPENROUTER_API_KEY", "sk-or-shared-secret")).toBe(false)
+  expect(isSyncedEnvAllowed("OPENROUTER_BASE_URL", "https://atlas.test/api/llm/proxy/openrouter/v1", atlasBase)).toBe(
+    true,
   )
+  expect(isSyncedEnvAllowed("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1", atlasBase)).toBe(false)
   expect(
-    isSyncedEnvAllowed("META_MODEL_BASE_URL", "https://evil.test/https://atlas.test/api/llm/proxy/meta/v1", atlasBase),
+    isSyncedEnvAllowed(
+      "OPENROUTER_BASE_URL",
+      "https://evil.test/https://atlas.test/api/llm/proxy/openrouter/v1",
+      atlasBase,
+    ),
   ).toBe(false)
   expect(
-    isSyncedEnvAllowed("META_MODEL_BASE_URL", "https://atlas.test.evil.test/api/llm/proxy/meta/v1", atlasBase),
+    isSyncedEnvAllowed("OPENROUTER_BASE_URL", "https://atlas.test.evil.test/api/llm/proxy/openrouter/v1", atlasBase),
   ).toBe(false)
   expect(
-    isSyncedEnvAllowed("META_MODEL_BASE_URL", "https://atlas.test/api/llm/proxy/meta/%2e%2e/openrouter", atlasBase),
+    isSyncedEnvAllowed(
+      "OPENROUTER_BASE_URL",
+      "https://atlas.test/api/llm/proxy/openrouter/%2e%2e/meta",
+      atlasBase,
+    ),
   ).toBe(false)
 })

--- a/backend/cli/test/provider/managed-routing.test.ts
+++ b/backend/cli/test/provider/managed-routing.test.ts
@@ -64,14 +64,13 @@ describe("Provider.managedRoutesCuratedProvidersOnly (pure)", () => {
 })
 
 describe("Provider.managedProviderAllowed (pure)", () => {
-  test("OpenRouter, Meta, and the hosted synsci demo are the only allowed providers", () => {
+  test("OpenRouter and the hosted synsci demo are the only managed providers", () => {
     expect(Provider.managedProviderAllowed("openrouter")).toBe(true)
-    expect(Provider.managedProviderAllowed("meta")).toBe(true)
     expect(Provider.managedProviderAllowed("synsci")).toBe(true)
     expect(Provider.managedProviderAllowed("synsci-hosted")).toBe(true)
   })
-  test("first-party managed proxies + everything else are rejected", () => {
-    for (const id of ["anthropic", "openai", "google", "openai-codex", "github-copilot", "gateway", "azure"]) {
+  test("first-party managed proxies, Meta, Codex, and everything else are rejected", () => {
+    for (const id of ["anthropic", "openai", "google", "meta", "openai-codex", "github-copilot", "gateway", "azure"]) {
       expect(Provider.managedProviderAllowed(id)).toBe(false)
     }
   })
@@ -103,7 +102,7 @@ describe("Provider.isManagedProxyBaseURL (pure)", () => {
 // ── Availability filter (hermetic, catalog-backed) ───────────────────────────
 
 describe("managed session availability", () => {
-  test("managed ⇒ OpenRouter + Meta load; unsupported first-party proxies are dropped", async () => {
+  test("managed ⇒ only OpenRouter loads; unsupported first-party and Meta proxies are dropped", async () => {
     await using tmp = await tmpdir({ config: { billing: { llm: "managed" } } })
     await Instance.provide({
       directory: tmp.path,
@@ -125,13 +124,54 @@ describe("managed session availability", () => {
         const providers = await Provider.list()
         expect(providers["openrouter"]).toBeDefined()
         expect(providers["openrouter"].options.baseURL).toBe(`${PROXY}/openrouter/v1`)
-        expect(providers["meta"]).toBeDefined()
-        expect(String(providers["meta"].options.apiKey).startsWith("thk_")).toBe(true)
-        expect(providers["meta"].options.baseURL).toBe(`${PROXY}/meta/v1`)
-        expect(providers["meta"].models["muse-spark-1.1"]).toBeDefined()
+        expect(providers["meta"]).toBeUndefined()
         expect(providers["anthropic"]).toBeUndefined()
         expect(providers["openai"]).toBeUndefined()
         expect(providers["google"]).toBeUndefined()
+      },
+    })
+  })
+
+  test("managed direct model selections resolve to OpenRouter vendor slugs", async () => {
+    await using tmp = await tmpdir({
+      config: {
+        billing: { llm: "managed" },
+        provider: {
+          openrouter: {
+            whitelist: [
+              "anthropic/claude-fable-5",
+              "google/gemini-3.6-flash",
+              "x-ai/grok-4.5",
+              "meta/muse-spark-1.1",
+            ],
+          },
+        },
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      init: async () => {
+        clearManagedLLMEnv()
+        Env.set("OPENROUTER_API_KEY", "thk_openrouter")
+        Env.set("OPENROUTER_BASE_URL", `${PROXY}/openrouter/v1`)
+        Provider.invalidate()
+      },
+      fn: async () => {
+        const fable = await Provider.getModel("anthropic", "claude-fable-5")
+        expect(fable.providerID).toBe("openrouter")
+        expect(fable.id).toBe("anthropic/claude-fable-5")
+
+        const gemini = await Provider.getModel("gemini", "gemini-3.6-flash")
+        expect(gemini.providerID).toBe("openrouter")
+        expect(gemini.id).toBe("google/gemini-3.6-flash")
+
+        const grok = await Provider.getModel("xai", "grok-4.5")
+        expect(grok.providerID).toBe("openrouter")
+        expect(grok.id).toBe("x-ai/grok-4.5")
+
+        const muse = await Provider.getModel("meta", "muse-spark-1.1")
+        expect(muse.providerID).toBe("openrouter")
+        expect(muse.id).toBe("meta/muse-spark-1.1")
       },
     })
   })

--- a/backend/cli/test/provider/transform-reasoning.test.ts
+++ b/backend/cli/test/provider/transform-reasoning.test.ts
@@ -306,7 +306,7 @@ describe("new model reasoning effort contracts", () => {
     expect(ProviderTransform.smallOptions(managed)).toEqual({ reasoning: { effort: "low" } })
   })
 
-  test("Muse Spark 1.1 exposes its exact effort ladder on BYOK and managed Meta", () => {
+  test("Muse Spark 1.1 exposes its exact effort ladder on BYOK and legacy Meta proxy", () => {
     const muse = model({
       id: "muse-spark-1.1",
       providerID: "meta",

--- a/frontend/workspace/src/components/dialog-manage-models.tsx
+++ b/frontend/workspace/src/components/dialog-manage-models.tsx
@@ -3,6 +3,7 @@ import { List } from "@synsci/ui/list"
 import { Switch } from "@synsci/ui/switch"
 import type { Component } from "solid-js"
 import { useLocal } from "@/context/local"
+import { displayProviderForModel } from "@/context/model-catalog"
 import { popularProviders } from "@/hooks/use-providers"
 import { useLanguage } from "@/context/language"
 
@@ -19,10 +20,10 @@ export const DialogManageModels: Component = () => {
         items={local.model.list()}
         filterKeys={["provider.name", "name", "id"]}
         sortBy={(a, b) => a.name.localeCompare(b.name)}
-        groupBy={(x) => x.provider.name}
+        groupBy={(x) => displayProviderForModel(x.provider, x.id).name}
         sortGroupsBy={(a, b) => {
-          const aProvider = a.items[0].provider.id
-          const bProvider = b.items[0].provider.id
+          const aProvider = displayProviderForModel(a.items[0].provider, a.items[0].id).id
+          const bProvider = displayProviderForModel(b.items[0].provider, b.items[0].id).id
           if (popularProviders.includes(aProvider) && !popularProviders.includes(bProvider)) return -1
           if (!popularProviders.includes(aProvider) && popularProviders.includes(bProvider)) return 1
           return popularProviders.indexOf(aProvider) - popularProviders.indexOf(bProvider)

--- a/frontend/workspace/src/components/dialog-select-model.tsx
+++ b/frontend/workspace/src/components/dialog-select-model.tsx
@@ -15,6 +15,7 @@ import type { IconName } from "@synsci/ui/icons/provider"
 import { DialogManageModels } from "./dialog-manage-models"
 import { ModelTooltip } from "./model-tooltip"
 import { useLanguage } from "@/context/language"
+import { displayProviderForModel } from "@/context/model-catalog"
 
 const ModelList: Component<{
   provider?: string
@@ -29,7 +30,11 @@ const ModelList: Component<{
     local.model
       .list()
       .filter((m) => local.model.visible({ modelID: m.id, providerID: m.provider.id }))
-      .filter((m) => (props.provider ? m.provider.id === props.provider : true)),
+      .filter((m) => {
+        if (!props.provider) return true
+        const display = displayProviderForModel(m.provider, m.id)
+        return m.provider.id === props.provider || display.id === props.provider
+      }),
   )
 
   return (
@@ -42,10 +47,10 @@ const ModelList: Component<{
       current={local.model.current()}
       filterKeys={["provider.name", "name", "id"]}
       sortBy={(a, b) => a.name.localeCompare(b.name)}
-      groupBy={(x) => x.provider.name}
+      groupBy={(x) => displayProviderForModel(x.provider, x.id).name}
       sortGroupsBy={(a, b) => {
-        const aProvider = a.items[0].provider.id
-        const bProvider = b.items[0].provider.id
+        const aProvider = displayProviderForModel(a.items[0].provider, a.items[0].id).id
+        const bProvider = displayProviderForModel(b.items[0].provider, b.items[0].id).id
         if (popularProviders.includes(aProvider) && !popularProviders.includes(bProvider)) return -1
         if (!popularProviders.includes(aProvider) && popularProviders.includes(bProvider)) return 1
         return popularProviders.indexOf(aProvider) - popularProviders.indexOf(bProvider)
@@ -58,7 +63,7 @@ const ModelList: Component<{
           forceMount={false}
           value={
             <ModelTooltip
-              model={item}
+              model={{ ...item, provider: displayProviderForModel(item.provider, item.id) }}
               latest={item.latest}
               free={item.provider.id === "synsci" && (!item.cost || item.cost.input === 0)}
             />
@@ -76,7 +81,7 @@ const ModelList: Component<{
     >
       {(i) => (
         <div class="w-full flex items-center gap-x-2 text-13-regular">
-          <ProviderIcon id={i.provider.id as IconName} class="size-4 shrink-0 opacity-90" />
+          <ProviderIcon id={displayProviderForModel(i.provider, i.id).id as IconName} class="size-4 shrink-0 opacity-90" />
           <span class="truncate">{i.name}</span>
           <span class="flex items-center gap-x-1.5 ml-auto shrink-0">
             <Show when={i.provider.id === "synsci" && (!i.cost || i.cost?.input === 0)}>

--- a/frontend/workspace/src/components/prompt-input.tsx
+++ b/frontend/workspace/src/components/prompt-input.tsx
@@ -45,6 +45,7 @@ import { ImagePreview } from "@synsci/ui/image-preview"
 import { ModelSelectorPopover } from "@/components/dialog-select-model"
 import { DialogSelectModelUnpaid } from "@/components/dialog-select-model-unpaid"
 import { useProviders } from "@/hooks/use-providers"
+import { displayProviderForModel } from "@/context/model-catalog"
 import { useCommand } from "@/context/command"
 import { Persist, persisted } from "@/utils/persist"
 import { Identifier } from "@/utils/id"
@@ -1987,7 +1988,13 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                       >
                         <Button as="div" variant="ghost" onClick={() => dialog.show(() => <DialogSelectModelUnpaid />)}>
                           <Show when={local.model.current()?.provider?.id}>
-                            <ProviderIcon id={local.model.current()!.provider.id as IconName} class="size-4 shrink-0" />
+                            <ProviderIcon
+                              id={
+                                displayProviderForModel(local.model.current()!.provider, local.model.current()!.id)
+                                  .id as IconName
+                              }
+                              class="size-4 shrink-0"
+                            />
                           </Show>
                           {local.model.current()?.name ?? language.t("dialog.model.select.title")}
                           <Icon name="chevron-down" size="small" />
@@ -2002,7 +2009,13 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                     >
                       <ModelSelectorPopover triggerAs={Button} triggerProps={{ variant: "ghost" }}>
                         <Show when={local.model.current()?.provider?.id}>
-                          <ProviderIcon id={local.model.current()!.provider.id as IconName} class="size-4 shrink-0" />
+                          <ProviderIcon
+                            id={
+                              displayProviderForModel(local.model.current()!.provider, local.model.current()!.id)
+                                .id as IconName
+                            }
+                            class="size-4 shrink-0"
+                          />
                         </Show>
                         {local.model.current()?.name ?? language.t("dialog.model.select.title")}
                         <Icon name="chevron-down" size="small" />

--- a/frontend/workspace/src/context/local.tsx
+++ b/frontend/workspace/src/context/local.tsx
@@ -6,6 +6,7 @@ import { useSync } from "./sync"
 import { base64Encode } from "@synsci/util/encode"
 import { useProviders } from "@/hooks/use-providers"
 import { useModels } from "@/context/models"
+import { routableModelKey } from "@/context/model-catalog"
 
 export type ModelKey = { providerID: string; modelID: string }
 
@@ -15,8 +16,9 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
     const sdk = useSDK()
     const sync = useSync()
     const providers = useProviders()
+    const models = useModels()
 
-    function isModelValid(model: ModelKey) {
+    function isExactModelValid(model: ModelKey) {
       const provider = providers.all().find((x) => x.id === model.providerID)
       return (
         !!provider?.models[model.modelID] &&
@@ -27,11 +29,21 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       )
     }
 
+    function resolveModel(model: ModelKey) {
+      const routed = routableModelKey(model, isExactModelValid)
+      if (isExactModelValid(routed)) return routed
+    }
+
+    function isModelValid(model: ModelKey) {
+      return !!resolveModel(model)
+    }
+
     function getFirstValidModel(...modelFns: (() => ModelKey | undefined)[]) {
       for (const modelFn of modelFns) {
         const model = modelFn()
         if (!model) continue
-        if (isModelValid(model)) return model
+        const resolved = resolveModel(model)
+        if (resolved) return resolved
       }
     }
 
@@ -159,8 +171,6 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
     })()
 
     const model = (() => {
-      const models = useModels()
-
       const [ephemeral, setEphemeral] = createStore<{
         model: Record<string, ModelKey | undefined>
       }>({
@@ -169,19 +179,15 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
 
       const fallbackModel = createMemo<ModelKey | undefined>(() => {
         if (sync.data.config.model) {
-          const [providerID, modelID] = sync.data.config.model.split("/")
-          if (isModelValid({ providerID, modelID })) {
-            return {
-              providerID,
-              modelID,
-            }
-          }
+          const [providerID, ...parts] = sync.data.config.model.split("/")
+          const modelID = parts.join("/")
+          const resolved = resolveModel({ providerID, modelID })
+          if (resolved) return resolved
         }
 
         for (const item of models.recent.list()) {
-          if (isModelValid(item)) {
-            return item
-          }
+          const resolved = resolveModel(item)
+          if (resolved) return resolved
         }
 
         const defaults = providers.default()
@@ -213,7 +219,9 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         return models.find(key)
       })
 
-      const recent = createMemo(() => models.recent.list().map(models.find).filter(Boolean))
+      const recent = createMemo(() =>
+        models.recent.list().map((item) => models.find(resolveModel(item) ?? item)).filter(Boolean),
+      )
 
       const cycle = (direction: 1 | -1) => {
         const recentList = recent()
@@ -247,10 +255,11 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         set(model: ModelKey | undefined, options?: { recent?: boolean }) {
           batch(() => {
             const currentAgent = agent.current()
-            const next = model ?? fallbackModel()
+            const selected = model ? (resolveModel(model) ?? model) : undefined
+            const next = selected ?? fallbackModel()
             if (currentAgent) setEphemeral("model", currentAgent.name, next)
-            if (model) models.setVisibility(model, true)
-            if (options?.recent && model) models.recent.push(model)
+            if (selected) models.setVisibility(selected, true)
+            if (options?.recent && selected) models.recent.push(selected)
           })
         },
         visible(model: ModelKey) {

--- a/frontend/workspace/src/context/model-catalog.ts
+++ b/frontend/workspace/src/context/model-catalog.ts
@@ -1,4 +1,34 @@
 export type ModelKey = { providerID: string; modelID: string }
+export type ModelProviderDisplay = { id: string; name: string }
+
+const OPENROUTER_VENDOR_DISPLAY: Record<string, ModelProviderDisplay> = {
+  anthropic: { id: "anthropic", name: "Anthropic" },
+  openai: { id: "openai", name: "OpenAI" },
+  google: { id: "google", name: "Google" },
+  gemini: { id: "google", name: "Google" },
+  "x-ai": { id: "xai", name: "xAI" },
+  xai: { id: "xai", name: "xAI" },
+  meta: { id: "meta", name: "Meta" },
+  "meta-llama": { id: "llama", name: "Meta Llama" },
+  deepseek: { id: "deepseek", name: "DeepSeek" },
+  moonshotai: { id: "moonshotai", name: "Moonshot AI" },
+  "z-ai": { id: "zai", name: "Z.AI" },
+  zhipuai: { id: "zhipuai", name: "Zhipu AI" },
+  zai: { id: "zai", name: "Z.AI" },
+  mistralai: { id: "mistral", name: "Mistral" },
+  qwen: { id: "openrouter", name: "Qwen" },
+}
+
+const OPENROUTER_PROVIDER_PREFIX: Record<string, string> = {
+  gemini: "google",
+  google: "google",
+  xai: "x-ai",
+  meta: "meta",
+  zai: "z-ai",
+  zhipuai: "z-ai",
+}
+
+const ANTHROPIC_DASHED_VERSION = /^(claude-(?:opus|sonnet|haiku)-\d+)-(\d+)(?:-\d{8})?$/
 
 // The curated "frontier" set shown in the model picker by default. Everything
 // else stays in the catalog and is one click away in Manage Models. Matched by
@@ -7,20 +37,51 @@ export type ModelKey = { providerID: string; modelID: string }
 export const FRONTIER_MODELS = new Set([
   "openai/gpt-5-6", // GPT-5.6 / Sol alias
   "openai/gpt-5-6-sol",
+  "openai/gpt-5-6-sol-pro",
   "openai/gpt-5-6-terra",
+  "openai/gpt-5-6-terra-pro",
   "openai/gpt-5-6-luna",
+  "openai/gpt-5-6-luna-pro",
   "xai/grok-4-5",
+  "xai/grok-4-20-multi-agent",
   "meta/muse-spark-1-1",
   "openai/gpt-5-5",
+  "openai/gpt-5-5-pro",
   "openai/gpt-5-5-mini", // announced tier, not yet in the live catalog
   "anthropic/claude-sonnet-5",
   "anthropic/claude-opus-4-8",
   "anthropic/claude-fable-5",
+  "google/gemini-3-6-flash",
+  "google/gemini-3-1-pro-preview",
   "zai/glm-5-2",
   "moonshotai/kimi-k2-7-code",
+  "moonshotai/kimi-k3",
   "deepseek/deepseek-v4-pro",
   "deepseek/deepseek-v4-flash",
 ])
+
+export function openrouterModelAlias(providerID: string, modelID: string): ModelKey | undefined {
+  if (providerID === "openrouter") return undefined
+  const vendor = OPENROUTER_PROVIDER_PREFIX[providerID] ?? providerID
+  const base = modelID.replace(/^~/, "")
+  if (!vendor || !base) return undefined
+  const normalized = vendor === "anthropic" ? base.replace(ANTHROPIC_DASHED_VERSION, "$1.$2") : base
+  const alias = providerID === "openai" && base === "gpt-5.6" ? "gpt-5.6-sol" : normalized
+  return { providerID: "openrouter", modelID: `${vendor}/${alias}` }
+}
+
+export function routableModelKey(model: ModelKey, hasModel: (model: ModelKey) => boolean): ModelKey {
+  if (hasModel(model)) return model
+  const alias = openrouterModelAlias(model.providerID, model.modelID)
+  if (alias && hasModel(alias)) return alias
+  return model
+}
+
+export function displayProviderForModel(provider: ModelProviderDisplay, modelID: string): ModelProviderDisplay {
+  if (provider.id !== "openrouter") return provider
+  const [vendor] = modelID.replace(/^~/, "").split("/")
+  return OPENROUTER_VENDOR_DISPLAY[vendor?.toLowerCase() ?? ""] ?? provider
+}
 
 /** Stable key shared by native ids and OpenRouter vendor/model slugs. */
 export function canonicalKey(providerID: string, modelID: string): string {

--- a/frontend/workspace/src/context/models-catalog.test.ts
+++ b/frontend/workspace/src/context/models-catalog.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test"
-import { canonicalKey, FRONTIER_MODELS } from "./model-catalog"
+import {
+  canonicalKey,
+  displayProviderForModel,
+  FRONTIER_MODELS,
+  routableModelKey,
+} from "./model-catalog"
 
 describe("frontier model canonicalization", () => {
   test("direct and OpenRouter GPT-5.6 ids collapse to the same frontier keys", () => {
@@ -18,5 +23,55 @@ describe("frontier model canonicalization", () => {
 
   test("Muse Spark is part of the default frontier set", () => {
     expect(FRONTIER_MODELS.has(canonicalKey("meta", "muse-spark-1.1"))).toBe(true)
+  })
+
+  test("OpenRouter vendor slugs display under their branded provider families", () => {
+    const openrouter = { id: "openrouter", name: "OpenRouter" }
+    expect(displayProviderForModel(openrouter, "anthropic/claude-fable-5")).toEqual({
+      id: "anthropic",
+      name: "Anthropic",
+    })
+    expect(displayProviderForModel(openrouter, "openai/gpt-5.6-sol")).toEqual({ id: "openai", name: "OpenAI" })
+    expect(displayProviderForModel(openrouter, "google/gemini-3.6-flash")).toEqual({ id: "google", name: "Google" })
+    expect(displayProviderForModel(openrouter, "x-ai/grok-4.5")).toEqual({ id: "xai", name: "xAI" })
+    expect(displayProviderForModel(openrouter, "z-ai/glm-5.2")).toEqual({ id: "zai", name: "Z.AI" })
+  })
+
+  test("stale direct model selections route to managed OpenRouter aliases when present", () => {
+    const available = new Set([
+      "openrouter:anthropic/claude-opus-4.8",
+      "openrouter:anthropic/claude-fable-5",
+      "openrouter:openai/gpt-5.6-sol",
+      "openrouter:google/gemini-3.6-flash",
+      "openrouter:x-ai/grok-4.5",
+      "openrouter:meta/muse-spark-1.1",
+    ])
+    const hasModel = (model: { providerID: string; modelID: string }) =>
+      available.has(`${model.providerID}:${model.modelID}`)
+
+    expect(routableModelKey({ providerID: "anthropic", modelID: "claude-fable-5" }, hasModel)).toEqual({
+      providerID: "openrouter",
+      modelID: "anthropic/claude-fable-5",
+    })
+    expect(routableModelKey({ providerID: "anthropic", modelID: "claude-opus-4-8" }, hasModel)).toEqual({
+      providerID: "openrouter",
+      modelID: "anthropic/claude-opus-4.8",
+    })
+    expect(routableModelKey({ providerID: "openai", modelID: "gpt-5.6" }, hasModel)).toEqual({
+      providerID: "openrouter",
+      modelID: "openai/gpt-5.6-sol",
+    })
+    expect(routableModelKey({ providerID: "gemini", modelID: "gemini-3.6-flash" }, hasModel)).toEqual({
+      providerID: "openrouter",
+      modelID: "google/gemini-3.6-flash",
+    })
+    expect(routableModelKey({ providerID: "xai", modelID: "grok-4.5" }, hasModel)).toEqual({
+      providerID: "openrouter",
+      modelID: "x-ai/grok-4.5",
+    })
+    expect(routableModelKey({ providerID: "meta", modelID: "muse-spark-1.1" }, hasModel)).toEqual({
+      providerID: "openrouter",
+      modelID: "meta/muse-spark-1.1",
+    })
   })
 })

--- a/frontend/workspace/src/context/models.tsx
+++ b/frontend/workspace/src/context/models.tsx
@@ -4,7 +4,7 @@ import { uniqueBy } from "remeda"
 import { createSimpleContext } from "@synsci/ui/context"
 import { useProviders } from "@/hooks/use-providers"
 import { Persist, persisted } from "@/utils/persist"
-import { isFrontier, type ModelKey } from "./model-catalog"
+import { isFrontier, routableModelKey, type ModelKey } from "./model-catalog"
 
 export { canonicalKey, FRONTIER_MODELS, type ModelKey } from "./model-catalog"
 
@@ -72,7 +72,13 @@ export const { use: useModels, provider: ModelsProvider } = createSimpleContext(
       })
     })
 
-    const find = (key: ModelKey) => list().find((m) => m.id === key.modelID && m.provider.id === key.providerID)
+    const findExact = (key: ModelKey) => list().find((m) => m.id === key.modelID && m.provider.id === key.providerID)
+    const find = (key: ModelKey) => {
+      const exact = findExact(key)
+      if (exact) return exact
+      const routed = routableModelKey(key, (candidate) => !!findExact(candidate))
+      return findExact(routed)
+    }
 
     function update(model: ModelKey, state: Visibility) {
       const index = store.user.findIndex((x) => x.modelID === model.modelID && x.providerID === model.providerID)

--- a/frontend/workspace/src/hooks/use-providers.ts
+++ b/frontend/workspace/src/hooks/use-providers.ts
@@ -11,9 +11,12 @@ export const popularProviders = [
   "openai",
   "google",
   "github-copilot",
-  "openrouter",
   "xai",
+  "deepseek",
+  "moonshotai",
+  "zai",
   "meta",
+  "openrouter",
   "vercel",
   "synsci",
 ]


### PR DESCRIPTION
## Summary
- Route managed LLM inference through OpenRouter only; BYOK/native providers stay direct and the Codex subscription stays on `openai-codex`.
- Resolve stale native managed model selections to OpenRouter vendor slugs, including Anthropic dotted-version aliases and GPT-5.6 Sol fallback.
- Display OpenRouter vendor slugs under branded provider families in the model picker, and expand the frontier catalog for GPT, Claude, Gemini, GLM, Kimi, DeepSeek, Grok, and Muse.

## Validation
- `bun test src/context/models-catalog.test.ts`
- `bun test test/provider/managed-routing.test.ts test/openscience/synced-env-policy.test.ts test/openscience/sync-precedence.test.ts test/openscience-env.test.ts test/provider/transform-reasoning.test.ts test/config/synced-merge.test.ts`
- `bun test` from `backend/cli`
- `bun run typecheck` from `backend/cli`
- `bun run typecheck` from `frontend/workspace`
- `bun run build` from `backend/cli`
- `bun run build` from `frontend/workspace`
