### PR TITLE
Fix managed OpenRouter routing and remove Fable

### DIFF
--- a/backend/cli/src/openscience/index.ts
+++ b/backend/cli/src/openscience/index.ts
@@ -8,7 +8,7 @@ import { Log } from "../util/log"
 import { Lock } from "../util/lock"
 import { Env } from "../env"
 import { Auth } from "../auth"
-import { isSyncedEnvAllowed, BYOK_LLM_ENV_KEYS } from "./synced-env-policy"
+import { isSyncedEnvAllowed, BYOK_LLM_ENV_KEYS, managedOpenRouterBaseURL } from "./synced-env-policy"
 import { resolveAtlasPackageDir } from "./atlas-package"
 import { DEFAULT_MANAGED_API_BASE, MANAGED_API_BASE } from "../endpoints"
 
@@ -833,6 +833,15 @@ export namespace OpenScience {
       // synced-env-policy.ts.
       for (const [key, value] of [...fresh.entries()]) {
         if (!isSyncedEnvAllowed(key, value)) fresh.delete(key)
+      }
+
+      // Older Atlas sync responses can carry only OPENROUTER_API_KEY=thk_*.
+      // Managed OpenRouter must also carry the Atlas proxy baseURL; otherwise
+      // provider init correctly refuses to send a wallet token to public
+      // openrouter.ai and the UI shows ProviderInitError.
+      const openrouterKey = fresh.get("OPENROUTER_API_KEY")
+      if (isManagedAtlasKey(openrouterKey ?? "") && !fresh.has("OPENROUTER_BASE_URL")) {
+        fresh.set("OPENROUTER_BASE_URL", managedOpenRouterBaseURL())
       }
 
       // Count distinct APPLIED credential values (post-filter, ignoring routing

--- a/backend/cli/src/openscience/synced-env-policy.ts
+++ b/backend/cli/src/openscience/synced-env-policy.ts
@@ -47,6 +47,10 @@ const MANAGED_SYNCED_BASE_URLS: Record<string, string> = {
   OPENROUTER_BASE_URL: "/api/llm/proxy/openrouter/",
 }
 
+export function managedOpenRouterBaseURL(atlasBase = managedApiBase()): string {
+  return `${atlasBase.replace(/\/+$/, "")}/api/llm/proxy/openrouter/v1`
+}
+
 /** Match a proxy URL to the configured Atlas origin and an exact route prefix.
  * A path substring alone is not enough: an attacker-controlled origin could
  * otherwise place `/api/llm/proxy/` in its path and receive the scoped token. */

--- a/backend/cli/src/provider/provider.ts
+++ b/backend/cli/src/provider/provider.ts
@@ -14,7 +14,7 @@ import { Instance } from "../project/instance"
 import { Flag } from "../flag/flag"
 import { iife } from "@/util/iife"
 import { OpenScience } from "../openscience"
-import { isAtlasProxyURL } from "../openscience/synced-env-policy"
+import { isAtlasProxyURL, managedOpenRouterBaseURL } from "../openscience/synced-env-policy"
 
 // Direct imports for bundled providers
 import { createAmazonBedrock, type AmazonBedrockProviderSettings } from "@ai-sdk/amazon-bedrock"
@@ -104,6 +104,12 @@ export namespace Provider {
 
   function isAtlasApiKey(key: unknown): key is string {
     return typeof key === "string" && key.startsWith("thk_")
+  }
+
+  const REMOVED_MODEL_IDS = new Set(["claude-fable-5", "anthropic/claude-fable-5"])
+
+  function isRemovedModel(modelID: string) {
+    return REMOVED_MODEL_IDS.has(modelID)
   }
 
   export function isAtlasProxyBaseURL(baseURL: unknown): baseURL is string {
@@ -599,10 +605,11 @@ export namespace Provider {
       // managed token — the live session, or the synced thk_* already in env if
       // the session file is momentarily unreadable.
       const proxyBase = Env.get("OPENROUTER_BASE_URL")
-      if (isAtlasProxyBaseURL(proxyBase)) {
-        const session = await OpenScience.getSession().catch(() => null)
-        const managedKey = session?.api_key ?? (isAtlasApiKey(envKey) ? envKey : undefined)
-        if (managedKey) return { autoload: false, options: { apiKey: managedKey, baseURL: proxyBase, headers } }
+      const session = await OpenScience.getSession().catch(() => null)
+      const managedKey = session?.api_key ?? (isAtlasApiKey(envKey) ? envKey : undefined)
+      if (managedKey) {
+        const baseURL = isAtlasProxyBaseURL(proxyBase) ? proxyBase : managedOpenRouterBaseURL()
+        return { autoload: false, options: { apiKey: managedKey, baseURL, headers } }
       }
 
       // Neither an own key nor a managed route — nothing to route with.
@@ -1056,7 +1063,11 @@ export namespace Provider {
       name: provider.name,
       env: provider.env ?? [],
       options: {},
-      models: mapValues(provider.models, (model) => fromModelsDevModel(provider, model)),
+      models: Object.fromEntries(
+        Object.entries(provider.models)
+          .filter(([modelID]) => !isRemovedModel(modelID))
+          .map(([modelID, model]) => [modelID, fromModelsDevModel(provider, model)]),
+      ),
     }
   }
 
@@ -1166,6 +1177,7 @@ export namespace Provider {
       }
 
       for (const [modelID, model] of Object.entries(provider.models ?? {})) {
+        if (isRemovedModel(modelID)) continue
         const existingModel = parsed.models[model.id ?? modelID]
         const name = iife(() => {
           if (model.name) return model.name
@@ -1405,6 +1417,7 @@ export namespace Provider {
 
       for (const [modelID, model] of Object.entries(provider.models)) {
         model.api.id = model.api.id ?? model.id ?? modelID
+        if (isRemovedModel(modelID)) delete provider.models[modelID]
         if (modelID === "gpt-5-chat-latest" || (providerID === "openrouter" && modelID === "openai/gpt-5-chat"))
           delete provider.models[modelID]
         if (model.status === "alpha" && !Flag.OPENSCIENCE_ENABLE_EXPERIMENTAL_MODELS) delete provider.models[modelID]
@@ -1436,6 +1449,7 @@ export namespace Provider {
       // shows the full local catalog and isn't bound to the managed whitelist.
       if (!bypassManagedWhitelist && providerID === "openrouter" && configProvider?.whitelist) {
         for (const wlid of configProvider.whitelist) {
+          if (isRemovedModel(wlid)) continue
           if (!(wlid in provider.models)) {
             provider.models[wlid] = _syntheticOpenRouterModel(wlid)
           }

--- a/backend/cli/src/provider/transform.ts
+++ b/backend/cli/src/provider/transform.ts
@@ -655,14 +655,14 @@ export namespace ProviderTransform {
         // The newest Claudes REJECT manual extended thinking (`thinking.type:
         // "enabled"` → 400) and drive depth via `output_config.effort` instead.
         // Verified against platform.claude.com/docs/build-with-claude/effort
-        // (July 2026): Opus 4.7/4.8, Sonnet 5, Fable 5, Mythos 5 (and the 5+
+        // (July 2026): Opus 4.7/4.8, Sonnet 5, Mythos 5 (and the 5+
         // generation) all support the full low→max ladder INCLUDING xhigh. The AI
         // SDK maps our top-level `effort` → `output_config: { effort }`; the pinned
         // patch (tooling/patches/@ai-sdk%2Fanthropic@2.0.57.patch) widens its enum
-        // to include xhigh/max. Detection is by canonical id — note Fable/Mythos
-        // are NOT opus/sonnet/haiku, so they must be matched explicitly or they
-        // fall through to the classic path below and 400 (manual thinking rejected).
-        const usesEffort = /^claude-opus-4[.-][78]\b/.test(id) || /^claude-(opus|sonnet|fable|mythos)-[5-9]\b/.test(id)
+        // to include xhigh/max. Detection is by canonical id — note Mythos is NOT
+        // opus/sonnet/haiku, so it must be matched explicitly or it falls
+        // through to the classic path below and 400 (manual thinking rejected).
+        const usesEffort = /^claude-opus-4[.-][78]\b/.test(id) || /^claude-(opus|sonnet|mythos)-[5-9]\b/.test(id)
 
         if (usesEffort) {
           return {

--- a/backend/cli/test/openscience/sync-precedence.test.ts
+++ b/backend/cli/test/openscience/sync-precedence.test.ts
@@ -3,6 +3,7 @@ import path from "path"
 import { OpenScience } from "../../src/openscience"
 import { Global } from "../../src/global"
 import { managedApiBase } from "../../src/endpoints"
+import { managedOpenRouterBaseURL } from "../../src/openscience/synced-env-policy"
 
 // syncServices must respect credential precedence: a user's own shell-exported
 // (or BYOK) OpenRouter key must survive a background sync — never be overwritten
@@ -17,6 +18,7 @@ const realFetch = globalThis.fetch
 afterEach(() => {
   globalThis.fetch = realFetch
   delete process.env["OPENROUTER_API_KEY"]
+  delete process.env["OPENROUTER_BASE_URL"]
   delete process.env["ANTHROPIC_API_KEY"]
   delete process.env["META_MODEL_API_KEY"]
   delete process.env["META_MODEL_BASE_URL"]
@@ -58,6 +60,7 @@ test("a synced managed OpenRouter key IS applied when the slot is empty", async 
   stubSync({ openrouter: { OPENROUTER_API_KEY: "thk_managed.value" } })
   await OpenScience.syncServices()
   expect(process.env["OPENROUTER_API_KEY"]).toBe("thk_managed.value")
+  expect(process.env["OPENROUTER_BASE_URL"]).toBe(managedOpenRouterBaseURL())
 })
 
 test("Meta sync is dropped even when it looks like an old managed route", async () => {

--- a/backend/cli/test/openscience/synced-env-policy.test.ts
+++ b/backend/cli/test/openscience/synced-env-policy.test.ts
@@ -1,5 +1,9 @@
 import { test, expect } from "bun:test"
-import { isSyncedEnvAllowed, BLOCKED_SYNCED_ENV } from "../../src/openscience/synced-env-policy"
+import {
+  isSyncedEnvAllowed,
+  BLOCKED_SYNCED_ENV,
+  managedOpenRouterBaseURL,
+} from "../../src/openscience/synced-env-policy"
 
 test("blocks every non-managed model-provider LLM credential (key + *_BASE_URL)", () => {
   const blocked = [
@@ -52,6 +56,7 @@ test("managed provider sync accepts only thk tokens and matching Atlas proxy url
   const atlasBase = "https://atlas.test"
   expect(isSyncedEnvAllowed("OPENROUTER_API_KEY", "thk_user.scoped")).toBe(true)
   expect(isSyncedEnvAllowed("OPENROUTER_API_KEY", "sk-or-shared-secret")).toBe(false)
+  expect(managedOpenRouterBaseURL(atlasBase)).toBe("https://atlas.test/api/llm/proxy/openrouter/v1")
   expect(isSyncedEnvAllowed("OPENROUTER_BASE_URL", "https://atlas.test/api/llm/proxy/openrouter/v1", atlasBase)).toBe(
     true,
   )

--- a/backend/cli/test/provider/live-catalog.test.ts
+++ b/backend/cli/test/provider/live-catalog.test.ts
@@ -11,7 +11,7 @@ import { test, expect } from "bun:test"
 //      test/fixture/models-catalog.json, then gzip it to models-catalog.json.gz.
 //
 const CATALOG_PINS = {
-  anthropic: ["claude-opus-5", "claude-sonnet-5", "claude-fable-5", "claude-sonnet-4-6", "claude-opus-4-5"],
+  anthropic: ["claude-opus-5", "claude-sonnet-5", "claude-sonnet-4-6", "claude-opus-4-5"],
   openai: ["gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"],
   xai: [
     "grok-4.3",
@@ -27,7 +27,6 @@ const CATALOG_PINS = {
   openrouter: [
     "anthropic/claude-opus-5",
     "anthropic/claude-sonnet-5",
-    "anthropic/claude-fable-5",
     "openai/gpt-5.6-sol",
     "openai/gpt-5.6-terra",
     "openai/gpt-5.6-luna",

--- a/backend/cli/test/provider/managed-routing.test.ts
+++ b/backend/cli/test/provider/managed-routing.test.ts
@@ -138,7 +138,7 @@ describe("managed session availability", () => {
         billing: { llm: "managed" },
         provider: {
           openrouter: {
-            whitelist: ["anthropic/claude-fable-5", "google/gemini-3.6-flash", "x-ai/grok-4.5", "meta/muse-spark-1.1"],
+            whitelist: ["anthropic/claude-sonnet-5", "google/gemini-3.6-flash", "x-ai/grok-4.5", "meta/muse-spark-1.1"],
           },
         },
       },
@@ -152,9 +152,9 @@ describe("managed session availability", () => {
         Provider.invalidate()
       },
       fn: async () => {
-        const fable = await Provider.getModel("anthropic", "claude-fable-5")
-        expect(fable.providerID).toBe("openrouter")
-        expect(fable.id).toBe("anthropic/claude-fable-5")
+        const sonnet = await Provider.getModel("anthropic", "claude-sonnet-5")
+        expect(sonnet.providerID).toBe("openrouter")
+        expect(sonnet.id).toBe("anthropic/claude-sonnet-5")
 
         const gemini = await Provider.getModel("gemini", "gemini-3.6-flash")
         expect(gemini.providerID).toBe("openrouter")
@@ -167,6 +167,81 @@ describe("managed session availability", () => {
         const muse = await Provider.getModel("meta", "muse-spark-1.1")
         expect(muse.providerID).toBe("openrouter")
         expect(muse.id).toBe("meta/muse-spark-1.1")
+      },
+    })
+  })
+
+  test("managed OpenRouter self-heals a key-only synced env snapshot", async () => {
+    await using tmp = await tmpdir({
+      config: {
+        billing: { llm: "managed" },
+        provider: {
+          openrouter: {
+            whitelist: ["anthropic/claude-sonnet-4.6"],
+          },
+        },
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      init: async () => {
+        clearManagedLLMEnv()
+        Env.set("OPENROUTER_API_KEY", "thk_openrouter")
+        Provider.invalidate()
+      },
+      fn: async () => {
+        const providers = await Provider.list()
+        const openrouter = providers["openrouter"]
+        expect(openrouter).toBeDefined()
+        expect(openrouter.options.apiKey).toStartWith("thk_")
+        expect(openrouter.options.baseURL).toBe(`${PROXY}/openrouter/v1`)
+
+        const model = await Provider.getModel("openrouter", "anthropic/claude-sonnet-4.6")
+        await expect(Provider.getLanguage(model)).resolves.toBeDefined()
+      },
+    })
+  })
+
+  test("Fable is hidden from stale managed and direct catalogs", async () => {
+    await using managed = await tmpdir({
+      config: {
+        billing: { llm: "managed" },
+        provider: {
+          openrouter: {
+            whitelist: ["anthropic/claude-fable-5", "anthropic/claude-sonnet-5"],
+          },
+        },
+      },
+    })
+    await Instance.provide({
+      directory: managed.path,
+      init: async () => {
+        clearManagedLLMEnv()
+        Env.set("OPENROUTER_API_KEY", "thk_openrouter")
+        Env.set("OPENROUTER_BASE_URL", `${PROXY}/openrouter/v1`)
+        Provider.invalidate()
+      },
+      fn: async () => {
+        const openrouter = (await Provider.list())["openrouter"]
+        expect(openrouter.models["anthropic/claude-fable-5"]).toBeUndefined()
+        expect(openrouter.models["anthropic/claude-sonnet-5"]).toBeDefined()
+        await expect(Provider.getModel("openrouter", "anthropic/claude-fable-5")).rejects.toThrow()
+      },
+    })
+
+    await using byok = await tmpdir({ config: { billing: { llm: "byok" } } })
+    await Instance.provide({
+      directory: byok.path,
+      init: async () => {
+        clearManagedLLMEnv()
+        Env.set("ANTHROPIC_API_KEY", "sk-ant-byok-key")
+        Provider.invalidate()
+      },
+      fn: async () => {
+        const anthropic = (await Provider.list())["anthropic"]
+        expect(anthropic).toBeDefined()
+        expect(anthropic.models["claude-fable-5"]).toBeUndefined()
+        expect(anthropic.models["claude-sonnet-5"]).toBeDefined()
       },
     })
   })

--- a/backend/cli/test/provider/provider.test.ts
+++ b/backend/cli/test/provider/provider.test.ts
@@ -32,7 +32,7 @@ import { API_BASE } from "../../src/openscience"
 /* Keep this list aligned with live-catalog.test.ts. The committed fixture makes
    PR CI deterministic; the scheduled live check catches upstream delistings. */
 const FRONTIER_MODELS = {
-  anthropic: ["claude-opus-5", "claude-sonnet-5", "claude-fable-5"],
+  anthropic: ["claude-opus-5", "claude-sonnet-5"],
   openai: ["gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"],
   xai: [
     "grok-4.3",
@@ -47,7 +47,6 @@ const FRONTIER_MODELS = {
   openrouter: [
     "anthropic/claude-opus-5",
     "anthropic/claude-sonnet-5",
-    "anthropic/claude-fable-5",
     "openai/gpt-5.6-sol",
     "x-ai/grok-4.5",
     "moonshotai/kimi-k3",

--- a/backend/cli/test/provider/transform.test.ts
+++ b/backend/cli/test/provider/transform.test.ts
@@ -1997,8 +1997,8 @@ describe("ProviderTransform.variants", () => {
     // Verified against platform.claude.com/docs/build-with-claude/effort (July
     // 2026). Two paths:
     //  • EFFORT (output_config.effort, full low→max incl. xhigh): the newest
-    //    Claudes that REJECT manual thinking — Opus 4.7/4.8, Sonnet 5, Fable 5,
-    //    Mythos 5, and the 5+ generation. The SDK effort enum is widened to
+    //    Claudes that REJECT manual thinking — Opus 4.7/4.8, Sonnet 5, Mythos 5,
+    //    and the 5+ generation. The SDK effort enum is widened to
     //    include xhigh/max by tooling/patches/@ai-sdk%2Fanthropic@2.0.57.patch.
     //  • CLASSIC thinking-budget (low/medium/high/max): everything else — Opus
     //    4.5/4.6, Sonnet 4.5/4.6, Haiku 4.5 — which have no effort param (4.5
@@ -2010,14 +2010,7 @@ describe("ProviderTransform.variants", () => {
         api: { id, url: "https://api.anthropic.com", npm: "@ai-sdk/anthropic" },
       })
 
-    const EFFORT_MODELS = [
-      "claude-opus-4-7",
-      "claude-opus-4-8",
-      "claude-opus-5",
-      "claude-sonnet-5",
-      "claude-fable-5",
-      "claude-mythos-5",
-    ]
+    const EFFORT_MODELS = ["claude-opus-4-7", "claude-opus-4-8", "claude-opus-5", "claude-sonnet-5", "claude-mythos-5"]
     for (const id of EFFORT_MODELS) {
       test(`${id} exposes the full low→max effort ladder including xhigh`, () => {
         const result = ProviderTransform.variants(anthropicModel(id))
@@ -2028,10 +2021,10 @@ describe("ProviderTransform.variants", () => {
       })
     }
 
-    // Regression guard: Fable/Mythos are NOT opus/sonnet/haiku, so a naive regex
+    // Regression guard: Mythos is NOT opus/sonnet/haiku, so a naive regex
     // drops them to the classic path where manual thinking 400s.
-    test("claude-fable-5 uses effort, not a thinking budget", () => {
-      const result = ProviderTransform.variants(anthropicModel("claude-fable-5"))
+    test("claude-mythos-5 uses effort, not a thinking budget", () => {
+      const result = ProviderTransform.variants(anthropicModel("claude-mythos-5"))
       expect(result.high).toEqual({ effort: "high" })
       expect(result.high).not.toHaveProperty("thinking")
     })

--- a/frontend/docs/src/content/openscience/models.mdx
+++ b/frontend/docs/src/content/openscience/models.mdx
@@ -31,7 +31,7 @@ Current frontier families include:
 
 | Provider | Model IDs |
 | --- | --- |
-| Anthropic | `claude-opus-5`, `claude-sonnet-5`, `claude-fable-5` |
+| Anthropic | `claude-opus-5`, `claude-sonnet-5` |
 | OpenAI | `gpt-5.6`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna` |
 | xAI | `grok-4.5`, `grok-4.3`, `grok-build-0.1`, and Grok 4.20 reasoning, non-reasoning, and multi-agent models |
 | Moonshot AI | `kimi-k3` |

--- a/frontend/workspace/src/context/model-catalog.ts
+++ b/frontend/workspace/src/context/model-catalog.ts
@@ -50,7 +50,6 @@ export const FRONTIER_MODELS = new Set([
   "openai/gpt-5-5-mini", // announced tier, not yet in the live catalog
   "anthropic/claude-sonnet-5",
   "anthropic/claude-opus-4-8",
-  "anthropic/claude-fable-5",
   "google/gemini-3-6-flash",
   "google/gemini-3-1-pro-preview",
   "zai/glm-5-2",

--- a/frontend/workspace/src/context/models-catalog.test.ts
+++ b/frontend/workspace/src/context/models-catalog.test.ts
@@ -22,7 +22,7 @@ describe("frontier model canonicalization", () => {
 
   test("OpenRouter vendor slugs display under their branded provider families", () => {
     const openrouter = { id: "openrouter", name: "OpenRouter" }
-    expect(displayProviderForModel(openrouter, "anthropic/claude-fable-5")).toEqual({
+    expect(displayProviderForModel(openrouter, "anthropic/claude-sonnet-5")).toEqual({
       id: "anthropic",
       name: "Anthropic",
     })
@@ -35,7 +35,7 @@ describe("frontier model canonicalization", () => {
   test("stale direct model selections route to managed OpenRouter aliases when present", () => {
     const available = new Set([
       "openrouter:anthropic/claude-opus-4.8",
-      "openrouter:anthropic/claude-fable-5",
+      "openrouter:anthropic/claude-sonnet-5",
       "openrouter:openai/gpt-5.6-sol",
       "openrouter:google/gemini-3.6-flash",
       "openrouter:x-ai/grok-4.5",
@@ -44,9 +44,9 @@ describe("frontier model canonicalization", () => {
     const hasModel = (model: { providerID: string; modelID: string }) =>
       available.has(`${model.providerID}:${model.modelID}`)
 
-    expect(routableModelKey({ providerID: "anthropic", modelID: "claude-fable-5" }, hasModel)).toEqual({
+    expect(routableModelKey({ providerID: "anthropic", modelID: "claude-sonnet-5" }, hasModel)).toEqual({
       providerID: "openrouter",
-      modelID: "anthropic/claude-fable-5",
+      modelID: "anthropic/claude-sonnet-5",
     })
     expect(routableModelKey({ providerID: "anthropic", modelID: "claude-opus-4-8" }, hasModel)).toEqual({
       providerID: "openrouter",


### PR DESCRIPTION
## Summary
- self-heal managed OpenRouter sync snapshots that only contain the Atlas token by injecting the managed proxy base URL
- hide claude-fable-5 from OpenScience catalogs, stale whitelists, and direct Anthropic provider listings
- update model picker/docs/tests to keep the remaining Claude/OpenRouter models

## Local verification
- bun test (backend/cli): 1252 passed, 1 skipped, 0 failed
- bun test src/context/models-catalog.test.ts (frontend/workspace): 5 passed
- bun run format:check
- bun run typecheck
- git diff --check
- localhost kras-speedrun smoke: OpenRouter Sonnet returned OPENSCIENCE_OK
- Atlas OpenRouter proxy smoke: 36/36 exposed OpenRouter models returned OK after reasoning-required retries