### PR TITLE
Fix model routing and thinking modes

### DIFF
--- a/backend/cli/src/provider/transform.ts
+++ b/backend/cli/src/provider/transform.ts
@@ -661,8 +661,11 @@ export namespace ProviderTransform {
       case "@ai-sdk/google-vertex/anthropic": {
         // https://v5.ai-sdk.dev/providers/ai-sdk-providers/google-vertex#anthropic-provider
         const cap = model.limit.output
+        const usesEffort = /^claude-opus-4[.-][78]\b/.test(id) || /^claude-(opus|sonnet|mythos)-[5-9]\b/.test(id)
         if (exact) {
-          return Object.fromEntries(exact.map((effort) => [effort, { effort }]))
+          return Object.fromEntries(
+            exact.map((effort) => [effort, usesEffort ? { thinking: { type: "adaptive" }, effort } : { effort }]),
+          )
         }
 
         // The newest Claudes REJECT manual extended thinking (`thinking.type:
@@ -675,15 +678,13 @@ export namespace ProviderTransform {
         // to include xhigh/max. Detection is by canonical id — note Mythos is NOT
         // opus/sonnet/haiku, so it must be matched explicitly or it falls
         // through to the classic path below and 400 (manual thinking rejected).
-        const usesEffort = /^claude-opus-4[.-][78]\b/.test(id) || /^claude-(opus|sonnet|mythos)-[5-9]\b/.test(id)
-
         if (usesEffort) {
           return {
-            low: { effort: "low" },
-            medium: { effort: "medium" },
-            high: { effort: "high" },
-            xhigh: { effort: "xhigh" },
-            max: { effort: "max" },
+            low: { thinking: { type: "adaptive" }, effort: "low" },
+            medium: { thinking: { type: "adaptive" }, effort: "medium" },
+            high: { thinking: { type: "adaptive" }, effort: "high" },
+            xhigh: { thinking: { type: "adaptive" }, effort: "xhigh" },
+            max: { thinking: { type: "adaptive" }, effort: "max" },
           }
         }
 

--- a/backend/cli/test/provider/transform-reasoning-wire.test.ts
+++ b/backend/cli/test/provider/transform-reasoning-wire.test.ts
@@ -157,4 +157,24 @@ describe("reasoning options serialize onto provider request bodies", () => {
 
     expect(wire.bodies[0].speed).toBe("fast")
   })
+
+  test("new Claude effort selections enable adaptive thinking on the wire", async () => {
+    const target = model({
+      id: "claude-opus-4-8",
+      providerID: "anthropic",
+      api: { id: "claude-opus-4-8", url: "https://api.anthropic.com/v1", npm: "@ai-sdk/anthropic" },
+    })
+    const options = mergeDeep(
+      ProviderTransform.options({ model: target, sessionID, providerOptions: {} }),
+      ProviderTransform.variants(target).xhigh,
+    )
+    const wire = recorder()
+    const sdk = createAnthropic({ apiKey: "test", baseURL: "https://anthropic.test/v1", fetch: wire.fetch })
+
+    await send(sdk(target.api.id), ProviderTransform.providerOptions(target, options))
+
+    expect(wire.bodies).toHaveLength(1)
+    expect(wire.bodies[0].thinking).toEqual({ type: "adaptive" })
+    expect(wire.bodies[0].output_config).toEqual({ effort: "xhigh" })
+  })
 })

--- a/backend/cli/test/provider/transform.test.ts
+++ b/backend/cli/test/provider/transform.test.ts
@@ -2126,9 +2126,9 @@ describe("ProviderTransform.variants", () => {
       test(`${id} exposes the full low→max effort ladder including xhigh`, () => {
         const result = ProviderTransform.variants(anthropicModel(id))
         expect(Object.keys(result)).toEqual(["low", "medium", "high", "xhigh", "max"])
-        expect(result.low).toEqual({ effort: "low" })
-        expect(result.xhigh).toEqual({ effort: "xhigh" })
-        expect(result.max).toEqual({ effort: "max" })
+        expect(result.low).toEqual({ thinking: { type: "adaptive" }, effort: "low" })
+        expect(result.xhigh).toEqual({ thinking: { type: "adaptive" }, effort: "xhigh" })
+        expect(result.max).toEqual({ thinking: { type: "adaptive" }, effort: "max" })
       })
     }
 
@@ -2136,8 +2136,8 @@ describe("ProviderTransform.variants", () => {
     // drops them to the classic path where manual thinking 400s.
     test("claude-mythos-5 uses effort, not a thinking budget", () => {
       const result = ProviderTransform.variants(anthropicModel("claude-mythos-5"))
-      expect(result.high).toEqual({ effort: "high" })
-      expect(result.high).not.toHaveProperty("thinking")
+      expect(result.high).toEqual({ thinking: { type: "adaptive" }, effort: "high" })
+      expect(result.high.thinking).not.toHaveProperty("budgetTokens")
     })
 
     const CLASSIC_MODELS = [

--- a/frontend/workspace/e2e/thinking-level.spec.ts
+++ b/frontend/workspace/e2e/thinking-level.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "./fixtures"
-import { modelVariantCycleSelector } from "./utils"
+import { modelTierCycleSelector, modelVariantCycleSelector, promptSelector } from "./utils"
 
-test("smoke model variant cycle updates label", async ({ page, gotoSession }) => {
+test("thinking effort starts at standard and reaches the prompt request", async ({ page, sdk, gotoSession }) => {
   await gotoSession()
 
   await page.addStyleTag({
@@ -14,12 +14,61 @@ test("smoke model variant cycle updates label", async ({ page, gotoSession }) =>
   if (!exists) return
 
   await expect(button).toBeVisible()
+  await expect(button).toHaveText("standard")
+  await expect(button).toHaveAttribute("aria-label", /thinking effort: standard/i)
 
-  const before = (await button.innerText()).trim()
-  await button.click()
-  await expect(button).not.toHaveText(before)
+  const send = async (options: { variant?: string; tier?: string } = {}) => {
+    const request = page.waitForRequest((request) => {
+      const path = new URL(request.url()).pathname
+      return request.method() === "POST" && /\/session\/[^/]+\/message$/.test(path)
+    })
+    const token = `E2E_OK_${Date.now()}`
+    const prompt = page.locator(promptSelector)
+    await prompt.click()
+    await page.keyboard.type(`Reply with exactly: ${token}`)
+    await page.keyboard.press("Enter")
 
-  const after = (await button.innerText()).trim()
-  await button.click()
-  await expect(button).not.toHaveText(after)
+    const body = (await request).postDataJSON() as { variant?: string; tier?: string }
+    expect(body.variant).toBe(options.variant)
+    expect(body.tier).toBe(options.tier)
+    return token
+  }
+
+  const standard = await send()
+  await expect(page).toHaveURL(/\/session\/[^/?#]+/, { timeout: 30_000 })
+  const sessionID = /\/session\/([^/?#]+)/.exec(page.url())?.[1]
+  if (!sessionID) throw new Error(`Failed to parse session id from url: ${page.url()}`)
+
+  const output = async () =>
+    sdk.session.messages({ sessionID, limit: 50 }).then((response) =>
+      (response.data ?? [])
+        .filter((message) => message.info.role === "assistant")
+        .flatMap((message) => message.parts)
+        .filter((part) => part.type === "text")
+        .map((part) => part.text)
+        .join("\n"),
+    )
+
+  try {
+    await expect.poll(output, { timeout: 20_000 }).toContain(standard)
+
+    await button.click()
+    await expect(button).toHaveText("low")
+    await button.click()
+    await expect(button).toHaveText("high")
+    await expect(button).toHaveAttribute("aria-label", /thinking effort: high/i)
+
+    const tier = page.locator(modelTierCycleSelector)
+    await tier.click()
+    await expect(tier).toHaveText("fast")
+
+    const high = await send({ variant: "high", tier: "fast" })
+    await expect.poll(output, { timeout: 20_000 }).toContain(high)
+
+    await page.reload()
+    await expect(button).toHaveText("high")
+    await expect(tier).toHaveText("fast")
+  } finally {
+    await sdk.session.delete({ sessionID }).catch(() => undefined)
+  }
 })

--- a/frontend/workspace/script/e2e-fake-model.ts
+++ b/frontend/workspace/script/e2e-fake-model.ts
@@ -175,8 +175,8 @@ export function fakeModelConfig(baseURL: string) {
             // Exercise the workspace's model-variant control without relying
             // on a real provider catalog or making an external inference.
             variants: {
-              fast: {},
-              thorough: {},
+              low: {},
+              high: {},
             },
             experimental: {
               modes: {
@@ -195,8 +195,8 @@ export function fakeModelConfig(baseURL: string) {
             tool_call: true,
             limit: { context: 128_000, output: 4_096 },
             variants: {
-              fast: {},
-              thorough: {},
+              low: {},
+              high: {},
             },
             experimental: {
               modes: {

--- a/frontend/workspace/src/atlas/model-tier.test.ts
+++ b/frontend/workspace/src/atlas/model-tier.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { modelTierOptions, normalizedTier, promptTier } from "./model-tier"
+import { modelTierOptions, normalizedTier, promptTier, resolvedTier } from "./model-tier"
 
 describe("model tier controls", () => {
   test("shows standard followed by only the selected model's real modes", () => {
@@ -14,5 +14,12 @@ describe("model tier controls", () => {
     expect(promptTier("standard", ["fast"])).toBeUndefined()
     expect(promptTier("fast", ["fast"])).toBe("fast")
     expect(promptTier("pro", ["fast"])).toBeUndefined()
+  })
+
+  test("migrates a folded service route while preserving an explicit standard choice", () => {
+    const migrated = resolvedTier(undefined, ["pro"], "pro")
+    expect(migrated).toBe("pro")
+    expect(promptTier(migrated, ["pro"])).toBe("pro")
+    expect(resolvedTier("standard", ["pro"], "pro")).toBe("standard")
   })
 })

--- a/frontend/workspace/src/atlas/model-tier.ts
+++ b/frontend/workspace/src/atlas/model-tier.ts
@@ -1,1 +1,1 @@
-export { modelTierOptions, normalizedTier, promptTier, type ModelTier } from "../context/model-tier"
+export { modelTierOptions, normalizedTier, promptTier, resolvedTier, type ModelTier } from "../context/model-tier"

--- a/frontend/workspace/src/components/prompt-input.tsx
+++ b/frontend/workspace/src/components/prompt-input.tsx
@@ -1185,7 +1185,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       providerID: currentModel.provider.id,
     }
     const agent = currentAgent.name
-    const variant = local.model.variant.current()
+    const variant = local.model.variant.prompt()
     const tier = local.model.tier.prompt()
 
     const errorMessage = (err: unknown) => {
@@ -2035,11 +2035,12 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                   >
                     <Button
                       data-action="model-variant-cycle"
+                      aria-label={`${language.t("command.model.variant.cycle")}: ${local.model.variant.current()}`}
                       variant="ghost"
                       class="text-text-base group-hover/prompt-input:inline-block capitalize"
                       onClick={() => local.model.variant.cycle()}
                     >
-                      {local.model.variant.current() ?? language.t("common.default")}
+                      {local.model.variant.current()}
                     </Button>
                   </TooltipKeybind>
                 </Show>

--- a/frontend/workspace/src/context/local.tsx
+++ b/frontend/workspace/src/context/local.tsx
@@ -6,8 +6,9 @@ import { useSync } from "./sync"
 import { base64Encode } from "@synsci/util/encode"
 import { useProviders } from "@/hooks/use-providers"
 import { useModels } from "@/context/models"
-import { routableModelKey } from "@/context/model-catalog"
-import { modelTierOptions, normalizedTier, promptTier } from "@/context/model-tier"
+import { foldedRouteMode, routableModelKey } from "@/context/model-catalog"
+import { modelTierOptions, normalizedTier, promptTier, resolvedTier } from "@/context/model-tier"
+import { modelVariantOptions, normalizedVariant, promptVariant } from "@/context/model-variant"
 
 export type ModelKey = { providerID: string; modelID: string }
 
@@ -208,14 +209,18 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         return undefined
       })
 
-      const current = createMemo(() => {
+      const selected = createMemo(() => {
         const a = agent.current()
         if (!a) return undefined
-        const key = getFirstValidModel(
+        return getFirstValidModel(
           () => ephemeral.model[a.name],
           () => a.model,
           fallbackModel,
         )
+      })
+
+      const current = createMemo(() => {
+        const key = selected()
         if (!key) return undefined
         return models.find(key)
       })
@@ -275,44 +280,43 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         variant: {
           current() {
             const m = current()
-            if (!m) return undefined
-            return models.variant.get({ providerID: m.provider.id, modelID: m.id })
+            if (!m) return "standard"
+            return normalizedVariant(
+              models.variant.get({ providerID: m.provider.id, modelID: m.id }),
+              Object.keys(m.variants ?? {}),
+            )
           },
           list() {
             const m = current()
             if (!m) return []
-            if (!m.variants) return []
-            return Object.keys(m.variants)
+            return modelVariantOptions(Object.keys(m.variants ?? {}))
           },
           set(value: string | undefined) {
             const m = current()
             if (!m) return
-            models.variant.set({ providerID: m.provider.id, modelID: m.id }, value)
+            const variants = Object.keys(m.variants ?? {})
+            models.variant.set({ providerID: m.provider.id, modelID: m.id }, promptVariant(value, variants))
           },
           cycle() {
             const variants = this.list()
             if (variants.length === 0) return
-            const currentVariant = this.current()
-            if (!currentVariant) {
-              this.set(variants[0])
-              return
-            }
-            const index = variants.indexOf(currentVariant)
-            if (index === -1 || index === variants.length - 1) {
-              this.set(undefined)
-              return
-            }
-            this.set(variants[index + 1])
+            const index = variants.indexOf(this.current())
+            this.set(variants[index === -1 || index === variants.length - 1 ? 0 : index + 1])
+          },
+          prompt() {
+            const m = current()
+            if (!m) return undefined
+            return promptVariant(this.current(), Object.keys(m.variants ?? {}))
           },
         },
         tier: {
           current() {
             const m = current()
             if (!m) return "standard"
-            return normalizedTier(
-              models.tier.get({ providerID: m.provider.id, modelID: m.id }),
-              Object.keys(m.modes ?? {}),
-            )
+            const saved = models.tier.get({ providerID: m.provider.id, modelID: m.id })
+            const legacy = selected()
+            const migrated = legacy ? foldedRouteMode(legacy, m) : undefined
+            return resolvedTier(saved, Object.keys(m.modes ?? {}), migrated)
           },
           list() {
             const m = current()
@@ -323,7 +327,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
             const m = current()
             if (!m) return
             const modes = Object.keys(m.modes ?? {})
-            models.tier.set({ providerID: m.provider.id, modelID: m.id }, promptTier(value, modes))
+            models.tier.set({ providerID: m.provider.id, modelID: m.id }, normalizedTier(value, modes))
           },
           cycle() {
             const tiers = this.list()

--- a/frontend/workspace/src/context/model-catalog.ts
+++ b/frontend/workspace/src/context/model-catalog.ts
@@ -98,4 +98,65 @@ export function canonicalKey(providerID: string, modelID: string): string {
   return `${vendor}/${base}`
 }
 
+type CatalogModel = {
+  id: string
+  provider: { id: string }
+  modes?: Record<string, unknown>
+}
+
+export function foldedRouteMode(model: ModelKey, target: CatalogModel): string | undefined {
+  if (model.providerID !== "openrouter" || target.provider.id !== model.providerID) return undefined
+  const match = model.modelID.match(/-(fast|pro)$/)
+  if (!match) return undefined
+  const mode = match[1]
+  const base = model.modelID.slice(0, -match[0].length)
+  if (target.id !== base || !target.modes?.[mode]) return undefined
+  return mode
+}
+
+export function preferredModels<T extends CatalogModel>(models: T[]): T[] {
+  const native = new Set(
+    models
+      .filter((model) => model.provider.id !== "openrouter")
+      .map((model) => canonicalKey(model.provider.id, model.id)),
+  )
+
+  const routed = models.filter((model) => {
+    if (model.provider.id !== "openrouter") return true
+    const match = model.id.match(/-(fast|pro)$/)
+    if (!match) return true
+    const mode = match[1]
+    const base = model.id.slice(0, -match[0].length)
+    return !models.some(
+      (candidate) => candidate.provider.id === model.provider.id && candidate.id === base && !!candidate.modes?.[mode],
+    )
+  })
+
+  const seen = new Set<string>()
+  return routed.filter((model) => {
+    const key = canonicalKey(model.provider.id, model.id)
+    if (model.provider.id === "openrouter" && native.has(key)) return false
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+}
+
+export function preferredModel<T extends CatalogModel>(models: T[], key: ModelKey): T | undefined {
+  const exact = (candidate: ModelKey) =>
+    models.find((model) => model.provider.id === candidate.providerID && model.id === candidate.modelID)
+  const found = exact(key)
+  if (found) return found
+
+  const folded = models.find((model) => foldedRouteMode(key, model))
+  if (folded) return folded
+
+  const routed = routableModelKey(key, (candidate) => !!exact(candidate))
+  const alias = exact(routed)
+  if (alias) return alias
+
+  const canonical = canonicalKey(key.providerID, key.modelID)
+  return models.find((model) => canonicalKey(model.provider.id, model.id) === canonical)
+}
+
 export const isFrontier = (model: ModelKey) => FRONTIER_MODELS.has(canonicalKey(model.providerID, model.modelID))

--- a/frontend/workspace/src/context/model-tier.ts
+++ b/frontend/workspace/src/context/model-tier.ts
@@ -11,6 +11,10 @@ export function normalizedTier(value: ModelTier | undefined, modes: string[]): M
   return "standard"
 }
 
+export function resolvedTier(value: ModelTier | undefined, modes: string[], fallback?: ModelTier): ModelTier {
+  return normalizedTier(value ?? fallback, modes)
+}
+
 export function promptTier(value: ModelTier | undefined, modes: string[]): ModelTier | undefined {
   const normalized = normalizedTier(value, modes)
   if (normalized === "standard") return undefined

--- a/frontend/workspace/src/context/model-variant.test.ts
+++ b/frontend/workspace/src/context/model-variant.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test"
+import { modelVariantOptions, normalizedVariant, promptVariant } from "./model-variant"
+
+describe("model thinking effort options", () => {
+  test("puts standard first and preserves provider-native effort order", () => {
+    expect(modelVariantOptions(["low", "medium", "high", "xhigh", "max"])).toEqual([
+      "standard",
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max",
+    ])
+  })
+
+  test("omits standard from requests and rejects stale effort selections", () => {
+    const variants = ["none", "low", "medium", "high", "xhigh", "max"]
+    expect(normalizedVariant(undefined, variants)).toBe("standard")
+    expect(normalizedVariant("ultra", variants)).toBe("standard")
+    expect(promptVariant("standard", variants)).toBeUndefined()
+    expect(promptVariant("xhigh", variants)).toBe("xhigh")
+  })
+})

--- a/frontend/workspace/src/context/model-variant.ts
+++ b/frontend/workspace/src/context/model-variant.ts
@@ -1,0 +1,19 @@
+export type ModelVariant = string
+
+export function modelVariantOptions(variants: string[]): ModelVariant[] {
+  if (variants.length === 0) return []
+  return ["standard", ...new Set(variants.filter((variant) => variant !== "standard"))]
+}
+
+export function normalizedVariant(value: ModelVariant | undefined, variants: string[]): ModelVariant {
+  const available = new Set(modelVariantOptions(variants))
+  if (value && available.has(value)) return value
+  return "standard"
+}
+
+export function promptVariant(value: ModelVariant | undefined, variants: string[]): ModelVariant | undefined {
+  const normalized = normalizedVariant(value, variants)
+  if (normalized === "standard") return undefined
+  if (!variants.includes(normalized)) return undefined
+  return normalized
+}

--- a/frontend/workspace/src/context/models-catalog.test.ts
+++ b/frontend/workspace/src/context/models-catalog.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, test } from "bun:test"
-import { canonicalKey, displayProviderForModel, FRONTIER_MODELS, routableModelKey } from "./model-catalog"
+import {
+  canonicalKey,
+  displayProviderForModel,
+  foldedRouteMode,
+  FRONTIER_MODELS,
+  preferredModel,
+  preferredModels,
+  routableModelKey,
+} from "./model-catalog"
 
 describe("frontier model canonicalization", () => {
   test("direct and OpenRouter GPT-5.6 ids collapse to the same frontier keys", () => {
@@ -30,6 +38,44 @@ describe("frontier model canonicalization", () => {
     expect(displayProviderForModel(openrouter, "google/gemini-3.6-flash")).toEqual({ id: "google", name: "Google" })
     expect(displayProviderForModel(openrouter, "x-ai/grok-4.5")).toEqual({ id: "xai", name: "xAI" })
     expect(displayProviderForModel(openrouter, "z-ai/glm-5.2")).toEqual({ id: "zai", name: "Z.AI" })
+  })
+
+  test("logical models appear once while subscription routes remain separate", () => {
+    const provider = (id: string) => ({ id, name: id })
+    const models = preferredModels([
+      {
+        id: "anthropic/claude-sonnet-5",
+        provider: provider("openrouter"),
+      },
+      {
+        id: "openai/gpt-5.6-sol",
+        provider: provider("openrouter"),
+        modes: { pro: { model: "openai/gpt-5.6-sol-pro" } },
+      },
+      {
+        id: "openai/gpt-5.6-sol-pro",
+        provider: provider("openrouter"),
+      },
+      {
+        id: "meta/muse-spark-1.1",
+        provider: provider("openrouter"),
+      },
+      {
+        id: "claude-sonnet-5",
+        provider: provider("anthropic"),
+      },
+      {
+        id: "gpt-5.6-sol",
+        provider: provider("openai-codex"),
+      },
+    ])
+
+    expect(models.map((model) => `${model.provider.id}/${model.id}`)).toEqual([
+      "openrouter/openai/gpt-5.6-sol",
+      "openrouter/meta/muse-spark-1.1",
+      "anthropic/claude-sonnet-5",
+      "openai-codex/gpt-5.6-sol",
+    ])
   })
 
   test("stale direct model selections route to managed OpenRouter aliases when present", () => {
@@ -68,5 +114,35 @@ describe("frontier model canonicalization", () => {
       providerID: "openrouter",
       modelID: "meta/muse-spark-1.1",
     })
+  })
+
+  test("persisted losing routes resolve to the preferred model", () => {
+    const provider = (id: string) => ({ id, name: id })
+    const managed = { id: "anthropic/claude-sonnet-5", provider: provider("openrouter") }
+    const native = { id: "claude-sonnet-5", provider: provider("anthropic") }
+
+    for (const input of [
+      [managed, native],
+      [native, managed],
+    ]) {
+      const models = preferredModels(input)
+      expect(preferredModel(models, { providerID: "openrouter", modelID: managed.id })).toEqual(native)
+    }
+  })
+
+  test("stale service-route selections resolve only to a base with the matching mode", () => {
+    const provider = { id: "openrouter", name: "OpenRouter" }
+    const key = { providerID: "openrouter", modelID: "openai/gpt-5.6-sol-pro" }
+    const base = {
+      id: "openai/gpt-5.6-sol",
+      provider,
+      modes: { pro: { model: "openai/gpt-5.6-sol-pro" } },
+    }
+    const unsupported = { id: "openai/gpt-5.6-sol", provider }
+
+    expect(preferredModel([base], key)).toBe(base)
+    expect(foldedRouteMode(key, base)).toBe("pro")
+    expect(preferredModel([unsupported], key)).toBeUndefined()
+    expect(foldedRouteMode(key, unsupported)).toBeUndefined()
   })
 })

--- a/frontend/workspace/src/context/models.tsx
+++ b/frontend/workspace/src/context/models.tsx
@@ -4,7 +4,7 @@ import { uniqueBy } from "remeda"
 import { createSimpleContext } from "@synsci/ui/context"
 import { useProviders } from "@/hooks/use-providers"
 import { Persist, persisted } from "@/utils/persist"
-import { isFrontier, routableModelKey, type ModelKey } from "./model-catalog"
+import { isFrontier, preferredModel, preferredModels, type ModelKey } from "./model-catalog"
 
 export { canonicalKey, FRONTIER_MODELS, type ModelKey } from "./model-catalog"
 
@@ -33,11 +33,13 @@ export const { use: useModels, provider: ModelsProvider } = createSimpleContext(
     )
 
     const available = createMemo(() =>
-      providers.connected().flatMap((p) =>
-        Object.values(p.models).map((m) => ({
-          ...m,
-          provider: p,
-        })),
+      preferredModels(
+        providers.connected().flatMap((p) =>
+          Object.values(p.models).map((m) => ({
+            ...m,
+            provider: p,
+          })),
+        ),
       ),
     )
 
@@ -74,13 +76,7 @@ export const { use: useModels, provider: ModelsProvider } = createSimpleContext(
       })
     })
 
-    const findExact = (key: ModelKey) => list().find((m) => m.id === key.modelID && m.provider.id === key.providerID)
-    const find = (key: ModelKey) => {
-      const exact = findExact(key)
-      if (exact) return exact
-      const routed = routableModelKey(key, (candidate) => !!findExact(candidate))
-      return findExact(routed)
-    }
+    const find = (key: ModelKey) => preferredModel(list(), key)
 
     function update(model: ModelKey, state: Visibility) {
       const index = store.user.findIndex((x) => x.modelID === model.modelID && x.providerID === model.providerID)

--- a/tooling/patches/@ai-sdk%2Fanthropic@2.0.57.patch
+++ b/tooling/patches/@ai-sdk%2Fanthropic@2.0.57.patch
@@ -1,7 +1,16 @@
 diff --git a/dist/index.d.mts b/dist/index.d.mts
-index 4b0502f71fcdf5f10cb1b4f227b42d123a5ba304..c7c8894fb4679be42c2ba79dcf25a378f77c04be 100644
+index 4b0502f71fcdf5f10cb1b4f227b42d123a5ba304..22609c74670712cbdb9e7092653bf3fdbeeae187 100644
 --- a/dist/index.d.mts
 +++ b/dist/index.d.mts
+@@ -51,7 +51,7 @@ declare const anthropicProviderOptions: z.ZodObject<{
+         auto: "auto";
+     }>>;
+     thinking: z.ZodOptional<z.ZodObject<{
+-        type: z.ZodUnion<readonly [z.ZodLiteral<"enabled">, z.ZodLiteral<"disabled">]>;
++        type: z.ZodUnion<readonly [z.ZodLiteral<"enabled">, z.ZodLiteral<"disabled">, z.ZodLiteral<"adaptive">]>;
+         budgetTokens: z.ZodOptional<z.ZodNumber>;
+     }, z.core.$strip>>;
+     disableParallelToolUse: z.ZodOptional<z.ZodBoolean>;
 @@ -71,6 +71,9 @@ declare const anthropicProviderOptions: z.ZodObject<{
          low: "low";
          medium: "medium";
@@ -13,9 +22,18 @@ index 4b0502f71fcdf5f10cb1b4f227b42d123a5ba304..c7c8894fb4679be42c2ba79dcf25a378
  }, z.core.$strip>;
  type AnthropicProviderOptions = z.infer<typeof anthropicProviderOptions>;
 diff --git a/dist/index.d.ts b/dist/index.d.ts
-index 4b0502f71fcdf5f10cb1b4f227b42d123a5ba304..c7c8894fb4679be42c2ba79dcf25a378f77c04be 100644
+index 4b0502f71fcdf5f10cb1b4f227b42d123a5ba304..22609c74670712cbdb9e7092653bf3fdbeeae187 100644
 --- a/dist/index.d.ts
 +++ b/dist/index.d.ts
+@@ -51,7 +51,7 @@ declare const anthropicProviderOptions: z.ZodObject<{
+         auto: "auto";
+     }>>;
+     thinking: z.ZodOptional<z.ZodObject<{
+-        type: z.ZodUnion<readonly [z.ZodLiteral<"enabled">, z.ZodLiteral<"disabled">]>;
++        type: z.ZodUnion<readonly [z.ZodLiteral<"enabled">, z.ZodLiteral<"disabled">, z.ZodLiteral<"adaptive">]>;
+         budgetTokens: z.ZodOptional<z.ZodNumber>;
+     }, z.core.$strip>>;
+     disableParallelToolUse: z.ZodOptional<z.ZodBoolean>;
 @@ -71,6 +71,9 @@ declare const anthropicProviderOptions: z.ZodObject<{
          low: "low";
          medium: "medium";
@@ -27,10 +45,23 @@ index 4b0502f71fcdf5f10cb1b4f227b42d123a5ba304..c7c8894fb4679be42c2ba79dcf25a378
  }, z.core.$strip>;
  type AnthropicProviderOptions = z.infer<typeof anthropicProviderOptions>;
 diff --git a/dist/index.js b/dist/index.js
-index e273a3cb0a7468481bc9b66baa1c434fbfdadd88..5cf76595e2c90e5f4d05b0670e94303d60c41aec 100644
+index e273a3cb0a7468481bc9b66baa1c434fbfdadd88..7891a1da825791393a98e6341545f3bd177f6a01 100644
 --- a/dist/index.js
 +++ b/dist/index.js
-@@ -615,7 +615,8 @@ var anthropicProviderOptions = import_v43.z.object({
+@@ -581,7 +581,11 @@ var anthropicProviderOptions = import_v43.z.object({
+    * Requires a minimum budget of 1,024 tokens and counts towards the `max_tokens` limit.
+    */
+   thinking: import_v43.z.object({
+-    type: import_v43.z.union([import_v43.z.literal("enabled"), import_v43.z.literal("disabled")]),
++    type: import_v43.z.union([
++      import_v43.z.literal("enabled"),
++      import_v43.z.literal("disabled"),
++      import_v43.z.literal("adaptive")
++    ]),
+     budgetTokens: import_v43.z.number().optional()
+   }).optional(),
+   /**
+@@ -615,7 +619,8 @@ var anthropicProviderOptions = import_v43.z.object({
    /**
     * @default 'high'
     */
@@ -40,7 +71,26 @@ index e273a3cb0a7468481bc9b66baa1c434fbfdadd88..5cf76595e2c90e5f4d05b0670e94303d
  });
  
  // src/anthropic-prepare-tools.ts
-@@ -1892,6 +1893,9 @@ var AnthropicMessagesLanguageModel = class {
+@@ -1873,7 +1878,9 @@ var AnthropicMessagesLanguageModel = class {
+       warnings,
+       cacheControlValidator
+     });
+-    const isThinking = ((_c = anthropicOptions == null ? void 0 : anthropicOptions.thinking) == null ? void 0 : _c.type) === "enabled";
++    const thinkingType = (_c = anthropicOptions == null ? void 0 : anthropicOptions.thinking) == null ? void 0 : _c.type;
++    const isThinking = thinkingType === "enabled";
++    const isAdaptive = thinkingType === "adaptive";
+     const thinkingBudget = (_d = anthropicOptions == null ? void 0 : anthropicOptions.thinking) == null ? void 0 : _d.budgetTokens;
+     const maxTokens = maxOutputTokens != null ? maxOutputTokens : maxOutputTokensForModel;
+     const baseArgs = {
+@@ -1886,12 +1893,15 @@ var AnthropicMessagesLanguageModel = class {
+       top_p: topP,
+       stop_sequences: stopSequences,
+       // provider specific settings:
+-      ...isThinking && {
+-        thinking: { type: "enabled", budget_tokens: thinkingBudget }
++      ...(isThinking || isAdaptive) && {
++        thinking: isAdaptive ? { type: "adaptive" } : { type: "enabled", budget_tokens: thinkingBudget }
+       },
        ...(anthropicOptions == null ? void 0 : anthropicOptions.effort) && {
          output_config: { effort: anthropicOptions.effort }
        },
@@ -51,9 +101,18 @@ index e273a3cb0a7468481bc9b66baa1c434fbfdadd88..5cf76595e2c90e5f4d05b0670e94303d
        ...useStructuredOutput && (responseFormat == null ? void 0 : responseFormat.type) === "json" && responseFormat.schema != null && {
          output_format: {
 diff --git a/dist/index.mjs b/dist/index.mjs
-index dc4157434cbf3f4afbf70b83c5d40fe85d40b883..146efaaf3ff5ba0d54e0a5824240cb774ad92bfd 100644
+index dc4157434cbf3f4afbf70b83c5d40fe85d40b883..ecd1153bbaa2b45dc1430e680ceae2b326c5daf2 100644
 --- a/dist/index.mjs
 +++ b/dist/index.mjs
+@@ -576,7 +576,7 @@ var anthropicProviderOptions = z3.object({
+    * Requires a minimum budget of 1,024 tokens and counts towards the `max_tokens` limit.
+    */
+   thinking: z3.object({
+-    type: z3.union([z3.literal("enabled"), z3.literal("disabled")]),
++    type: z3.union([z3.literal("enabled"), z3.literal("disabled"), z3.literal("adaptive")]),
+     budgetTokens: z3.number().optional()
+   }).optional(),
+   /**
 @@ -610,7 +610,8 @@ var anthropicProviderOptions = z3.object({
    /**
     * @default 'high'
@@ -64,7 +123,26 @@ index dc4157434cbf3f4afbf70b83c5d40fe85d40b883..146efaaf3ff5ba0d54e0a5824240cb77
  });
  
  // src/anthropic-prepare-tools.ts
-@@ -1911,6 +1912,9 @@ var AnthropicMessagesLanguageModel = class {
+@@ -1892,7 +1893,9 @@ var AnthropicMessagesLanguageModel = class {
+       warnings,
+       cacheControlValidator
+     });
+-    const isThinking = ((_c = anthropicOptions == null ? void 0 : anthropicOptions.thinking) == null ? void 0 : _c.type) === "enabled";
++    const thinkingType = (_c = anthropicOptions == null ? void 0 : anthropicOptions.thinking) == null ? void 0 : _c.type;
++    const isThinking = thinkingType === "enabled";
++    const isAdaptive = thinkingType === "adaptive";
+     const thinkingBudget = (_d = anthropicOptions == null ? void 0 : anthropicOptions.thinking) == null ? void 0 : _d.budgetTokens;
+     const maxTokens = maxOutputTokens != null ? maxOutputTokens : maxOutputTokensForModel;
+     const baseArgs = {
+@@ -1905,12 +1908,15 @@ var AnthropicMessagesLanguageModel = class {
+       top_p: topP,
+       stop_sequences: stopSequences,
+       // provider specific settings:
+-      ...isThinking && {
+-        thinking: { type: "enabled", budget_tokens: thinkingBudget }
++      ...(isThinking || isAdaptive) && {
++        thinking: isAdaptive ? { type: "adaptive" } : { type: "enabled", budget_tokens: thinkingBudget }
+       },
        ...(anthropicOptions == null ? void 0 : anthropicOptions.effort) && {
          output_config: { effort: anthropicOptions.effort }
        },
@@ -75,10 +153,23 @@ index dc4157434cbf3f4afbf70b83c5d40fe85d40b883..146efaaf3ff5ba0d54e0a5824240cb77
        ...useStructuredOutput && (responseFormat == null ? void 0 : responseFormat.type) === "json" && responseFormat.schema != null && {
          output_format: {
 diff --git a/dist/internal/index.js b/dist/internal/index.js
-index c80b1e9d5c73f3256f4f645a614339db4b734cbb..9b77654e4a01b34162013fd09d7006909755fa2b 100644
+index c80b1e9d5c73f3256f4f645a614339db4b734cbb..ef207ecbceae73eb440f68ce994fdf539254a5a3 100644
 --- a/dist/internal/index.js
 +++ b/dist/internal/index.js
-@@ -608,7 +608,8 @@ var anthropicProviderOptions = import_v43.z.object({
+@@ -574,7 +574,11 @@ var anthropicProviderOptions = import_v43.z.object({
+    * Requires a minimum budget of 1,024 tokens and counts towards the `max_tokens` limit.
+    */
+   thinking: import_v43.z.object({
+-    type: import_v43.z.union([import_v43.z.literal("enabled"), import_v43.z.literal("disabled")]),
++    type: import_v43.z.union([
++      import_v43.z.literal("enabled"),
++      import_v43.z.literal("disabled"),
++      import_v43.z.literal("adaptive")
++    ]),
+     budgetTokens: import_v43.z.number().optional()
+   }).optional(),
+   /**
+@@ -608,7 +612,8 @@ var anthropicProviderOptions = import_v43.z.object({
    /**
     * @default 'high'
     */
@@ -88,7 +179,26 @@ index c80b1e9d5c73f3256f4f645a614339db4b734cbb..9b77654e4a01b34162013fd09d700690
  });
  
  // src/anthropic-prepare-tools.ts
-@@ -1885,6 +1886,9 @@ var AnthropicMessagesLanguageModel = class {
+@@ -1866,7 +1871,9 @@ var AnthropicMessagesLanguageModel = class {
+       warnings,
+       cacheControlValidator
+     });
+-    const isThinking = ((_c = anthropicOptions == null ? void 0 : anthropicOptions.thinking) == null ? void 0 : _c.type) === "enabled";
++    const thinkingType = (_c = anthropicOptions == null ? void 0 : anthropicOptions.thinking) == null ? void 0 : _c.type;
++    const isThinking = thinkingType === "enabled";
++    const isAdaptive = thinkingType === "adaptive";
+     const thinkingBudget = (_d = anthropicOptions == null ? void 0 : anthropicOptions.thinking) == null ? void 0 : _d.budgetTokens;
+     const maxTokens = maxOutputTokens != null ? maxOutputTokens : maxOutputTokensForModel;
+     const baseArgs = {
+@@ -1879,12 +1886,15 @@ var AnthropicMessagesLanguageModel = class {
+       top_p: topP,
+       stop_sequences: stopSequences,
+       // provider specific settings:
+-      ...isThinking && {
+-        thinking: { type: "enabled", budget_tokens: thinkingBudget }
++      ...(isThinking || isAdaptive) && {
++        thinking: isAdaptive ? { type: "adaptive" } : { type: "enabled", budget_tokens: thinkingBudget }
+       },
        ...(anthropicOptions == null ? void 0 : anthropicOptions.effort) && {
          output_config: { effort: anthropicOptions.effort }
        },
@@ -99,9 +209,18 @@ index c80b1e9d5c73f3256f4f645a614339db4b734cbb..9b77654e4a01b34162013fd09d700690
        ...useStructuredOutput && (responseFormat == null ? void 0 : responseFormat.type) === "json" && responseFormat.schema != null && {
          output_format: {
 diff --git a/dist/internal/index.mjs b/dist/internal/index.mjs
-index cd1c18d50c2f1a1d8a3d8d73cac4f34149cb1626..e5e6c6e80463c2c2b04032f97a8dc0b9b44489cf 100644
+index cd1c18d50c2f1a1d8a3d8d73cac4f34149cb1626..ed3f2284bc7a656aed8b5bc41dc4ff52c6d5ad01 100644
 --- a/dist/internal/index.mjs
 +++ b/dist/internal/index.mjs
+@@ -561,7 +561,7 @@ var anthropicProviderOptions = z3.object({
+    * Requires a minimum budget of 1,024 tokens and counts towards the `max_tokens` limit.
+    */
+   thinking: z3.object({
+-    type: z3.union([z3.literal("enabled"), z3.literal("disabled")]),
++    type: z3.union([z3.literal("enabled"), z3.literal("disabled"), z3.literal("adaptive")]),
+     budgetTokens: z3.number().optional()
+   }).optional(),
+   /**
 @@ -595,7 +595,8 @@ var anthropicProviderOptions = z3.object({
    /**
     * @default 'high'
@@ -112,7 +231,26 @@ index cd1c18d50c2f1a1d8a3d8d73cac4f34149cb1626..e5e6c6e80463c2c2b04032f97a8dc0b9
  });
  
  // src/anthropic-prepare-tools.ts
-@@ -1896,6 +1897,9 @@ var AnthropicMessagesLanguageModel = class {
+@@ -1877,7 +1878,9 @@ var AnthropicMessagesLanguageModel = class {
+       warnings,
+       cacheControlValidator
+     });
+-    const isThinking = ((_c = anthropicOptions == null ? void 0 : anthropicOptions.thinking) == null ? void 0 : _c.type) === "enabled";
++    const thinkingType = (_c = anthropicOptions == null ? void 0 : anthropicOptions.thinking) == null ? void 0 : _c.type;
++    const isThinking = thinkingType === "enabled";
++    const isAdaptive = thinkingType === "adaptive";
+     const thinkingBudget = (_d = anthropicOptions == null ? void 0 : anthropicOptions.thinking) == null ? void 0 : _d.budgetTokens;
+     const maxTokens = maxOutputTokens != null ? maxOutputTokens : maxOutputTokensForModel;
+     const baseArgs = {
+@@ -1890,12 +1893,15 @@ var AnthropicMessagesLanguageModel = class {
+       top_p: topP,
+       stop_sequences: stopSequences,
+       // provider specific settings:
+-      ...isThinking && {
+-        thinking: { type: "enabled", budget_tokens: thinkingBudget }
++      ...(isThinking || isAdaptive) && {
++        thinking: isAdaptive ? { type: "adaptive" } : { type: "enabled", budget_tokens: thinkingBudget }
+       },
        ...(anthropicOptions == null ? void 0 : anthropicOptions.effort) && {
          output_config: { effort: anthropicOptions.effort }
        },


### PR DESCRIPTION
## Summary

- deduplicate provider-equivalent model rows while keeping Codex subscription routes separate
- fold OpenRouter fast/pro siblings into service modes and preserve legacy selections
- expose Standard plus provider-native reasoning efforts, independently from Fast/Pro service modes
- send adaptive thinking and effort for current Claude models, while retaining token-budget thinking for older Claude models
- expand browser coverage for independent reasoning and service-mode selection

## Root cause

The workspace treated provider aliases and OpenRouter service variants as distinct catalog entries, and the thinking selector had no explicit Standard state. Current Anthropic effort values were also sent without enabling adaptive thinking, so direct Claude requests did not match Anthropic's current request contract.

## Validation

- `bun run check` (`1271` pass, `1` skip, `0` fail)
- provider transform tests (`121` pass, `0` fail)
- model catalog/tier/variant tests (`13` pass, `0` fail)
- Playwright thinking + service-mode flows (`2` pass)
- frontend production build
- forced frozen install verifies the pinned Anthropic patch applies
- Prettier check and `git diff --check`