### PR TITLE
Stabilize home projects E2E selector

### DIFF
--- a/frontend/workspace/e2e/home-projects.spec.ts
+++ b/frontend/workspace/e2e/home-projects.spec.ts
@@ -7,10 +7,7 @@ const HIDDEN_KEY = "thesis-project-hidden-v1"
 
 test("home project search, view, favorite, and hide state are functional", async ({ page, directory }) => {
   await page.goto("/")
-  const project = page
-    .getByRole("main")
-    .getByRole("button", { name: new RegExp(directory.split("/").at(-1) ?? "OpenScience") })
-    .first()
+  const project = page.getByRole("main").getByRole("button").filter({ hasText: directory }).first()
   await expect(project).toBeVisible()
 
   const search = page.getByRole("textbox", { name: "search projects" })


### PR DESCRIPTION
## Summary
- Select the home project card by exact worktree path in the E2E test
- Avoid matching unrelated projects whose names also contain openscience

## Test
- bun run test:e2e:local e2e/home-projects.spec.ts