### PR TITLE
Remove unhealthy managed Mistral Small route

### DIFF
--- a/backend/cli/src/provider/provider.ts
+++ b/backend/cli/src/provider/provider.ts
@@ -106,8 +106,12 @@ export namespace Provider {
     return typeof key === "string" && key.startsWith("thk_")
   }
 
+  const REMOVED_MODEL_IDS = new Set(["mistralai/mistral-small-3.2-24b-instruct"])
+
   function isRemovedModel(modelID: string) {
-    return modelID.toLowerCase().includes("fable")
+    const normalized = modelID.toLowerCase()
+    if (normalized.includes("fable")) return true
+    return REMOVED_MODEL_IDS.has(normalized)
   }
 
   export function isAtlasProxyBaseURL(baseURL: unknown): baseURL is string {

--- a/backend/cli/test/provider/managed-routing.test.ts
+++ b/backend/cli/test/provider/managed-routing.test.ts
@@ -250,6 +250,34 @@ describe("managed session availability", () => {
     })
   })
 
+  test("unhealthy managed OpenRouter slugs are hidden from stale synced catalogs", async () => {
+    await using tmp = await tmpdir({
+      config: {
+        billing: { llm: "managed" },
+        provider: {
+          openrouter: {
+            whitelist: ["mistralai/mistral-small-3.2-24b-instruct", "mistralai/mistral-medium-3.1"],
+          },
+        },
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      init: async () => {
+        clearManagedLLMEnv()
+        Env.set("OPENROUTER_API_KEY", "thk_openrouter")
+        Env.set("OPENROUTER_BASE_URL", `${PROXY}/openrouter/v1`)
+        Provider.invalidate()
+      },
+      fn: async () => {
+        const openrouter = (await Provider.list())["openrouter"]
+        expect(openrouter.models["mistralai/mistral-small-3.2-24b-instruct"]).toBeUndefined()
+        expect(openrouter.models["mistralai/mistral-medium-3.1"]).toBeDefined()
+        await expect(Provider.getModel("openrouter", "mistralai/mistral-small-3.2-24b-instruct")).rejects.toThrow()
+      },
+    })
+  })
+
   test("Meta BYOK overrides a path-prefixed stale managed proxy and bypasses the managed whitelist", async () => {
     await using tmp = await tmpdir({
       config: {


### PR DESCRIPTION
## Summary
- hide the repeatedly timing-out OpenRouter Mistral Small 3.2 route from stale managed synced catalogs
- keep Fable removal and neighboring Mistral routes intact
- add a regression test for stale OpenRouter whitelists

## Tests
- bun test
- bun run format:check
- bun run typecheck
- git diff --check