### PR TITLE
Format managed model routing changes

### DIFF
--- a/backend/cli/src/provider/provider.ts
+++ b/backend/cli/src/provider/provider.ts
@@ -256,8 +256,7 @@ export namespace Provider {
     const base = modelID.replace(/^~/, "")
     if (!vendor || !base) return []
     const direct = `${vendor}/${base}`
-    const normalized =
-      vendor === "anthropic" ? `${vendor}/${base.replace(ANTHROPIC_DASHED_VERSION, "$1.$2")}` : direct
+    const normalized = vendor === "anthropic" ? `${vendor}/${base.replace(ANTHROPIC_DASHED_VERSION, "$1.$2")}` : direct
     const aliased = providerID === "openai" && base === "gpt-5.6" ? ["openai/gpt-5.6-sol"] : []
     return Array.from(new Set([direct, normalized, ...aliased]))
   }

--- a/backend/cli/test/openscience/synced-env-policy.test.ts
+++ b/backend/cli/test/openscience/synced-env-policy.test.ts
@@ -67,10 +67,6 @@ test("managed provider sync accepts only thk tokens and matching Atlas proxy url
     isSyncedEnvAllowed("OPENROUTER_BASE_URL", "https://atlas.test.evil.test/api/llm/proxy/openrouter/v1", atlasBase),
   ).toBe(false)
   expect(
-    isSyncedEnvAllowed(
-      "OPENROUTER_BASE_URL",
-      "https://atlas.test/api/llm/proxy/openrouter/%2e%2e/meta",
-      atlasBase,
-    ),
+    isSyncedEnvAllowed("OPENROUTER_BASE_URL", "https://atlas.test/api/llm/proxy/openrouter/%2e%2e/meta", atlasBase),
   ).toBe(false)
 })

--- a/backend/cli/test/provider/managed-routing.test.ts
+++ b/backend/cli/test/provider/managed-routing.test.ts
@@ -138,12 +138,7 @@ describe("managed session availability", () => {
         billing: { llm: "managed" },
         provider: {
           openrouter: {
-            whitelist: [
-              "anthropic/claude-fable-5",
-              "google/gemini-3.6-flash",
-              "x-ai/grok-4.5",
-              "meta/muse-spark-1.1",
-            ],
+            whitelist: ["anthropic/claude-fable-5", "google/gemini-3.6-flash", "x-ai/grok-4.5", "meta/muse-spark-1.1"],
           },
         },
       },

--- a/frontend/workspace/src/components/dialog-select-model.tsx
+++ b/frontend/workspace/src/components/dialog-select-model.tsx
@@ -81,7 +81,10 @@ const ModelList: Component<{
     >
       {(i) => (
         <div class="w-full flex items-center gap-x-2 text-13-regular">
-          <ProviderIcon id={displayProviderForModel(i.provider, i.id).id as IconName} class="size-4 shrink-0 opacity-90" />
+          <ProviderIcon
+            id={displayProviderForModel(i.provider, i.id).id as IconName}
+            class="size-4 shrink-0 opacity-90"
+          />
           <span class="truncate">{i.name}</span>
           <span class="flex items-center gap-x-1.5 ml-auto shrink-0">
             <Show when={i.provider.id === "synsci" && (!i.cost || i.cost?.input === 0)}>

--- a/frontend/workspace/src/context/local.tsx
+++ b/frontend/workspace/src/context/local.tsx
@@ -220,7 +220,10 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       })
 
       const recent = createMemo(() =>
-        models.recent.list().map((item) => models.find(resolveModel(item) ?? item)).filter(Boolean),
+        models.recent
+          .list()
+          .map((item) => models.find(resolveModel(item) ?? item))
+          .filter(Boolean),
       )
 
       const cycle = (direction: 1 | -1) => {

--- a/frontend/workspace/src/context/models-catalog.test.ts
+++ b/frontend/workspace/src/context/models-catalog.test.ts
@@ -1,10 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import {
-  canonicalKey,
-  displayProviderForModel,
-  FRONTIER_MODELS,
-  routableModelKey,
-} from "./model-catalog"
+import { canonicalKey, displayProviderForModel, FRONTIER_MODELS, routableModelKey } from "./model-catalog"
 
 describe("frontier model canonicalization", () => {
   test("direct and OpenRouter GPT-5.6 ids collapse to the same frontier keys", () => {


### PR DESCRIPTION
## Summary
- Apply Prettier to the managed OpenRouter/model-routing files that failed CI format check

## Verification
- bun run format:check
- bun run typecheck
- bun test frontend/workspace/src/context/models-catalog.test.ts
- bun test backend/cli/test/provider/managed-routing.test.ts backend/cli/test/openscience/synced-env-policy.test.ts
- bun run --cwd frontend/workspace test:e2e:local e2e/home-projects.spec.ts
- npm-test publish workflow on main is green: https://github.com/synthetic-sciences/openscience/actions/runs/30249408007