### PR TITLE
Remove Fable variants from provider catalogs

### DIFF
--- a/backend/cli/src/provider/provider.ts
+++ b/backend/cli/src/provider/provider.ts
@@ -106,10 +106,8 @@ export namespace Provider {
     return typeof key === "string" && key.startsWith("thk_")
   }
 
-  const REMOVED_MODEL_IDS = new Set(["claude-fable-5", "anthropic/claude-fable-5"])
-
   function isRemovedModel(modelID: string) {
-    return REMOVED_MODEL_IDS.has(modelID)
+    return modelID.toLowerCase().includes("fable")
   }
 
   export function isAtlasProxyBaseURL(baseURL: unknown): baseURL is string {

--- a/backend/cli/test/provider/managed-routing.test.ts
+++ b/backend/cli/test/provider/managed-routing.test.ts
@@ -226,6 +226,10 @@ describe("managed session availability", () => {
         expect(openrouter.models["anthropic/claude-fable-5"]).toBeUndefined()
         expect(openrouter.models["anthropic/claude-sonnet-5"]).toBeDefined()
         await expect(Provider.getModel("openrouter", "anthropic/claude-fable-5")).rejects.toThrow()
+        await expect(Provider.getModel("amazon-bedrock", "anthropic.claude-fable-5")).rejects.toThrow()
+        await expect(Provider.getModel("amazon-bedrock", "global.anthropic.claude-fable-5")).rejects.toThrow()
+        await expect(Provider.getModel("digitalocean", "anthropic-claude-fable-5")).rejects.toThrow()
+        await expect(Provider.getModel("gitlab", "duo-chat-fable-5")).rejects.toThrow()
       },
     })
 


### PR DESCRIPTION
## Summary
- remove any Fable/Fabled model IDs from provider catalogs, including vendor-wrapped Claude Fable IDs
- add regression coverage for OpenRouter, Anthropic, Bedrock, DigitalOcean, and GitLab Fable IDs

## Verification
- cd backend/cli && bun test test/provider/managed-routing.test.ts test/provider/provider.test.ts
- cd backend/cli && bun test
- bun run format:check
- bun run typecheck
- git diff --check