### PR TITLE
Disable tools for no-tool-call models

### DIFF
--- a/backend/cli/src/session/llm.ts
+++ b/backend/cli/src/session/llm.ts
@@ -161,7 +161,7 @@ export namespace LLM {
           OUTPUT_TOKEN_MAX,
         )
 
-    const tools = await resolveTools(input)
+    const tools = await modelTools(input)
 
     // LiteLLM and some Anthropic proxies require the tools parameter to be present
     // when message history contains tool calls, even if no tools are being used.
@@ -279,6 +279,11 @@ export namespace LLM {
         },
       },
     })
+  }
+
+  export async function modelTools(input: Pick<StreamInput, "tools" | "agent" | "model" | "user">) {
+    if (!input.model.capabilities.toolcall) return {}
+    return resolveTools(input)
   }
 
   async function resolveTools(input: Pick<StreamInput, "tools" | "agent" | "user">) {

--- a/backend/cli/test/session/llm.test.ts
+++ b/backend/cli/test/session/llm.test.ts
@@ -1,6 +1,103 @@
 import { describe, expect, test } from "bun:test"
 import { LLM } from "../../src/session/llm"
-import type { ModelMessage } from "ai"
+import { jsonSchema, tool, type ModelMessage } from "ai"
+import type { Agent } from "../../src/agent/agent"
+import type { Provider } from "../../src/provider/provider"
+import type { MessageV2 } from "../../src/session/message-v2"
+
+function testModel(toolcall: boolean): Provider.Model {
+  return {
+    id: "test-model",
+    providerID: "openrouter",
+    api: {
+      id: "test-model",
+      url: "https://example.com",
+      npm: "@openrouter/ai-sdk-provider",
+    },
+    name: "Test Model",
+    capabilities: {
+      temperature: true,
+      reasoning: false,
+      attachment: false,
+      toolcall,
+      input: {
+        text: true,
+        audio: false,
+        image: false,
+        video: false,
+        pdf: false,
+      },
+      output: {
+        text: true,
+        audio: false,
+        image: false,
+        video: false,
+        pdf: false,
+      },
+      interleaved: false,
+    },
+    cost: {
+      input: 0,
+      output: 0,
+      cache: {
+        read: 0,
+        write: 0,
+      },
+    },
+    limit: {
+      context: 0,
+      output: 0,
+    },
+    status: "active",
+    options: {},
+    headers: {},
+    release_date: "2026-01-01",
+  }
+}
+
+const agent = {
+  permission: [],
+} as unknown as Agent.Info
+
+const user = {
+  tools: {},
+} as unknown as MessageV2.User
+
+function questionTool() {
+  return tool({
+    description: "Ask the user a question",
+    inputSchema: jsonSchema({ type: "object", properties: {} }),
+    execute: async () => ({ output: "", title: "", metadata: {} }),
+  })
+}
+
+describe("session.llm.modelTools", () => {
+  test("drops native tools for models without tool-call support", async () => {
+    const tools = { question: questionTool() }
+    const resolved = await LLM.modelTools({
+      agent,
+      model: testModel(false),
+      tools,
+      user,
+    })
+
+    expect(resolved).toStrictEqual({})
+    expect(tools.question).toBeDefined()
+  })
+
+  test("keeps native tools for models with tool-call support", async () => {
+    const tools = { question: questionTool() }
+    const resolved = await LLM.modelTools({
+      agent,
+      model: testModel(true),
+      tools,
+      user,
+    })
+
+    expect(resolved).toBe(tools)
+    expect(Object.keys(resolved)).toStrictEqual(["question"])
+  })
+})
 
 describe("session.llm.isCodexSubscriptionModel", () => {
   test("returns true for the synthesized openai-codex OAuth provider", () => {


### PR DESCRIPTION
## Summary
- skip native/MCP tool declarations when a selected model does not support tool calls
- add a regression test for no-tool-call OpenRouter-style models

## Tests
- bun test test/session/llm.test.ts test/provider/managed-routing.test.ts test/provider/provider.test.ts
- bun test
- bun run format:check
- bun run typecheck
- git diff --check