### PR TITLE
UI: Focus and simplify the OpenScience research workspace

### DIFF
--- a/docs/superpowers/plans/2026-07-29-codex-style-ui.md
+++ b/docs/superpowers/plans/2026-07-29-codex-style-ui.md
@@ -1,0 +1,171 @@
+# Codex-style OpenScience UI implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn OpenScience into a calm, Codex-style research workspace while preserving every research capability.
+
+**Architecture:** Keep the existing SolidJS workspace, stores, routes, semantic
+theme tokens, and tool components. Simplify the shell in reviewable batches:
+first the navigation frame, then the start surface and conversation, then the
+contextual research inspector and secondary workbenches. Progressive disclosure
+replaces permanent chrome; no backend or Atlas changes are required.
+
+**Tech Stack:** SolidJS, TypeScript, existing `@synsci/ui` primitives, CSS theme
+tokens, Bun tests, Playwright browser tests.
+
+## Global constraints
+
+- Work only on `openscience/ui-changes`; keep one open PR and never merge it.
+- Preserve sessions, files, skills, artifacts, Atlas, evidence, compute,
+  terminal, settings, themes, and keyboard access.
+- Do not add a UI framework, icon package, gradient, heavy shadow, or npm
+  production release.
+- Keep `AUDIT.md` and `openscience-starters/` untracked and untouched.
+- Write and run the focused failing test before every production behavior change.
+- Push cohesive batches after focused tests, typecheck, formatting, and browser
+  verification pass.
+
+---
+
+### Task 1: Quiet workspace shell
+
+**Files:**
+
+- Modify: `frontend/workspace/src/pages/session.tsx`
+- Modify: `frontend/workspace/src/atlas/AppHeader.tsx`
+- Modify: `frontend/workspace/src/styles/atlas.css`
+- Test: `frontend/workspace/src/pages/session-shell.test.ts`
+- Test: `frontend/workspace/e2e/research-shell.spec.ts`
+
+**Interfaces:**
+
+- Consumes: `uiStore`, `centerTabs`, existing route parameters, and session CRUD
+  callbacks.
+- Produces: the same session route with a quieter header, rail, and document bar;
+  no store or route signature changes.
+
+- [ ] Write a source-contract test requiring semantic shell class names and
+  proving the old repeated wordmark/header divider composition is absent.
+- [ ] Run `bun test frontend/workspace/src/pages/session-shell.test.ts` and
+  confirm it fails on the current shell.
+- [ ] Replace the crowded header with the workspace title, rail toggle, command
+  search, tools entry, and overflow actions.
+- [ ] Restyle the session rail and document bar with flat surfaces, reduced
+  border density, and sentence-case copy.
+- [ ] Add Playwright coverage that creates a session and reaches Files, Skills,
+  Settings, and the command palette from the simplified shell.
+- [ ] Run the focused test, workspace typecheck, format check, and Playwright
+  spec.
+- [ ] Commit and push the shell batch to the permanent UI PR.
+
+### Task 2: Focused new research surface
+
+**Files:**
+
+- Modify: `frontend/workspace/src/components/session/session-new-view.tsx`
+- Modify: `frontend/workspace/src/components/session/research-launchpad.ts`
+- Modify: `frontend/workspace/src/styles/atlas.css`
+- Test: `frontend/workspace/src/components/session/research-launchpad.test.ts`
+- Test: `frontend/workspace/e2e/research-launchpad.spec.ts`
+
+**Interfaces:**
+
+- Consumes: existing model state, starter creation endpoint, worktree selection,
+  `centerTabs`, and `PromptInput`.
+- Produces: the same starter/workflow actions through a compact progressive
+  disclosure surface.
+
+- [ ] Write failing tests for the compact primary actions and hidden detailed
+  workflow catalog.
+- [ ] Run the focused tests and confirm the missing compact surface is the
+  failure.
+- [ ] Put the research question, guidance, and composer first; collapse readiness
+  into one actionable status.
+- [ ] Replace starter and workflow card grids with concise rows and a “Browse
+  workflows” disclosure.
+- [ ] Verify starter creation, model-settings routing, worktree selection, and
+  workflow prompt insertion in Playwright.
+- [ ] Run focused tests, typecheck, format, and browser checks.
+- [ ] Commit and push the start-surface batch.
+
+### Task 3: Conversation and composer calmness
+
+**Files:**
+
+- Modify: `frontend/workspace/src/pages/session.tsx`
+- Modify: `frontend/workspace/src/components/prompt-input.tsx`
+- Modify: `frontend/workspace/src/styles/atlas.css`
+- Test: `frontend/workspace/e2e/session-composer.spec.ts`
+
+**Interfaces:**
+
+- Consumes: the existing prompt submission, attachment, model, agent, effort,
+  permission, and revert APIs.
+- Produces: unchanged prompt behavior with a lower-noise control hierarchy.
+
+- [ ] Add a failing browser test for the intended primary/secondary composer
+  controls and keyboard behavior.
+- [ ] Run the spec and confirm it fails on the current control hierarchy.
+- [ ] Increase transcript whitespace and readable measure; remove decorative
+  turn chrome that does not convey state.
+- [ ] Keep attachment, model, and send visible; move lower-frequency controls
+  behind one options control without changing their underlying actions.
+- [ ] Verify submit, multiline entry, attachments, stop, undo/revert, model
+  selection, and keyboard focus.
+- [ ] Run browser regression, typecheck, and format.
+- [ ] Commit and push the conversation batch.
+
+### Task 4: Contextual research inspector
+
+**Files:**
+
+- Modify: `frontend/workspace/src/atlas/RightPane.tsx`
+- Modify: `frontend/workspace/src/atlas/store/ui.ts`
+- Modify: `frontend/workspace/src/styles/atlas.css`
+- Test: `frontend/workspace/src/pages/session-shell.test.ts`
+- Test: `frontend/workspace/e2e/research-inspector.spec.ts`
+
+**Interfaces:**
+
+- Consumes: existing right-pane tabs, artifact context, terminal command queue,
+  and persisted width.
+- Produces: one collapsed Tools affordance and the unchanged tab implementations
+  when expanded.
+
+- [ ] Add failing tests that require the inspector to start closed and expose one
+  collapsed Tools control.
+- [ ] Run the tests and verify the current multi-icon rail causes the failure.
+- [ ] Replace the icon stack with one quiet Tools entry while keeping automatic
+  artifact and terminal opening.
+- [ ] Simplify the expanded tab/header treatment and preserve resize,
+  persistence, close, and overlay behavior.
+- [ ] Verify Atlas, Evidence, Compute, Terminal, artifact inspection, and mobile
+  dismissal in Playwright.
+- [ ] Run focused tests, typecheck, format, and browser regression.
+- [ ] Commit and push the inspector batch.
+
+### Task 5: Secondary workbench polish
+
+**Files:**
+
+- Modify: `frontend/workspace/src/atlas/FileExplorer.tsx`
+- Modify: `frontend/workspace/src/atlas/SkillsPage.tsx`
+- Modify: `frontend/workspace/src/components/dialog-settings.tsx`
+- Modify: `frontend/workspace/src/styles/atlas.css`
+- Test: relevant existing file, skills, settings, and science viewer E2E specs.
+
+**Interfaces:**
+
+- Consumes: existing file, skill, settings, notebook, manuscript, data, and
+  scientific visualization APIs.
+- Produces: visually consistent secondary surfaces with unchanged domain logic.
+
+- [ ] Add the smallest failing contract for each surface before changing it.
+- [ ] Flatten unnecessary cards, normalize headings and toolbars, and improve
+  empty/loading/error states.
+- [ ] Verify `.ipynb`, `.xyz`, PDB/SDF, genomic, data-table, manuscript, and
+  artifact flows remain usable from the simplified shell.
+- [ ] Check desktop/mobile and light/dark visual states plus console errors.
+- [ ] Run the complete workspace browser suite, typecheck, format, builds, and
+  smoke checks.
+- [ ] Commit and push the polish batch; keep the PR open and unmerged.

--- a/docs/superpowers/specs/2026-07-29-codex-style-ui-design.md
+++ b/docs/superpowers/specs/2026-07-29-codex-style-ui-design.md
@@ -1,0 +1,141 @@
+# Codex-style OpenScience UI design
+
+## Intent
+
+OpenScience should feel like a focused research workspace, not a collection of
+dashboards. The conversation or active scientific artifact is the primary
+surface. Sessions, files, compute, evidence, skills, and settings remain fully
+available, but they should not compete for attention before the researcher asks
+for them.
+
+The visual reference is the Codex desktop app: quiet neutral surfaces, strong
+typographic hierarchy, generous space around the active work, restrained
+controls, and progressive disclosure. OpenScience keeps its research identity
+through scientific file previews, notebooks, compute, evidence, and local
+project context rather than through extra chrome.
+
+## Product principles
+
+1. **The work is the interface.** Chat, notebooks, data, manuscripts, and
+   visualizations receive the largest uninterrupted area.
+2. **Reveal tools in context.** The research inspector is closed by default and
+   opens when a file, artifact, compute job, terminal, or evidence view needs it.
+3. **One clear action per region.** Header, session rail, start screen, and
+   composer each have a single dominant action.
+4. **Quiet by default.** Status, readiness, provider, and setup information is
+   collapsed into compact, actionable states instead of permanent cards.
+5. **Research-specific, not dashboard-like.** Scientific starters and workflows
+   are concise prompts or rows. They do not become a grid of competing cards.
+6. **No functionality regression.** Sessions, files, skills, command palette,
+   settings, theme selection, artifacts, Atlas, evidence, compute, and terminal
+   remain reachable by mouse and keyboard.
+
+## Information architecture
+
+### Session rail
+
+The left rail is a calm, full-height navigation surface. It contains:
+
+- OpenScience identity and a compact collapse control.
+- One prominent “New research” action.
+- Recent sessions with a quiet active state.
+- Search behind an explicit control or keyboard shortcut instead of a permanent
+  input.
+- Project navigation and low-frequency settings at the bottom.
+
+The rail is resizable only if the existing behavior already supports it. It
+becomes an overlay on small screens and can be dismissed without changing the
+active work.
+
+### Workspace header
+
+The header belongs to the active workspace, not the whole product. It shows:
+
+- A session-rail toggle when needed.
+- The project or session title, with the path available as secondary text or a
+  tooltip.
+- A compact “Open” or workspace-tools menu.
+- Search/command palette and one overflow menu for help, settings, and theme.
+
+The header does not repeat the wordmark, project breadcrumb, path, and multiple
+equal-weight icon buttons.
+
+### Center workspace
+
+Chat is the default center tab. Files and Skills remain available, but the tab
+strip reads like a lightweight document bar. It appears only when useful and
+does not look like a second global navigation bar.
+
+Conversation content uses a readable central measure, generous turn spacing,
+subtle separators, and a composer that visually belongs to the document. The
+composer keeps attachments, model selection, research mode, and submission, but
+secondary switches collapse into menus.
+
+### New research screen
+
+The start screen contains:
+
+- A simple research question heading.
+- One sentence of guidance.
+- The composer in the primary visual position.
+- A short list of high-value starting actions.
+- Compact setup feedback only when action is required.
+
+Detailed workspace readiness, artifact counts, starter packs, workflow
+categories, worktree controls, and local/reproducible metadata use progressive
+disclosure below the fold or a single “Browse workflows” surface.
+
+### Research inspector
+
+The inspector is closed by default. Its collapsed rail is visually quiet and
+has one clear “Tools” affordance rather than four equally prominent icons. When
+open, its tabs remain Atlas, Evidence, Compute, and Terminal, plus contextual
+artifact inspection. Closing it restores the center workspace without losing
+state.
+
+## Visual system
+
+- Use the existing theme tokens and stack. Do not migrate frameworks or add a
+  design library.
+- Prefer Avenir Next / SF Pro / native app typography for UI and the configured
+  mono font for code and measurements.
+- Use warm or neutral monochrome surfaces, off-black text, and hairline borders.
+- Avoid gradients, large shadows, glow, glass cards, colored ambient
+  backgrounds, excessive all-caps labels, and rounded pills.
+- Use `4px` to `8px` radii for controls and containers. Reserve full pills for
+  tiny statuses.
+- Motion is limited to `transform` and `opacity`, respects reduced motion, and
+  should be felt more than noticed.
+- Every interactive control keeps a visible keyboard focus state and a minimum
+  practical hit target.
+
+## Responsive behavior
+
+- At desktop widths, the session rail is stable and the inspector is contextual.
+- Below the current tablet breakpoint, both side surfaces become independent
+  overlays with backdrops; opening one closes or visually dominates the other.
+- At narrow mobile widths, the header keeps only rail toggle, title, and
+  overflow. The composer remains fully usable above the virtual keyboard.
+- No horizontal page scrolling is introduced at any supported width.
+
+## Verification
+
+Each batch must include a failing automated contract or browser test before its
+implementation. Verification includes:
+
+- Focused Solid/Bun tests for state and source contracts.
+- Existing workspace typecheck and formatting.
+- Hosted or local Playwright flows for session creation, navigation, files,
+  skills, inspector tools, and composer interaction.
+- Visual inspection at desktop and mobile widths in light and dark themes.
+- Console error inspection after each major browser pass.
+
+## Branch and release contract
+
+- All redesign work stays on `openscience/ui-changes`.
+- The branch has one permanent pull request into `main`.
+- New UI commits are pushed to that PR continuously.
+- The UI pull request is never merged without a new explicit user instruction.
+- Unrelated functional bug fixes use separate branches and pull requests and may
+  be merged to `main` after their own tests pass.
+- No npm production workflow is triggered from this work.

--- a/frontend/workspace/e2e/artifact-inspector.spec.ts
+++ b/frontend/workspace/e2e/artifact-inspector.spec.ts
@@ -32,7 +32,7 @@ test("opened files drive a contextual artifact inspector without stale state", a
   await expect(inspector).toHaveAttribute("data-artifact-id", /water\.xyz/)
   await expect(inspector.locator("header strong")).toHaveText("water.xyz")
   await expect(inspector.getByRole("tab")).toHaveCount(7)
-  expect((await inspector.boundingBox())?.width).toBeGreaterThanOrEqual(400)
+  expect((await inspector.boundingBox())?.width).toBeGreaterThanOrEqual(340)
   await expect(inspector.getByText("3 atoms", { exact: true })).toBeVisible()
   await expect(inspector.getByText("PNG export", { exact: true })).toBeVisible()
 

--- a/frontend/workspace/e2e/research-launchpad.spec.ts
+++ b/frontend/workspace/e2e/research-launchpad.spec.ts
@@ -23,9 +23,13 @@ test("turns a scientific workflow into an editable research brief", async ({ pag
   const launchpad = page.locator('[data-component="research-launchpad"]')
   await expect(launchpad).toBeVisible()
   await expect(launchpad.getByRole("heading", { name: "What are we trying to find out?" })).toBeVisible()
+  await expect(launchpad.locator(".research-launchpad__quick-action")).toHaveCount(6)
+  await expect(launchpad.getByRole("button", { name: /artifacts$/ })).toBeVisible()
+  await expect(launchpad.locator("[data-workflow]")).toHaveCount(0)
+  await expect(launchpad.locator("[data-starter]")).toHaveCount(0)
+  await launchpad.getByRole("button", { name: /Browse all workflows/ }).click()
   await expect(launchpad.locator("[data-workflow]")).toHaveCount(23)
   await expect(launchpad.locator("[data-starter]")).toHaveCount(3)
-  await expect(launchpad.getByText("Research artifacts", { exact: true })).toBeVisible()
   await expect(page.locator(".session-right-pane")).toHaveCount(0)
 
   await launchpad.locator('[data-starter="dose-response"]').click()
@@ -40,6 +44,7 @@ test("turns a scientific workflow into an editable research brief", async ({ pag
 
   await page.reload()
   await expect(launchpad).toBeVisible()
+  await launchpad.getByRole("button", { name: /Browse all workflows/ }).click()
   await launchpad.getByRole("button", { name: /Compute 7/ }).click()
   await expect(launchpad.locator("[data-workflow]")).toHaveCount(7)
   await expect(launchpad.locator('[data-workflow="protein-design"]')).toBeVisible()
@@ -51,6 +56,7 @@ test("recovers starter controls when the local server request drops", async ({ p
   await page.route("**/file/starters?**", (route) => route.abort("connectionfailed"))
   await gotoSession()
 
+  await page.getByRole("button", { name: /Browse all workflows/ }).click()
   const starter = page.locator('[data-starter="single-cell"]')
   await starter.click()
   await expect(page.getByText("starter could not be created", { exact: true })).toBeVisible()

--- a/frontend/workspace/e2e/session.spec.ts
+++ b/frontend/workspace/e2e/session.spec.ts
@@ -33,14 +33,14 @@ test("session lifecycle works through the sidebar UI", async ({ page, slug, sdk,
   try {
     await gotoSession()
 
-    const search = page.getByPlaceholder("Search sessions")
-    const sidebar = page.getByRole("complementary").filter({ has: search })
+    const newResearch = page.getByRole("button", { name: "New research", exact: true })
+    const sidebar = page.getByRole("complementary").filter({ has: newResearch })
     const rows = sidebar.locator('div[role="button"]')
     await expect(sidebar).toBeVisible()
     const baselineCount = await rows.count()
 
     const createResponsePromise = page.waitForResponse((response) => isSessionResponse(response, "POST"))
-    await sidebar.getByRole("button", { name: "New session" }).click()
+    await newResearch.click()
     const createResponse = await createResponsePromise
     expect(createResponse.ok()).toBe(true)
 

--- a/frontend/workspace/e2e/settings-panels.spec.ts
+++ b/frontend/workspace/e2e/settings-panels.spec.ts
@@ -20,7 +20,8 @@ test("every settings panel loads inside the fixed dialog shell", async ({ page, 
   page.on("pageerror", (error) => pageErrors.push(error.message))
 
   await gotoSession()
-  await page.getByRole("button", { name: "settings", exact: true }).click()
+  await page.getByRole("button", { name: "More", exact: true }).click()
+  await page.getByRole("menuitem", { name: "Settings", exact: true }).click()
   const dialog = page.getByRole("dialog")
   await expect(dialog).toBeVisible()
 

--- a/frontend/workspace/e2e/settings-providers.spec.ts
+++ b/frontend/workspace/e2e/settings-providers.spec.ts
@@ -3,7 +3,8 @@ import { test, expect } from "./fixtures"
 test("credentials settings exposes provider connection controls", async ({ page, gotoSession }) => {
   await gotoSession()
 
-  await page.getByRole("button", { name: "settings", exact: true }).click()
+  await page.getByRole("button", { name: "More", exact: true }).click()
+  await page.getByRole("menuitem", { name: "Settings", exact: true }).click()
   const dialog = page.getByRole("dialog")
   await dialog.getByRole("button", { name: "Credentials", exact: true }).click()
 
@@ -22,7 +23,8 @@ test("credentials settings saves and removes a local provider key", async ({ pag
 
   try {
     await gotoSession()
-    await page.getByRole("button", { name: "settings", exact: true }).click()
+    await page.getByRole("button", { name: "More", exact: true }).click()
+    await page.getByRole("menuitem", { name: "Settings", exact: true }).click()
     const dialog = page.getByRole("dialog")
     await dialog.getByRole("button", { name: "Credentials", exact: true }).click()
 

--- a/frontend/workspace/e2e/settings.spec.ts
+++ b/frontend/workspace/e2e/settings.spec.ts
@@ -3,7 +3,8 @@ import { test, expect } from "./fixtures"
 test("settings dialog navigates between sections and closes", async ({ page, gotoSession }) => {
   await gotoSession()
 
-  await page.getByRole("button", { name: "settings", exact: true }).click()
+  await page.getByRole("button", { name: "More", exact: true }).click()
+  await page.getByRole("menuitem", { name: "Settings", exact: true }).click()
   const dialog = page.getByRole("dialog")
   await expect(dialog.getByRole("heading", { name: "Connectors" })).toBeVisible()
 

--- a/frontend/workspace/e2e/sidebar-session-links.spec.ts
+++ b/frontend/workspace/e2e/sidebar-session-links.spec.ts
@@ -14,7 +14,9 @@ test("sidebar session rows navigate to the selected session", async ({ page, slu
   try {
     await gotoSession(one.id)
 
-    const sidebar = page.getByRole("complementary").filter({ has: page.getByPlaceholder("Search sessions") })
+    const sidebar = page
+      .getByRole("complementary")
+      .filter({ has: page.getByRole("button", { name: "New research" }) })
     const target = sidebar.locator('[role="button"]').filter({ hasText: twoTitle })
     await expect(target).toBeVisible()
     await target.scrollIntoViewIfNeeded()

--- a/frontend/workspace/e2e/sidebar-session-links.spec.ts
+++ b/frontend/workspace/e2e/sidebar-session-links.spec.ts
@@ -14,9 +14,7 @@ test("sidebar session rows navigate to the selected session", async ({ page, slu
   try {
     await gotoSession(one.id)
 
-    const sidebar = page
-      .getByRole("complementary")
-      .filter({ has: page.getByRole("button", { name: "New research" }) })
+    const sidebar = page.getByRole("complementary").filter({ has: page.getByRole("button", { name: "New research" }) })
     const target = sidebar.locator('[role="button"]').filter({ hasText: twoTitle })
     await expect(target).toBeVisible()
     await target.scrollIntoViewIfNeeded()

--- a/frontend/workspace/e2e/sidebar.spec.ts
+++ b/frontend/workspace/e2e/sidebar.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "./fixtures"
 
-test("sidebar filters sessions and clears the search", async ({ page, sdk, gotoSession }) => {
+test("sidebar keeps recent sessions visible without a permanent search field", async ({ page, sdk, gotoSession }) => {
   const stamp = Date.now()
   const oneTitle = `e2e sidebar search alpha ${stamp}`
   const twoTitle = `e2e sidebar search beta ${stamp}`
@@ -13,17 +13,10 @@ test("sidebar filters sessions and clears the search", async ({ page, sdk, gotoS
   try {
     await gotoSession(one.id)
 
-    const search = page.getByPlaceholder("Search sessions")
-    const sidebar = page.getByRole("complementary").filter({ has: search })
+    const sidebar = page.getByRole("complementary").filter({ has: page.getByRole("button", { name: "New research" }) })
     await expect(sidebar).toBeVisible()
-    await expect(sidebar.getByRole("button", { name: "New session" })).toBeVisible()
-
-    await search.fill(`beta ${stamp}`)
-    await expect(sidebar.locator('[role="button"]').filter({ hasText: twoTitle })).toBeVisible()
-    await expect(sidebar.locator('[role="button"]').filter({ hasText: oneTitle })).toHaveCount(0)
-
-    await sidebar.getByRole("button", { name: "clear search" }).click()
-    await expect(search).toHaveValue("")
+    await expect(sidebar.getByRole("button", { name: "New research" })).toBeVisible()
+    await expect(sidebar.getByPlaceholder("Search sessions")).toHaveCount(0)
     await expect(sidebar.locator('[role="button"]').filter({ hasText: oneTitle })).toBeVisible()
     await expect(sidebar.locator('[role="button"]').filter({ hasText: twoTitle })).toBeVisible()
   } finally {
@@ -38,12 +31,14 @@ test.describe("mobile workspace", () => {
   test("sessions open as a drawer instead of squeezing the active pane", async ({ page, gotoSession }) => {
     await gotoSession()
 
-    const sidebar = page.getByRole("complementary").filter({ has: page.getByLabel("search sessions") })
+    const sidebar = page
+      .getByRole("complementary")
+      .filter({ has: page.getByRole("button", { name: "New research" }) })
     await expect(sidebar).toHaveAttribute("data-mobile-open", "false")
 
-    await page.getByRole("button", { name: "sessions" }).click()
+    await page.getByRole("button", { name: "Show sessions" }).click()
     await expect(sidebar).toHaveAttribute("data-mobile-open", "true")
-    await expect(page.getByLabel("search sessions")).toBeVisible()
+    await expect(sidebar.getByRole("button", { name: "New research" })).toBeVisible()
 
     await page.getByRole("button", { name: "close sessions" }).click()
     await expect(sidebar).toHaveAttribute("data-mobile-open", "false")

--- a/frontend/workspace/e2e/sidebar.spec.ts
+++ b/frontend/workspace/e2e/sidebar.spec.ts
@@ -31,9 +31,7 @@ test.describe("mobile workspace", () => {
   test("sessions open as a drawer instead of squeezing the active pane", async ({ page, gotoSession }) => {
     await gotoSession()
 
-    const sidebar = page
-      .getByRole("complementary")
-      .filter({ has: page.getByRole("button", { name: "New research" }) })
+    const sidebar = page.getByRole("complementary").filter({ has: page.getByRole("button", { name: "New research" }) })
     await expect(sidebar).toHaveAttribute("data-mobile-open", "false")
 
     await page.getByRole("button", { name: "Show sessions" }).click()

--- a/frontend/workspace/e2e/titlebar-history.spec.ts
+++ b/frontend/workspace/e2e/titlebar-history.spec.ts
@@ -16,9 +16,7 @@ test("browser back/forward navigates between sessions", async ({ page, slug, sdk
   try {
     await gotoSession(one.id)
 
-    const sidebar = page
-      .getByRole("complementary")
-      .filter({ has: page.getByRole("button", { name: "New research" }) })
+    const sidebar = page.getByRole("complementary").filter({ has: page.getByRole("button", { name: "New research" }) })
     const target = sidebar.locator('[role="button"]').filter({ hasText: twoTitle })
     await expect(target).toBeVisible()
     await target.scrollIntoViewIfNeeded()

--- a/frontend/workspace/e2e/titlebar-history.spec.ts
+++ b/frontend/workspace/e2e/titlebar-history.spec.ts
@@ -16,7 +16,9 @@ test("browser back/forward navigates between sessions", async ({ page, slug, sdk
   try {
     await gotoSession(one.id)
 
-    const sidebar = page.getByRole("complementary").filter({ has: page.getByPlaceholder("Search sessions") })
+    const sidebar = page
+      .getByRole("complementary")
+      .filter({ has: page.getByRole("button", { name: "New research" }) })
     const target = sidebar.locator('[role="button"]').filter({ hasText: twoTitle })
     await expect(target).toBeVisible()
     await target.scrollIntoViewIfNeeded()

--- a/frontend/workspace/src/atlas/AppHeader.tsx
+++ b/frontend/workspace/src/atlas/AppHeader.tsx
@@ -5,10 +5,10 @@
  */
 import { type JSX } from "solid-js"
 
-export function AppHeader(props: { children: JSX.Element }): JSX.Element {
+export function AppHeader(props: { children: JSX.Element; class?: string }): JSX.Element {
   return (
     <header
-      class="g-strip"
+      class={`g-strip${props.class ? ` ${props.class}` : ""}`}
       style={{
         display: "flex",
         "align-items": "center",

--- a/frontend/workspace/src/atlas/RightPane.tsx
+++ b/frontend/workspace/src/atlas/RightPane.tsx
@@ -24,16 +24,16 @@ import {
   IconNetwork,
 } from "@/atlas/shared/Icon"
 
-const RIGHT_PANE_WIDTH_KEY = "thesis-right-pane-width-v1"
+const RIGHT_PANE_WIDTH_KEY = "openscience-research-inspector-width-v2"
 const MIN_PANE_WIDTH = 280
-const MAX_PANE_WIDTH = 880
+const MAX_PANE_WIDTH = 680
 
 function readSavedWidth(): number {
   try {
     const v = Number(localStorage.getItem(RIGHT_PANE_WIDTH_KEY))
     if (Number.isFinite(v) && v >= MIN_PANE_WIDTH && v <= MAX_PANE_WIDTH) return v
   } catch {}
-  return 420
+  return 360
 }
 
 export function RightPane(): JSX.Element {
@@ -154,20 +154,16 @@ export function RightPane(): JSX.Element {
         </Show>
         <aside
           class="session-right-pane"
+          data-overlay={narrow() ? "true" : "false"}
           style={{
             flex: narrow() ? "none" : `0 0 ${width()}px`,
-            width: narrow() ? "min(420px, calc(100vw - 52px))" : `${width()}px`,
-            display: "flex",
-            "flex-direction": "column",
-            "border-left": "1px solid var(--color-border)",
-            background: "var(--color-bg-subtle)",
+            width: narrow() ? "min(380px, calc(100vw - 44px))" : `${width()}px`,
             "min-width": narrow() ? "280px" : `${MIN_PANE_WIDTH}px`,
             position: narrow() ? "fixed" : "relative",
             top: narrow() ? "0" : undefined,
             right: narrow() ? "0" : undefined,
             bottom: narrow() ? "0" : undefined,
             "z-index": narrow() ? 70 : undefined,
-            "box-shadow": narrow() ? "-18px 0 48px rgba(0, 0, 0, 0.22)" : "none",
           }}
         >
           {/* Drag handle on the left edge of the right pane. 6px wide, full
@@ -192,26 +188,8 @@ export function RightPane(): JSX.Element {
             onMouseEnter={(e) => (e.currentTarget.style.background = "var(--color-accent-subtle)")}
             onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
           />
-          <div
-            role="tablist"
-            style={{
-              display: "flex",
-              "align-items": "stretch",
-              "border-bottom": "1px solid var(--color-border)",
-              background: "var(--color-bg-subtle)",
-              "flex-shrink": 0,
-            }}
-          >
-            <div
-              style={{
-                display: "flex",
-                gap: "5px",
-                padding: "7px 10px",
-                flex: 1,
-                "min-width": 0,
-                "overflow-x": "auto",
-              }}
-            >
+          <div class="research-inspector__tabs" role="tablist">
+            <div class="research-inspector__tab-list">
               <Show when={artifact()}>
                 <TabBtn
                   k="artifact"
@@ -236,11 +214,16 @@ export function RightPane(): JSX.Element {
                 )}
               </For>
             </div>
-            <div style={{ position: "relative", display: "flex", "align-items": "center", "flex-shrink": 0 }}>
-              <button onClick={openSkillLibrary} title="skill library" style={paneCtl(false)}>
+            <div class="research-inspector__controls">
+              <button class="research-inspector__control" onClick={openSkillLibrary} title="skill library">
                 <IconBraces size={12} strokeWidth={1.5} />
               </button>
-              <button onClick={() => setPanelMenu((v) => !v)} title="panel settings" style={paneCtl(panelMenu())}>
+              <button
+                class="research-inspector__control"
+                data-active={panelMenu() ? "true" : "false"}
+                onClick={() => setPanelMenu((v) => !v)}
+                title="panel settings"
+              >
                 <IconSettings size={12} strokeWidth={1.5} />
               </button>
               <Show when={panelMenu()}>
@@ -291,7 +274,11 @@ export function RightPane(): JSX.Element {
                   </button>
                 </div>
               </Show>
-              <button onClick={() => uiStore.setRightPaneOpen(false)} title="hide panel" style={paneCtl(false)}>
+              <button
+                class="research-inspector__control"
+                onClick={() => uiStore.setRightPaneOpen(false)}
+                title="hide panel"
+              >
                 <IconChevronRight size={13} strokeWidth={1.5} />
               </button>
             </div>
@@ -477,35 +464,33 @@ function CollapsedRail(props: {
   onOpen: (t?: RightPaneTab) => void
 }): JSX.Element {
   return (
-    <aside
-      style={{
-        flex: "0 0 40px",
-        width: "40px",
-        display: "flex",
-        "flex-direction": "column",
-        "align-items": "center",
-        gap: "4px",
-        padding: "10px 0",
-        "border-left": "1px solid var(--color-border)",
-        background: "var(--color-bg-subtle)",
-      }}
-    >
-      <button onClick={() => props.onOpen()} title="show panel" aria-label="show panel" style={railBtn()}>
+    <aside class="research-tool-rail">
+      <button
+        class="research-tool-rail__button"
+        onClick={() => props.onOpen()}
+        title="show panel"
+        aria-label="show panel"
+      >
         <IconChevronLeft size={14} strokeWidth={1.5} />
       </button>
-      <span style={{ width: "18px", height: "1px", background: "var(--color-border)", margin: "4px 0" }} />
+      <span class="research-tool-rail__divider" />
       <Show when={props.artifact}>
-        <button onClick={props.onInspect} title="inspect artifact" aria-label="inspect artifact" style={railBtn()}>
+        <button
+          class="research-tool-rail__button"
+          onClick={props.onInspect}
+          title="inspect artifact"
+          aria-label="inspect artifact"
+        >
           <IconAtom size={15} strokeWidth={1.5} />
         </button>
       </Show>
       <For each={props.tabs}>
         {(t) => (
           <button
+            class="research-tool-rail__button"
             onClick={() => props.onOpen(t.k)}
             title={t.label ?? t.k}
             aria-label={t.label ?? t.k}
-            style={railBtn()}
           >
             <t.Icon size={15} strokeWidth={1.5} />
           </button>
@@ -513,18 +498,6 @@ function CollapsedRail(props: {
       </For>
     </aside>
   )
-}
-
-function paneCtl(active: boolean): JSX.CSSProperties {
-  return {
-    all: "unset",
-    cursor: "pointer",
-    display: "inline-flex",
-    "align-items": "center",
-    "justify-content": "center",
-    padding: "0 8px",
-    color: active ? "var(--color-text)" : "var(--color-text-faint)",
-  } as JSX.CSSProperties
 }
 
 const paneMenuLabel: JSX.CSSProperties = {
@@ -571,21 +544,6 @@ function emptyAction(): JSX.CSSProperties {
   } as JSX.CSSProperties
 }
 
-function railBtn(): JSX.CSSProperties {
-  return {
-    all: "unset",
-    cursor: "pointer",
-    position: "relative",
-    width: "30px",
-    height: "30px",
-    display: "inline-flex",
-    "align-items": "center",
-    "justify-content": "center",
-    "border-radius": "4px",
-    color: "var(--color-text-muted)",
-  } as JSX.CSSProperties
-}
-
 function TabBtn(props: {
   k: string
   label?: string
@@ -596,42 +554,13 @@ function TabBtn(props: {
 }): JSX.Element {
   return (
     <button
+      class="research-inspector__tab"
+      data-active={props.active ? "true" : "false"}
       role="tab"
       aria-selected={props.active}
       onClick={props.onClick}
-      style={{
-        all: "unset",
-        cursor: "pointer",
-        display: "inline-flex",
-        "align-items": "center",
-        gap: "7px",
-        padding: "6px 10px",
-        "border-radius": "4px",
-        border: props.active ? "1px solid var(--color-border-strong)" : "1px solid transparent",
-        background: props.active ? "var(--color-surface-solid)" : "transparent",
-        "box-shadow": props.active ? "0 1px 2px rgba(0,0,0,0.10)" : "none",
-        "font-family": FONT_MONO,
-        "font-size": "11px",
-        "font-weight": props.active ? 700 : 400,
-        color: props.active ? "var(--color-text)" : "var(--color-text-muted)",
-        transition:
-          "background var(--duration-fast) var(--ease-standard), color var(--duration-fast) var(--ease-standard), border-color var(--duration-fast) var(--ease-standard)",
-        "flex-shrink": 0,
-      }}
-      onMouseEnter={(e) => {
-        if (!props.active) e.currentTarget.style.background = "var(--color-accent-subtle)"
-      }}
-      onMouseLeave={(e) => {
-        if (!props.active) e.currentTarget.style.background = "transparent"
-      }}
     >
-      <span
-        style={{
-          display: "inline-flex",
-          color: props.active ? "var(--color-text)" : "var(--color-text-faint)",
-          "flex-shrink": 0,
-        }}
-      >
+      <span class="research-inspector__tab-icon">
         <props.Icon size={12} strokeWidth={1.6} />
       </span>
       <span>{props.label ?? props.k}</span>

--- a/frontend/workspace/src/atlas/SkillsPage.tsx
+++ b/frontend/workspace/src/atlas/SkillsPage.tsx
@@ -11,8 +11,7 @@ import { currentDirectory } from "@/utils/base64"
 import { useGlobalSDK } from "@/context/global-sdk"
 import { usePlatform } from "@/context/platform"
 import { useGlobalSync } from "@/context/global-sync"
-import { FONT_MONO, FONT_SANS } from "@/styles/tokens"
-import { IconBrain } from "@/atlas/shared/Icon"
+import { FONT_SANS } from "@/styles/tokens"
 import type { Config } from "@synsci/sdk/v2/client"
 import {
   SearchInput,
@@ -131,84 +130,21 @@ export default function SkillsPage(): JSX.Element {
   })
 
   return (
-    <div
-      style={{
-        flex: 1,
-        "min-height": 0,
-        display: "flex",
-        "flex-direction": "column",
-        background: "var(--color-background-base)",
-      }}
-    >
-      {/* ── Hero + toolbar ─────────────────────────────────────────────── */}
-      <div
-        style={{
-          "flex-shrink": 0,
-          padding: "22px 24px 16px",
-          "border-bottom": "1px solid var(--color-border)",
-          background: "var(--color-bg-subtle)",
-        }}
-      >
-        <div style={{ display: "flex", "align-items": "flex-start", gap: "13px", "max-width": "1080px" }}>
-          <div
-            style={{
-              display: "flex",
-              "align-items": "center",
-              "justify-content": "center",
-              width: "38px",
-              height: "38px",
-              "border-radius": "9px",
-              border: "1px solid var(--color-border)",
-              background: "var(--color-surface-solid)",
-              color: "var(--color-text)",
-              "flex-shrink": 0,
-            }}
-          >
-            <IconBrain size={20} strokeWidth={1.6} />
+    <div class="skills-workspace">
+      <div class="skills-workspace__header">
+        <div class="skills-workspace__heading">
+          <div>
+            <h1>Skills</h1>
+            <p>Playbooks available to this workspace and its research agents.</p>
           </div>
-          <div style={{ display: "flex", "flex-direction": "column", gap: "3px", "min-width": 0 }}>
-            <h1
-              style={{ "font-family": FONT_SANS, "font-size": "19px", "font-weight": 600, color: "var(--color-text)" }}
-            >
-              Skills
-            </h1>
-            <p
-              style={{
-                "font-family": FONT_SANS,
-                "font-size": "13px",
-                "line-height": 1.5,
-                color: "var(--color-text-muted)",
-                "max-width": "560px",
-              }}
-            >
-              Expert playbooks your agents load on demand — bundled, learned, and installed. Toggle one off to hide it
-              from every agent.
-            </p>
-            <div
-              style={{
-                display: "flex",
-                gap: "14px",
-                "margin-top": "5px",
-                "font-family": FONT_MONO,
-                "font-size": "11px",
-                color: "var(--color-text-faint)",
-              }}
-            >
-              <span>
-                <span style={{ color: "var(--color-text)" }}>{enabledCount()}</span> enabled
-              </span>
-              <span>
-                <span style={{ color: "var(--color-text)" }}>{all().length}</span> total
-              </span>
-              <span>
-                <span style={{ color: "var(--color-text)" }}>{Math.max(0, categories().length - 1)}</span> categories
-              </span>
-            </div>
+          <div class="skills-workspace__summary">
+            <span>{enabledCount()} enabled</span>
+            <span>{all().length} total</span>
           </div>
         </div>
 
         <Show when={view() === "list"}>
-          <div style={{ "margin-top": "14px", "max-width": "1080px" }}>
+          <div class="skills-workspace__toolbar">
             <Toolbar>
               <FilterMenu options={categories()} value={category()} onSelect={setCategory} />
               <SearchInput value={search()} onInput={setSearch} placeholder="Search skills" />
@@ -252,9 +188,8 @@ export default function SkillsPage(): JSX.Element {
         }}
       />
 
-      {/* ── Body ───────────────────────────────────────────────────────── */}
-      <div class="atlas-scroll" style={{ flex: 1, "min-height": 0, "overflow-y": "auto", padding: "20px 24px 40px" }}>
-        <div style={{ "max-width": "1080px", margin: "0 auto" }}>
+      <div class="atlas-scroll skills-workspace__body">
+        <div class="skills-workspace__content">
           <Show when={view() === "scratch"}>
             <ScratchForm
               busy={busy()}
@@ -316,28 +251,18 @@ export default function SkillsPage(): JSX.Element {
                   </div>
                 }
               >
-                <div style={{ display: "flex", "flex-direction": "column", gap: "26px" }}>
+                <div class="skills-workspace__list">
                   <For each={shelves()}>
                     {([cat, items]) => (
-                      <section style={{ display: "flex", "flex-direction": "column", gap: "11px" }}>
-                        <div style={{ display: "flex", "align-items": "baseline", gap: "8px" }}>
+                      <section class="skills-workspace__group">
+                        <div class="skills-workspace__group-heading">
                           <span class="atlas-section-label">{cat}</span>
-                          <span
-                            style={{ "font-family": FONT_MONO, "font-size": "10px", color: "var(--color-text-faint)" }}
-                          >
-                            {items.length}
-                          </span>
+                          <span>{items.length}</span>
                         </div>
-                        <div
-                          style={{
-                            display: "grid",
-                            "grid-template-columns": "repeat(auto-fill, minmax(280px, 1fr))",
-                            gap: "10px",
-                          }}
-                        >
+                        <div class="skills-workspace__rows">
                           <For each={items}>
                             {(skill) => (
-                              <SkillCard
+                              <SkillRow
                                 skill={skill}
                                 on={enabled(skill.name)}
                                 onToggle={(v) => void toggle(skill.name, v)}
@@ -376,103 +301,28 @@ export default function SkillsPage(): JSX.Element {
   }
 }
 
-function SkillCard(props: { skill: Skill; on: boolean; onToggle: (v: boolean) => void }): JSX.Element {
+function SkillRow(props: { skill: Skill; on: boolean; onToggle: (v: boolean) => void }): JSX.Element {
   const source = () => sourceOf(props.skill.location)
   return (
-    <div
-      style={{
-        display: "flex",
-        "flex-direction": "column",
-        gap: "8px",
-        padding: "13px 14px",
-        "border-radius": "8px",
-        border: "1px solid var(--color-border)",
-        background: props.on ? "var(--color-surface-solid)" : "transparent",
-        opacity: props.on ? 1 : 0.62,
-        transition: "opacity 120ms ease, border-color 120ms ease, background 120ms ease",
-        "min-width": 0,
-      }}
-      onMouseEnter={(e) => (e.currentTarget.style.borderColor = "var(--color-border-strong)")}
-      onMouseLeave={(e) => (e.currentTarget.style.borderColor = "var(--color-border)")}
-    >
-      <div style={{ display: "flex", "align-items": "center", gap: "8px" }}>
-        <span
-          style={{
-            "font-family": FONT_MONO,
-            "font-size": "13px",
-            "font-weight": 600,
-            color: "var(--color-text)",
-            flex: 1,
-            "min-width": 0,
-            overflow: "hidden",
-            "text-overflow": "ellipsis",
-            "white-space": "nowrap",
-          }}
-          title={props.skill.name}
-        >
-          {props.skill.name}
+    <div class="skills-workspace__row" data-enabled={props.on ? "true" : "false"}>
+      <div class="skills-workspace__identity">
+        <strong title={props.skill.name}>{props.skill.name}</strong>
+        <span>
+          <i style={{ background: SOURCE_DOT[source()] }} />
+          {source()}
         </span>
-        <Switch data-action="skill-toggle" checked={props.on} onChange={props.onToggle} hideLabel>
-          {props.skill.name}
-        </Switch>
       </div>
 
       <Show when={props.skill.description}>
-        <p
-          style={{
-            "font-family": FONT_SANS,
-            "font-size": "12px",
-            "line-height": 1.5,
-            color: "var(--color-text-muted)",
-            display: "-webkit-box",
-            "-webkit-line-clamp": "2",
-            "-webkit-box-orient": "vertical",
-            overflow: "hidden",
-          }}
-        >
-          {props.skill.description}
-        </p>
+        <p>{props.skill.description}</p>
       </Show>
 
-      <div style={{ display: "flex", "align-items": "center", gap: "6px", "flex-wrap": "wrap", "margin-top": "1px" }}>
-        <span
-          style={{
-            display: "inline-flex",
-            "align-items": "center",
-            gap: "5px",
-            "font-family": FONT_MONO,
-            "font-size": "10px",
-            color: "var(--color-text-faint)",
-          }}
-        >
-          <span
-            style={{
-              width: "5px",
-              height: "5px",
-              "border-radius": "50%",
-              background: SOURCE_DOT[source()],
-              "flex-shrink": 0,
-            }}
-          />
-          {source()}
-        </span>
-        <For each={(props.skill.tags ?? []).slice(0, 3)}>
-          {(tag) => (
-            <span
-              style={{
-                "font-family": FONT_MONO,
-                "font-size": "10px",
-                color: "var(--color-text-faint)",
-                padding: "1px 6px",
-                "border-radius": "4px",
-                background: "var(--color-accent-subtle)",
-              }}
-            >
-              {tag}
-            </span>
-          )}
-        </For>
+      <div class="skills-workspace__tags">
+        <For each={(props.skill.tags ?? []).slice(0, 3)}>{(tag) => <span>{tag}</span>}</For>
       </div>
+      <Switch data-action="skill-toggle" checked={props.on} onChange={props.onToggle} hideLabel>
+        {props.skill.name}
+      </Switch>
     </div>
   )
 }

--- a/frontend/workspace/src/atlas/skills-page.test.ts
+++ b/frontend/workspace/src/atlas/skills-page.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+
+const source = () => readFileSync(fileURLToPath(new URL("./SkillsPage.tsx", import.meta.url)), "utf8")
+
+test("skills use a compact searchable list instead of a card dashboard", () => {
+  const page = source()
+
+  expect(page).toContain('class="skills-workspace"')
+  expect(page).toContain('class="skills-workspace__header"')
+  expect(page).toContain('class="skills-workspace__list"')
+  expect(page).toContain('class="skills-workspace__row"')
+  expect(page).not.toContain("SkillCard")
+  expect(page).not.toContain('"grid-template-columns": "repeat(auto-fill')
+})

--- a/frontend/workspace/src/components/dialog-settings.test.ts
+++ b/frontend/workspace/src/components/dialog-settings.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+
+const source = () => readFileSync(fileURLToPath(new URL("./dialog-settings.tsx", import.meta.url)), "utf8")
+
+test("settings use a compact responsive navigation frame", () => {
+  const dialog = source()
+
+  expect(dialog).toContain('class="settings-layout"')
+  expect(dialog).toContain('class="settings-nav"')
+  expect(dialog).toContain('class="settings-nav__sections')
+  expect(dialog).toContain('class="settings-nav__item')
+  expect(dialog).toContain("@media (max-width: 720px)")
+  expect(dialog).not.toContain("w-[224px]")
+})

--- a/frontend/workspace/src/components/dialog-settings.tsx
+++ b/frontend/workspace/src/components/dialog-settings.tsx
@@ -64,6 +64,140 @@ const SETTINGS_STYLES = `
   min-height: 0;
   overflow: hidden;
 }
+
+.settings-layout {
+  display: flex;
+  width: 100%;
+  height: 100%;
+}
+.settings-nav {
+  width: 184px;
+  flex: 0 0 184px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 10px 8px;
+  border-right: 1px solid var(--border-weak-base);
+  background: var(--surface-weak);
+}
+.settings-nav__sections {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding-top: 2px;
+  overflow-y: auto;
+  scrollbar-width: none;
+}
+.settings-nav__sections::-webkit-scrollbar {
+  display: none;
+}
+.settings-nav__section {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.settings-nav__label {
+  padding: 0 9px 4px;
+}
+.settings-nav__item {
+  min-width: 0;
+  height: 31px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 9px;
+  border-radius: 5px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-weak);
+  text-align: left;
+  transition: background 120ms ease, color 120ms ease;
+}
+.settings-nav__item:hover {
+  background: var(--surface-raised-base);
+  color: var(--text-strong);
+}
+.settings-nav__item[data-active="true"] {
+  background: var(--surface-raised-base-active);
+  color: var(--text-strong);
+}
+.settings-nav__footer {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  padding: 8px 9px 0;
+  color: var(--text-weak);
+}
+.settings-main {
+  min-width: 0;
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+}
+.settings-main__header {
+  min-height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 0 12px;
+  border-bottom: 1px solid var(--border-weak-base);
+  flex-shrink: 0;
+}
+
+@media (max-width: 720px) {
+  [data-component="dialog"]:has([data-slot="dialog-content"].settings-dialog) [data-slot="dialog-container"] {
+    width: calc(100vw - 16px);
+    height: calc(100vh - 20px);
+  }
+  .settings-layout {
+    flex-direction: column;
+  }
+  .settings-nav {
+    width: 100%;
+    height: 42px;
+    flex: 0 0 42px;
+    padding: 0 4px;
+    border-right: 0;
+    border-bottom: 1px solid var(--border-weak-base);
+    overflow: hidden;
+  }
+  .settings-nav__sections {
+    flex-direction: row;
+    gap: 0;
+    padding: 0;
+    overflow-x: auto;
+    overflow-y: hidden;
+  }
+  .settings-nav__section {
+    flex: 0 0 auto;
+    flex-direction: row;
+    gap: 0;
+  }
+  .settings-nav__label,
+  .settings-nav__footer {
+    display: none;
+  }
+  .settings-nav__item {
+    height: 42px;
+    flex: 0 0 auto;
+    gap: 6px;
+    padding: 0 9px;
+    border-bottom: 1px solid transparent;
+    border-radius: 0;
+    font-size: 11px;
+  }
+  .settings-nav__item:hover {
+    background: transparent;
+  }
+  .settings-nav__item[data-active="true"] {
+    border-bottom-color: var(--text-base);
+    background: transparent;
+  }
+  .settings-main__header {
+    min-height: 44px;
+  }
+}
 `
 
 export const DialogSettings: Component = () => {
@@ -92,24 +226,20 @@ export const DialogSettings: Component = () => {
   return (
     <Dialog size="x-large" transition class="settings-dialog" classList={{ "settings-expanded": expanded() }}>
       <style>{SETTINGS_STYLES}</style>
-      <div class="flex h-full w-full">
+      <div class="settings-layout">
         {/* ── Left rail ── */}
-        <nav class="flex flex-col justify-between w-[224px] flex-shrink-0 border-r border-border-weak-base bg-surface-base/30 py-3 px-2.5">
-          <div class="flex flex-col gap-5 overflow-y-auto no-scrollbar pt-1">
+        <nav class="settings-nav">
+          <div class="settings-nav__sections">
             <For each={SETTINGS_SECTIONS}>
               {(section) => (
-                <div class="flex flex-col gap-1">
-                  <span class="px-2.5 pb-1 atlas-section-label">{section.label}</span>
+                <div class="settings-nav__section">
+                  <span class="settings-nav__label atlas-section-label">{section.label}</span>
                   <For each={SETTINGS_PANELS.filter((p) => p.section === section.id)}>
                     {(panel) => (
                       <button
                         type="button"
-                        class="flex items-center gap-2.5 h-8 px-2.5 rounded-xs text-13-medium transition-colors text-left"
-                        classList={{
-                          "bg-surface-raised-base-active text-text-strong": current().id === panel.id,
-                          "text-text-weak hover:text-text-strong hover:bg-surface-raised-base/60":
-                            current().id !== panel.id,
-                        }}
+                        class="settings-nav__item"
+                        data-active={current().id === panel.id ? "true" : "false"}
                         onClick={() => navigate(panel.id)}
                         aria-current={current().id === panel.id ? "page" : undefined}
                       >
@@ -122,16 +252,16 @@ export const DialogSettings: Component = () => {
               )}
             </For>
           </div>
-          <div class="flex flex-col gap-0.5 px-2.5 pt-2 text-text-weak">
+          <div class="settings-nav__footer">
             <span class="text-12-medium">OpenScience</span>
             <span class="text-11-regular">v{platform.version}</span>
           </div>
         </nav>
 
         {/* ── Right column ── */}
-        <div class="flex flex-col flex-1 min-w-0">
+        <div class="settings-main">
           {/* Header */}
-          <header class="flex items-center justify-between gap-2 min-h-[52px] px-3 border-b border-border-weak-base flex-shrink-0">
+          <header class="settings-main__header">
             <div class="flex items-center gap-1 min-w-0">
               <IconButton icon="arrow-left" variant="ghost" disabled={!canBack()} onClick={back} aria-label="Back" />
               <IconButton

--- a/frontend/workspace/src/components/prompt-input.tsx
+++ b/frontend/workspace/src/components/prompt-input.tsx
@@ -1778,6 +1778,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
         onSubmit={handleSubmit}
         classList={{
           "group/prompt-input": true,
+          "workspace-composer": true,
           "bg-surface-raised-stronger-non-alpha shadow-xs-border relative": true,
           "rounded-[14px] overflow-clip focus-within:shadow-xs-border": true,
           "border-icon-info-active border-dashed": store.dragging,
@@ -1946,8 +1947,8 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
             </div>
           </Show>
         </div>
-        <div class="relative p-3 flex items-center justify-between">
-          <div data-slot="prompt-controls" class="flex items-center justify-start gap-2">
+        <div class="workspace-composer__footer">
+          <div data-slot="prompt-controls" class="workspace-composer__controls flex items-center justify-start gap-2">
             <Switch>
               <Match when={store.mode === "shell"}>
                 <div class="flex items-center gap-2 px-2 h-6">
@@ -2110,7 +2111,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
               </Match>
             </Switch>
           </div>
-          <div class="flex items-center gap-3 absolute right-3 bottom-3">
+          <div class="workspace-composer__actions flex items-center gap-3">
             <input
               ref={fileInputRef}
               type="file"

--- a/frontend/workspace/src/components/session/research-launchpad.test.ts
+++ b/frontend/workspace/src/components/session/research-launchpad.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
 import { researchStarters, researchWorkflows, workflowGroups, workflowPrompt } from "./research-launchpad"
+
+const view = () => readFileSync(fileURLToPath(new URL("./session-new-view.tsx", import.meta.url)), "utf8")
 
 describe("research launchpad", () => {
   test("ships launch-ready workflows across the core scientific loop", () => {
@@ -62,5 +66,16 @@ describe("research launchpad", () => {
   test("ships local-first starter projects with valid backend template ids", () => {
     expect(researchStarters.map((starter) => starter.id)).toEqual(["single-cell", "dose-response", "protein-structure"])
     expect(researchStarters.every((starter) => starter.files.length >= 2)).toBe(true)
+  })
+
+  test("keeps the first screen focused and progressively reveals the full catalog", () => {
+    const source = view()
+
+    expect(source).toContain('class="research-launchpad__quick"')
+    expect(source).toContain("Browse all workflows")
+    expect(source).toContain('aria-expanded={catalogOpen() ? "true" : "false"}')
+    expect(source).toContain("<Show when={catalogOpen()}>")
+    expect(source).not.toContain('class="research-launchpad__status"')
+    expect(source).not.toContain('class="research-launchpad__starter-visual"')
   })
 })

--- a/frontend/workspace/src/components/session/session-new-view.tsx
+++ b/frontend/workspace/src/components/session/session-new-view.tsx
@@ -5,7 +5,7 @@ import { useModels } from "@/context/models"
 import { useSDK } from "@/context/sdk"
 import { usePlatform } from "@/context/platform"
 import { useDialog } from "@synsci/ui/context/dialog"
-import { getDirectory, getFilename } from "@synsci/util/path"
+import { getFilename } from "@synsci/util/path"
 import { DialogSettings } from "@/components/dialog-settings"
 import { centerTabs } from "@/atlas/store/centerTabs"
 import { uiStore } from "@/atlas/store/ui"
@@ -15,9 +15,8 @@ import {
   IconArrowRight,
   IconAtom,
   IconBraces,
-  IconCheckCircle,
+  IconChevronDown,
   IconFile,
-  IconFolder,
   IconLayoutGrid,
   IconNetwork,
   IconRefresh,
@@ -33,6 +32,14 @@ import {
 
 const MAIN_WORKTREE = "main"
 const CREATE_WORKTREE = "create"
+const FEATURED_WORKFLOWS = [
+  "analyze-data",
+  "run-notebook",
+  "survey-literature",
+  "inspect-structure",
+  "reproduce-result",
+  "write-report",
+] as const
 
 interface NewSessionViewProps {
   worktree: string
@@ -62,8 +69,6 @@ export function NewSessionView(props: NewSessionViewProps) {
   const sandboxes = createMemo(() => sync.project?.sandboxes ?? [])
   const options = createMemo(() => [MAIN_WORKTREE, ...sandboxes(), CREATE_WORKTREE])
   const current = createMemo(() => (options().includes(props.worktree) ? props.worktree : MAIN_WORKTREE))
-  const projectRoot = createMemo(() => sync.project?.worktree ?? sync.data.path.directory)
-  const projectName = createMemo(() => getFilename(projectRoot()) || "research project")
   const branch = createMemo(() => sync.data.vcs?.branch || "working tree")
   const [artifacts] = createResource(
     () => sdk.directory,
@@ -75,6 +80,12 @@ export function NewSessionView(props: NewSessionViewProps) {
   )
   const [workflowGroup, setWorkflowGroup] = createSignal<ResearchWorkflow["group"] | "all">("all")
   const [creating, setCreating] = createSignal<ResearchStarter["id"]>()
+  const [catalogOpen, setCatalogOpen] = createSignal(false)
+  const featuredWorkflows = createMemo(() =>
+    FEATURED_WORKFLOWS.map((id) => researchWorkflows.find((workflow) => workflow.id === id)).filter(
+      (workflow): workflow is ResearchWorkflow => Boolean(workflow),
+    ),
+  )
   const visibleWorkflows = createMemo(() =>
     workflowGroup() === "all"
       ? researchWorkflows
@@ -129,184 +140,50 @@ export function NewSessionView(props: NewSessionViewProps) {
     <main class="atlas-scroll research-launchpad" data-component="research-launchpad">
       <div class="research-launchpad__inner">
         <section class="research-launchpad__intro" aria-labelledby="research-launchpad-title">
-          <div>
-            <div class="research-launchpad__eyebrow">Research workspace</div>
-            <h1 id="research-launchpad-title">What are we trying to find out?</h1>
-            <p>
-              Start with a concrete workflow or describe the result you need. OpenScience can inspect project files, run
-              code, edit notebooks, and keep the evidence next to the work.
-            </p>
-          </div>
-          <div class="research-launchpad__project" title={projectRoot()}>
-            <IconFolder size={15} strokeWidth={1.45} />
-            <div>
-              <strong>{projectName()}</strong>
-              <span>
-                {getDirectory(projectRoot())}
-                {projectName()}
-              </span>
-            </div>
-          </div>
-        </section>
-
-        <section class="research-launchpad__status" aria-label="Workspace readiness">
-          <button
-            type="button"
-            class="research-launchpad__status-item"
-            data-state={noModel() ? "attention" : "ready"}
-            onClick={() => {
-              if (noModel()) dialog.show(() => <DialogSettings />)
-            }}
-          >
-            <span class="research-launchpad__status-dot" />
-            <span>
-              <strong>{noModel() ? "Connect a model" : `${models.list().length} models ready`}</strong>
-              <small>{noModel() ? "required before the first run" : "choose one in the composer"}</small>
-            </span>
-          </button>
-          <div class="research-launchpad__status-item" data-state="ready">
-            <span class="research-launchpad__status-dot" />
-            <span>
-              <strong>{local() ? "Local compute ready" : "Remote compute connected"}</strong>
-              <small>{local() ? "terminal and notebook kernels available" : sdk.url}</small>
-            </span>
-          </div>
-          <button type="button" class="research-launchpad__status-item" onClick={() => centerTabs.setActive("files")}>
-            <span class="research-launchpad__status-count">
-              <Show when={!artifacts.loading} fallback="··">
-                {(artifacts.latest?.length ?? 0).toLocaleString()}
-              </Show>
-            </span>
-            <span>
-              <strong>Research artifacts</strong>
-              <small>
-                {artifacts.error ? "scan unavailable · open Files" : "notebooks, data, figures, and models"}
-              </small>
-            </span>
-          </button>
+          <div class="research-launchpad__eyebrow">New research</div>
+          <h1 id="research-launchpad-title">What are we trying to find out?</h1>
+          <p>
+            Ask a question below or choose a starting point. OpenScience can inspect the project, run code and
+            notebooks, and keep the evidence beside the result.
+          </p>
         </section>
 
         <Show when={noModel()}>
-          <section class="research-launchpad__notice" role="status">
-            <div>
-              <strong>No model is connected yet</strong>
-              <span>
-                Add OpenAI, Anthropic, Gemini, OpenRouter, or a local model. Your project files stay on the selected
-                compute host.
-              </span>
-            </div>
-            <button type="button" onClick={() => dialog.show(() => <DialogSettings />)}>
-              open model settings
-              <IconArrowRight size={12} strokeWidth={1.7} />
-            </button>
-          </section>
+          <button type="button" class="research-launchpad__setup" onClick={() => dialog.show(() => <DialogSettings />)}>
+            <span>
+              <strong>Connect a model</strong>
+              <small>Required before the first run</small>
+            </span>
+            <IconArrowRight size={13} strokeWidth={1.7} />
+          </button>
         </Show>
 
-        <section class="research-launchpad__starters" aria-labelledby="research-starters-title">
+        <section class="research-launchpad__quick" aria-labelledby="research-quick-title">
           <div class="research-launchpad__section-heading">
             <div>
-              <h2 id="research-starters-title">Start with working science</h2>
-              <p>
-                Create a valid notebook, sample data, and a short local README in one click. No download or gateway.
-              </p>
+              <h2 id="research-quick-title">Start here</h2>
+              <p>These open as editable prompts in the composer.</p>
             </div>
-            <span class="research-launchpad__local-badge">local · reproducible</span>
+            <button type="button" class="research-launchpad__artifacts" onClick={() => centerTabs.setActive("files")}>
+              <Show when={!artifacts.loading} fallback="Scanning files">
+                {(artifacts.latest?.length ?? 0).toLocaleString()} artifacts
+              </Show>
+            </button>
           </div>
-          <div class="research-launchpad__starter-grid">
-            <For each={researchStarters}>
-              {(starter) => (
-                <button
-                  type="button"
-                  class="research-launchpad__starter"
-                  data-starter={starter.id}
-                  disabled={Boolean(creating())}
-                  onClick={() => void createStarter(starter)}
-                  style={{ "--starter-accent": starter.accent }}
-                >
-                  <span class="research-launchpad__starter-visual">
-                    <For each={Array.from({ length: 9 })}>
-                      {(_, index) => <i style={{ height: `${22 + ((index() * 31 + starter.title.length) % 65)}%` }} />}
-                    </For>
-                  </span>
-                  <span class="research-launchpad__starter-copy">
-                    <strong>{starter.title}</strong>
-                    <span>{starter.description}</span>
-                    <small>{starter.files.join(" · ")}</small>
-                  </span>
-                  <span class="research-launchpad__starter-action">
-                    {creating() === starter.id ? "creating…" : "create starter"}
-                    <IconArrowRight size={12} strokeWidth={1.7} />
-                  </span>
-                </button>
-              )}
-            </For>
-          </div>
-        </section>
-
-        <section class="research-launchpad__workflows" aria-labelledby="research-workflows-title">
-          <div class="research-launchpad__section-heading">
-            <div>
-              <h2 id="research-workflows-title">Start from a workflow</h2>
-              <p>Each one writes a detailed, editable brief into the composer.</p>
-            </div>
-            <label class="research-launchpad__worktree">
-              <span>Run on</span>
-              <select value={current()} onChange={(event) => props.onWorktreeChange(event.currentTarget.value)}>
-                <For each={options()}>{(option) => <option value={option}>{worktreeLabel(option)}</option>}</For>
-              </select>
-            </label>
-          </div>
-
-          <nav class="research-launchpad__workflow-filters" aria-label="Workflow categories">
-            <For
-              each={
-                [
-                  ["all", "All workflows"],
-                  ["analyze", "Analyze"],
-                  ["compute", "Compute"],
-                  ["discover", "Discover"],
-                  ["communicate", "Communicate"],
-                ] as const
-              }
-            >
-              {(item) => (
-                <button
-                  type="button"
-                  data-active={workflowGroup() === item[0] ? "true" : "false"}
-                  onClick={() => setWorkflowGroup(item[0])}
-                >
-                  {item[1]}
-                  <span>
-                    {item[0] === "all"
-                      ? researchWorkflows.length
-                      : researchWorkflows.filter((workflow) => workflow.group === item[0]).length}
-                  </span>
-                </button>
-              )}
-            </For>
-          </nav>
-
-          <div class="research-launchpad__grid">
-            <For each={visibleWorkflows()}>
-              {(workflow, index) => {
+          <div class="research-launchpad__quick-list">
+            <For each={featuredWorkflows()}>
+              {(workflow) => {
                 const Icon = icons[workflow.icon]
                 return (
-                  <button
-                    type="button"
-                    class="research-launchpad__workflow"
-                    data-workflow={workflow.id}
-                    data-featured={index() === 0 ? "true" : "false"}
-                    onClick={() => start(workflow)}
-                  >
-                    <span class="research-launchpad__workflow-icon">
-                      <Icon size={16} strokeWidth={1.45} />
+                  <button type="button" class="research-launchpad__quick-action" onClick={() => start(workflow)}>
+                    <span class="research-launchpad__quick-icon">
+                      <Icon size={15} strokeWidth={1.45} />
                     </span>
-                    <span class="research-launchpad__workflow-copy">
+                    <span>
                       <strong>{workflow.title}</strong>
-                      <span>{workflow.description}</span>
-                      <small>{workflow.shortcut}</small>
+                      <small>{workflow.description}</small>
                     </span>
-                    <IconArrowRight class="research-launchpad__workflow-arrow" size={13} strokeWidth={1.7} />
+                    <IconArrowRight size={13} strokeWidth={1.7} />
                   </button>
                 )
               }}
@@ -314,22 +191,143 @@ export function NewSessionView(props: NewSessionViewProps) {
           </div>
         </section>
 
+        <div class="research-launchpad__controls">
+          <button
+            type="button"
+            class="research-launchpad__catalog-toggle"
+            aria-expanded={catalogOpen() ? "true" : "false"}
+            onClick={() => setCatalogOpen((open) => !open)}
+          >
+            <span>Browse all workflows</span>
+            <small>{researchWorkflows.length + researchStarters.length}</small>
+            <IconChevronDown
+              size={13}
+              strokeWidth={1.7}
+              style={{ transform: catalogOpen() ? "rotate(180deg)" : "rotate(0deg)" }}
+            />
+          </button>
+          <label class="research-launchpad__worktree">
+            <span>Run on</span>
+            <select value={current()} onChange={(event) => props.onWorktreeChange(event.currentTarget.value)}>
+              <For each={options()}>{(option) => <option value={option}>{worktreeLabel(option)}</option>}</For>
+            </select>
+          </label>
+        </div>
+
+        <Show when={catalogOpen()}>
+          <div class="research-launchpad__catalog">
+            <section class="research-launchpad__starters" aria-labelledby="research-starters-title">
+              <div class="research-launchpad__section-heading">
+                <div>
+                  <h2 id="research-starters-title">Starter projects</h2>
+                  <p>Create a valid local notebook and sample data.</p>
+                </div>
+              </div>
+              <div class="research-launchpad__starter-list">
+                <For each={researchStarters}>
+                  {(starter) => (
+                    <button
+                      type="button"
+                      class="research-launchpad__starter"
+                      data-starter={starter.id}
+                      disabled={Boolean(creating())}
+                      onClick={() => void createStarter(starter)}
+                    >
+                      <span class="research-launchpad__starter-copy">
+                        <strong>{starter.title}</strong>
+                        <span>{starter.description}</span>
+                        <small>{starter.files.join(" · ")}</small>
+                      </span>
+                      <span class="research-launchpad__starter-action">
+                        {creating() === starter.id ? "Creating…" : "Create"}
+                        <IconArrowRight size={12} strokeWidth={1.7} />
+                      </span>
+                    </button>
+                  )}
+                </For>
+              </div>
+            </section>
+
+            <section class="research-launchpad__workflows" aria-labelledby="research-workflows-title">
+              <div class="research-launchpad__section-heading">
+                <div>
+                  <h2 id="research-workflows-title">All workflows</h2>
+                  <p>Choose a detailed brief, then edit it before sending.</p>
+                </div>
+              </div>
+
+              <nav class="research-launchpad__workflow-filters" aria-label="Workflow categories">
+                <For
+                  each={
+                    [
+                      ["all", "All"],
+                      ["analyze", "Analyze"],
+                      ["compute", "Compute"],
+                      ["discover", "Discover"],
+                      ["communicate", "Communicate"],
+                    ] as const
+                  }
+                >
+                  {(item) => (
+                    <button
+                      type="button"
+                      data-active={workflowGroup() === item[0] ? "true" : "false"}
+                      onClick={() => setWorkflowGroup(item[0])}
+                    >
+                      {item[1]}
+                      <span>
+                        {item[0] === "all"
+                          ? researchWorkflows.length
+                          : researchWorkflows.filter((workflow) => workflow.group === item[0]).length}
+                      </span>
+                    </button>
+                  )}
+                </For>
+              </nav>
+
+              <div class="research-launchpad__grid">
+                <For each={visibleWorkflows()}>
+                  {(workflow) => {
+                    const Icon = icons[workflow.icon]
+                    return (
+                      <button
+                        type="button"
+                        class="research-launchpad__workflow"
+                        data-workflow={workflow.id}
+                        onClick={() => start(workflow)}
+                      >
+                        <span class="research-launchpad__workflow-icon">
+                          <Icon size={15} strokeWidth={1.45} />
+                        </span>
+                        <span class="research-launchpad__workflow-copy">
+                          <strong>{workflow.title}</strong>
+                          <span>{workflow.description}</span>
+                          <small>{workflow.shortcut}</small>
+                        </span>
+                        <IconArrowRight class="research-launchpad__workflow-arrow" size={13} strokeWidth={1.7} />
+                      </button>
+                    )
+                  }}
+                </For>
+              </div>
+            </section>
+          </div>
+        </Show>
+
         <footer class="research-launchpad__footer">
-          <span>
-            <IconCheckCircle size={13} strokeWidth={1.5} />
-            {branch()}
-          </span>
+          <span>{branch()}</span>
+          <span>{local() ? "Local compute" : "Remote compute"}</span>
+          <span>{models.list().length.toLocaleString()} models</span>
           <Show when={sync.project}>
             {(project) => (
               <span>
-                updated{" "}
+                Updated{" "}
                 {DateTime.fromMillis(project().time.updated ?? project().time.created)
                   .setLocale("en")
                   .toRelative()}
               </span>
             )}
           </Show>
-          <span>or describe your goal below</span>
         </footer>
       </div>
     </main>

--- a/frontend/workspace/src/pages/session-shell.test.ts
+++ b/frontend/workspace/src/pages/session-shell.test.ts
@@ -49,4 +49,27 @@ describe("focused workspace shell", () => {
     expect(session).not.toContain(">New session</span> above.")
     expect(session).toContain(">New research</span> above.")
   })
+
+  test("keeps the composer calm and gives narrow screens non-overlapping controls", () => {
+    const session = read("./session.tsx")
+    const prompt = read("../components/prompt-input.tsx")
+
+    expect(session).toContain('class="session-prompt-dock"')
+    expect(session).toContain('class="session-prompt-dock__inner"')
+    expect(session).not.toContain("bg-gradient-to-t")
+    expect(prompt).toContain('"workspace-composer": true')
+    expect(prompt).toContain('class="workspace-composer__footer"')
+    expect(prompt).toContain('class="workspace-composer__controls')
+    expect(prompt).toContain('class="workspace-composer__actions')
+  })
+
+  test("lets research turns flow without sticky cards or heavy dividers", () => {
+    const session = read("./session.tsx")
+    const styles = read("../styles/atlas.css")
+
+    expect(session).toContain('class="session-turn-divider"')
+    expect(session).not.toContain('class="h-[2px] bg-border-weak-base rounded-full"')
+    expect(styles).toContain('.session-scroller [data-slot="session-turn-sticky"]')
+    expect(styles).toContain('.session-scroller [data-slot="session-turn-message-content"]')
+  })
 })

--- a/frontend/workspace/src/pages/session-shell.test.ts
+++ b/frontend/workspace/src/pages/session-shell.test.ts
@@ -72,4 +72,14 @@ describe("focused workspace shell", () => {
     expect(styles).toContain('.session-scroller [data-slot="session-turn-sticky"]')
     expect(styles).toContain('.session-scroller [data-slot="session-turn-message-content"]')
   })
+
+  test("keeps research tools in a compact contextual inspector", () => {
+    const pane = read("../atlas/RightPane.tsx")
+
+    expect(pane).toContain('const RIGHT_PANE_WIDTH_KEY = "openscience-research-inspector-width-v2"')
+    expect(pane).toContain("return 360")
+    expect(pane).toContain('class="research-inspector__tabs"')
+    expect(pane).toContain('class="research-inspector__tab"')
+    expect(pane).toContain('class="research-tool-rail"')
+  })
 })

--- a/frontend/workspace/src/pages/session-shell.test.ts
+++ b/frontend/workspace/src/pages/session-shell.test.ts
@@ -34,3 +34,19 @@ describe("session render boundary", () => {
     expect(children).toBeGreaterThan(code)
   })
 })
+
+describe("focused workspace shell", () => {
+  test("keeps navigation quiet and gives each shell region a semantic contract", () => {
+    const session = read("./session.tsx")
+
+    expect(session).toContain('class="workspace-header"')
+    expect(session).toContain('class="session-sidebar__new"')
+    expect(session).toContain('class="workspace-tabs')
+    expect(session).toContain('class="workspace-header__menu"')
+    expect(session).not.toContain("<HeaderDivider")
+    expect(session).not.toContain('<Wordmark size="sm"')
+    expect(session).not.toContain('placeholder="Search sessions"')
+    expect(session).not.toContain(">New session</span> above.")
+    expect(session).toContain(">New research</span> above.")
+  })
+})

--- a/frontend/workspace/src/pages/session.tsx
+++ b/frontend/workspace/src/pages/session.tsx
@@ -22,8 +22,7 @@ import { useTheme } from "@synsci/ui/theme"
 import { PromptInput } from "@/components/prompt-input"
 import { NewSessionView } from "@/components/session/session-new-view"
 import { AsciiSpinner } from "@/atlas/shared/AsciiSpinner"
-import { Wordmark } from "@/atlas/Wordmark"
-import { AppHeader, HeaderIconButton, HeaderDivider } from "@/atlas/AppHeader"
+import { AppHeader, HeaderIconButton } from "@/atlas/AppHeader"
 import { RightPane } from "@/atlas/RightPane"
 import { FileExplorer } from "@/atlas/FileExplorer"
 import { FileView } from "@/atlas/FilePreview"
@@ -55,6 +54,8 @@ import {
   IconFile,
   IconBrain,
   IconX,
+  IconLayoutGrid,
+  IconMoreH,
 } from "@/atlas/shared/Icon"
 import { StatusDot } from "@/atlas/shared/StatusDot"
 import { DateTime } from "luxon"
@@ -470,6 +471,7 @@ export default function Page(): JSX.Element {
         onOpenSettings={() => dialog.show(() => <DialogSettings />)}
         onToggleTheme={() => theme.setColorScheme(isDark() ? "light" : "dark")}
         onToggleSessions={() => setMobileSessionsOpen((open) => !open)}
+        onOpenTools={() => uiStore.setRightPaneOpen(true)}
       />
 
       <div
@@ -849,19 +851,7 @@ function PaneLoading(): JSX.Element {
 function CenterTabStrip(props: { chatTitle: string }): JSX.Element {
   const active = centerTabs.active
   return (
-    <div
-      class="atlas-scroll"
-      style={{
-        display: "flex",
-        "align-items": "stretch",
-        gap: "5px",
-        padding: "7px 10px",
-        "border-bottom": "1px solid var(--color-border)",
-        background: "var(--color-bg-subtle)",
-        "overflow-x": "auto",
-        "flex-shrink": 0,
-      }}
-    >
+    <div class="workspace-tabs atlas-scroll" role="tablist" aria-label="Open work">
       <CenterTab active={active() === "chat"} label={props.chatTitle} onClick={() => centerTabs.setActive("chat")}>
         <IconMessageSquare size={12} strokeWidth={1.6} />
       </CenterTab>
@@ -896,70 +886,23 @@ function CenterTab(props: {
 }): JSX.Element {
   return (
     <div
+      class="workspace-tab"
       role="tab"
       aria-selected={props.active}
+      data-active={props.active ? "true" : "false"}
       onClick={props.onClick}
       title={props.label}
-      style={{
-        cursor: "pointer",
-        display: "inline-flex",
-        "align-items": "center",
-        gap: "7px",
-        "max-width": "220px",
-        padding: "6px 10px",
-        "border-radius": "4px",
-        border: props.active ? "1px solid var(--color-border-strong)" : "1px solid transparent",
-        background: props.active ? "var(--color-surface-solid)" : "transparent",
-        "box-shadow": props.active ? "0 1px 2px rgba(0,0,0,0.10)" : "none",
-        "font-family": FONT_MONO,
-        "font-size": "11px",
-        "font-weight": props.active ? 700 : 400,
-        color: props.active ? "var(--color-text)" : "var(--color-text-muted)",
-        transition: "background 120ms ease, color 120ms ease, border-color 120ms ease",
-        "flex-shrink": 0,
-      }}
-      onMouseEnter={(e) => {
-        if (!props.active) e.currentTarget.style.background = "var(--color-accent-subtle)"
-      }}
-      onMouseLeave={(e) => {
-        if (!props.active) e.currentTarget.style.background = "transparent"
-      }}
     >
-      <span
-        style={{
-          display: "inline-flex",
-          color: props.active ? "var(--color-text)" : "var(--color-text-faint)",
-          "flex-shrink": 0,
-        }}
-      >
-        {props.children}
-      </span>
+      <span class="workspace-tab__icon">{props.children}</span>
       <span style={{ overflow: "hidden", "text-overflow": "ellipsis", "white-space": "nowrap" }}>{props.label}</span>
       <Show when={props.onClose}>
         <span
+          class="workspace-tab__close"
           role="button"
           aria-label="close tab"
           onClick={(e) => {
             e.stopPropagation()
             props.onClose!()
-          }}
-          style={{
-            display: "inline-flex",
-            "align-items": "center",
-            "justify-content": "center",
-            width: "16px",
-            height: "16px",
-            "border-radius": "4px",
-            color: "var(--color-text-faint)",
-            "flex-shrink": 0,
-          }}
-          onMouseEnter={(e) => {
-            e.currentTarget.style.background = "var(--color-accent-subtle)"
-            e.currentTarget.style.color = "var(--color-text)"
-          }}
-          onMouseLeave={(e) => {
-            e.currentTarget.style.background = "transparent"
-            e.currentTarget.style.color = "var(--color-text-faint)"
           }}
         >
           <IconX size={11} strokeWidth={1.8} />
@@ -979,77 +922,78 @@ function Header(props: {
   onOpenSettings: () => void
   onToggleTheme: () => void
   onToggleSessions: () => void
+  onOpenTools: () => void
 }): JSX.Element {
+  const [menu, setMenu] = createSignal(false)
   return (
-    <AppHeader>
-      <HeaderIconButton class="session-sidebar-toggle" onClick={props.onToggleSessions} title="sessions">
+    <AppHeader class="workspace-header">
+      <HeaderIconButton class="session-sidebar-toggle" onClick={props.onToggleSessions} title="Show sessions">
         <IconMessageSquare size={13} strokeWidth={1.5} />
       </HeaderIconButton>
       <button
+        class="workspace-header__back"
         onClick={props.onBack}
-        title="back to projects"
-        style={{
-          all: "unset",
-          cursor: "pointer",
-          display: "inline-flex",
-          "align-items": "center",
-          gap: "5px",
-          padding: "5px 10px",
-          "border-radius": "4px",
-          "font-family": FONT_MONO,
-          "font-size": "11px",
-          color: "var(--color-text-muted)",
-          transition: "background 120ms ease",
-        }}
-        onMouseEnter={(e) => (e.currentTarget.style.background = "var(--color-accent-subtle)")}
-        onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
+        title="Back to projects"
+        aria-label="Back to projects"
       >
-        <IconChevronLeft size={11} strokeWidth={1.5} />
-        <span class="session-back-label">projects</span>
+        <IconChevronLeft size={14} strokeWidth={1.6} />
       </button>
-      <HeaderDivider />
-      <Wordmark size="sm" />
-      <HeaderDivider />
-      <span
-        class="session-project-name"
-        style={{
-          "font-family": FONT_SANS,
-          "font-size": "13px",
-          "font-weight": 400,
-          color: "var(--color-text)",
-        }}
-      >
-        {props.projectName}
-      </span>
-      <span
-        class="session-project-path"
-        style={{
-          "font-family": FONT_MONO,
-          "font-size": "10px",
-          color: "var(--color-text-faint)",
-          overflow: "hidden",
-          "text-overflow": "ellipsis",
-          "white-space": "nowrap",
-          "max-width": "320px",
-        }}
-      >
-        {props.projectPath}
-      </span>
-      <span style={{ flex: 1 }} />
-      <HeaderIconButton onClick={props.onOpenPalette} title="command palette">
+      <div class="workspace-header__title" title={props.projectPath}>
+        <strong>{props.projectName}</strong>
+        <span>Research workspace</span>
+      </div>
+      <span class="workspace-header__spacer" />
+      <button class="workspace-header__tools" type="button" onClick={props.onOpenTools}>
+        <IconLayoutGrid size={13} strokeWidth={1.5} />
+        <span>Tools</span>
+      </button>
+      <HeaderIconButton class="workspace-header__search" onClick={props.onOpenPalette} title="Search and commands">
         <IconSearch size={13} strokeWidth={1.5} />
       </HeaderIconButton>
-      <HeaderIconButton class="session-header-secondary" onClick={props.onOpenHelp} title="help">
-        <IconBookOpen size={13} strokeWidth={1.5} />
-      </HeaderIconButton>
-      <HeaderIconButton onClick={props.onOpenSettings} title="settings">
-        <IconSettings size={13} strokeWidth={1.5} />
-      </HeaderIconButton>
-      <HeaderIconButton class="session-header-secondary" onClick={props.onToggleTheme} title="toggle theme">
-        <Show when={props.isDark} fallback={<IconMoon size={13} strokeWidth={1.5} />}>
-          <IconSun size={13} strokeWidth={1.5} />
+      <div class="workspace-header__menu-wrap" onMouseLeave={() => setMenu(false)}>
+        <HeaderIconButton class="workspace-header__menu" onClick={() => setMenu((open) => !open)} title="More">
+          <IconMoreH size={14} strokeWidth={1.7} />
+        </HeaderIconButton>
+        <Show when={menu()}>
+          <div class="workspace-header__popover" role="menu">
+            <button
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                setMenu(false)
+                props.onOpenHelp()
+              }}
+            >
+              <IconBookOpen size={13} strokeWidth={1.5} />
+              Help and shortcuts
+            </button>
+            <button
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                setMenu(false)
+                props.onOpenSettings()
+              }}
+            >
+              <IconSettings size={13} strokeWidth={1.5} />
+              Settings
+            </button>
+            <button
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                setMenu(false)
+                props.onToggleTheme()
+              }}
+            >
+              <Show when={props.isDark} fallback={<IconMoon size={13} strokeWidth={1.5} />}>
+                <IconSun size={13} strokeWidth={1.5} />
+              </Show>
+              {props.isDark ? "Use light theme" : "Use dark theme"}
+            </button>
+          </div>
         </Show>
-      </HeaderIconButton>
+      </div>
     </AppHeader>
   )
 }
@@ -1135,156 +1079,22 @@ function SessionsSidebar(props: {
   onDelete: (id: string) => void
   onRename: (id: string, title: string) => void
 }): JSX.Element {
-  const [query, setQuery] = createSignal("")
-  const searching = () => query().trim().length > 0
-  const filtered = createMemo(() => {
-    const q = query().trim().toLowerCase()
-    if (!q) return props.sessions
-    return props.sessions.filter((s) => (s.title || "session").toLowerCase().includes(q))
-  })
   return (
-    <aside
-      class="atlas-scroll session-sidebar"
-      data-mobile-open={props.mobileOpen ? "true" : "false"}
-      style={{
-        width: "240px",
-        "min-width": "240px",
-        "border-right": "1px solid var(--color-border)",
-        background: "var(--color-bg-subtle)",
-        display: "flex",
-        "flex-direction": "column",
-        "overflow-y": "auto",
-      }}
-    >
-      <div
-        style={{
-          padding: "12px 12px 8px",
-          display: "flex",
-          "flex-direction": "column",
-          gap: "8px",
-        }}
-      >
-        <button
-          onClick={props.onNew}
-          disabled={props.creating}
-          style={{
-            all: "unset",
-            cursor: "pointer",
-            display: "flex",
-            "align-items": "center",
-            "justify-content": "center",
-            gap: "6px",
-            padding: "7px 12px",
-            "border-radius": "8px",
-            background: "var(--color-surface-solid)",
-            border: "1px solid var(--color-border-strong)",
-            "font-family": FONT_MONO,
-            "font-size": "12px",
-            "font-weight": 400,
-            color: "var(--color-text)",
-            transition: "all 120ms ease",
-          }}
-          onMouseEnter={(e) => (e.currentTarget.style.background = "var(--color-bg-elevated)")}
-          onMouseLeave={(e) => (e.currentTarget.style.background = "var(--color-surface-solid)")}
-          onFocusIn={(e) => (e.currentTarget.style.background = "var(--color-bg-elevated)")}
-          onFocusOut={(e) => (e.currentTarget.style.background = "var(--color-surface-solid)")}
-        >
-          <IconPlus size={12} strokeWidth={2} />
-          {props.creating ? "creating…" : "New session"}
+    <aside class="atlas-scroll session-sidebar" data-mobile-open={props.mobileOpen ? "true" : "false"}>
+      <div class="session-sidebar__top">
+        <button class="session-sidebar__new" onClick={props.onNew} disabled={props.creating}>
+          <IconPlus size={13} strokeWidth={1.8} />
+          {props.creating ? "Creating…" : "New research"}
         </button>
-
-        {/* Search — filters the loaded list live; Esc clears. */}
-        <div style={{ position: "relative", display: "flex", "align-items": "center" }}>
-          <span
-            style={{
-              position: "absolute",
-              left: "10px",
-              display: "inline-flex",
-              "align-items": "center",
-              color: "var(--color-text-faint)",
-              "pointer-events": "none",
-            }}
-          >
-            <IconSearch size={13} strokeWidth={1.6} />
-          </span>
-          <input
-            aria-label="search sessions"
-            value={query()}
-            onInput={(e) => setQuery(e.currentTarget.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Escape") {
-                e.preventDefault()
-                setQuery("")
-                e.currentTarget.blur()
-              }
-            }}
-            placeholder="Search sessions"
-            spellcheck={false}
-            autocomplete="off"
-            style={{
-              all: "unset",
-              "box-sizing": "border-box",
-              width: "100%",
-              padding: "8px 28px 8px 30px",
-              "border-radius": "8px",
-              background: "var(--color-surface-solid)",
-              border: "1px solid var(--color-border)",
-              "font-family": FONT_MONO,
-              "font-size": "12.5px",
-              color: "var(--color-text)",
-              transition: "border-color 120ms ease",
-            }}
-            onFocusIn={(e) => (e.currentTarget.style.borderColor = "var(--color-border-strong)")}
-            onFocusOut={(e) => (e.currentTarget.style.borderColor = "var(--color-border)")}
-          />
-          <Show when={searching()}>
-            <button
-              type="button"
-              title="clear search"
-              aria-label="clear search"
-              onClick={() => setQuery("")}
-              style={{
-                all: "unset",
-                position: "absolute",
-                right: "8px",
-                cursor: "pointer",
-                display: "inline-flex",
-                "align-items": "center",
-                "justify-content": "center",
-                width: "18px",
-                height: "18px",
-                "border-radius": "5px",
-                color: "var(--color-text-faint)",
-              }}
-              onMouseEnter={(e) => (e.currentTarget.style.color = "var(--color-text)")}
-              onMouseLeave={(e) => (e.currentTarget.style.color = "var(--color-text-faint)")}
-            >
-              <IconX size={12} strokeWidth={1.8} />
-            </button>
-          </Show>
-        </div>
       </div>
 
-      {/* Quiet section label — sentence case, no shouty uppercase. */}
-      <div
-        style={{
-          display: "flex",
-          "align-items": "baseline",
-          "justify-content": "space-between",
-          padding: "2px 14px 6px",
-          "font-family": FONT_MONO,
-          "font-size": "11px",
-          color: "var(--color-text-faint)",
-        }}
-      >
-        <span>{searching() ? "Results" : "Sessions"}</span>
-        <span style={{ "font-variant-numeric": "tabular-nums" }}>
-          {searching() ? `${filtered().length} of ${props.sessions.length}` : props.sessions.length}
-        </span>
+      <div class="session-sidebar__label">
+        <span>Recent</span>
+        <span>{props.sessions.length}</span>
       </div>
 
-      <div style={{ display: "flex", "flex-direction": "column", gap: "1px", padding: "0 8px 10px" }}>
-        <For each={filtered()}>
+      <div class="session-sidebar__list">
+        <For each={props.sessions}>
           {(s) => (
             <SessionRow
               session={s}
@@ -1305,20 +1115,7 @@ function SessionsSidebar(props: {
               "line-height": 1.55,
             }}
           >
-            No sessions yet — click <span style={{ color: "var(--color-text-muted)" }}>New session</span> above.
-          </div>
-        </Show>
-        <Show when={props.sessions.length > 0 && filtered().length === 0}>
-          <div
-            style={{
-              padding: "12px 10px",
-              "font-family": FONT_MONO,
-              "font-size": "11px",
-              color: "var(--color-text-faint)",
-              "line-height": 1.55,
-            }}
-          >
-            No sessions match “{query().trim()}”.
+            No sessions yet — click <span style={{ color: "var(--color-text-muted)" }}>New research</span> above.
           </div>
         </Show>
       </div>

--- a/frontend/workspace/src/pages/session.tsx
+++ b/frontend/workspace/src/pages/session.tsx
@@ -669,9 +669,7 @@ export default function Page(): JSX.Element {
                                   compaction row, which already draws its own "context
                                   compacted" divider (avoids a doubled rule). */}
                               <Show when={index() < turnMessages().length - 1 && !hasCompactionPart(message.id)}>
-                                <div class="w-full px-4 md:px-6 pt-2 pb-1">
-                                  <div class="h-[2px] bg-border-weak-base rounded-full" />
-                                </div>
+                                <div class="session-turn-divider" />
                               </Show>
                             </div>
                           )}
@@ -719,9 +717,8 @@ export default function Page(): JSX.Element {
                 </Match>
               </Switch>
 
-              {/* Prompt dock — gradient fade + centered PromptInput (v1.1.116) */}
-              <div class="absolute inset-x-0 bottom-0 pt-12 pb-4 flex flex-col justify-center items-center z-50 px-4 md:px-0 bg-gradient-to-t from-background-base via-background-base to-transparent pointer-events-none">
-                <div class="w-full px-4 pointer-events-auto md:max-w-200 md:mx-auto">
+              <div class="session-prompt-dock">
+                <div class="session-prompt-dock__inner">
                   <Show when={revertInfo()}>
                     <div
                       class="mb-3"

--- a/frontend/workspace/src/styles/atlas.css
+++ b/frontend/workspace/src/styles/atlas.css
@@ -2752,6 +2752,220 @@ button.research-launchpad__status-item:hover {
   background: var(--color-border);
 }
 
+.skills-workspace {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--color-bg);
+}
+
+.skills-workspace__header {
+  flex-shrink: 0;
+  padding: 17px 24px 14px;
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-bg);
+}
+
+.skills-workspace__heading {
+  max-width: 1080px;
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.skills-workspace__heading h1 {
+  margin: 0;
+  font-family: var(--font-family-sans);
+  font-size: 17px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: var(--color-text);
+}
+
+.skills-workspace__heading p {
+  margin: 3px 0 0;
+  font-family: var(--font-family-sans);
+  font-size: 11px;
+  color: var(--color-text-faint);
+}
+
+.skills-workspace__summary {
+  display: flex;
+  gap: 12px;
+  flex-shrink: 0;
+  font-family: var(--font-family-mono);
+  font-size: 9px;
+  color: var(--color-text-faint);
+}
+
+.skills-workspace__toolbar {
+  max-width: 1080px;
+  margin-top: 12px;
+}
+
+.skills-workspace__body {
+  flex: 1;
+  min-height: 0;
+  padding: 0 24px 40px;
+  overflow-y: auto;
+}
+
+.skills-workspace__content {
+  max-width: 1080px;
+  margin: 0 auto;
+}
+
+.skills-workspace__list,
+.skills-workspace__group {
+  display: flex;
+  flex-direction: column;
+}
+
+.skills-workspace__group-heading {
+  min-height: 38px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding-top: 8px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.skills-workspace__group-heading > span:last-child {
+  font-family: var(--font-family-mono);
+  font-size: 9px;
+  color: var(--color-text-faint);
+}
+
+.skills-workspace__rows {
+  display: flex;
+  flex-direction: column;
+}
+
+.skills-workspace__row {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: minmax(150px, 0.7fr) minmax(220px, 1.5fr) minmax(90px, 0.7fr) auto;
+  align-items: center;
+  gap: 16px;
+  padding: 11px 4px;
+  border-bottom: 1px solid var(--color-border);
+  transition:
+    background 120ms ease,
+    opacity 120ms ease;
+}
+
+.skills-workspace__row:hover {
+  background: var(--color-bg-subtle);
+}
+
+.skills-workspace__row[data-enabled="false"] {
+  opacity: 0.56;
+}
+
+.skills-workspace__identity {
+  min-width: 0;
+  display: grid;
+  gap: 3px;
+}
+
+.skills-workspace__identity strong {
+  overflow: hidden;
+  font-family: var(--font-family-mono);
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--color-text);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.skills-workspace__identity span {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-family: var(--font-family-mono);
+  font-size: 8px;
+  color: var(--color-text-faint);
+}
+
+.skills-workspace__identity i {
+  width: 4px;
+  height: 4px;
+  flex-shrink: 0;
+  border-radius: 50%;
+}
+
+.skills-workspace__row > p {
+  display: -webkit-box;
+  margin: 0;
+  overflow: hidden;
+  font-family: var(--font-family-sans);
+  font-size: 10px;
+  line-height: 1.45;
+  color: var(--color-text-muted);
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.skills-workspace__tags {
+  min-width: 0;
+  display: flex;
+  gap: 5px;
+  overflow: hidden;
+}
+
+.skills-workspace__tags span {
+  overflow: hidden;
+  font-family: var(--font-family-mono);
+  font-size: 8px;
+  color: var(--color-text-faint);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.skills-workspace__tags span + span::before {
+  margin-right: 5px;
+  color: var(--color-border-strong);
+  content: "·";
+}
+
+@media (max-width: 760px) {
+  .skills-workspace__header {
+    padding: 14px 16px 12px;
+  }
+
+  .skills-workspace__body {
+    padding: 0 16px 32px;
+  }
+
+  .skills-workspace__heading p,
+  .skills-workspace__summary {
+    display: none;
+  }
+
+  .skills-workspace__row {
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 5px 12px;
+    padding: 11px 2px;
+  }
+
+  .skills-workspace__row > p,
+  .skills-workspace__tags {
+    grid-column: 1 / -1;
+  }
+
+  .skills-workspace__row > [data-action="skill-toggle"] {
+    grid-row: 1;
+    grid-column: 2;
+    justify-self: end;
+  }
+
+  .skills-workspace__row > p {
+    -webkit-line-clamp: 1;
+  }
+}
+
 @media (max-width: 640px) {
   .g-strip {
     gap: 8px !important;

--- a/frontend/workspace/src/styles/atlas.css
+++ b/frontend/workspace/src/styles/atlas.css
@@ -2621,6 +2621,137 @@ button.research-launchpad__status-item:hover {
   color: var(--color-text);
 }
 
+.session-right-pane {
+  display: flex;
+  flex-direction: column;
+  border-left: 1px solid var(--color-border);
+  background: var(--color-bg);
+}
+
+.session-right-pane[data-overlay="true"] {
+  box-shadow: -10px 0 28px color-mix(in srgb, #000 18%, transparent);
+}
+
+.research-inspector__tabs {
+  min-height: 42px;
+  display: flex;
+  align-items: stretch;
+  flex-shrink: 0;
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-bg);
+}
+
+.research-inspector__tab-list {
+  min-width: 0;
+  display: flex;
+  flex: 1;
+  align-items: stretch;
+  gap: 2px;
+  padding: 0 7px;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.research-inspector__tab-list::-webkit-scrollbar {
+  display: none;
+}
+
+.research-inspector__tab {
+  all: unset;
+  box-sizing: border-box;
+  position: relative;
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 8px;
+  border-bottom: 1px solid transparent;
+  font-family: var(--font-family-sans);
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--color-text-faint);
+  cursor: pointer;
+  transition:
+    border-color 140ms ease,
+    color 140ms ease;
+}
+
+.research-inspector__tab:hover {
+  color: var(--color-text-muted);
+}
+
+.research-inspector__tab[data-active="true"] {
+  border-bottom-color: var(--color-text-muted);
+  color: var(--color-text);
+}
+
+.research-inspector__tab-icon {
+  display: inline-flex;
+  flex-shrink: 0;
+  color: currentColor;
+}
+
+.research-inspector__controls {
+  position: relative;
+  display: flex;
+  align-items: stretch;
+  flex-shrink: 0;
+  padding-right: 3px;
+}
+
+.research-inspector__control {
+  all: unset;
+  box-sizing: border-box;
+  width: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-faint);
+  cursor: pointer;
+}
+
+.research-inspector__control:hover,
+.research-inspector__control[data-active="true"] {
+  color: var(--color-text);
+}
+
+.research-tool-rail {
+  width: 36px;
+  flex: 0 0 36px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  padding: 8px 0;
+  border-left: 1px solid var(--color-border);
+  background: var(--color-bg);
+}
+
+.research-tool-rail__button {
+  all: unset;
+  box-sizing: border-box;
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 5px;
+  color: var(--color-text-faint);
+  cursor: pointer;
+}
+
+.research-tool-rail__button:hover {
+  background: var(--color-bg-subtle);
+  color: var(--color-text);
+}
+
+.research-tool-rail__divider {
+  width: 16px;
+  height: 1px;
+  margin: 4px 0;
+  background: var(--color-border);
+}
+
 @media (max-width: 640px) {
   .g-strip {
     gap: 8px !important;

--- a/frontend/workspace/src/styles/atlas.css
+++ b/frontend/workspace/src/styles/atlas.css
@@ -1804,6 +1804,283 @@ button.research-launchpad__status-item:hover {
   display: none !important;
 }
 
+/* The workspace frame is intentionally quieter than the marketing/home shell.
+   The active research surface owns the visual hierarchy; navigation recedes. */
+.workspace-header.g-strip {
+  min-height: 52px;
+  gap: 8px !important;
+  padding: 8px 12px !important;
+  background: color-mix(in srgb, var(--color-bg) 96%, var(--color-bg-subtle)) !important;
+  border-bottom-color: color-mix(in srgb, var(--color-border) 72%, transparent);
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+}
+
+.workspace-header__back,
+.workspace-header__tools {
+  all: unset;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-muted);
+  transition:
+    background 160ms var(--agent-ease),
+    color 160ms var(--agent-ease),
+    transform 120ms var(--agent-ease);
+}
+
+.workspace-header__back {
+  width: 30px;
+  height: 30px;
+  border-radius: 6px;
+}
+
+.workspace-header__back:hover,
+.workspace-header__tools:hover {
+  color: var(--color-text);
+  background: var(--color-accent-subtle);
+}
+
+.workspace-header__back:active,
+.workspace-header__tools:active {
+  transform: scale(0.97);
+}
+
+.workspace-header__title {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  padding-left: 2px;
+}
+
+.workspace-header__title strong,
+.workspace-header__title span {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workspace-header__title strong {
+  max-width: min(32vw, 360px);
+  font-family: var(--font-sans);
+  font-size: 13px;
+  line-height: 1.25;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--color-text);
+}
+
+.workspace-header__title span {
+  font-family: var(--font-sans);
+  font-size: 10.5px;
+  line-height: 1.25;
+  color: var(--color-text-faint);
+}
+
+.workspace-header__spacer {
+  flex: 1;
+}
+
+.workspace-header__tools {
+  height: 30px;
+  gap: 6px;
+  padding: 0 10px;
+  border-radius: 6px;
+  font-family: var(--font-sans);
+  font-size: 11.5px;
+  font-weight: 500;
+}
+
+.workspace-header .workspace-header__search,
+.workspace-header .workspace-header__menu {
+  width: 30px !important;
+  height: 30px !important;
+  border-color: transparent !important;
+  background: transparent !important;
+  border-radius: 6px !important;
+}
+
+.workspace-header__menu-wrap {
+  position: relative;
+  display: flex;
+}
+
+.workspace-header__popover {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: var(--z-overlay);
+  width: 190px;
+  padding: 5px;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  background: var(--color-surface-solid);
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.08);
+  animation: atlas-pop-up 140ms var(--agent-ease);
+  transform-origin: top right;
+}
+
+.workspace-header__popover button {
+  all: unset;
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 32px;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 7px 9px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-family: var(--font-sans);
+  font-size: 12px;
+  color: var(--color-text-muted);
+}
+
+.workspace-header__popover button:hover {
+  background: var(--color-accent-subtle);
+  color: var(--color-text);
+}
+
+.session-sidebar {
+  width: 228px;
+  min-width: 228px;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  border-right: 1px solid color-mix(in srgb, var(--color-border) 72%, transparent);
+  background: color-mix(in srgb, var(--color-bg-subtle) 62%, var(--color-bg));
+}
+
+.session-sidebar__top {
+  padding: 12px 10px 14px;
+}
+
+.session-sidebar__new {
+  all: unset;
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 34px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 7px 10px;
+  border-radius: 7px;
+  font-family: var(--font-sans);
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--color-text);
+  transition:
+    background 160ms var(--agent-ease),
+    transform 120ms var(--agent-ease);
+}
+
+.session-sidebar__new:hover {
+  background: var(--color-accent-subtle);
+}
+
+.session-sidebar__new:active {
+  transform: scale(0.985);
+}
+
+.session-sidebar__new:disabled {
+  cursor: wait;
+  color: var(--color-text-faint);
+}
+
+.session-sidebar__label {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  padding: 7px 14px 6px;
+  font-family: var(--font-sans);
+  font-size: 10.5px;
+  font-weight: 500;
+  color: var(--color-text-faint);
+}
+
+.session-sidebar__label span:last-child {
+  font-family: var(--font-code);
+  font-variant-numeric: tabular-nums;
+  font-size: 9.5px;
+}
+
+.session-sidebar__list {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  padding: 0 7px 16px;
+}
+
+.workspace-tabs {
+  min-height: 40px;
+  display: flex;
+  align-items: stretch;
+  gap: 2px;
+  padding: 5px 8px 4px;
+  overflow-x: auto;
+  flex-shrink: 0;
+  border-bottom: 1px solid color-mix(in srgb, var(--color-border) 68%, transparent);
+  background: var(--color-bg);
+}
+
+.workspace-tab {
+  min-width: 0;
+  max-width: 220px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 6px 9px;
+  border-radius: 6px;
+  border: 0;
+  background: transparent;
+  flex-shrink: 0;
+  font-family: var(--font-sans);
+  font-size: 11.5px;
+  font-weight: 500;
+  color: var(--color-text-faint);
+  transition:
+    background 160ms var(--agent-ease),
+    color 160ms var(--agent-ease);
+}
+
+.workspace-tab:hover {
+  color: var(--color-text-muted);
+  background: var(--color-accent-subtle);
+}
+
+.workspace-tab[data-active="true"] {
+  color: var(--color-text);
+  background: var(--color-bg-subtle);
+}
+
+.workspace-tab__icon {
+  display: inline-flex;
+  flex-shrink: 0;
+  color: currentColor;
+}
+
+.workspace-tab__close {
+  width: 16px;
+  height: 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  border-radius: 4px;
+  color: var(--color-text-faint);
+}
+
+.workspace-tab__close:hover {
+  background: var(--color-bg-elevated);
+  color: var(--color-text);
+}
+
 @media (max-width: 640px) {
   .g-strip {
     gap: 8px !important;
@@ -1840,6 +2117,16 @@ button.research-launchpad__status-item:hover {
   .session-project-path,
   .session-header-secondary {
     display: none !important;
+  }
+
+  .workspace-header__title span,
+  .workspace-header__tools span {
+    display: none;
+  }
+
+  .workspace-header__tools {
+    width: 30px;
+    padding: 0;
   }
 
   .session-sidebar-backdrop {

--- a/frontend/workspace/src/styles/atlas.css
+++ b/frontend/workspace/src/styles/atlas.css
@@ -1792,6 +1792,417 @@ button.research-launchpad__status-item:hover {
   }
 }
 
+/* Focused launch state. The workflow catalog stays available without turning
+   the first screen into a dashboard. */
+.research-launchpad {
+  padding: clamp(38px, 7vh, 76px) clamp(24px, 6vw, 72px) calc(var(--prompt-height, 11.25rem) + 78px);
+  background: var(--color-bg);
+}
+
+.research-launchpad__inner {
+  width: min(100%, 800px);
+  gap: 24px;
+}
+
+.research-launchpad__intro {
+  display: block;
+}
+
+.research-launchpad__intro h1 {
+  max-width: 660px;
+  font-size: clamp(34px, 4.5vw, 48px);
+  line-height: 1.04;
+}
+
+.research-launchpad__intro p {
+  max-width: 620px;
+  margin-top: 12px;
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.research-launchpad__setup {
+  all: unset;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px 14px;
+  border: 1px solid color-mix(in srgb, var(--color-warning) 28%, var(--color-border));
+  border-radius: 7px;
+  background: color-mix(in srgb, var(--color-warning-muted) 34%, transparent);
+  color: var(--color-text-muted);
+  cursor: pointer;
+}
+
+.research-launchpad__setup > span {
+  display: grid;
+  gap: 2px;
+}
+
+.research-launchpad__setup strong {
+  font-family: var(--font-family-sans);
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.research-launchpad__setup small {
+  font-family: var(--font-family-sans);
+  font-size: 10px;
+  color: var(--color-text-faint);
+}
+
+.research-launchpad__quick {
+  display: grid;
+  gap: 12px;
+}
+
+.research-launchpad__section-heading {
+  align-items: end;
+}
+
+.research-launchpad__section-heading h2 {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.research-launchpad__section-heading p {
+  margin-top: 2px;
+  font-size: 10px;
+}
+
+.research-launchpad__artifacts {
+  all: unset;
+  box-sizing: border-box;
+  font-family: var(--font-family-mono);
+  font-size: 9px;
+  color: var(--color-text-faint);
+  cursor: pointer;
+}
+
+.research-launchpad__artifacts:hover {
+  color: var(--color-text);
+}
+
+.research-launchpad__quick-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  border-top: 1px solid var(--color-border);
+}
+
+.research-launchpad__quick-action {
+  all: unset;
+  box-sizing: border-box;
+  min-width: 0;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 11px;
+  padding: 12px 10px;
+  border-bottom: 1px solid var(--color-border);
+  cursor: pointer;
+  transition:
+    background 140ms ease,
+    color 140ms ease;
+}
+
+.research-launchpad__quick-action:nth-child(odd) {
+  border-right: 1px solid var(--color-border);
+}
+
+.research-launchpad__quick-action:hover {
+  background: var(--color-bg-subtle);
+}
+
+.research-launchpad__quick-icon {
+  width: 27px;
+  height: 27px;
+  display: inline-grid;
+  place-items: center;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  color: var(--color-text-muted);
+}
+
+.research-launchpad__quick-action > span:nth-child(2) {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+}
+
+.research-launchpad__quick-action strong {
+  overflow: hidden;
+  font-family: var(--font-family-sans);
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--color-text);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.research-launchpad__quick-action small {
+  overflow: hidden;
+  font-family: var(--font-family-sans);
+  font-size: 9px;
+  color: var(--color-text-faint);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.research-launchpad__quick-action > svg {
+  color: var(--color-text-faint);
+  transition: transform 140ms ease;
+}
+
+.research-launchpad__quick-action:hover > svg {
+  transform: translateX(2px);
+}
+
+.research-launchpad__controls {
+  min-height: 42px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  border-top: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.research-launchpad__catalog-toggle {
+  all: unset;
+  box-sizing: border-box;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 11px 2px;
+  font-family: var(--font-family-sans);
+  font-size: 10px;
+  font-weight: 550;
+  color: var(--color-text-muted);
+  cursor: pointer;
+}
+
+.research-launchpad__catalog-toggle:hover {
+  color: var(--color-text);
+}
+
+.research-launchpad__catalog-toggle small {
+  font-family: var(--font-family-mono);
+  font-size: 8px;
+  color: var(--color-text-faint);
+}
+
+.research-launchpad__catalog-toggle svg {
+  transition: transform 160ms ease;
+}
+
+.research-launchpad__worktree {
+  padding-right: 2px;
+}
+
+.research-launchpad__worktree select {
+  max-width: 180px;
+  padding-top: 5px;
+  padding-bottom: 5px;
+  border-color: transparent;
+  background: transparent;
+}
+
+.research-launchpad__worktree select:hover {
+  border-color: var(--color-border);
+  background: var(--color-bg-subtle);
+}
+
+.research-launchpad__catalog {
+  display: grid;
+  gap: 32px;
+  padding-top: 4px;
+}
+
+.research-launchpad__starters,
+.research-launchpad__workflows {
+  gap: 12px;
+}
+
+.research-launchpad__starter-list {
+  display: grid;
+  border-top: 1px solid var(--color-border);
+}
+
+.research-launchpad__starter {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-rows: auto;
+  align-items: center;
+  gap: 16px;
+  padding: 13px 10px;
+  border: 0;
+  border-bottom: 1px solid var(--color-border);
+  border-radius: 0;
+  background: transparent;
+  overflow: visible;
+  transition: background 140ms ease;
+}
+
+.research-launchpad__starter:hover {
+  transform: none;
+  border-color: var(--color-border);
+  background: var(--color-bg-subtle);
+  box-shadow: none;
+}
+
+.research-launchpad__starter-copy {
+  padding: 0;
+  gap: 3px;
+}
+
+.research-launchpad__starter-copy strong {
+  font-size: 11px;
+}
+
+.research-launchpad__starter-copy > span {
+  font-size: 10px;
+}
+
+.research-launchpad__starter-copy small {
+  font-size: 8px;
+}
+
+.research-launchpad__starter-action {
+  justify-content: flex-start;
+  padding: 0;
+  border: 0;
+  color: var(--color-text-muted);
+}
+
+.research-launchpad__workflow-filters {
+  gap: 16px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.research-launchpad__workflow-filters button {
+  gap: 5px;
+  padding: 7px 0;
+  border: 0;
+  border-bottom: 1px solid transparent;
+  border-radius: 0;
+  background: transparent;
+}
+
+.research-launchpad__workflow-filters button:hover {
+  border-color: transparent;
+}
+
+.research-launchpad__workflow-filters button[data-active="true"] {
+  border-color: var(--color-text-muted);
+  background: transparent;
+  color: var(--color-text);
+}
+
+.research-launchpad__workflow-filters button span {
+  min-width: 0;
+  padding: 0;
+  border-radius: 0;
+  background: transparent;
+}
+
+.research-launchpad__grid {
+  gap: 0;
+  border-top: 1px solid var(--color-border);
+}
+
+.research-launchpad__workflow {
+  gap: 10px;
+  padding: 12px 10px;
+  border: 0;
+  border-bottom: 1px solid var(--color-border);
+  border-radius: 0;
+  background: transparent;
+  transition: background 140ms ease;
+}
+
+.research-launchpad__workflow:nth-child(odd) {
+  border-right: 1px solid var(--color-border);
+}
+
+.research-launchpad__workflow:hover {
+  transform: none;
+  border-color: var(--color-border);
+  background: var(--color-bg-subtle);
+  box-shadow: none;
+}
+
+.research-launchpad__workflow-icon {
+  width: 27px;
+  height: 27px;
+  border-radius: 6px;
+  background: transparent;
+}
+
+.research-launchpad__workflow-copy {
+  gap: 3px;
+}
+
+.research-launchpad__workflow-copy strong {
+  font-size: 11px;
+}
+
+.research-launchpad__workflow-copy > span {
+  font-size: 10px;
+}
+
+.research-launchpad__workflow-copy small {
+  display: none;
+}
+
+.research-launchpad__footer {
+  flex-wrap: wrap;
+  gap: 8px 14px;
+  padding-top: 0;
+  font-size: 8px;
+}
+
+@media (max-width: 640px) {
+  .research-launchpad {
+    padding: 30px 16px calc(var(--prompt-height, 11.25rem) + 72px);
+  }
+
+  .research-launchpad__inner {
+    gap: 21px;
+  }
+
+  .research-launchpad__intro h1 {
+    font-size: 32px;
+  }
+
+  .research-launchpad__quick-list,
+  .research-launchpad__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .research-launchpad__quick-action:nth-child(odd),
+  .research-launchpad__workflow:nth-child(odd) {
+    border-right: 0;
+  }
+
+  .research-launchpad__controls {
+    align-items: stretch;
+    flex-direction: column;
+    gap: 0;
+    padding-bottom: 8px;
+  }
+
+  .research-launchpad__worktree {
+    padding-bottom: 2px;
+  }
+
+  .research-launchpad__footer {
+    flex-direction: row;
+  }
+}
+
 /* ==========================================================
    Compact workspace shell
 

--- a/frontend/workspace/src/styles/atlas.css
+++ b/frontend/workspace/src/styles/atlas.css
@@ -181,6 +181,99 @@
   font-size: 14px;
 }
 
+/* Composer dock — one quiet, opaque working surface with controls in normal
+   document flow. Keeping the action group out of absolute positioning prevents
+   model and reasoning controls from colliding with send on narrow screens. */
+.session-prompt-dock {
+  position: absolute;
+  z-index: 50;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  display: flex;
+  justify-content: center;
+  padding: 14px 16px 16px;
+  pointer-events: none;
+}
+
+.session-prompt-dock__inner {
+  width: min(100%, 800px);
+  padding: 0 16px;
+  pointer-events: auto;
+}
+
+.workspace-composer {
+  border: 1px solid var(--color-border-strong);
+  background: var(--color-surface-solid);
+  box-shadow: 0 1px 3px color-mix(in srgb, var(--color-text) 8%, transparent);
+}
+
+.workspace-composer:focus-within {
+  border-color: color-mix(in srgb, var(--color-text) 34%, var(--color-border));
+  box-shadow: 0 1px 3px color-mix(in srgb, var(--color-text) 9%, transparent);
+}
+
+.workspace-composer__footer {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px 11px;
+}
+
+.workspace-composer__controls {
+  min-width: 0;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.workspace-composer__controls::-webkit-scrollbar {
+  display: none;
+}
+
+.workspace-composer__controls > * {
+  flex: 0 0 auto;
+}
+
+.workspace-composer__actions {
+  position: static;
+  flex: 0 0 auto;
+}
+
+@media (max-width: 640px) {
+  .session-prompt-dock {
+    padding: 10px 8px 12px;
+  }
+
+  .session-prompt-dock__inner {
+    padding: 0;
+  }
+
+  .workspace-composer__footer {
+    gap: 6px;
+    padding: 8px 9px 9px;
+  }
+
+  .workspace-composer__controls {
+    gap: 4px;
+  }
+
+  .workspace-composer__controls [data-component="button"],
+  .workspace-composer__controls [data-component="select"] {
+    max-width: 138px;
+  }
+
+  .workspace-composer__controls [data-component="button"] {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .workspace-composer__actions {
+    gap: 5px;
+  }
+}
+
 /* The old light-mode "cream neutralisation" remap block is gone: the default
    openscience theme now ships the product's neutral greys directly, so the ui
    semantic layer needs no app-side patching (and non-default themes render
@@ -751,6 +844,42 @@ html[data-color-scheme="dark"] .atlas-agent-orbit {
   flex-grow: 0;
   overflow-y: visible;
   overflow-x: visible;
+}
+
+.session-scroller [data-slot="session-turn-sticky"] {
+  position: static;
+  width: 100%;
+  margin-left: 0;
+  padding-left: 0;
+  background: transparent;
+}
+
+.session-scroller [data-slot="session-turn-sticky"]::before,
+.session-scroller [data-slot="session-turn-sticky"]::after {
+  display: none;
+}
+
+.session-scroller [data-slot="session-turn-message-content"] {
+  width: fit-content;
+  max-width: min(84%, 680px);
+  margin-left: auto;
+}
+
+.session-scroller [data-component="user-message"] [data-slot="user-message-text"] {
+  padding: 9px 13px;
+  border-color: var(--color-border);
+  border-radius: 11px;
+  background: var(--color-bg-subtle);
+}
+
+.session-turn-divider {
+  height: 22px;
+}
+
+@media (max-width: 640px) {
+  .session-scroller [data-slot="session-turn-message-content"] {
+    max-width: 92%;
+  }
 }
 
 /* ==========================================================


### PR DESCRIPTION
## Summary

Redesigns the primary OpenScience workspace into a calmer, more focused research environment inspired by the clarity of the Codex app. The update reduces persistent chrome and visual noise while keeping notebooks, scientific files, compute, Atlas, evidence, terminal, and artifact workflows immediately available.

## What changed

- Simplified the application header, session sidebar, and open-work tabs.
- Reworked **New research** around six high-value starting workflows, with the complete workflow catalog available through progressive disclosure.
- Calmed the conversation surface and composer, including clearer prompt hierarchy and a mobile-safe control layout.
- Streamlined the contextual research inspector with a focused default width, quieter tabs, a compact collapsed rail, and a full-screen mobile treatment.
- Replaced the large skills card wall with a dense, searchable registry that keeps source, category, description, and enabled state easy to scan.
- Made settings more compact and responsive, including a horizontal mobile section navigator.
- Preserved the existing scientific workbenches for notebooks, CSV datasets, molecules, proteins, sequences, PDFs, manuscripts, and compute jobs.
- Updated unit and browser coverage to match the focused navigation and progressive-disclosure behavior.

## Validation

- `73/73` local Chromium browser tests passed.
- Typecheck, formatting, standard tests, web and landing builds, workflow lint, launcher smoke, Gitleaks, CodeQL, and Vercel checks passed.
- Published and installed `@synsci/openscience@1.3.6-test.26.1` and `synsci@1.3.6-test.26.1` under the npm `test` tag.
- Packaged browser E2E passed against the published npm artifact.
- Published-package smoke tests passed on Linux x64, Linux ARM64, macOS, and Windows.

[Test publication workflow](https://github.com/synthetic-sciences/openscience/actions/runs/30438632369)

## Test the published package

```bash
mkdir -p ~/.openscience-test-npm
npm install -g --prefix ~/.openscience-test-npm @synsci/openscience@test synsci@test
export PATH="$HOME/.openscience-test-npm/bin:$PATH"
openscience --version
openscience serve
```

Then open `http://localhost:4096`.

## Rollout notes

- This is a frontend-focused change; it does not require Atlas gateway changes or data migrations.
- npm production/latest was not changed. Only the `test` dist-tag was published.
- The branch remains available for review follow-ups until the PR is merged.

## Checklist

- [x] Desktop workspace reviewed
- [x] Mobile workspace reviewed
- [x] Scientific viewers and notebook UI reviewed
- [x] Full browser regression passed
- [x] Published npm test package verified
- [x] Cross-platform package smoke tests passed
- [x] Ready for review and merge