### PR TITLE
Add provider-native model modes and /goal

### DIFF
--- a/backend/cli/skills/other/goal/SKILL.md
+++ b/backend/cli/skills/other/goal/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: goal
+description: Set an explicit objective, success criteria, and stopping conditions for the current OpenScience session.
+category: other
+tags: [workflow, planning, persistence]
+---
+
+# Goal
+
+Use this skill when the user invokes `/goal` or asks OpenScience to work toward a concrete outcome over multiple turns.
+
+## Contract
+
+Establish the session goal as a compact completion contract:
+
+- Objective: the specific outcome the user wants.
+- Success criteria: the checks that prove the outcome is reached.
+- Constraints: files, branches, budgets, tools, credentials, publishing rules, or safety limits the user names.
+- Stop conditions: complete, blocked, cancelled, budget exhausted, or superseded by a newer user instruction.
+
+If the user provided enough detail, proceed without another question. Ask only when the missing detail would make the work unsafe, irreversible, or impossible to verify.
+
+## Execution
+
+1. Restate the goal briefly in working terms.
+2. Keep a short visible checklist while working.
+3. Prefer real verification over confidence: tests, builds, local runs, screenshots, logs, or provider/API checks as appropriate.
+4. Persist durable checkpoints in project files, commits, PRs, or Atlas records when the user asks for persistence or the repository already uses that workflow.
+5. Update the user when the goal changes, a stop condition is hit, or verification gives new evidence.
+
+## Completion
+
+Before calling the goal complete, verify each success criterion with fresh evidence. If the goal is blocked, report the exact blocker, the evidence gathered, and the smallest user or external action that would unblock it.

--- a/backend/cli/src/provider/models.ts
+++ b/backend/cli/src/provider/models.ts
@@ -13,6 +13,40 @@ import { lazy } from "@/util/lazy"
 export namespace ModelsDev {
   const log = Log.create({ service: "models.dev" })
   const filepath = path.join(Global.Path.cache, "models.json")
+  const Mode = z
+    .object({
+      model: z.string().optional(),
+      cost: z
+        .object({
+          input: z.number(),
+          output: z.number(),
+          cache_read: z.number().optional(),
+          cache_write: z.number().optional(),
+        })
+        .optional(),
+      provider: z
+        .object({
+          body: z.record(z.string(), z.any()).optional(),
+          headers: z.record(z.string(), z.string()).optional(),
+        })
+        .optional(),
+    })
+    .optional()
+
+  const ReasoningOption = z.discriminatedUnion("type", [
+    z.object({
+      type: z.literal("toggle"),
+    }),
+    z.object({
+      type: z.literal("effort"),
+      values: z.array(z.string().nullable()),
+    }),
+    z.object({
+      type: z.literal("budget_tokens"),
+      min: z.number().optional(),
+      max: z.number().optional(),
+    }),
+  ])
 
   export const Model = z.object({
     id: z.string(),
@@ -21,6 +55,7 @@ export namespace ModelsDev {
     release_date: z.string(),
     attachment: z.boolean(),
     reasoning: z.boolean(),
+    reasoning_options: z.array(ReasoningOption).optional(),
     temperature: z.boolean(),
     tool_call: z.boolean(),
     interleaved: z
@@ -60,7 +95,14 @@ export namespace ModelsDev {
         output: z.array(z.enum(["text", "audio", "image", "video", "pdf"])),
       })
       .optional(),
-    experimental: z.boolean().optional(),
+    experimental: z
+      .union([
+        z.boolean(),
+        z.object({
+          modes: z.record(z.string(), Mode).optional(),
+        }),
+      ])
+      .optional(),
     status: z.enum(["alpha", "beta", "deprecated"]).optional(),
     options: z.record(z.string(), z.any()),
     headers: z.record(z.string(), z.string()).optional(),

--- a/backend/cli/src/provider/provider.ts
+++ b/backend/cli/src/provider/provider.ts
@@ -65,6 +65,21 @@ export namespace Provider {
     return CODEX_MODEL_IDS.has(modelID)
   }
 
+  function codexOAuthModes(modelID: string) {
+    if (/^gpt-5[.-]4-mini$/.test(modelID)) return undefined
+    if (!/^gpt-5[.-](?:4|5|6)(?:-(?:sol|terra|luna))?$/.test(modelID)) return undefined
+    return {
+      fast: {
+        provider: {
+          body: {
+            service_tier: "priority",
+          },
+          headers: {},
+        },
+      },
+    }
+  }
+
   function isGpt5OrLater(modelID: string): boolean {
     const match = /^gpt-(\d+)/.exec(modelID)
     if (!match) {
@@ -837,6 +852,26 @@ export namespace Provider {
     },
   }
 
+  const Mode = z.object({
+    model: z.string().optional(),
+    cost: z
+      .object({
+        input: z.number(),
+        output: z.number(),
+        cache: z.object({
+          read: z.number(),
+          write: z.number(),
+        }),
+      })
+      .optional(),
+    provider: z
+      .object({
+        body: z.record(z.string(), z.any()).optional(),
+        headers: z.record(z.string(), z.string()).optional(),
+      })
+      .optional(),
+  })
+
   export const Model = z
     .object({
       id: z.string(),
@@ -901,7 +936,9 @@ export namespace Provider {
       options: z.record(z.string(), z.any()),
       headers: z.record(z.string(), z.string()),
       release_date: z.string(),
+      reasoningOptions: z.array(z.record(z.string(), z.any())).optional(),
       variants: z.record(z.string(), z.record(z.string(), z.any())).optional(),
+      modes: z.record(z.string(), Mode).optional(),
     })
     .meta({
       ref: "Model",
@@ -977,6 +1014,69 @@ export namespace Provider {
     return m
   }
 
+  function modelModes(provider: ModelsDev.Provider, model: ModelsDev.Model): Model["modes"] | undefined {
+    const experimental = model.experimental
+    const modes = experimental && typeof experimental === "object" ? experimental.modes : undefined
+    const direct = Object.fromEntries(
+      Object.entries(modes ?? {})
+        .filter(([key, mode]) => {
+          if (!mode) return false
+          if (provider.id !== "anthropic" || key !== "fast") return true
+          const id = model.id.toLowerCase().replaceAll(".", "-")
+          return id.startsWith("claude-opus-5") || id.startsWith("claude-opus-4-8")
+        })
+        .map(([key, mode]) => [
+          key,
+          {
+            model: mode?.model,
+            cost: mode?.cost
+              ? {
+                  input: mode.cost.input,
+                  output: mode.cost.output,
+                  cache: {
+                    read: mode.cost.cache_read ?? 0,
+                    write: mode.cost.cache_write ?? 0,
+                  },
+                }
+              : undefined,
+            provider: mode?.provider
+              ? {
+                  body: mode.provider.body ?? {},
+                  headers: mode.provider.headers ?? {},
+                }
+              : undefined,
+          },
+        ]),
+    )
+    const sibling =
+      provider.id === "openrouter" && !/-(?:fast|pro)$/.test(model.id)
+        ? Object.fromEntries(
+            ["fast", "pro"]
+              .map((key) => [key, provider.models[`${model.id}-${key}`]] as const)
+              .filter((entry) => !!entry[1])
+              .map(([key, route]) => [
+                key,
+                {
+                  model: route!.id,
+                  cost: route!.cost
+                    ? {
+                        input: route!.cost.input,
+                        output: route!.cost.output,
+                        cache: {
+                          read: route!.cost.cache_read ?? 0,
+                          write: route!.cost.cache_write ?? 0,
+                        },
+                      }
+                    : undefined,
+                },
+              ]),
+          )
+        : {}
+    const result = { ...direct, ...sibling }
+    if (Object.keys(result).length === 0) return undefined
+    return result
+  }
+
   function fromModelsDevModel(provider: ModelsDev.Provider, model: ModelsDev.Model): Model {
     // models.dev can lag a just-launched model's authoritative provider
     // contract. Normalize Muse at the ingestion seam so cached, bundled, and
@@ -1005,6 +1105,8 @@ export namespace Provider {
       status: model.status ?? "active",
       headers: model.headers ?? {},
       options: model.options ?? {},
+      modes: modelModes(provider, model),
+      reasoningOptions: model.reasoning_options,
       cost: {
         input: model.cost?.input ?? 0,
         output: model.cost?.output ?? 0,
@@ -1242,7 +1344,9 @@ export namespace Provider {
           headers: mergeDeep(existingModel?.headers ?? {}, model.headers ?? {}),
           family: model.family ?? existingModel?.family ?? "",
           release_date: model.release_date ?? existingModel?.release_date ?? "",
+          reasoningOptions: existingModel?.reasoningOptions,
           variants: {},
+          modes: existingModel?.modes,
         }
         const merged = mergeDeep(ProviderTransform.variants(parsedModel), model.variants ?? {})
         parsedModel.variants = mapValues(
@@ -1277,6 +1381,9 @@ export namespace Provider {
             // Codex OAuth advertises a separate 272k window even when the
             // copied public-API entry has a million-token context.
             limit: { ...model.limit, context: 272_000 },
+            // Codex advertises its own fast tier independently of the public
+            // API catalog, so synthesize only the modes in the OAuth contract.
+            modes: codexOAuthModes(model.id),
           }
           // The public API and ChatGPT/Codex expose different GPT-5.6 effort
           // ladders. Recompute after changing providerID instead of copying the

--- a/backend/cli/src/provider/transform.ts
+++ b/backend/cli/src/provider/transform.ts
@@ -434,6 +434,15 @@ export namespace ProviderTransform {
 
   const WIDELY_SUPPORTED_EFFORTS = ["low", "medium", "high"]
 
+  function catalogEfforts(model: Provider.Model) {
+    const options = model.reasoningOptions
+    if (!options) return undefined
+    const effort = options.find((option) => option.type === "effort")
+    if (!effort) return undefined
+    const values = Array.isArray(effort.values) ? effort.values : []
+    return values.filter((value): value is string => typeof value === "string")
+  }
+
   // The reasoning-effort ladder OpenAI actually accepts, per model — verified
   // against developers.openai.com model pages + the API changelog (July 2026):
   //   o-series          low/medium/high
@@ -486,6 +495,9 @@ export namespace ProviderTransform {
     if (!model.capabilities.reasoning) return {}
 
     const id = model.id.toLowerCase()
+    const exact = catalogEfforts(model)
+    const budget = model.reasoningOptions?.some((option) => option.type === "budget_tokens") ?? false
+    if (model.reasoningOptions && exact === undefined && !budget) return {}
 
     // The synthesized provider recomputes variants after changing provider id,
     // so this transport-specific contract cannot inherit public-API options.
@@ -509,7 +521,7 @@ export namespace ProviderTransform {
     // explicitly below because its low/high/max ladder differs from the common
     // low/medium/high set. Older Kimi models reject `reasoning_effort` alongside
     // `thinking`, and MiniMax/Mistral have no effort dial.
-    if (model.api.npm !== "@openrouter/ai-sdk-provider") {
+    if (!exact && model.api.npm !== "@openrouter/ai-sdk-provider") {
       if (id.includes("minimax") || id.includes("mistral")) return {}
       if (id.includes("kimi") && !/kimi-k3\b/.test(id)) return {}
       if (id.includes("glm") && !/glm-[5-9]/.test(id)) return {}
@@ -525,16 +537,17 @@ export namespace ProviderTransform {
       )
 
     // https://www.kimi.com/help/kimi-api/api-model-selection
-    if (/kimi-k3\b/.test(id)) return efforts(["low", "high", "max"])
+    if (/kimi-k3\b/.test(id)) return efforts(exact ?? ["low", "high", "max"])
 
     // see: https://docs.x.ai/docs/guides/reasoning#control-how-hard-the-model-thinks
     if (id.includes("grok") && id.includes("grok-3-mini")) {
-      return efforts(["low", "high"])
+      return efforts(exact ?? ["low", "high"])
     }
     // https://docs.x.ai/developers/model-capabilities/text/reasoning
-    if (/grok-4[.-]5\b/.test(id)) return efforts(WIDELY_SUPPORTED_EFFORTS)
-    if (/grok-4[.-]3\b/.test(id)) return efforts(["none", ...WIDELY_SUPPORTED_EFFORTS])
-    if (/grok-4[.-]20/.test(id) && id.includes("multi-agent")) return efforts([...WIDELY_SUPPORTED_EFFORTS, "xhigh"])
+    if (/grok-4[.-]5\b/.test(id)) return efforts(exact ?? WIDELY_SUPPORTED_EFFORTS)
+    if (/grok-4[.-]3\b/.test(id)) return efforts(exact ?? ["none", ...WIDELY_SUPPORTED_EFFORTS])
+    if (/grok-4[.-]20/.test(id) && id.includes("multi-agent"))
+      return efforts(exact ?? [...WIDELY_SUPPORTED_EFFORTS, "xhigh"])
     if (id.includes("grok")) return {}
 
     // Meta's OpenAI-compatible Muse endpoint accepts this exact ladder. Keep it
@@ -542,21 +555,12 @@ export namespace ProviderTransform {
     // HTTP 400, while `minimal` is the lowest supported tier and there is no
     // `max` tier.
     if (/muse-spark-1[.-]1\b/.test(id)) {
-      const values = ["minimal", ...WIDELY_SUPPORTED_EFFORTS, "xhigh"]
+      const values = exact ?? ["minimal", ...WIDELY_SUPPORTED_EFFORTS, "xhigh"]
       return Object.fromEntries(values.map((effort) => [effort, { reasoningEffort: effort }]))
     }
 
     switch (model.api.npm) {
       case "@openrouter/ai-sdk-provider": {
-        // Claude via OpenRouter cannot round-trip reasoning (#167): Anthropic requires
-        // the signed thinking block replayed unmodified on the next step of a tool-use
-        // turn, but @openrouter/ai-sdk-provider@1.5.x strips that signature → 400
-        // "Invalid signature" that stalls multi-step turns. Offer NO reasoning for
-        // Claude here so no thinking block is ever generated to fail; native-Anthropic
-        // BYOK (@ai-sdk/anthropic) carries a valid signature and keeps its full ladder.
-        // Re-enable when @openrouter/ai-sdk-provider@2.x + ai@^6 lands (drop this guard
-        // AND the options() one). Same predicate as options() so the guards can't drift.
-        if (isAnthropic(model)) return {}
         // OpenRouter takes a unified `reasoning.effort` and clamps any level a model
         // doesn't support to the nearest one (no 400) — verified against
         // openrouter.ai/docs/use-cases/reasoning-tokens. The only hazard is silent
@@ -566,6 +570,7 @@ export namespace ProviderTransform {
           Object.fromEntries(efforts.map((effort) => [effort, { reasoning: { effort } }]))
         // No effort dial (reasoning is on/off only): low/medium/high would be three
         // identical "on" options — misleading — so expose none (runs at default).
+        if (exact) return orEffort(exact)
         if (id.includes("kimi") || id.includes("minimax") || id.includes("mistral")) return {}
         if (id.includes("glm") && !/glm-[5-9]/.test(id)) return {} // GLM-4.6 = thinking toggle only
         if (model.id.includes("gpt")) return orEffort(openaiEfforts(model))
@@ -578,7 +583,9 @@ export namespace ProviderTransform {
       // conflict is resolved in maxOutputTokens() (drops the cap for gateway
       // calls carrying a reasoningEffort), so the effort variants are safe here.
       case "@ai-sdk/gateway":
-        return Object.fromEntries(openaiEfforts(model).map((effort) => [effort, { reasoningEffort: effort }]))
+        return Object.fromEntries(
+          (exact ?? openaiEfforts(model)).map((effort) => [effort, { reasoningEffort: effort }]),
+        )
 
       case "@ai-sdk/github-copilot":
         const copilotEfforts = iife(() => {
@@ -605,6 +612,9 @@ export namespace ProviderTransform {
       case "@ai-sdk/deepinfra":
       // https://v5.ai-sdk.dev/providers/ai-sdk-providers/deepinfra
       case "@ai-sdk/openai-compatible":
+        if (exact) {
+          return Object.fromEntries(exact.map((effort) => [effort, { reasoningEffort: effort }]))
+        }
         // DeepSeek-v4 and GLM-5.2+ accept a `max` tier above high; their OpenAI-
         // compatible provider maps `reasoningEffort` -> body `reasoning_effort`.
         // Other openai-compatible providers use the widely-supported floor.
@@ -636,7 +646,7 @@ export namespace ProviderTransform {
         // https://v5.ai-sdk.dev/providers/ai-sdk-providers/openai
         // openaiEfforts() returns [] for gpt-5-pro (fixed high) → no variants.
         return Object.fromEntries(
-          openaiEfforts(model).map((effort) => [
+          (exact ?? openaiEfforts(model)).map((effort) => [
             effort,
             {
               reasoningEffort: effort,
@@ -651,6 +661,9 @@ export namespace ProviderTransform {
       case "@ai-sdk/google-vertex/anthropic": {
         // https://v5.ai-sdk.dev/providers/ai-sdk-providers/google-vertex#anthropic-provider
         const cap = model.limit.output
+        if (exact) {
+          return Object.fromEntries(exact.map((effort) => [effort, { effort }]))
+        }
 
         // The newest Claudes REJECT manual extended thinking (`thinking.type:
         // "enabled"` → 400) and drive depth via `output_config.effort` instead.
@@ -749,6 +762,19 @@ export namespace ProviderTransform {
       // https://v5.ai-sdk.dev/providers/ai-sdk-providers/google-vertex
       case "@ai-sdk/google":
         // https://v5.ai-sdk.dev/providers/ai-sdk-providers/google-generative-ai
+        if (exact) {
+          return Object.fromEntries(
+            exact.map((effort) => [
+              effort,
+              {
+                thinkingConfig: {
+                  includeThoughts: true,
+                  thinkingLevel: effort,
+                },
+              },
+            ]),
+          )
+        }
         if (id.includes("2.5")) {
           return {
             low: {
@@ -806,7 +832,7 @@ export namespace ProviderTransform {
         // https://v5.ai-sdk.dev/providers/ai-sdk-providers/groq
         // Groq uses reasoningEffort + reasoningFormat — NOT the Google
         // includeThoughts/thinkingLevel keys (which groq ignores/rejects).
-        const groqEffort = ["none", ...WIDELY_SUPPORTED_EFFORTS]
+        const groqEffort = exact ?? ["none", ...WIDELY_SUPPORTED_EFFORTS]
         return Object.fromEntries(
           groqEffort.map((effort) => [
             effort,
@@ -852,30 +878,7 @@ export namespace ProviderTransform {
       // overrides this via mergeDeep in llm.ts). This is the single normalized
       // reasoning path that all managed wallet inference now flows through.
       //
-      // EXCEPT Claude via OpenRouter: Anthropic requires the signed thinking block
-      // to be replayed unmodified on the next step of a tool-use turn, but OpenRouter
-      // strips that signature on these routes — so any multi-step turn that produced
-      // thinking is rejected with 400 "Invalid `signature`…" / "…cannot be modified",
-      // surfaced as the generic "Provider returned error" that stalls the loop. Don't
-      // request reasoning for it, so no unreplayable thinking block is ever generated
-      // (1.2.5 requested reasoning for gemini-3 only). Native-Anthropic BYOK is a
-      // different npm (@ai-sdk/anthropic) and keeps its properly-signed reasoning.
-      //
-      // This is a workaround, not the ceiling. The corruption lives in
-      // @openrouter/ai-sdk-provider@1.5.x: it emits per-`reasoning-delta`
-      // reasoning_details fragments with no signature and duplicates them across the
-      // message on replay, so the signed block can never be reconstructed intact
-      // (see Kilo-Org/kilo#303). Re-enabling Claude-OR reasoning requires the fix in
-      // @openrouter/ai-sdk-provider@2.x, which needs ai@^6 — a breaking upgrade
-      // tracked separately. When that lands, drop this guard AND the one in variants().
-      //
-      // Explicitly DISABLE rather than merely omit: adaptive-thinking Claude (Opus
-      // 4.7+/Claude 5) defaults thinking ON on the wire, and llm.ts merges
-      // model/agent `options.reasoning` AFTER this base — `{ enabled: false }` (the
-      // same shape smallOptions() uses) survives both, where an omission would not.
-      const claude = isAnthropic(input.model)
-      if (claude) result["reasoning"] = { enabled: false }
-      if (!claude && input.model.capabilities.reasoning) {
+      if (input.model.capabilities.reasoning) {
         const id = input.model.api.id.toLowerCase()
         // Grok 4.5's documented default is high and reasoning is mandatory.
         // Preserve that default through OpenRouter instead of replacing it with
@@ -981,6 +984,26 @@ export namespace ProviderTransform {
     }
 
     return result
+  }
+
+  export function tier(model: Provider.Model, tier?: string) {
+    const mode = tier ? model.modes?.[tier] : undefined
+    const body = mode?.provider?.body ?? {}
+    const options =
+      model.api?.npm === "@ai-sdk/openai"
+        ? {
+            ...Object.fromEntries(
+              Object.entries(body).filter(([key]) => key !== "service_tier" && key !== "reasoning"),
+            ),
+            ...(typeof body.service_tier === "string" ? { serviceTier: body.service_tier } : {}),
+            ...(typeof body.reasoning?.mode === "string" ? { reasoningMode: body.reasoning.mode } : {}),
+          }
+        : body
+    return {
+      model: mode?.model,
+      options,
+      headers: mode?.provider?.headers ?? {},
+    }
   }
 
   export function smallOptions(model: Provider.Model) {

--- a/backend/cli/src/session/llm.ts
+++ b/backend/cli/src/session/llm.ts
@@ -44,6 +44,10 @@ export namespace LLM {
   export type StreamOutput = StreamTextResult<ToolSet, unknown>
 
   export async function stream(input: StreamInput) {
+    const tier = input.small
+      ? { model: undefined, options: {}, headers: {} }
+      : ProviderTransform.tier(input.model, input.user.tier)
+    const routed = tier.model ? await Provider.getModel(input.model.providerID, tier.model) : input.model
     const l = log
       .clone()
       .tag("providerID", input.model.providerID)
@@ -57,7 +61,7 @@ export namespace LLM {
       providerID: input.model.providerID,
     })
     const [language, cfg, provider, auth] = await Promise.all([
-      Provider.getLanguage(input.model),
+      Provider.getLanguage(routed),
       Config.get(),
       Provider.getProvider(input.model.providerID),
       Auth.get(input.model.providerID),
@@ -112,6 +116,7 @@ export namespace LLM {
     const options: Record<string, any> = pipe(
       base,
       mergeDeep(input.model.options),
+      mergeDeep(tier.options),
       mergeDeep(input.agent.options),
       mergeDeep(variant),
     )
@@ -232,6 +237,7 @@ export namespace LLM {
               }
             : undefined),
         ...input.model.headers,
+        ...tier.headers,
         ...headers,
       },
       maxRetries: input.retries ?? 0,

--- a/backend/cli/src/session/message-v2.ts
+++ b/backend/cli/src/session/message-v2.ts
@@ -332,7 +332,7 @@ export namespace MessageV2 {
     system: z.string().optional(),
     tools: z.record(z.string(), z.boolean()).optional(),
     variant: z.string().optional(),
-    tier: z.enum(["fast", "pro", "ultra"]).optional(),
+    tier: z.string().optional(),
   }).meta({
     ref: "UserMessage",
   })

--- a/backend/cli/src/session/prompt.ts
+++ b/backend/cli/src/session/prompt.ts
@@ -136,7 +136,7 @@ export namespace SessionPrompt {
       ),
     system: z.string().optional(),
     variant: z.string().optional(),
-    tier: z.enum(["fast", "pro", "ultra"]).optional(),
+    tier: z.string().optional(),
     parts: z.array(
       z.discriminatedUnion("type", [
         MessageV2.TextPart.omit({
@@ -2041,6 +2041,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
     arguments: z.string(),
     command: z.string(),
     variant: z.string().optional(),
+    tier: z.string().optional(),
     parts: z
       .array(
         z.discriminatedUnion("type", [
@@ -2254,6 +2255,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       agent: userAgent,
       parts,
       variant: input.variant,
+      tier: input.tier,
     })) as MessageV2.WithParts
 
     Bus.publish(Command.Event.Executed, {

--- a/backend/cli/src/skill/skill.ts
+++ b/backend/cli/src/skill/skill.ts
@@ -9,6 +9,7 @@ import { runtimeRegexPass, classifierInjectionRegexPass } from "./install/review
 import { NamedError } from "@synsci/util/error"
 import { ConfigMarkdown } from "../config/markdown"
 import INITIALIZE_ATLAS_GRAPH_MD from "./system/initialize-atlas-graph.txt"
+import GOAL_MD from "./system/goal.txt"
 import { Log } from "../util/log"
 import { Global } from "@/global"
 import { Filesystem } from "@/util/filesystem"
@@ -25,6 +26,7 @@ import { Installation } from "@/installation"
 // including the compiled binary, which ships no skills and otherwise depends on
 // the API index. Kept in sync with skills/research/<name>/SKILL.md by a test.
 const SYSTEM_SKILLS: Array<{ name: string; content: string }> = [
+  { name: "goal", content: GOAL_MD },
   { name: "initialize-atlas-graph", content: INITIALIZE_ATLAS_GRAPH_MD },
 ]
 

--- a/backend/cli/src/skill/system/goal.txt
+++ b/backend/cli/src/skill/system/goal.txt
@@ -1,0 +1,33 @@
+---
+name: goal
+description: Set an explicit objective, success criteria, and stopping conditions for the current OpenScience session.
+category: other
+tags: [workflow, planning, persistence]
+---
+
+# Goal
+
+Use this skill when the user invokes `/goal` or asks OpenScience to work toward a concrete outcome over multiple turns.
+
+## Contract
+
+Establish the session goal as a compact completion contract:
+
+- Objective: the specific outcome the user wants.
+- Success criteria: the checks that prove the outcome is reached.
+- Constraints: files, branches, budgets, tools, credentials, publishing rules, or safety limits the user names.
+- Stop conditions: complete, blocked, cancelled, budget exhausted, or superseded by a newer user instruction.
+
+If the user provided enough detail, proceed without another question. Ask only when the missing detail would make the work unsafe, irreversible, or impossible to verify.
+
+## Execution
+
+1. Restate the goal briefly in working terms.
+2. Keep a short visible checklist while working.
+3. Prefer real verification over confidence: tests, builds, local runs, screenshots, logs, or provider/API checks as appropriate.
+4. Persist durable checkpoints in project files, commits, PRs, or Atlas records when the user asks for persistence or the repository already uses that workflow.
+5. Update the user when the goal changes, a stop condition is hit, or verification gives new evidence.
+
+## Completion
+
+Before calling the goal complete, verify each success criterion with fresh evidence. If the goal is blocked, report the exact blocker, the evidence gathered, and the smallest user or external action that would unblock it.

--- a/backend/cli/test/installation/release-order.test.ts
+++ b/backend/cli/test/installation/release-order.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from "bun:test"
+import path from "path"
+
+test("production publish pushes the release commit before targeting it on GitHub", async () => {
+  const script = await Bun.file(path.join(import.meta.dir, "../../../../tooling/repo/publish.ts")).text()
+  const tag = script.indexOf("git push origin refs/tags/")
+  const release = script.indexOf("gh release edit v${Script.version} --target ${sha}")
+
+  expect(tag).toBeGreaterThan(-1)
+  expect(release).toBeGreaterThan(tag)
+  expect(script.slice(tag, release)).not.toContain(".nothrow()")
+})

--- a/backend/cli/test/provider/provider.test.ts
+++ b/backend/cli/test/provider/provider.test.ts
@@ -98,9 +98,13 @@ test("synthesized Codex OAuth models use Codex variants and context instead of p
         expect(sol.limit.context).toBe(272_000)
         expect(sol.cost).toEqual({ input: 0, output: 0, cache: { read: 0, write: 0 } })
         expect(Object.keys(sol.variants ?? {})).toEqual(["low", "medium", "high", "xhigh", "max", "ultra"])
+        expect(Object.keys(sol.modes ?? {})).toEqual(["fast"])
+        expect(sol.modes?.fast.provider?.body).toEqual({ service_tier: "priority" })
 
         const codex54 = codex.models["gpt-5.4"]
         expect(Object.keys(codex54.variants ?? {})).toEqual(["low", "medium", "high", "xhigh"])
+        expect(Object.keys(codex54.modes ?? {})).toEqual(["fast"])
+        expect(codex.models["gpt-5.4-mini"].modes).toBeUndefined()
 
         const publicSol = providers.openai?.models["gpt-5.6-sol"]
         expect(Object.keys(publicSol?.variants ?? {})).toEqual(["none", "low", "medium", "high", "xhigh", "max"])
@@ -143,6 +147,17 @@ test("current frontier models are routable from the seeded catalog", async () =>
         "high",
         "xhigh",
       ])
+      expect((providers["openai"].models["gpt-5.4"] as any).modes?.fast?.provider?.body).toEqual({
+        service_tier: "priority",
+      })
+      expect((providers["anthropic"].models["claude-opus-4-8"] as any).modes?.fast?.provider?.body).toEqual({
+        speed: "fast",
+      })
+      expect((providers["anthropic"].models["claude-opus-4-8"] as any).modes?.fast?.provider?.headers).toEqual({
+        "anthropic-beta": "fast-mode-2026-02-01",
+      })
+      expect((providers["anthropic"].models["claude-opus-4-7"] as any).modes).toBeUndefined()
+      expect((providers["anthropic"].models["claude-opus-4-6"] as any).modes).toBeUndefined()
     },
   })
 })
@@ -176,6 +191,7 @@ test("Codex OAuth exposes the GPT-5.6 family as subscription models", async () =
             output: 0,
             cache: { read: 0, write: 0 },
           })
+          expect(Object.keys(codex.models[id].modes ?? {})).toEqual(["fast"])
         }
       },
     })
@@ -2445,8 +2461,8 @@ test("variant config merges with generated variants", async () => {
       const providers = await Provider.list()
       const model = providers["anthropic"].models[SONNET]
       expect(model.variants!["high"]).toBeDefined()
-      // Should have both the generated thinking config and the custom option
-      expect(model.variants!["high"].thinking).toBeDefined()
+      // Should have both the generated native effort and the custom option.
+      expect(model.variants!["high"].effort).toBe("high")
       expect(model.variants!["high"].extraOption).toBe("custom-value")
     },
   })

--- a/backend/cli/test/provider/transform-reasoning-wire.test.ts
+++ b/backend/cli/test/provider/transform-reasoning-wire.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test"
+import { createAnthropic } from "@ai-sdk/anthropic"
 import { createOpenAI } from "@ai-sdk/openai"
 import { createXai } from "@ai-sdk/xai"
 import { generateText } from "ai"
@@ -104,5 +105,56 @@ describe("reasoning options serialize onto provider request bodies", () => {
       include: ["reasoning.encrypted_content"],
     })
     expect(wire.bodies[0].reasoning).toBeUndefined()
+  })
+
+  test("OpenAI fast and pro modes reach their native request fields", async () => {
+    const target = model({
+      id: "gpt-5.6-sol",
+      providerID: "openai",
+      api: { id: "gpt-5.6-sol", url: "https://api.openai.com/v1", npm: "@ai-sdk/openai" },
+      modes: {
+        fast: { provider: { body: { service_tier: "priority" } } },
+        pro: { provider: { body: { reasoning: { mode: "pro" } } } },
+      },
+    })
+    const wire = recorder()
+    const sdk = createOpenAI({ apiKey: "test", baseURL: "https://openai.test/v1", fetch: wire.fetch })
+
+    for (const mode of ["fast", "pro"]) {
+      const options = mergeDeep(
+        ProviderTransform.options({ model: target, sessionID, providerOptions: {} }),
+        ProviderTransform.tier(target, mode).options,
+      )
+      await send(sdk.responses(target.api.id), ProviderTransform.providerOptions(target, options))
+    }
+
+    expect(wire.bodies[0].service_tier).toBe("priority")
+    expect(wire.bodies[1].reasoning).toMatchObject({ mode: "pro" })
+  })
+
+  test("Anthropic fast mode reaches the speed field", async () => {
+    const target = model({
+      id: "claude-opus-4-8",
+      providerID: "anthropic",
+      api: { id: "claude-opus-4-8", url: "https://api.anthropic.com/v1", npm: "@ai-sdk/anthropic" },
+      modes: {
+        fast: {
+          provider: {
+            body: { speed: "fast" },
+            headers: { "anthropic-beta": "fast-mode-2026-02-01" },
+          },
+        },
+      },
+    })
+    const options = mergeDeep(
+      ProviderTransform.options({ model: target, sessionID, providerOptions: {} }),
+      ProviderTransform.tier(target, "fast").options,
+    )
+    const wire = recorder()
+    const sdk = createAnthropic({ apiKey: "test", baseURL: "https://anthropic.test/v1", fetch: wire.fetch })
+
+    await send(sdk(target.api.id), ProviderTransform.providerOptions(target, options))
+
+    expect(wire.bodies[0].speed).toBe("fast")
   })
 })

--- a/backend/cli/test/provider/transform-reasoning.test.ts
+++ b/backend/cli/test/provider/transform-reasoning.test.ts
@@ -50,42 +50,41 @@ describe("ProviderTransform.options — managed OpenRouter reasoning", () => {
     expect(result.include).toBeUndefined()
   })
 
-  test("Claude via OpenRouter explicitly DISABLES reasoning (unreplayable signed thinking → 400)", () => {
+  test("Claude via OpenRouter requests unified reasoning for managed inference", () => {
     const result = ProviderTransform.options({
       model: orModel("openrouter/anthropic/claude-sonnet-4", "anthropic/claude-sonnet-4"),
       sessionID,
       providerOptions: { baseURL: PROXY_OR },
     })
-    // usage tracking still on, reasoning explicitly off → no thinking blocks, even
-    // for adaptive-thinking models that default on and past a config effort merge.
     expect(result.usage).toEqual({ include: true })
-    expect(result.reasoning).toEqual({ enabled: false })
+    expect(result.reasoning).toEqual({ effort: "medium" })
   })
 
-  test("Claude-OR reasoning is disabled even when only api.id (mixed-case) carries the token", () => {
-    // options() and variants() must key off the SAME both-field, lowercased predicate,
-    // or an uppercase/aliased Claude id slips options() and re-triggers the 400.
+  test("Claude via OpenRouter supports reasoning when only api.id carries a mixed-case token", () => {
     const upper = ProviderTransform.options({
       model: orModel("openrouter/some-alias", "Anthropic/Claude-Sonnet-4"),
       sessionID,
       providerOptions: { baseURL: PROXY_OR },
     })
-    expect(upper.reasoning).toEqual({ enabled: false })
-    // model.id carries the token, api.id does not → still caught (both fields checked).
+    expect(upper.reasoning).toEqual({ effort: "medium" })
+
     const aliased = ProviderTransform.options({
       model: orModel("openrouter/anthropic/claude-x", "vendor/opaque-slug"),
       sessionID,
       providerOptions: { baseURL: PROXY_OR },
     })
-    expect(aliased.reasoning).toEqual({ enabled: false })
+    expect(aliased.reasoning).toEqual({ effort: "medium" })
   })
 
-  test("Claude via OpenRouter offers no reasoning-effort variants (same predicate as options)", () => {
+  test("Claude via OpenRouter offers the unified reasoning-effort variants", () => {
     expect(
-      ProviderTransform.variants(orModel("openrouter/anthropic/claude-sonnet-4", "anthropic/claude-sonnet-4")),
-    ).toEqual({})
-    // mixed-case api.id must also yield no picker, matching options() above.
-    expect(ProviderTransform.variants(orModel("openrouter/some-alias", "Anthropic/Claude-Sonnet-4"))).toEqual({})
+      Object.keys(
+        ProviderTransform.variants(orModel("openrouter/anthropic/claude-sonnet-4", "anthropic/claude-sonnet-4")),
+      ),
+    ).toEqual(["low", "medium", "high"])
+    expect(
+      Object.keys(ProviderTransform.variants(orModel("openrouter/some-alias", "Anthropic/Claude-Sonnet-4"))),
+    ).toEqual(["low", "medium", "high"])
   })
 
   test("a non-Claude OR model whose id merely contains a vendor token is unaffected", () => {

--- a/backend/cli/test/provider/transform.test.ts
+++ b/backend/cli/test/provider/transform.test.ts
@@ -101,6 +101,111 @@ describe("ProviderTransform.options - setCacheKey", () => {
     })
     expect(result.store).toBe(false)
   })
+
+  test("enables managed Claude reasoning through OpenRouter", () => {
+    const result = ProviderTransform.options({
+      model: {
+        ...mockModel,
+        id: "anthropic/claude-opus-4.8",
+        providerID: "openrouter",
+        api: {
+          id: "anthropic/claude-opus-4.8",
+          url: "https://openrouter.ai/api/v1",
+          npm: "@openrouter/ai-sdk-provider",
+        },
+        capabilities: {
+          ...mockModel.capabilities,
+          reasoning: true,
+          interleaved: { field: "reasoning_details" },
+        },
+      },
+      sessionID,
+      providerOptions: {},
+    })
+
+    expect(result.reasoning).toEqual({ effort: "medium" })
+  })
+})
+
+describe("ProviderTransform.tier", () => {
+  test("catalog mode applies provider body, headers, and sibling model route", () => {
+    const result = ProviderTransform.tier(
+      {
+        modes: {
+          pro: {
+            model: "openai/gpt-5.6-sol-pro",
+            provider: {
+              body: { reasoning: { mode: "pro" } },
+              headers: { "x-model-mode": "pro" },
+            },
+          },
+        },
+      } as any,
+      "pro",
+    )
+
+    expect(result.model).toBe("openai/gpt-5.6-sol-pro")
+    expect(result.options).toEqual({ reasoning: { mode: "pro" } })
+    expect(result.headers).toEqual({ "x-model-mode": "pro" })
+  })
+
+  test("missing mode metadata leaves provider payload and model untouched", () => {
+    expect(ProviderTransform.tier({ modes: {} } as any, "pro")).toEqual({
+      model: undefined,
+      options: {},
+      headers: {},
+    })
+    expect(ProviderTransform.tier({} as any, "fast")).toEqual({
+      model: undefined,
+      options: {},
+      headers: {},
+    })
+  })
+})
+
+describe("ProviderTransform.variants - exact catalog efforts", () => {
+  const model = {
+    id: "deepseek/deepseek-v4-pro",
+    providerID: "openrouter",
+    api: {
+      id: "deepseek/deepseek-v4-pro",
+      url: "https://openrouter.ai/api/v1",
+      npm: "@openrouter/ai-sdk-provider",
+    },
+    capabilities: {
+      reasoning: true,
+      temperature: true,
+      attachment: false,
+      toolcall: true,
+      input: { text: true, audio: false, image: false, video: false, pdf: false },
+      output: { text: true, audio: false, image: false, video: false, pdf: false },
+      interleaved: false,
+    },
+    reasoningOptions: [{ type: "effort", values: ["high", "xhigh"] }],
+    limit: { context: 1_000_000, output: 384_000 },
+    cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+    status: "active",
+    options: {},
+    headers: {},
+  } as any
+
+  test("uses the model's exact effort ladder instead of a family-wide guess", () => {
+    expect(ProviderTransform.variants(model)).toEqual({
+      high: { reasoning: { effort: "high" } },
+      xhigh: { reasoning: { effort: "xhigh" } },
+    })
+  })
+
+  test("an explicit empty reasoning contract exposes no effort control", () => {
+    expect(
+      ProviderTransform.variants({
+        ...model,
+        id: "z-ai/glm-5",
+        api: { ...model.api, id: "z-ai/glm-5" },
+        reasoningOptions: [],
+      }),
+    ).toEqual({})
+  })
 })
 
 describe("ProviderTransform.maxOutputTokens", () => {
@@ -1450,20 +1555,26 @@ describe("ProviderTransform.variants", () => {
       expect(result.xhigh).toEqual({ reasoning: { effort: "xhigh" } })
     })
 
-    test("claude via OpenRouter offers NO reasoning variants (#167: unsignable round-trip)", () => {
-      // OpenRouter strips Anthropic's thinking-block signature, so Claude reasoning
-      // 400s on multi-step tool-use turns — variants() must return {} for Claude on
-      // OR (native-Anthropic BYOK keeps its full ladder, tested separately).
-      for (const apiId of ["anthropic/claude-opus-4.8", "anthropic/claude-sonnet-5", "anthropic/claude-sonnet-4-5"]) {
-        const result = ProviderTransform.variants(
-          createMockModel({
-            id: apiId,
-            providerID: "openrouter",
-            api: { id: apiId, url: "https://openrouter.ai", npm: "@openrouter/ai-sdk-provider" },
-          }),
-        )
-        expect(result).toEqual({})
-      }
+    test("claude via OpenRouter uses its exact catalog effort ladder", () => {
+      const result = ProviderTransform.variants(
+        createMockModel({
+          id: "anthropic/claude-opus-4.8",
+          providerID: "openrouter",
+          api: {
+            id: "anthropic/claude-opus-4.8",
+            url: "https://openrouter.ai",
+            npm: "@openrouter/ai-sdk-provider",
+          },
+          reasoningOptions: [
+            {
+              type: "effort",
+              values: ["low", "medium", "high", "xhigh", "max"],
+            },
+          ],
+        }),
+      )
+      expect(Object.keys(result)).toEqual(["low", "medium", "high", "xhigh", "max"])
+      expect(result.xhigh).toEqual({ reasoning: { effort: "xhigh" } })
     })
 
     test("no-effort-dial models expose no variants (kimi = on/off only)", () => {

--- a/backend/cli/test/skill/system-skills.test.ts
+++ b/backend/cli/test/skill/system-skills.test.ts
@@ -13,4 +13,10 @@ describe("system skills", () => {
     const canonical = await Bun.file(path.join(root, "skills/research/initialize-atlas-graph/SKILL.md")).text()
     expect(embedded).toBe(canonical)
   })
+
+  test("embedded goal matches the canonical SKILL.md", async () => {
+    const embedded = await Bun.file(path.join(root, "src/skill/system/goal.txt")).text()
+    const canonical = await Bun.file(path.join(root, "skills/other/goal/SKILL.md")).text()
+    expect(embedded).toBe(canonical)
+  })
 })

--- a/bun.lock
+++ b/bun.lock
@@ -293,6 +293,7 @@
     "tree-sitter-bash",
   ],
   "patchedDependencies": {
+    "@ai-sdk/openai@2.0.89": "tooling/patches/@ai-sdk%2Fopenai@2.0.89.patch",
     "@ai-sdk/anthropic@2.0.57": "tooling/patches/@ai-sdk%2Fanthropic@2.0.57.patch",
     "ghostty-web@0.3.0": "tooling/patches/ghostty-web@0.3.0.patch",
   },

--- a/frontend/workspace/src/atlas/Composer.tsx
+++ b/frontend/workspace/src/atlas/Composer.tsx
@@ -25,6 +25,7 @@ import { useGlobalSync } from "@/context/global-sync"
 import { useDialog } from "@synsci/ui/context/dialog"
 import { openSetupDialog } from "@/atlas/SetupDialog"
 import { resolveModelSource, type ModelSource } from "@/utils/model-cost"
+import { modelTierOptions, normalizedTier, promptTier, type ModelTier } from "./model-tier"
 
 const BYOK_URL = URLS.dashboard
 
@@ -57,7 +58,7 @@ const SOURCE_DOT: Record<ModelSource, { color: string; opacity: number; meters: 
 
 // The effort control renders a model's OWN reasoning-effort variant keys
 // (low/medium/high/xhigh/none/minimal, exactly as the backend emits them) and
-// persists the choice via models.variant. No relabeling.
+// persists the choice via models.variant. Speed/context modes are separate.
 //
 
 // Collapse a model id to its FAMILY so the picker shows one current entry per
@@ -98,6 +99,10 @@ interface ModelCostShape {
   input?: number
   output?: number
   experimentalOver200K?: { input?: number; output?: number }
+}
+
+interface ModelModeShape {
+  modes?: Record<string, unknown>
 }
 function rateFor(cost: ModelCostShape | undefined, over: boolean) {
   const tier = over && cost?.experimentalOver200K ? cost.experimentalOver200K : cost
@@ -218,6 +223,7 @@ export function Composer(): JSX.Element {
     agent: string
     model: ModelKey
     variant: string | undefined
+    tier: ModelTier | undefined
   }
   const [queue, setQueue] = createSignal<QueuedPrompt[]>([])
   const [inflight, setInflight] = createSignal(false)
@@ -331,17 +337,16 @@ export function Composer(): JSX.Element {
     if (m) models.variant.set(m, value)
   }
 
-  // Context tier (Cursor "MAX mode" analogue). Only meaningful when the model
-  // prices the >200k window differently. This is a price-preview + intent signal;
-  // the long-context request flag is threaded through submit in a later pass.
-  const [longCtx, setLongCtx] = createSignal(false)
-  const selectedCost = createMemo(() => selectedInfo()?.cost as ModelCostShape | undefined)
-  const hasLongTier = createMemo(() => !!selectedCost()?.experimentalOver200K)
-  // Reset the tier toggle whenever the model changes — pricing is per-model.
+  const [tier, setTier] = createSignal<ModelTier>("standard")
+  const selectedModes = createMemo(() => (selectedInfo() as ModelModeShape | undefined)?.modes)
+  const modeKeys = createMemo(() => Object.keys(selectedModes() ?? {}))
+  const tierOptions = createMemo(() => modelTierOptions(modeKeys()))
+  const selectedTier = createMemo(() => normalizedTier(tier(), modeKeys()))
+  // Reset the tier whenever the model changes — modes and pricing are per-model.
   createEffect(
     on(
       () => model()?.providerID + "/" + model()?.modelID,
-      () => setLongCtx(false),
+      () => setTier("standard"),
       { defer: true },
     ),
   )
@@ -716,6 +721,7 @@ export function Composer(): JSX.Element {
       agent: agent(),
       model: chosen,
       variant: models.variant.get(chosen),
+      tier: promptTier(tier(), modeKeys()),
     }
     // Clear the input immediately in both paths so typing can continue.
     setText("")
@@ -800,6 +806,7 @@ export function Composer(): JSX.Element {
           model: p.model,
           agent: p.agent,
           variant: p.variant,
+          tier: p.tier,
           parts: promptParts,
         } as any)
         .catch((e: any) => {
@@ -1349,7 +1356,7 @@ export function Composer(): JSX.Element {
                                       model()?.providerID === row.provider.id && model()?.modelID === row.id
                                     const highlighted = () => modelIndex() === flatIndex()
                                     const dot = SOURCE_DOT[rowSource(row.provider.id)]
-                                    const price = () => rateFor(row.cost as ModelCostShape, active() && longCtx())
+                                    const price = () => rateFor(row.cost as ModelCostShape, false)
                                     return (
                                       <div
                                         ref={(el) => (modelRowRefs[flatIndex()] = el)}
@@ -1532,8 +1539,8 @@ export function Composer(): JSX.Element {
                       </div>
 
                       {/* controls for the selected model — one home for effort /
-                          speed / context, so every list row stays uniform */}
-                      <Show when={!!model() && (variantKeys().length > 0 || hasLongTier())}>
+                          mode, so every list row stays uniform */}
+                      <Show when={!!model() && (variantKeys().length > 0 || tierOptions().length > 0)}>
                         <div
                           onClick={(e) => e.stopPropagation()}
                           style={{
@@ -1556,16 +1563,13 @@ export function Composer(): JSX.Element {
                               />
                             </span>
                           </Show>
-                          <Show when={hasLongTier()}>
+                          <Show when={tierOptions().length > 0}>
                             <span style={{ display: "inline-flex", "align-items": "center", gap: "6px" }}>
-                              <span style={CONTROL_LABEL}>context</span>
+                              <span style={CONTROL_LABEL}>mode</span>
                               <Segmented
-                                options={[
-                                  { id: "std", label: "≤200k" },
-                                  { id: "long", label: ">200k" },
-                                ]}
-                                value={longCtx() ? "long" : "std"}
-                                onPick={(id) => setLongCtx(id === "long")}
+                                options={tierOptions()}
+                                value={selectedTier()}
+                                onPick={(id) => setTier(id as ModelTier)}
                               />
                             </span>
                           </Show>
@@ -1838,7 +1842,7 @@ export function Composer(): JSX.Element {
   )
 }
 
-// Faint caption preceding a segmented control ("effort" / "speed" / "context").
+// Faint caption preceding a segmented control ("effort" / "mode").
 const CONTROL_LABEL: JSX.CSSProperties = {
   "font-family": FONT_MONO,
   "font-size": "10px",
@@ -1848,8 +1852,7 @@ const CONTROL_LABEL: JSX.CSSProperties = {
 
 // Cursor-style segmented control: a quiet row of peers where the selected one is
 // marked by a faint tint + hairline border at a consistent weight — never bold.
-// Used on the active model row for the effort keys, the fast/normal speed toggle,
-// and the context tier.
+// Used on the active model row for effort keys and provider-native modes.
 function Segmented(props: {
   options: { id: string; label: string }[]
   value: string

--- a/frontend/workspace/src/atlas/model-tier.test.ts
+++ b/frontend/workspace/src/atlas/model-tier.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test"
+import { modelTierOptions, normalizedTier, promptTier } from "./model-tier"
+
+describe("model tier controls", () => {
+  test("shows standard followed by only the selected model's real modes", () => {
+    expect(modelTierOptions(["fast", "pro"]).map((x) => x.id)).toEqual(["standard", "fast", "pro"])
+  })
+
+  test("does not invent modes and drops stale selections at the request boundary", () => {
+    expect(modelTierOptions([])).toEqual([])
+    expect(modelTierOptions(["fast"]).map((x) => x.id)).toEqual(["standard", "fast"])
+    expect(normalizedTier("ultra", ["fast"])).toBe("standard")
+    expect(promptTier("standard", ["fast"])).toBeUndefined()
+    expect(promptTier("fast", ["fast"])).toBe("fast")
+    expect(promptTier("pro", ["fast"])).toBeUndefined()
+  })
+})

--- a/frontend/workspace/src/atlas/model-tier.ts
+++ b/frontend/workspace/src/atlas/model-tier.ts
@@ -1,0 +1,19 @@
+export type ModelTier = string
+
+export function modelTierOptions(modes: string[]) {
+  if (modes.length === 0) return []
+  return ["standard", ...new Set(modes)].map((id) => ({ id, label: id }))
+}
+
+export function normalizedTier(value: ModelTier | undefined, modes: string[]): ModelTier {
+  const available = new Set(modelTierOptions(modes).map((option) => option.id))
+  if (value && available.has(value)) return value
+  return "standard"
+}
+
+export function promptTier(value: ModelTier | undefined, modes: string[]): ModelTier | undefined {
+  const normalized = normalizedTier(value, modes)
+  if (normalized === "standard") return undefined
+  if (!modes.includes(normalized)) return undefined
+  return normalized
+}

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
   },
   "patchedDependencies": {
     "ghostty-web@0.3.0": "tooling/patches/ghostty-web@0.3.0.patch",
-    "@ai-sdk/anthropic@2.0.57": "tooling/patches/@ai-sdk%2Fanthropic@2.0.57.patch"
+    "@ai-sdk/anthropic@2.0.57": "tooling/patches/@ai-sdk%2Fanthropic@2.0.57.patch",
+    "@ai-sdk/openai@2.0.89": "tooling/patches/@ai-sdk%2Fopenai@2.0.89.patch"
   }
 }

--- a/tooling/patches/@ai-sdk%2Fanthropic@2.0.57.patch
+++ b/tooling/patches/@ai-sdk%2Fanthropic@2.0.57.patch
@@ -1,78 +1,124 @@
 diff --git a/dist/index.d.mts b/dist/index.d.mts
-index 4b0502f71fcdf5f10cb1b4f227b42d123a5ba304..49a69db094805d388abe3f833294ca5f38445877 100644
+index 4b0502f71fcdf5f10cb1b4f227b42d123a5ba304..c7c8894fb4679be42c2ba79dcf25a378f77c04be 100644
 --- a/dist/index.d.mts
 +++ b/dist/index.d.mts
-@@ -71,6 +71,8 @@ declare const anthropicProviderOptions: z.ZodObject<{
+@@ -71,6 +71,9 @@ declare const anthropicProviderOptions: z.ZodObject<{
          low: "low";
          medium: "medium";
          high: "high";
 +        xhigh: "xhigh";
 +        max: "max";
      }>>;
++    speed: z.ZodOptional<z.ZodLiteral<"fast">>;
  }, z.core.$strip>;
  type AnthropicProviderOptions = z.infer<typeof anthropicProviderOptions>;
 diff --git a/dist/index.d.ts b/dist/index.d.ts
-index 4b0502f71fcdf5f10cb1b4f227b42d123a5ba304..49a69db094805d388abe3f833294ca5f38445877 100644
+index 4b0502f71fcdf5f10cb1b4f227b42d123a5ba304..c7c8894fb4679be42c2ba79dcf25a378f77c04be 100644
 --- a/dist/index.d.ts
 +++ b/dist/index.d.ts
-@@ -71,6 +71,8 @@ declare const anthropicProviderOptions: z.ZodObject<{
+@@ -71,6 +71,9 @@ declare const anthropicProviderOptions: z.ZodObject<{
          low: "low";
          medium: "medium";
          high: "high";
 +        xhigh: "xhigh";
 +        max: "max";
      }>>;
++    speed: z.ZodOptional<z.ZodLiteral<"fast">>;
  }, z.core.$strip>;
  type AnthropicProviderOptions = z.infer<typeof anthropicProviderOptions>;
 diff --git a/dist/index.js b/dist/index.js
-index e273a3cb0a7468481bc9b66baa1c434fbfdadd88..7fd82aecf5c65d334fe7d4ad7b5a805b37d3fd4a 100644
+index e273a3cb0a7468481bc9b66baa1c434fbfdadd88..5cf76595e2c90e5f4d05b0670e94303d60c41aec 100644
 --- a/dist/index.js
 +++ b/dist/index.js
-@@ -615,7 +615,7 @@ var anthropicProviderOptions = import_v43.z.object({
+@@ -615,7 +615,8 @@ var anthropicProviderOptions = import_v43.z.object({
    /**
     * @default 'high'
     */
 -  effort: import_v43.z.enum(["low", "medium", "high"]).optional()
-+  effort: import_v43.z.enum(["low", "medium", "high", "xhigh", "max"]).optional()
++  effort: import_v43.z.enum(["low", "medium", "high", "xhigh", "max"]).optional(),
++  speed: import_v43.z.literal("fast").optional()
  });
  
  // src/anthropic-prepare-tools.ts
+@@ -1892,6 +1893,9 @@ var AnthropicMessagesLanguageModel = class {
+       ...(anthropicOptions == null ? void 0 : anthropicOptions.effort) && {
+         output_config: { effort: anthropicOptions.effort }
+       },
++      ...(anthropicOptions == null ? void 0 : anthropicOptions.speed) && {
++        speed: anthropicOptions.speed
++      },
+       // structured output:
+       ...useStructuredOutput && (responseFormat == null ? void 0 : responseFormat.type) === "json" && responseFormat.schema != null && {
+         output_format: {
 diff --git a/dist/index.mjs b/dist/index.mjs
-index dc4157434cbf3f4afbf70b83c5d40fe85d40b883..c02a76236c048a4313683105a59100f71743cfac 100644
+index dc4157434cbf3f4afbf70b83c5d40fe85d40b883..146efaaf3ff5ba0d54e0a5824240cb774ad92bfd 100644
 --- a/dist/index.mjs
 +++ b/dist/index.mjs
-@@ -610,7 +610,7 @@ var anthropicProviderOptions = z3.object({
+@@ -610,7 +610,8 @@ var anthropicProviderOptions = z3.object({
    /**
     * @default 'high'
     */
 -  effort: z3.enum(["low", "medium", "high"]).optional()
-+  effort: z3.enum(["low", "medium", "high", "xhigh", "max"]).optional()
++  effort: z3.enum(["low", "medium", "high", "xhigh", "max"]).optional(),
++  speed: z3.literal("fast").optional()
  });
  
  // src/anthropic-prepare-tools.ts
+@@ -1911,6 +1912,9 @@ var AnthropicMessagesLanguageModel = class {
+       ...(anthropicOptions == null ? void 0 : anthropicOptions.effort) && {
+         output_config: { effort: anthropicOptions.effort }
+       },
++      ...(anthropicOptions == null ? void 0 : anthropicOptions.speed) && {
++        speed: anthropicOptions.speed
++      },
+       // structured output:
+       ...useStructuredOutput && (responseFormat == null ? void 0 : responseFormat.type) === "json" && responseFormat.schema != null && {
+         output_format: {
 diff --git a/dist/internal/index.js b/dist/internal/index.js
-index c80b1e9d5c73f3256f4f645a614339db4b734cbb..d50cead1eb997e767a9fabe4c1ec0c5bb923d673 100644
+index c80b1e9d5c73f3256f4f645a614339db4b734cbb..9b77654e4a01b34162013fd09d7006909755fa2b 100644
 --- a/dist/internal/index.js
 +++ b/dist/internal/index.js
-@@ -608,7 +608,7 @@ var anthropicProviderOptions = import_v43.z.object({
+@@ -608,7 +608,8 @@ var anthropicProviderOptions = import_v43.z.object({
    /**
     * @default 'high'
     */
 -  effort: import_v43.z.enum(["low", "medium", "high"]).optional()
-+  effort: import_v43.z.enum(["low", "medium", "high", "xhigh", "max"]).optional()
++  effort: import_v43.z.enum(["low", "medium", "high", "xhigh", "max"]).optional(),
++  speed: import_v43.z.literal("fast").optional()
  });
  
  // src/anthropic-prepare-tools.ts
+@@ -1885,6 +1886,9 @@ var AnthropicMessagesLanguageModel = class {
+       ...(anthropicOptions == null ? void 0 : anthropicOptions.effort) && {
+         output_config: { effort: anthropicOptions.effort }
+       },
++      ...(anthropicOptions == null ? void 0 : anthropicOptions.speed) && {
++        speed: anthropicOptions.speed
++      },
+       // structured output:
+       ...useStructuredOutput && (responseFormat == null ? void 0 : responseFormat.type) === "json" && responseFormat.schema != null && {
+         output_format: {
 diff --git a/dist/internal/index.mjs b/dist/internal/index.mjs
-index cd1c18d50c2f1a1d8a3d8d73cac4f34149cb1626..73eb8682bf56af01efaf9d6811e3f266ffb384a6 100644
+index cd1c18d50c2f1a1d8a3d8d73cac4f34149cb1626..e5e6c6e80463c2c2b04032f97a8dc0b9b44489cf 100644
 --- a/dist/internal/index.mjs
 +++ b/dist/internal/index.mjs
-@@ -595,7 +595,7 @@ var anthropicProviderOptions = z3.object({
+@@ -595,7 +595,8 @@ var anthropicProviderOptions = z3.object({
    /**
     * @default 'high'
     */
 -  effort: z3.enum(["low", "medium", "high"]).optional()
-+  effort: z3.enum(["low", "medium", "high", "xhigh", "max"]).optional()
++  effort: z3.enum(["low", "medium", "high", "xhigh", "max"]).optional(),
++  speed: z3.literal("fast").optional()
  });
  
  // src/anthropic-prepare-tools.ts
+@@ -1896,6 +1897,9 @@ var AnthropicMessagesLanguageModel = class {
+       ...(anthropicOptions == null ? void 0 : anthropicOptions.effort) && {
+         output_config: { effort: anthropicOptions.effort }
+       },
++      ...(anthropicOptions == null ? void 0 : anthropicOptions.speed) && {
++        speed: anthropicOptions.speed
++      },
+       // structured output:
+       ...useStructuredOutput && (responseFormat == null ? void 0 : responseFormat.type) === "json" && responseFormat.schema != null && {
+         output_format: {

--- a/tooling/patches/@ai-sdk%2Fopenai@2.0.89.patch
+++ b/tooling/patches/@ai-sdk%2Fopenai@2.0.89.patch
@@ -1,0 +1,136 @@
+diff --git a/dist/index.d.mts b/dist/index.d.mts
+index 9754c0afb02f570ace9c58c3fb973764d1104925..259e666a9d8235450c25dc104946247f17293fd1 100644
+--- a/dist/index.d.mts
++++ b/dist/index.d.mts
+@@ -342,6 +342,7 @@ declare const openaiResponsesProviderOptionsSchema: _ai_sdk_provider_utils.LazyV
+     promptCacheKey?: string | null | undefined;
+     promptCacheRetention?: "in_memory" | "24h" | null | undefined;
+     reasoningEffort?: string | null | undefined;
++    reasoningMode?: "pro" | null | undefined;
+     reasoningSummary?: string | null | undefined;
+     safetyIdentifier?: string | null | undefined;
+     serviceTier?: "default" | "auto" | "flex" | "priority" | null | undefined;
+diff --git a/dist/index.d.ts b/dist/index.d.ts
+index 9754c0afb02f570ace9c58c3fb973764d1104925..259e666a9d8235450c25dc104946247f17293fd1 100644
+--- a/dist/index.d.ts
++++ b/dist/index.d.ts
+@@ -342,6 +342,7 @@ declare const openaiResponsesProviderOptionsSchema: _ai_sdk_provider_utils.LazyV
+     promptCacheKey?: string | null | undefined;
+     promptCacheRetention?: "in_memory" | "24h" | null | undefined;
+     reasoningEffort?: string | null | undefined;
++    reasoningMode?: "pro" | null | undefined;
+     reasoningSummary?: string | null | undefined;
+     safetyIdentifier?: string | null | undefined;
+     serviceTier?: "default" | "auto" | "flex" | "priority" | null | undefined;
+diff --git a/dist/index.js b/dist/index.js
+index ba86783033e3fa24faf7c919374d548316f2cd1f..a681310b6a2ee7c69f1b0947acf0e8e784001c87 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -2983,6 +2983,7 @@ var openaiResponsesProviderOptionsSchema = (0, import_provider_utils22.lazyValid
+        * an error.
+        */
+       reasoningEffort: import_v417.z.string().nullish(),
++      reasoningMode: import_v417.z.literal("pro").nullish(),
+       reasoningSummary: import_v417.z.string().nullish(),
+       safetyIdentifier: import_v417.z.string().nullish(),
+       serviceTier: import_v417.z.enum(["auto", "flex", "priority", "default"]).nullish(),
+@@ -3279,11 +3280,14 @@ var OpenAIResponsesLanguageModel = class {
+       top_logprobs: topLogprobs,
+       truncation: openaiOptions == null ? void 0 : openaiOptions.truncation,
+       // model-specific settings:
+-      ...modelCapabilities.isReasoningModel && ((openaiOptions == null ? void 0 : openaiOptions.reasoningEffort) != null || (openaiOptions == null ? void 0 : openaiOptions.reasoningSummary) != null) && {
++      ...modelCapabilities.isReasoningModel && ((openaiOptions == null ? void 0 : openaiOptions.reasoningEffort) != null || (openaiOptions == null ? void 0 : openaiOptions.reasoningMode) != null || (openaiOptions == null ? void 0 : openaiOptions.reasoningSummary) != null) && {
+         reasoning: {
+           ...(openaiOptions == null ? void 0 : openaiOptions.reasoningEffort) != null && {
+             effort: openaiOptions.reasoningEffort
+           },
++          ...(openaiOptions == null ? void 0 : openaiOptions.reasoningMode) != null && {
++            mode: openaiOptions.reasoningMode
++          },
+           ...(openaiOptions == null ? void 0 : openaiOptions.reasoningSummary) != null && {
+             summary: openaiOptions.reasoningSummary
+           }
+diff --git a/dist/index.mjs b/dist/index.mjs
+index a740f1650ff7cf157bd5b7dc78b1256e5a204292..f9ca1b66e78fa0a86e5941f5a5927401e8c0fcac 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -3054,6 +3054,7 @@ var openaiResponsesProviderOptionsSchema = lazyValidator9(
+        * an error.
+        */
+       reasoningEffort: z17.string().nullish(),
++      reasoningMode: z17.literal("pro").nullish(),
+       reasoningSummary: z17.string().nullish(),
+       safetyIdentifier: z17.string().nullish(),
+       serviceTier: z17.enum(["auto", "flex", "priority", "default"]).nullish(),
+@@ -3352,11 +3353,14 @@ var OpenAIResponsesLanguageModel = class {
+       top_logprobs: topLogprobs,
+       truncation: openaiOptions == null ? void 0 : openaiOptions.truncation,
+       // model-specific settings:
+-      ...modelCapabilities.isReasoningModel && ((openaiOptions == null ? void 0 : openaiOptions.reasoningEffort) != null || (openaiOptions == null ? void 0 : openaiOptions.reasoningSummary) != null) && {
++      ...modelCapabilities.isReasoningModel && ((openaiOptions == null ? void 0 : openaiOptions.reasoningEffort) != null || (openaiOptions == null ? void 0 : openaiOptions.reasoningMode) != null || (openaiOptions == null ? void 0 : openaiOptions.reasoningSummary) != null) && {
+         reasoning: {
+           ...(openaiOptions == null ? void 0 : openaiOptions.reasoningEffort) != null && {
+             effort: openaiOptions.reasoningEffort
+           },
++          ...(openaiOptions == null ? void 0 : openaiOptions.reasoningMode) != null && {
++            mode: openaiOptions.reasoningMode
++          },
+           ...(openaiOptions == null ? void 0 : openaiOptions.reasoningSummary) != null && {
+             summary: openaiOptions.reasoningSummary
+           }
+diff --git a/dist/internal/index.js b/dist/internal/index.js
+index d191a78cd4874889239b15b1ec131f65a1cd9e41..18a4a89c031cac5e374d512b09e45b133f666cc7 100644
+--- a/dist/internal/index.js
++++ b/dist/internal/index.js
+@@ -3052,6 +3052,7 @@ var openaiResponsesProviderOptionsSchema = (0, import_provider_utils22.lazyValid
+        * an error.
+        */
+       reasoningEffort: import_v415.z.string().nullish(),
++      reasoningMode: import_v415.z.literal("pro").nullish(),
+       reasoningSummary: import_v415.z.string().nullish(),
+       safetyIdentifier: import_v415.z.string().nullish(),
+       serviceTier: import_v415.z.enum(["auto", "flex", "priority", "default"]).nullish(),
+@@ -3583,11 +3584,14 @@ var OpenAIResponsesLanguageModel = class {
+       top_logprobs: topLogprobs,
+       truncation: openaiOptions == null ? void 0 : openaiOptions.truncation,
+       // model-specific settings:
+-      ...modelCapabilities.isReasoningModel && ((openaiOptions == null ? void 0 : openaiOptions.reasoningEffort) != null || (openaiOptions == null ? void 0 : openaiOptions.reasoningSummary) != null) && {
++      ...modelCapabilities.isReasoningModel && ((openaiOptions == null ? void 0 : openaiOptions.reasoningEffort) != null || (openaiOptions == null ? void 0 : openaiOptions.reasoningMode) != null || (openaiOptions == null ? void 0 : openaiOptions.reasoningSummary) != null) && {
+         reasoning: {
+           ...(openaiOptions == null ? void 0 : openaiOptions.reasoningEffort) != null && {
+             effort: openaiOptions.reasoningEffort
+           },
++          ...(openaiOptions == null ? void 0 : openaiOptions.reasoningMode) != null && {
++            mode: openaiOptions.reasoningMode
++          },
+           ...(openaiOptions == null ? void 0 : openaiOptions.reasoningSummary) != null && {
+             summary: openaiOptions.reasoningSummary
+           }
+diff --git a/dist/internal/index.mjs b/dist/internal/index.mjs
+index d3959d8bd4fe137d32202b871ed6a354a4606492..13d04619d91985ec6d88835fe45efe6e66f49663 100644
+--- a/dist/internal/index.mjs
++++ b/dist/internal/index.mjs
+@@ -3091,6 +3091,7 @@ var openaiResponsesProviderOptionsSchema = lazyValidator12(
+        * an error.
+        */
+       reasoningEffort: z15.string().nullish(),
++      reasoningMode: z15.literal("pro").nullish(),
+       reasoningSummary: z15.string().nullish(),
+       safetyIdentifier: z15.string().nullish(),
+       serviceTier: z15.enum(["auto", "flex", "priority", "default"]).nullish(),
+@@ -3644,11 +3645,14 @@ var OpenAIResponsesLanguageModel = class {
+       top_logprobs: topLogprobs,
+       truncation: openaiOptions == null ? void 0 : openaiOptions.truncation,
+       // model-specific settings:
+-      ...modelCapabilities.isReasoningModel && ((openaiOptions == null ? void 0 : openaiOptions.reasoningEffort) != null || (openaiOptions == null ? void 0 : openaiOptions.reasoningSummary) != null) && {
++      ...modelCapabilities.isReasoningModel && ((openaiOptions == null ? void 0 : openaiOptions.reasoningEffort) != null || (openaiOptions == null ? void 0 : openaiOptions.reasoningMode) != null || (openaiOptions == null ? void 0 : openaiOptions.reasoningSummary) != null) && {
+         reasoning: {
+           ...(openaiOptions == null ? void 0 : openaiOptions.reasoningEffort) != null && {
+             effort: openaiOptions.reasoningEffort
+           },
++          ...(openaiOptions == null ? void 0 : openaiOptions.reasoningMode) != null && {
++            mode: openaiOptions.reasoningMode
++          },
+           ...(openaiOptions == null ? void 0 : openaiOptions.reasoningSummary) != null && {
+             summary: openaiOptions.reasoningSummary
+           }

--- a/tooling/repo/publish.ts
+++ b/tooling/repo/publish.ts
@@ -56,14 +56,11 @@ if (Script.release) {
   }
   const sha = await $`git rev-parse HEAD`.text().then((x) => x.trim())
   await $`git tag -f v${Script.version} ${sha}`
-  await $`gh release edit v${Script.version} --target ${sha}`
   // Tags are exempt from branch protection; push the tag on its own so the
-  // release assets and npm publishes can proceed regardless of what happens
-  // to the branch push below.
-  const tagPush = await $`git push origin refs/tags/v${Script.version} --force --no-verify`.nothrow()
-  if (tagPush.exitCode !== 0) {
-    console.warn(`::warning::tag push failed for v${Script.version} (already pushed?)`)
-  }
+  // release commit exists on GitHub before the draft release targets its SHA.
+  // GitHub rejects a local-only target_commitish with HTTP 422.
+  await $`git push origin refs/tags/v${Script.version} --force --no-verify`
+  await $`gh release edit v${Script.version} --target ${sha}`
   // Branch protection rejects direct pushes to main, and the old .nothrow()
   // swallowed that — every release left its version-bump commit orphaned and
   // main's package versions permanently stale. Try the direct push (works if

--- a/tooling/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/tooling/sdk/js/src/v2/gen/sdk.gen.ts
@@ -11,6 +11,7 @@ import type {
   AccountGetResponses,
   AccountLoginKeyResponses,
   AccountLogoutResponses,
+  AccountSessionResponses,
   AgentPartInput,
   AppAgentsResponses,
   AppLogErrors,
@@ -458,6 +459,18 @@ export class BillingMode extends HeyApiClient {
 }
 
 export class Account extends HeyApiClient {
+  /**
+   * Get local session status
+   *
+   * Check whether this OpenScience server has a local Atlas session without contacting Atlas.
+   */
+  public session<ThrowOnError extends boolean = false>(options?: Options<never, ThrowOnError>) {
+    return (options?.client ?? this.client).get<AccountSessionResponses, unknown, ThrowOnError>({
+      url: "/account/session",
+      ...options,
+    })
+  }
+
   /**
    * Get account
    *
@@ -2409,7 +2422,7 @@ export class Session extends HeyApiClient {
       }
       system?: string
       variant?: string
-      tier?: "fast" | "pro" | "ultra"
+      tier?: string
       parts?: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
     },
     options?: Options<never, ThrowOnError>,
@@ -2499,7 +2512,7 @@ export class Session extends HeyApiClient {
       }
       system?: string
       variant?: string
-      tier?: "fast" | "pro" | "ultra"
+      tier?: string
       parts?: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
     },
     options?: Options<never, ThrowOnError>,
@@ -2551,6 +2564,7 @@ export class Session extends HeyApiClient {
       arguments?: string
       command?: string
       variant?: string
+      tier?: string
       parts?: Array<{
         id?: string
         type: "file"
@@ -2575,6 +2589,7 @@ export class Session extends HeyApiClient {
             { in: "body", key: "arguments" },
             { in: "body", key: "command" },
             { in: "body", key: "variant" },
+            { in: "body", key: "tier" },
             { in: "body", key: "parts" },
           ],
         },

--- a/tooling/sdk/js/src/v2/gen/types.gen.ts
+++ b/tooling/sdk/js/src/v2/gen/types.gen.ts
@@ -135,7 +135,7 @@ export type UserMessage = {
     [key: string]: boolean
   }
   variant?: string
-  tier?: "fast" | "pro" | "ultra"
+  tier?: string
 }
 
 export type ProviderAuthError = {
@@ -1429,6 +1429,20 @@ export type ProviderConfig = {
       release_date?: string
       attachment?: boolean
       reasoning?: boolean
+      reasoning_options?: Array<
+        | {
+            type: "toggle"
+          }
+        | {
+            type: "effort"
+            values: Array<string | null>
+          }
+        | {
+            type: "budget_tokens"
+            min?: number
+            max?: number
+          }
+      >
       temperature?: boolean
       tool_call?: boolean
       interleaved?:
@@ -1457,7 +1471,29 @@ export type ProviderConfig = {
         input: Array<"text" | "audio" | "image" | "video" | "pdf">
         output: Array<"text" | "audio" | "image" | "video" | "pdf">
       }
-      experimental?: boolean
+      experimental?:
+        | boolean
+        | {
+            modes?: {
+              [key: string]: {
+                model?: string
+                cost?: {
+                  input: number
+                  output: number
+                  cache_read?: number
+                  cache_write?: number
+                }
+                provider?: {
+                  body?: {
+                    [key: string]: unknown
+                  }
+                  headers?: {
+                    [key: string]: string
+                  }
+                }
+              }
+            }
+          }
       status?: "alpha" | "beta" | "deprecated"
       options?: {
         [key: string]: unknown
@@ -1942,9 +1978,33 @@ export type Model = {
     [key: string]: string
   }
   release_date: string
+  reasoningOptions?: Array<{
+    [key: string]: unknown
+  }>
   variants?: {
     [key: string]: {
       [key: string]: unknown
+    }
+  }
+  modes?: {
+    [key: string]: {
+      model?: string
+      cost?: {
+        input: number
+        output: number
+        cache: {
+          read: number
+          write: number
+        }
+      }
+      provider?: {
+        body?: {
+          [key: string]: unknown
+        }
+        headers?: {
+          [key: string]: string
+        }
+      }
     }
   }
 }
@@ -2382,6 +2442,24 @@ export type GlobalSyncResponses = {
 }
 
 export type GlobalSyncResponse = GlobalSyncResponses[keyof GlobalSyncResponses]
+
+export type AccountSessionData = {
+  body?: never
+  path?: never
+  query?: never
+  url: "/account/session"
+}
+
+export type AccountSessionResponses = {
+  /**
+   * Local session status
+   */
+  200: {
+    session: boolean
+  }
+}
+
+export type AccountSessionResponse = AccountSessionResponses[keyof AccountSessionResponses]
 
 export type AccountGetData = {
   body?: never
@@ -4383,7 +4461,7 @@ export type SessionPromptData = {
     }
     system?: string
     variant?: string
-    tier?: "fast" | "pro" | "ultra"
+    tier?: string
     parts: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
   }
   path: {
@@ -4571,7 +4649,7 @@ export type SessionPromptAsyncData = {
     }
     system?: string
     variant?: string
-    tier?: "fast" | "pro" | "ultra"
+    tier?: string
     parts: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
   }
   path: {
@@ -4616,6 +4694,7 @@ export type SessionCommandData = {
     arguments: string
     command: string
     variant?: string
+    tier?: string
     parts?: Array<{
       id?: string
       type: "file"
@@ -4981,6 +5060,20 @@ export type ProviderListResponses = {
           release_date: string
           attachment: boolean
           reasoning: boolean
+          reasoning_options?: Array<
+            | {
+                type: "toggle"
+              }
+            | {
+                type: "effort"
+                values: Array<string | null>
+              }
+            | {
+                type: "budget_tokens"
+                min?: number
+                max?: number
+              }
+          >
           temperature: boolean
           tool_call: boolean
           interleaved?:
@@ -5009,7 +5102,29 @@ export type ProviderListResponses = {
             input: Array<"text" | "audio" | "image" | "video" | "pdf">
             output: Array<"text" | "audio" | "image" | "video" | "pdf">
           }
-          experimental?: boolean
+          experimental?:
+            | boolean
+            | {
+                modes?: {
+                  [key: string]: {
+                    model?: string
+                    cost?: {
+                      input: number
+                      output: number
+                      cache_read?: number
+                      cache_write?: number
+                    }
+                    provider?: {
+                      body?: {
+                        [key: string]: unknown
+                      }
+                      headers?: {
+                        [key: string]: string
+                      }
+                    }
+                  }
+                }
+              }
           status?: "alpha" | "beta" | "deprecated"
           options: {
             [key: string]: unknown

--- a/tooling/sdk/openapi.json
+++ b/tooling/sdk/openapi.json
@@ -342,6 +342,39 @@
         ]
       }
     },
+    "/account/session": {
+      "get": {
+        "operationId": "account.session",
+        "summary": "Get local session status",
+        "description": "Check whether this OpenScience server has a local Atlas session without contacting Atlas.",
+        "responses": {
+          "200": {
+            "description": "Local session status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "session": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "session"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpenScienceClient } from \"@synsci/sdk\"\n\nconst client = createOpenScienceClient()\nawait client.account.session({\n  ...\n})"
+          }
+        ]
+      }
+    },
     "/account": {
       "get": {
         "operationId": "account.get",
@@ -5405,12 +5438,7 @@
                     "type": "string"
                   },
                   "tier": {
-                    "type": "string",
-                    "enum": [
-                      "fast",
-                      "pro",
-                      "ultra"
-                    ]
+                    "type": "string"
                   },
                   "parts": {
                     "type": "array",
@@ -5797,12 +5825,7 @@
                     "type": "string"
                   },
                   "tier": {
-                    "type": "string",
-                    "enum": [
-                      "fast",
-                      "pro",
-                      "ultra"
-                    ]
+                    "type": "string"
                   },
                   "parts": {
                     "type": "array",
@@ -5932,6 +5955,9 @@
                     "type": "string"
                   },
                   "variant": {
+                    "type": "string"
+                  },
+                  "tier": {
                     "type": "string"
                   },
                   "parts": {
@@ -6702,6 +6728,69 @@
                                 "reasoning": {
                                   "type": "boolean"
                                 },
+                                "reasoning_options": {
+                                  "type": "array",
+                                  "items": {
+                                    "anyOf": [
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "const": "toggle"
+                                          }
+                                        },
+                                        "required": [
+                                          "type"
+                                        ]
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "const": "effort"
+                                          },
+                                          "values": {
+                                            "type": "array",
+                                            "items": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "null"
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "values"
+                                        ]
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "const": "budget_tokens"
+                                          },
+                                          "min": {
+                                            "type": "number"
+                                          },
+                                          "max": {
+                                            "type": "number"
+                                          }
+                                        },
+                                        "required": [
+                                          "type"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                },
                                 "temperature": {
                                   "type": "boolean"
                                 },
@@ -6828,7 +6917,72 @@
                                   ]
                                 },
                                 "experimental": {
-                                  "type": "boolean"
+                                  "anyOf": [
+                                    {
+                                      "type": "boolean"
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "modes": {
+                                          "type": "object",
+                                          "propertyNames": {
+                                            "type": "string"
+                                          },
+                                          "additionalProperties": {
+                                            "type": "object",
+                                            "properties": {
+                                              "model": {
+                                                "type": "string"
+                                              },
+                                              "cost": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "input": {
+                                                    "type": "number"
+                                                  },
+                                                  "output": {
+                                                    "type": "number"
+                                                  },
+                                                  "cache_read": {
+                                                    "type": "number"
+                                                  },
+                                                  "cache_write": {
+                                                    "type": "number"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "input",
+                                                  "output"
+                                                ]
+                                              },
+                                              "provider": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "body": {
+                                                    "type": "object",
+                                                    "propertyNames": {
+                                                      "type": "string"
+                                                    },
+                                                    "additionalProperties": {}
+                                                  },
+                                                  "headers": {
+                                                    "type": "object",
+                                                    "propertyNames": {
+                                                      "type": "string"
+                                                    },
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  ]
                                 },
                                 "status": {
                                   "type": "string",
@@ -9929,12 +10083,7 @@
             "type": "string"
           },
           "tier": {
-            "type": "string",
-            "enum": [
-              "fast",
-              "pro",
-              "ultra"
-            ]
+            "type": "string"
           }
         },
         "required": [
@@ -13340,6 +13489,69 @@
                 "reasoning": {
                   "type": "boolean"
                 },
+                "reasoning_options": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "toggle"
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "effort"
+                          },
+                          "values": {
+                            "type": "array",
+                            "items": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "values"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "budget_tokens"
+                          },
+                          "min": {
+                            "type": "number"
+                          },
+                          "max": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ]
+                      }
+                    ]
+                  }
+                },
                 "temperature": {
                   "type": "boolean"
                 },
@@ -13466,7 +13678,72 @@
                   ]
                 },
                 "experimental": {
-                  "type": "boolean"
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "modes": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "additionalProperties": {
+                            "type": "object",
+                            "properties": {
+                              "model": {
+                                "type": "string"
+                              },
+                              "cost": {
+                                "type": "object",
+                                "properties": {
+                                  "input": {
+                                    "type": "number"
+                                  },
+                                  "output": {
+                                    "type": "number"
+                                  },
+                                  "cache_read": {
+                                    "type": "number"
+                                  },
+                                  "cache_write": {
+                                    "type": "number"
+                                  }
+                                },
+                                "required": [
+                                  "input",
+                                  "output"
+                                ]
+                              },
+                              "provider": {
+                                "type": "object",
+                                "properties": {
+                                  "body": {
+                                    "type": "object",
+                                    "propertyNames": {
+                                      "type": "string"
+                                    },
+                                    "additionalProperties": {}
+                                  },
+                                  "headers": {
+                                    "type": "object",
+                                    "propertyNames": {
+                                      "type": "string"
+                                    },
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
                 },
                 "status": {
                   "type": "string",
@@ -14632,6 +14909,16 @@
           "release_date": {
             "type": "string"
           },
+          "reasoningOptions": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "propertyNames": {
+                "type": "string"
+              },
+              "additionalProperties": {}
+            }
+          },
           "variants": {
             "type": "object",
             "propertyNames": {
@@ -14643,6 +14930,72 @@
                 "type": "string"
               },
               "additionalProperties": {}
+            }
+          },
+          "modes": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "model": {
+                  "type": "string"
+                },
+                "cost": {
+                  "type": "object",
+                  "properties": {
+                    "input": {
+                      "type": "number"
+                    },
+                    "output": {
+                      "type": "number"
+                    },
+                    "cache": {
+                      "type": "object",
+                      "properties": {
+                        "read": {
+                          "type": "number"
+                        },
+                        "write": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "read",
+                        "write"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "input",
+                    "output",
+                    "cache"
+                  ]
+                },
+                "provider": {
+                  "type": "object",
+                  "properties": {
+                    "body": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      },
+                      "additionalProperties": {}
+                    },
+                    "headers": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      },
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
             }
           }
         },


### PR DESCRIPTION
## Summary
- derive each model's exact reasoning controls and provider-native fast/pro modes
- keep managed OpenRouter, direct BYOK, and Codex subscription routing separate
- add the preinstalled `/goal` skill and dynamic model-mode controls
- fix production release tagging so GitHub sees the release commit before targeting it

Companion backend PR: synthetic-sciences/atlas#204

## Verification
- `bun run test` (1263 passed, 1 skipped)
- workspace unit tests (42 passed)
- workspace Playwright E2E (50 passed)
- `bun run typecheck`
- `bun run format:check`
- `bun run build` (all native npm targets)