### PR TITLE
release: v2.0.1

### DIFF
--- a/backend/cli/package.json
+++ b/backend/cli/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.2.3",
+  "version": "2.0.1",
   "name": "@synsci/openscience",
   "type": "module",
   "description": "AI-powered CLI for ML research and development workflows",

--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
     },
     "backend/cli": {
       "name": "@synsci/openscience",
-      "version": "1.2.3",
+      "version": "2.0.1",
       "bin": {
         "openscience": "./bin/openscience",
       },
@@ -124,7 +124,7 @@
     },
     "frontend/docs": {
       "name": "@synsci/docs",
-      "version": "1.2.2",
+      "version": "2.0.1",
       "dependencies": {
         "lucide-react": "^0.453.0",
         "react": "^19.0.0",
@@ -142,7 +142,7 @@
     },
     "frontend/ui": {
       "name": "@synsci/ui",
-      "version": "1.2.2",
+      "version": "2.0.1",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@pierre/diffs": "catalog:",
@@ -187,7 +187,7 @@
     },
     "frontend/workspace": {
       "name": "@synsci/workspace",
-      "version": "1.2.2",
+      "version": "2.0.1",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@rdkit/rdkit": "^2025.3.4-1.0.0",
@@ -240,14 +240,14 @@
     },
     "tooling/launcher": {
       "name": "synsci",
-      "version": "1.2.5",
+      "version": "2.0.1",
       "bin": {
         "synsci": "bin/synsci.mjs",
       },
     },
     "tooling/plugin": {
       "name": "@synsci/plugin",
-      "version": "1.2.2",
+      "version": "2.0.1",
       "dependencies": {
         "@synsci/sdk": "workspace:*",
         "zod": "catalog:",
@@ -267,7 +267,7 @@
     },
     "tooling/sdk/js": {
       "name": "@synsci/sdk",
-      "version": "1.2.2",
+      "version": "2.0.1",
       "devDependencies": {
         "@hey-api/openapi-ts": "0.90.10",
         "@tsconfig/node22": "catalog:",
@@ -278,7 +278,7 @@
     },
     "tooling/util": {
       "name": "@synsci/util",
-      "version": "1.2.2",
+      "version": "2.0.1",
       "dependencies": {
         "zod": "catalog:",
       },

--- a/frontend/docs/package.json
+++ b/frontend/docs/package.json
@@ -2,7 +2,7 @@
   "name": "@synsci/docs",
   "private": true,
   "type": "module",
-  "version": "1.2.2",
+  "version": "2.0.1",
   "license": "Apache-2.0",
   "scripts": {
     "dev": "vite",

--- a/frontend/landing/package.json
+++ b/frontend/landing/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openscience-landing",
   "private": true,
-  "version": "1.0.0",
+  "version": "2.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/ui/package.json
+++ b/frontend/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synsci/ui",
-  "version": "1.2.2",
+  "version": "2.0.1",
   "type": "module",
   "license": "Apache-2.0",
   "exports": {

--- a/frontend/workspace/package.json
+++ b/frontend/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synsci/workspace",
-  "version": "1.2.2",
+  "version": "2.0.1",
   "description": "",
   "type": "module",
   "exports": {

--- a/tooling/launcher/package.json
+++ b/tooling/launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synsci",
-  "version": "1.2.5",
+  "version": "2.0.1",
   "description": "Install wizard for OpenScience, the open-source AI research workspace (optionally with Atlas)",
   "license": "Apache-2.0",
   "type": "module",

--- a/tooling/plugin/package.json
+++ b/tooling/plugin/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@synsci/plugin",
-  "version": "1.2.2",
+  "version": "2.0.1",
   "type": "module",
   "license": "Apache-2.0",
   "scripts": {

--- a/tooling/sdk/js/package.json
+++ b/tooling/sdk/js/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@synsci/sdk",
-  "version": "1.2.2",
+  "version": "2.0.1",
   "type": "module",
   "license": "Apache-2.0",
   "scripts": {

--- a/tooling/util/package.json
+++ b/tooling/util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synsci/util",
-  "version": "1.2.2",
+  "version": "2.0.1",
   "private": true,
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
Version bumps generated by the successful production v2.0.1 publish workflow. The release commit remains under the openscience identity.