### PR TITLE
Scope the skills switch browser test

### DIFF
--- a/frontend/workspace/e2e/skills.spec.ts
+++ b/frontend/workspace/e2e/skills.spec.ts
@@ -16,7 +16,7 @@ test("skills can be searched, disabled, and authored from scratch", async ({ pag
   await expect(page.getByText(knownSkill, { exact: true }).first()).toBeVisible()
 
   await search.fill("")
-  const toggle = page.locator('[data-component="switch"]').first()
+  const toggle = page.locator('[data-action="skill-toggle"]').first()
   await expect(toggle).toBeVisible()
   const initiallyEnabled = (await toggle.getAttribute("data-checked")) !== null
   await toggle.click()

--- a/frontend/workspace/src/atlas/SkillsPage.tsx
+++ b/frontend/workspace/src/atlas/SkillsPage.tsx
@@ -412,7 +412,7 @@ function SkillCard(props: { skill: Skill; on: boolean; onToggle: (v: boolean) =>
         >
           {props.skill.name}
         </span>
-        <Switch checked={props.on} onChange={props.onToggle} hideLabel>
+        <Switch data-action="skill-toggle" checked={props.on} onChange={props.onToggle} hideLabel>
           {props.skill.name}
         </Switch>
       </div>


### PR DESCRIPTION
## Summary
- add a stable action hook to skill-card switches
- scope the Skills E2E away from the prompt's hidden Fast switch

## Validation
- focused Playwright E2E: Skills and Fast mode, 2 passed