### PR TITLE
Fix native source picking, Atlas navigation, and compute UX

### DIFF
--- a/backend/cli/src/pty/index.ts
+++ b/backend/cli/src/pty/index.ts
@@ -104,7 +104,11 @@ export namespace Pty {
     })
     const id = Identifier.create("pty", false)
     const command = Shell.preferred()
-    const args = command.endsWith("sh") ? ["-l"] : []
+    // A sandboxed zsh cannot safely lock history or run dotfiles that expect
+    // unrestricted home-directory access. Start it without user rc files so a
+    // fresh browser terminal opens cleanly instead of printing permission
+    // errors before the prompt. Other POSIX shells keep their login behavior.
+    const args = command.endsWith("zsh") ? ["-f"] : command.endsWith("sh") ? ["-l"] : []
     const cwd = authority.workspace
     const source = await OpenScience.subprocessEnv(process.env)
     const env = Object.fromEntries(
@@ -113,6 +117,7 @@ export namespace Pty {
     const runtime = {
       ...env,
       TERM: "xterm-256color",
+      ...(command.endsWith("zsh") ? { PROMPT: "%1~ %# ", PS1: "%1~ %# " } : {}),
       OPENSCIENCE_TERMINAL: "1",
       OPENSCIENCE_PROJECT_ID: Instance.project.id,
       OPENSCIENCE_SESSION_ID: input.sessionID,

--- a/backend/cli/src/science/kernel/registry.ts
+++ b/backend/cli/src/science/kernel/registry.ts
@@ -453,11 +453,12 @@ export namespace KernelRuntime {
     value.lastActivityAt = startedAt
     return kernel.execute(code, options).then(
       async (result) => {
-        value.executionCount = result.executionCount ?? value.executionCount + 1
+        const executionCount = result.executionCount ?? value.executionCount + 1
+        value.executionCount = executionCount
         const completedAt = Date.now()
         value.lastActivityAt = completedAt
         await persist(value)
-        const complete = { ...result, executionCount: value.executionCount }
+        const complete = { ...result, executionCount }
         const node = await provenance(
           identity,
           value,

--- a/backend/cli/src/server/routes/folder-resolve.ts
+++ b/backend/cli/src/server/routes/folder-resolve.ts
@@ -10,12 +10,12 @@
  *
  * Routes (all under `/api/resolve-folder`):
  *   GET  /probe              — can we list ~/Desktop? (mac FDA check)
- *   GET  /dialog             — open OS-native folder dialog (mac only)
+ *   POST /dialog             — open the host OS-native file/folder dialog
  *   POST /validate           — { path } → resolved absolute path
  *   POST /                   — { name, hint?, children? } → best candidate
  */
 
-import { Hono } from "hono"
+import { Hono, type Context } from "hono"
 import { spawn } from "child_process"
 import fs from "fs/promises"
 import os from "os"
@@ -159,6 +159,121 @@ function run(command: string, args: string[]): Promise<string> {
   })
 }
 
+type NativePickerInput = {
+  kind: "folder" | "file"
+  title: string
+  multiple: boolean
+}
+
+export type NativePickerPlan = {
+  command: string
+  args: string[]
+  format: "lines" | "json"
+}
+
+const powershellString = (value: string) => `'${value.replaceAll("'", "''")}'`
+
+export function nativePickerPlan(
+  input: NativePickerInput,
+  platform: NodeJS.Platform = process.platform,
+): NativePickerPlan | undefined {
+  if (platform === "darwin") {
+    const script = [
+      "on run argv",
+      "set dialogTitle to item 1 of argv",
+      "set selectionKind to item 2 of argv",
+      'set allowMany to item 3 of argv is "true"',
+      'if selectionKind is "file" then',
+      "if allowMany then",
+      "set pickedItems to choose file with prompt dialogTitle with multiple selections allowed",
+      "else",
+      "set pickedItems to {choose file with prompt dialogTitle}",
+      "end if",
+      "else",
+      "if allowMany then",
+      "set pickedItems to choose folder with prompt dialogTitle with multiple selections allowed",
+      "else",
+      "set pickedItems to {choose folder with prompt dialogTitle}",
+      "end if",
+      "end if",
+      "set selectedPaths to {}",
+      "repeat with pickedItem in pickedItems",
+      "set end of selectedPaths to POSIX path of pickedItem",
+      "end repeat",
+      "set AppleScript's text item delimiters to linefeed",
+      "return selectedPaths as text",
+      "end run",
+    ]
+    return {
+      command: "osascript",
+      args: [...script.flatMap((line) => ["-e", line]), "--", input.title, input.kind, String(input.multiple)],
+      format: "lines",
+    }
+  }
+
+  if (platform !== "win32") return
+
+  const setup = [
+    "[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)",
+    "Add-Type -AssemblyName System.Windows.Forms",
+    "[System.Windows.Forms.Application]::EnableVisualStyles()",
+  ]
+  const dialog =
+    input.kind === "file"
+      ? [
+          "$picker = New-Object System.Windows.Forms.OpenFileDialog",
+          `$picker.Title = ${powershellString(input.title)}`,
+          `$picker.Multiselect = ${input.multiple ? "$true" : "$false"}`,
+          "$picker.CheckFileExists = $true",
+          "$picker.CheckPathExists = $true",
+          "$result = $picker.ShowDialog()",
+          "if ($result -ne [System.Windows.Forms.DialogResult]::OK) { [Console]::Write('[]'); exit 0 }",
+          "$paths = @($picker.FileNames)",
+        ]
+      : [
+          "$picker = New-Object System.Windows.Forms.FolderBrowserDialog",
+          `$picker.Description = ${powershellString(input.title)}`,
+          "$picker.ShowNewFolderButton = $true",
+          "$result = $picker.ShowDialog()",
+          "if ($result -ne [System.Windows.Forms.DialogResult]::OK) { [Console]::Write('[]'); exit 0 }",
+          "$paths = @($picker.SelectedPath)",
+        ]
+  const script = [...setup, ...dialog, "[Console]::Write((ConvertTo-Json -Compress -InputObject $paths))"].join("; ")
+  return {
+    command: "powershell.exe",
+    args: ["-NoProfile", "-STA", "-Command", script],
+    format: "json",
+  }
+}
+
+export async function openNativePicker(input: NativePickerInput, platform: NodeJS.Platform = process.platform) {
+  const plan = nativePickerPlan(input, platform)
+  if (!plan) return
+  const output = await run(plan.command, plan.args)
+  const values = (() => {
+    if (plan.format === "lines") return output.split(/\r?\n/)
+    const parsed = JSON.parse(output || "[]") as unknown
+    return Array.isArray(parsed) ? parsed : []
+  })()
+  return values
+    .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+    .map(path.normalize)
+}
+
+async function pickerResponse(c: Context, input: NativePickerInput) {
+  const plan = nativePickerPlan(input)
+  if (!plan) return c.json({ unsupported: true, message: `native dialog unsupported on ${process.platform}` }, 501)
+  return openNativePicker(input).then(
+    (paths) => c.json({ paths: paths ?? [] }),
+    (error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error)
+      const cancelled = /User canceled|cancelled/i.test(message)
+      if (cancelled) return c.json({ error: "cancelled" }, 400)
+      return c.json({ error: message }, 500)
+    },
+  )
+}
+
 export const FolderResolveRoutes = lazy(() =>
   new Hono()
     .get("/probe", async (c) => {
@@ -168,25 +283,15 @@ export const FolderResolveRoutes = lazy(() =>
         reason: result.reason,
       })
     })
-    .get("/dialog", async (c) => {
-      // Only macOS gets a reliable scriptable native dialog. Linux/Windows
-      // fall through to the in-app FolderPicker the SPA renders next.
-      if (process.platform !== "darwin") {
-        return c.json({ unsupported: true, message: `native dialog unsupported on ${process.platform}` }, 501)
-      }
-      try {
-        const script = ['set picked to choose folder with prompt "Open project folder"', "POSIX path of picked"]
-        const out = await run(
-          "osascript",
-          script.flatMap((s) => ["-e", s]),
-        )
-        const folder = out.trim().replace(/\/+$/, "")
-        return c.json({ paths: folder ? [folder] : [] })
-      } catch (e: any) {
-        const message = String(e?.message ?? e)
-        const cancelled = /User canceled|cancelled/i.test(message)
-        return c.json({ error: cancelled ? "cancelled" : message }, (cancelled ? 499 : 500) as any)
-      }
+    .get("/dialog", (c) => pickerResponse(c, { kind: "folder", title: "Open project folder", multiple: false }))
+    .post("/dialog", async (c) => {
+      const body = await c.req.json().catch(() => undefined)
+      if (!body || typeof body !== "object" || Array.isArray(body)) return c.json({ error: "invalid json" }, 400)
+      const kind = "kind" in body && body.kind === "file" ? "file" : "folder"
+      const title =
+        "title" in body && typeof body.title === "string" ? body.title.trim().slice(0, 160) : "Choose a location"
+      const multiple = "multiple" in body && body.multiple === true
+      return pickerResponse(c, { kind, title: title || "Choose a location", multiple })
     })
     .post("/validate", async (c) => {
       let body: { path?: string; project?: string; projectID?: string } = {}

--- a/backend/cli/test/project/execution-authority.test.ts
+++ b/backend/cli/test/project/execution-authority.test.ts
@@ -192,6 +192,7 @@ test("trusted terminal derives its process contract from the owning session", as
           status: "running",
         })
         expect(terminal.command).toBeTruthy()
+        if (terminal.command.endsWith("zsh")) expect(terminal.args).toEqual(["-f"])
         expect(terminal.pid).toBeGreaterThan(0)
         await Session.remove(session.id)
       } finally {

--- a/backend/cli/test/server/native-picker.test.ts
+++ b/backend/cli/test/server/native-picker.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test"
+import { nativePickerPlan } from "../../src/server/routes/folder-resolve"
+
+describe("native picker commands", () => {
+  test("uses Finder through AppleScript on macOS", () => {
+    const plan = nativePickerPlan({ kind: "folder", title: "Add source folders", multiple: true }, "darwin")
+
+    expect(plan?.command).toBe("osascript")
+    expect(plan?.format).toBe("lines")
+    expect(plan?.args).toContain("Add source folders")
+    expect(plan?.args.join("\n")).toContain("choose folder with prompt dialogTitle with multiple selections allowed")
+  })
+
+  test("uses the Windows system dialogs and safely quotes titles", () => {
+    const plan = nativePickerPlan({ kind: "file", title: "Researcher's source", multiple: true }, "win32")
+    const script = plan?.args.at(-1) ?? ""
+
+    expect(plan?.command).toBe("powershell.exe")
+    expect(plan?.format).toBe("json")
+    expect(script).toContain("System.Windows.Forms.OpenFileDialog")
+    expect(script).toContain("Researcher''s source")
+    expect(script).toContain("$picker.Multiselect = $true")
+  })
+
+  test("lets unsupported hosts use the in-app fallback", () => {
+    expect(nativePickerPlan({ kind: "folder", title: "Choose", multiple: false }, "linux")).toBeUndefined()
+  })
+})

--- a/frontend/workspace/e2e/home-projects.spec.ts
+++ b/frontend/workspace/e2e/home-projects.spec.ts
@@ -22,18 +22,22 @@ test("home project search filters the recent list and clears back to it", async 
   await expect(card).toBeVisible()
 })
 
-test("existing folder import remains available through the in-app picker", async ({ page, directory, slug }) => {
+test("existing folder import uses the host-native picker", async ({ page, directory, slug }) => {
+  const calls: Array<{ kind: string; title: string; multiple: boolean }> = []
+  await page.route("**/api/resolve-folder/dialog", async (route) => {
+    const body = route.request().postDataJSON() as { kind: string; title: string; multiple: boolean }
+    calls.push(body)
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ paths: [directory] }),
+    })
+  })
+
   await page.goto("/")
   await page.getByRole("button", { name: "Import existing folder", exact: true }).first().click()
 
-  // The picker renders in "lite" mode (plain divs, no role=dialog), so target
-  // its controls at the page level.
-  const location = page.getByPlaceholder(/paste any absolute path/)
-  await expect(location).toBeVisible()
-  await location.fill(directory)
-  await location.press("Enter")
-  await page.getByRole("button", { name: "use this folder", exact: true }).click()
-
   await expect(page).toHaveURL(new RegExp(`/${slug}/session`))
   await expect(page.locator(promptSelector)).toBeVisible()
+  expect(calls).toEqual([{ kind: "folder", title: "open project", multiple: true }])
 })

--- a/frontend/workspace/e2e/native-picker.spec.ts
+++ b/frontend/workspace/e2e/native-picker.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from "./fixtures"
+import { openFilesSources } from "./utils"
+
+test("project sources use the host-native folder picker", async ({ page, directory }) => {
+  const calls: Array<{ kind: string; title: string; multiple: boolean }> = []
+  await page.route("**/api/resolve-folder/dialog", async (route) => {
+    const body = route.request().postDataJSON() as { kind: string; title: string; multiple: boolean }
+    calls.push(body)
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ paths: [directory] }),
+    })
+  })
+
+  await page.goto("/")
+  await page
+    .getByRole("button", { name: /new project/i })
+    .first()
+    .click()
+  const dialog = page.getByRole("dialog", { name: "Create project" })
+  await dialog.getByRole("button", { name: /add source folders/i }).click()
+
+  await expect(dialog.getByRole("button", { name: `Remove source folder ${directory}` })).toBeVisible()
+  expect(calls).toEqual([{ kind: "folder", title: "Add source folders", multiple: true }])
+})
+
+test("source files and folders use the host-native picker", async ({ page, openSession }) => {
+  const selected = {
+    folder: "/tmp/native-source-folder",
+    file: "/tmp/native-source-file.csv",
+  }
+  const calls: string[] = []
+  await page.route("**/api/resolve-folder/dialog", async (route) => {
+    const body = route.request().postDataJSON() as { kind: "folder" | "file" }
+    calls.push(body.kind)
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ paths: [selected[body.kind]] }),
+    })
+  })
+
+  await openSession()
+  await openFilesSources(page)
+  await page.getByRole("button", { name: "Connect another location", exact: true }).click()
+
+  const form = page.getByRole("form", { name: "Connect file or folder access" })
+  const input = form.getByPlaceholder("Choose or paste a file or folder path")
+  await form.getByRole("button", { name: "Choose folder", exact: true }).click()
+  await expect(input).toHaveValue(selected.folder)
+  await form.getByRole("button", { name: "Choose file", exact: true }).click()
+  await expect(input).toHaveValue(selected.file)
+  expect(calls).toEqual(["folder", "file"])
+})

--- a/frontend/workspace/e2e/session.spec.ts
+++ b/frontend/workspace/e2e/session.spec.ts
@@ -164,7 +164,7 @@ test("opening Compute from a new route creates a durable session and keeps the s
     const panel = page.getByTestId("kernel-panel")
     await expect(panel.getByText("No kernels yet", { exact: true })).toBeVisible()
     await expect(panel).not.toContainText("Unavailable")
-    await expect(panel.locator("details.kernel-panel__scope")).not.toHaveAttribute("open", "")
+    await expect(panel.locator("details.kernel-panel__scope")).toHaveCount(0)
   } finally {
     if (sessionID) await sdk.session.delete({ sessionID }).catch(() => undefined)
   }

--- a/frontend/workspace/e2e/session.spec.ts
+++ b/frontend/workspace/e2e/session.spec.ts
@@ -161,6 +161,10 @@ test("opening Compute from a new route creates a durable session and keeps the s
     await expect(page).toHaveURL(new RegExp(`/${slug}/session/${sessionID}(?:\\?|#|$)`))
     await expect(page.getByRole("region", { name: "Compute", exact: true })).toBeVisible()
     await expect(page.getByRole("tab", { name: "Kernels", exact: true })).toHaveAttribute("aria-selected", "true")
+    const panel = page.getByTestId("kernel-panel")
+    await expect(panel.getByText("No kernels yet", { exact: true })).toBeVisible()
+    await expect(panel).not.toContainText("Unavailable")
+    await expect(panel.locator("details.kernel-panel__scope")).not.toHaveAttribute("open", "")
   } finally {
     if (sessionID) await sdk.session.delete({ sessionID }).catch(() => undefined)
   }

--- a/frontend/workspace/src/atlas/ComputeSurface.css
+++ b/frontend/workspace/src/atlas/ComputeSurface.css
@@ -4,168 +4,205 @@
 
 .compute-surface__tabs {
   box-sizing: border-box;
-  min-height: 40px;
-  gap: 4px;
-  margin: 8px 10px 0;
-  padding: 4px;
-  border-radius: var(--compute-radius);
-  background: color-mix(in srgb, var(--color-bg-subtle) 72%, transparent);
+  min-height: 42px;
+  display: flex;
+  gap: 18px;
+  margin: 0;
+  padding: 0 14px;
+  border: 0;
+  border-bottom: 1px solid var(--color-border);
+  border-radius: 0;
+  background: transparent;
 }
 
 .compute-surface__tab {
-  min-height: 32px;
-  padding: 0 12px;
-  border-radius: 8px;
-  font-size: 13px;
+  position: relative;
+  min-height: 42px;
+  padding: 0 1px;
+  border-radius: 0;
+  color: var(--color-text-faint);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.compute-surface__tab::after {
+  position: absolute;
+  right: 0;
+  bottom: -1px;
+  left: 0;
+  height: 1px;
+  content: "";
+  background: transparent;
+}
+
+.compute-surface__tab:hover {
+  color: var(--color-text);
 }
 
 .compute-surface__tab[data-active="true"] {
-  background: var(--color-surface-solid);
+  color: var(--color-text);
+  background: transparent;
   box-shadow: none;
+}
+
+.compute-surface__tab[data-active="true"]::after {
+  background: var(--color-text);
+}
+
+.compute-surface__tab:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--color-accent) 54%, transparent);
+  outline-offset: -3px;
 }
 
 .compute-surface .kernel-panel__header {
   box-sizing: border-box;
-  min-height: 44px;
+  min-height: 42px;
   gap: 10px;
-  padding: 6px 10px 6px 12px;
-  background: var(--color-bg);
+  padding: 6px 10px 6px 14px;
+  border-bottom: 1px solid color-mix(in srgb, var(--color-border) 72%, transparent);
+  background: transparent;
 }
 
 .compute-surface .kernel-panel__heading {
-  grid-template-columns: 1fr;
-  gap: 1px;
-}
-
-.compute-surface .kernel-panel__heading strong {
-  font-size: 14px;
-  font-weight: 600;
-  letter-spacing: -0.01em;
+  display: block;
+  min-width: 0;
 }
 
 .compute-surface .kernel-panel__heading > span:last-child {
-  grid-column: 1;
+  display: block;
+  overflow: hidden;
+  color: var(--color-text-muted);
   font-size: 11px;
-  line-height: 1.3;
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .compute-surface .kernel-panel__refresh {
-  gap: 7px;
-  font-size: 10px;
+  gap: 4px;
+  color: var(--color-text-faint);
+  font-size: 9px;
 }
 
 .compute-surface .kernel-panel__refresh button {
-  width: 30px;
-  height: 30px;
-  border: 1px solid var(--color-border);
-  border-radius: 8px;
+  width: 28px;
+  height: 28px;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  transition:
+    background-color 150ms ease,
+    color 150ms ease,
+    transform 120ms ease;
+}
+
+.compute-surface .kernel-panel__refresh button:hover:not(:disabled) {
+  color: var(--color-text);
   background: var(--color-bg-elevated);
 }
 
+.compute-surface .kernel-panel__refresh button:active:not(:disabled) {
+  transform: scale(0.96);
+}
+
 .compute-surface .kernel-panel__body {
-  padding: 8px 10px 12px;
+  padding: 12px;
 }
 
 .compute-surface .kernel-panel__create {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 110px auto;
+  grid-template-columns: minmax(0, 1fr) minmax(108px, 0.42fr);
   align-items: end;
-  gap: 8px;
-  margin-bottom: 10px;
-  padding: 10px;
+  gap: 9px;
+  margin-bottom: 12px;
+  padding: 12px;
   border: 1px solid var(--color-border);
-  border-radius: 10px;
-  background: var(--color-bg-elevated);
+  border-radius: var(--compute-radius);
+  background: color-mix(in srgb, var(--color-bg-elevated) 72%, var(--color-bg));
 }
 
 .compute-surface .kernel-panel__create label {
   display: grid;
-  gap: 4px;
+  gap: 5px;
   min-width: 0;
-  font-size: 10px;
   color: var(--color-text-faint);
+  font-size: 10px;
 }
 
 .compute-surface .kernel-panel__create input,
 .compute-surface .kernel-panel__create select,
 .compute-surface .kernel-panel__create button {
   box-sizing: border-box;
-  min-height: 32px;
+  width: 100%;
+  min-height: 34px;
   padding: 6px 9px;
   border: 1px solid var(--color-border);
-  border-radius: 8px;
+  border-radius: 7px;
   color: var(--color-text);
   background: var(--color-bg);
   font: inherit;
 }
 
+.compute-surface .kernel-panel__create input:focus,
+.compute-surface .kernel-panel__create select:focus {
+  border-color: var(--color-border-strong);
+  outline: none;
+}
+
 .compute-surface .kernel-panel__create > div {
+  grid-column: 1 / -1;
   display: flex;
+  justify-content: flex-end;
   gap: 6px;
+}
+
+.compute-surface .kernel-panel__create > div button {
+  width: auto;
+  min-width: 78px;
 }
 
 .compute-surface .kernel-panel__create button[type="submit"] {
   color: var(--color-bg);
+  border-color: var(--color-text);
   background: var(--color-text);
 }
 
-.compute-surface .kernel-panel__scope {
-  display: block;
-  margin: 0 2px 8px;
-  padding: 0;
-  border: 0;
-  background: none;
-}
-
-.compute-surface .kernel-panel__scope summary {
-  width: max-content;
-  font-size: 10px;
-  color: var(--color-text-faint);
-  cursor: pointer;
-}
-
-.compute-surface .kernel-panel__scope p {
-  max-width: 54ch;
-  margin: 5px 0 0;
-  padding-left: 13px;
-  font-size: 10px;
-  line-height: 1.4;
-  color: var(--color-text-faint);
-}
-
 .compute-surface .kernel-panel__message {
+  margin-bottom: 10px;
   padding: 9px 10px;
-  margin-bottom: 9px;
   border-radius: 8px;
-  font-size: 12px;
+  font-size: 11px;
 }
 
 .compute-surface .kernel-panel__message--authority {
   color: var(--color-text-muted);
-  background: color-mix(in srgb, var(--color-warning) 7%, var(--color-bg));
-  border-color: color-mix(in srgb, var(--color-warning) 20%, var(--color-border));
+  border-color: color-mix(in srgb, var(--color-warning) 18%, var(--color-border));
+  background: color-mix(in srgb, var(--color-warning) 6%, var(--color-bg));
 }
 
 .compute-surface .kernel-panel__empty {
   min-height: 220px;
   gap: 7px;
-  padding: 30px 22px;
+  padding: 34px 24px;
 }
 
 .compute-surface .kernel-panel__empty > span {
-  width: 38px;
-  height: 38px;
-  border-radius: 10px;
+  width: 34px;
+  height: 34px;
+  border: 0;
+  border-radius: 9px;
+  background: var(--color-bg-elevated);
 }
 
 .compute-surface .kernel-panel__empty strong {
-  font-size: 14px;
+  font-size: 13px;
 }
 
 .compute-surface .kernel-panel__empty p {
   max-width: 280px;
-  font-size: 12px;
-  line-height: 1.45;
+  color: var(--color-text-faint);
+  font-size: 11px;
+  line-height: 1.5;
 }
 
 .compute-surface .kernel-panel__list {
@@ -173,120 +210,118 @@
 }
 
 .compute-surface .kernel-card {
-  gap: 9px;
-  padding: 11px;
-  border-radius: 12px;
-  background: color-mix(in srgb, var(--color-bg-elevated) 78%, var(--color-bg));
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid color-mix(in srgb, var(--color-border) 82%, transparent);
+  border-radius: var(--compute-radius);
+  background: color-mix(in srgb, var(--color-bg-elevated) 68%, var(--color-bg));
   box-shadow: none;
 }
 
+.compute-surface .kernel-card[data-owner-current="true"] {
+  border-color: color-mix(in srgb, var(--color-border-strong) 82%, transparent);
+}
+
 .compute-surface .kernel-card__header {
-  grid-template-columns: 32px minmax(0, 1fr) auto;
+  grid-template-columns: 26px minmax(0, 1fr);
   gap: 9px;
+  align-items: start;
 }
 
 .compute-surface .kernel-card__language {
-  width: 32px;
-  height: 32px;
-  border-radius: 8px;
-  font-size: 10px;
+  width: 26px;
+  height: 26px;
+  border: 0;
+  border-radius: 7px;
+  color: var(--color-text-muted);
+  background: var(--color-bg-subtle);
+  font-size: 9px;
 }
 
 .compute-surface .kernel-card__title {
-  gap: 1px;
+  gap: 2px;
+}
+
+.compute-surface .kernel-card__name {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
 }
 
 .compute-surface .kernel-card__title strong {
-  font-size: 14px;
+  min-width: 0;
+  color: var(--color-text);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
 }
 
-.compute-surface .kernel-card__title span {
-  font-size: 11px;
-}
-
-.compute-surface .kernel-card__meta {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 7px;
-}
-
-.compute-surface .kernel-card__owner {
-  padding: 3px 6px;
-  border-radius: 6px;
+.compute-surface .kernel-card__title > span {
+  color: var(--color-text-faint);
   font-size: 10px;
 }
 
 .compute-surface .kernel-card__state {
-  gap: 6px;
+  flex: none;
+  gap: 5px;
   min-height: 0;
-  font-size: 11px;
+  color: var(--color-text-muted);
 }
 
 .compute-surface .kernel-card__state strong {
-  font-size: 12px;
+  color: inherit;
+  font-size: 10px;
+  font-weight: 500;
 }
 
 .compute-surface .kernel-card__state-dot {
-  width: 7px;
-  height: 7px;
+  width: 6px;
+  height: 6px;
 }
 
 .compute-surface .kernel-card__metrics {
   display: flex;
   flex-wrap: wrap;
-  gap: 5px;
+  gap: 5px 12px;
   border: 0;
   border-radius: 0;
   background: transparent;
   overflow: visible;
 }
 
-.compute-surface .kernel-card__metric {
+.compute-surface .kernel-card__metric,
+.compute-surface .kernel-card__metric:nth-child(2n),
+.compute-surface .kernel-card__metric:nth-last-child(-n + 2) {
   min-height: 0;
-  box-sizing: border-box;
   display: flex;
   align-items: baseline;
-  gap: 5px;
-  padding: 4px 7px;
-  border: 1px solid color-mix(in srgb, var(--color-border) 82%, transparent) !important;
-  border-radius: 7px;
-  background: color-mix(in srgb, var(--color-bg-subtle) 76%, transparent);
+  gap: 4px;
+  padding: 0;
+  border: 0;
+  background: transparent;
 }
 
 .compute-surface .kernel-card__metric span {
+  color: var(--color-text-faint);
   font-size: 9px;
   letter-spacing: 0;
   text-transform: none;
 }
 
 .compute-surface .kernel-card__metric strong {
-  font-size: 10px;
-}
-
-.compute-surface .kernel-card__environment {
-  gap: 6px;
-  padding: 8px;
-  border: 1px solid var(--color-border);
-  border-radius: 8px;
-}
-
-.compute-surface .kernel-card__environment-header strong,
-.compute-surface .kernel-card__environment-header span {
-  font-size: 11px;
-}
-
-.compute-surface .kernel-card__environment-row > span,
-.compute-surface .kernel-card__environment-row code,
-.compute-surface .kernel-card__environment-row p {
-  font-size: 11px;
+  color: var(--color-text-muted);
+  font-size: 9px;
+  font-weight: 500;
 }
 
 .compute-surface .kernel-card__recovery {
   padding-left: 0;
-  font-size: 11px;
   color: var(--color-text-faint);
   border-left: 0;
+  font-size: 10px;
+  line-height: 1.45;
 }
 
 .compute-surface .kernel-card__controls {
@@ -298,8 +333,16 @@
 .compute-surface .kernel-card__controls button {
   min-height: 30px;
   padding: 5px 10px;
-  border-radius: 8px;
-  font-size: 11px;
+  border-radius: 7px;
+  font-size: 10px;
+  transition:
+    background-color 150ms ease,
+    border-color 150ms ease,
+    transform 120ms ease;
+}
+
+.compute-surface .kernel-card__controls button:active:not(:disabled) {
+  transform: scale(0.97);
 }
 
 .compute-surface .kernel-card__controls .kernel-card__primary {
@@ -308,10 +351,15 @@
   background: var(--color-text);
 }
 
+.compute-surface .kernel-card__identity {
+  border-top-color: color-mix(in srgb, var(--color-border) 72%, transparent);
+}
+
 .compute-surface .kernel-card__identity summary {
+  width: max-content;
   padding-top: 7px;
-  font-size: 10px;
   color: var(--color-text-faint);
+  font-size: 9px;
 }
 
 .compute-surface .kernel-card__identity > div {
@@ -319,9 +367,22 @@
   padding-top: 8px;
 }
 
+.compute-surface .kernel-card__environment {
+  gap: 6px;
+  padding: 8px;
+  border: 0;
+  border-radius: 7px;
+  background: var(--color-bg-subtle);
+}
+
+.compute-surface .kernel-card__environment-header strong,
+.compute-surface .kernel-card__environment-header span,
+.compute-surface .kernel-card__environment-row > span,
+.compute-surface .kernel-card__environment-row code,
+.compute-surface .kernel-card__environment-row p,
 .compute-surface .kernel-card__identity-row span,
 .compute-surface .kernel-card__identity-row code {
-  font-size: 10px;
+  font-size: 9px;
 }
 
 .compute-jobs :where(button, input, select, textarea):focus-visible {
@@ -329,22 +390,12 @@
   outline: none;
 }
 
-@media (max-width: 720px) {
+@media (max-width: 520px) {
   .compute-surface .kernel-panel__create {
-    grid-template-columns: minmax(0, 1fr) 96px;
+    grid-template-columns: 1fr;
   }
 
   .compute-surface .kernel-panel__create > div {
-    grid-column: 1 / -1;
-    justify-content: flex-end;
-  }
-
-  .compute-surface .kernel-card__header {
-    grid-template-columns: 32px minmax(0, 1fr);
-  }
-
-  .compute-surface .kernel-card__meta {
-    grid-column: 1 / -1;
-    justify-content: flex-start;
+    grid-column: 1;
   }
 }

--- a/frontend/workspace/src/atlas/ComputeSurface.css
+++ b/frontend/workspace/src/atlas/ComputeSurface.css
@@ -26,9 +26,9 @@
 
 .compute-surface .kernel-panel__header {
   box-sizing: border-box;
-  min-height: 48px;
+  min-height: 44px;
   gap: 10px;
-  padding: 7px 10px 7px 12px;
+  padding: 6px 10px 6px 12px;
   background: var(--color-bg);
 }
 
@@ -38,7 +38,7 @@
 }
 
 .compute-surface .kernel-panel__heading strong {
-  font-size: 15px;
+  font-size: 14px;
   font-weight: 600;
   letter-spacing: -0.01em;
 }
@@ -63,7 +63,7 @@
 }
 
 .compute-surface .kernel-panel__body {
-  padding: 10px;
+  padding: 8px 10px 12px;
 }
 
 .compute-surface .kernel-panel__create {
@@ -110,36 +110,27 @@
 }
 
 .compute-surface .kernel-panel__scope {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  margin: 0 2px 9px;
+  display: block;
+  margin: 0 2px 8px;
   padding: 0;
   border: 0;
-  border-radius: 0;
-  background: transparent;
+  background: none;
 }
 
-.compute-surface .kernel-panel__scope-icon {
-  width: 20px;
-  height: 20px;
-  flex: 0 0 auto;
-  border: 0;
-  border-radius: 0;
-  background: transparent;
+.compute-surface .kernel-panel__scope summary {
+  width: max-content;
+  font-size: 10px;
+  color: var(--color-text-faint);
+  cursor: pointer;
 }
 
 .compute-surface .kernel-panel__scope p {
-  max-width: none;
-  font-size: 11px;
+  max-width: 54ch;
+  margin: 5px 0 0;
+  padding-left: 13px;
+  font-size: 10px;
   line-height: 1.4;
   color: var(--color-text-faint);
-}
-
-.compute-surface .kernel-panel__scope strong {
-  font-size: inherit;
-  font-weight: 600;
-  color: var(--color-text-muted);
 }
 
 .compute-surface .kernel-panel__message {
@@ -182,10 +173,10 @@
 }
 
 .compute-surface .kernel-card {
-  gap: 8px;
-  padding: 12px;
+  gap: 9px;
+  padding: 11px;
   border-radius: 12px;
-  background: var(--surface-raised-strong);
+  background: color-mix(in srgb, var(--color-bg-elevated) 78%, var(--color-bg));
   box-shadow: none;
 }
 
@@ -213,6 +204,13 @@
   font-size: 11px;
 }
 
+.compute-surface .kernel-card__meta {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 7px;
+}
+
 .compute-surface .kernel-card__owner {
   padding: 3px 6px;
   border-radius: 6px;
@@ -221,7 +219,7 @@
 
 .compute-surface .kernel-card__state {
   gap: 6px;
-  min-height: 18px;
+  min-height: 0;
   font-size: 11px;
 }
 
@@ -235,44 +233,42 @@
 }
 
 .compute-surface .kernel-card__metrics {
-  border-radius: 10px;
-}
-
-.compute-surface .kernel-card__metrics--usage {
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-}
-
-.compute-surface .kernel-card__metrics--usage .kernel-card__metric:nth-child(2n) {
-  border-right: 1px solid var(--color-border);
-}
-
-.compute-surface .kernel-card__metrics--usage .kernel-card__metric:nth-child(3n) {
-  border-right: 0;
-}
-
-.compute-surface .kernel-card__metrics--usage .kernel-card__metric:nth-last-child(-n + 3) {
-  border-bottom: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  overflow: visible;
 }
 
 .compute-surface .kernel-card__metric {
-  min-height: 40px;
+  min-height: 0;
   box-sizing: border-box;
-  gap: 2px;
-  padding: 7px 9px;
+  display: flex;
+  align-items: baseline;
+  gap: 5px;
+  padding: 4px 7px;
+  border: 1px solid color-mix(in srgb, var(--color-border) 82%, transparent) !important;
+  border-radius: 7px;
+  background: color-mix(in srgb, var(--color-bg-subtle) 76%, transparent);
 }
 
 .compute-surface .kernel-card__metric span {
-  font-size: 10px;
+  font-size: 9px;
+  letter-spacing: 0;
+  text-transform: none;
 }
 
 .compute-surface .kernel-card__metric strong {
-  font-size: 12px;
+  font-size: 10px;
 }
 
 .compute-surface .kernel-card__environment {
   gap: 6px;
-  padding: 9px 10px;
-  border-radius: 10px;
+  padding: 8px;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
 }
 
 .compute-surface .kernel-card__environment-header strong,
@@ -287,34 +283,40 @@
 }
 
 .compute-surface .kernel-card__recovery {
-  padding-left: 9px;
+  padding-left: 0;
   font-size: 11px;
+  color: var(--color-text-faint);
+  border-left: 0;
 }
 
 .compute-surface .kernel-card__controls {
-  gap: 7px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
 }
 
 .compute-surface .kernel-card__controls button {
-  min-height: 34px;
-  padding: 6px 10px;
+  min-height: 30px;
+  padding: 5px 10px;
   border-radius: 8px;
-  font-size: 12px;
-}
-
-.compute-surface .kernel-card__control-note {
-  margin-top: -2px;
-  font-size: 10px;
-}
-
-.compute-surface .kernel-card__identity summary {
-  padding-top: 8px;
   font-size: 11px;
 }
 
-.compute-surface .kernel-card__identity > div {
-  gap: 5px;
+.compute-surface .kernel-card__controls .kernel-card__primary {
+  color: var(--color-bg);
+  border-color: var(--color-text);
+  background: var(--color-text);
+}
+
+.compute-surface .kernel-card__identity summary {
   padding-top: 7px;
+  font-size: 10px;
+  color: var(--color-text-faint);
+}
+
+.compute-surface .kernel-card__identity > div {
+  gap: 6px;
+  padding-top: 8px;
 }
 
 .compute-surface .kernel-card__identity-row span,
@@ -335,5 +337,14 @@
   .compute-surface .kernel-panel__create > div {
     grid-column: 1 / -1;
     justify-content: flex-end;
+  }
+
+  .compute-surface .kernel-card__header {
+    grid-template-columns: 32px minmax(0, 1fr);
+  }
+
+  .compute-surface .kernel-card__meta {
+    grid-column: 1 / -1;
+    justify-content: flex-start;
   }
 }

--- a/frontend/workspace/src/atlas/FileExplorer.tsx
+++ b/frontend/workspace/src/atlas/FileExplorer.tsx
@@ -4,6 +4,7 @@ import { useParams } from "@solidjs/router"
 import { useDialog } from "@synsci/ui/context/dialog"
 import { Select } from "@synsci/ui/select"
 import { useSDK } from "@/context/sdk"
+import { useServer } from "@/context/server"
 import { useSync } from "@/context/sync"
 import { usePlatform } from "@/context/platform"
 import { FONT_MONO, FONT_SANS } from "@/styles/tokens"
@@ -493,6 +494,7 @@ export function FilesSourceList(props: FilesSourceListProps): JSX.Element {
 
 export function FileExplorer(): JSX.Element {
   const sdk = useSDK()
+  const server = useServer()
   const sync = useSync()
   const params = useParams()
   const platform = usePlatform()
@@ -576,10 +578,15 @@ export function FileExplorer(): JSX.Element {
   }
   const choose = async (kind: "folder" | "file") => {
     const picker = kind === "folder" ? platform.openDirectoryPickerDialog : platform.openFilePickerDialog
-    if (picker) {
-      const result = await picker({ title: kind === "folder" ? "Connect a folder" : "Connect a file" })
-      if (Array.isArray(result)) return result[0]
-      return result ?? undefined
+    if (picker && server.isLocal()) {
+      const result = await picker({
+        title: kind === "folder" ? "Connect a folder" : "Connect a file",
+        server: sdk.url,
+      })
+      if (result !== undefined) {
+        if (Array.isArray(result)) return result[0]
+        return result ?? undefined
+      }
     }
 
     return new Promise<string | undefined>((resolve) => {

--- a/frontend/workspace/src/atlas/FileExplorer.tsx
+++ b/frontend/workspace/src/atlas/FileExplorer.tsx
@@ -386,7 +386,7 @@ export function FilesSourceList(props: FilesSourceListProps): JSX.Element {
               type="button"
               aria-label="Connect another location"
               onClick={() => setForm("open", true)}
-              disabled={!props.sessionReady}
+              disabled={props.busy}
               style={connect()}
             >
               <IconPlus size={15} strokeWidth={1.6} />
@@ -485,14 +485,14 @@ export function FilesSourceList(props: FilesSourceListProps): JSX.Element {
           </form>
         </Show>
         <Show when={!props.sessionReady}>
-          <p style={note()}>Start a research session before connecting an outside file or folder.</p>
+          <p style={note()}>A research session will start automatically when you connect a location.</p>
         </Show>
       </section>
     </div>
   )
 }
 
-export function FileExplorer(): JSX.Element {
+export function FileExplorer(props: { onEnsureSession?: () => Promise<string | undefined> } = {}): JSX.Element {
   const sdk = useSDK()
   const server = useServer()
   const sync = useSync()
@@ -510,8 +510,7 @@ export function FileExplorer(): JSX.Element {
 
   const projectRoot = () => sdk.directory || sync.data.path.directory || sync.project?.worktree || ""
   const sessionID = () => (params.id && params.id !== "new" ? params.id : undefined)
-  const identity = (): FilesystemIdentity | undefined => {
-    const session = sessionID()
+  const identity = (session = sessionID()): FilesystemIdentity | undefined => {
     if (!session || !projectRoot()) return
     return { sessionID: session, projectID: sdk.projectID, directory: projectRoot() }
   }
@@ -630,11 +629,16 @@ export function FileExplorer(): JSX.Element {
     const path = view.source?.kind === "connected" ? node.absolute : node.path
     uiStore.openFile(projectRoot(), path)
   }
-  const connect = (input: ConnectInput) => {
-    const current = identity()
-    if (!current || view.busy) return
+  const connect = async (input: ConnectInput) => {
+    if (view.busy) return
     setView({ busy: true, error: undefined })
-    grantAccess(sdk.request, current, input)
+    const session = sessionID() ?? (await props.onEnsureSession?.())
+    const current = identity(session)
+    if (!current) {
+      setView({ busy: false, error: "OpenScience could not start a session for this connection." })
+      return
+    }
+    return grantAccess(sdk.request, current, input)
       .then(() => refetchSnapshot())
       .then(() => {
         setView({ busy: false, error: undefined })
@@ -835,7 +839,12 @@ export function FileExplorer(): JSX.Element {
   )
 }
 
-export function ExternalFileAccess(props: { file: ContextFile; active: boolean; onClose: () => void }): JSX.Element {
+export function ExternalFileAccess(props: {
+  file: ContextFile
+  active: boolean
+  onEnsureSession?: () => Promise<string | undefined>
+  onClose: () => void
+}): JSX.Element {
   const sdk = useSDK()
   const sync = useSync()
   const params = useParams()
@@ -847,18 +856,22 @@ export function ExternalFileAccess(props: { file: ContextFile; active: boolean; 
   })
   const projectRoot = () => sdk.directory || sync.data.path.directory || sync.project?.worktree || ""
   const sessionID = () => (params.id && params.id !== "new" ? params.id : undefined)
-  const identity = (): FilesystemIdentity | undefined => {
-    const session = sessionID()
+  const identity = (session = sessionID()): FilesystemIdentity | undefined => {
     if (!session || !projectRoot()) return
     return { sessionID: session, projectID: sdk.projectID, directory: projectRoot() }
   }
   const [snapshot, { refetch }] = createResource(identity, (current) => readAccess(sdk.request, current))
   const grant = createMemo(() => findFilesystemGrant(snapshot.latest, props.file.path, "read"))
-  const request = () => {
-    const current = identity()
-    if (!current || state.busy) return
+  const request = async () => {
+    if (state.busy) return
     setState({ busy: true, error: undefined })
-    grantAccess(sdk.request, current, {
+    const session = sessionID() ?? (await props.onEnsureSession?.())
+    const current = identity(session)
+    if (!current) {
+      setState({ busy: false, error: "OpenScience could not start a session for this connection." })
+      return
+    }
+    return grantAccess(sdk.request, current, {
       path: requestedFolder(props.file.path),
       access: state.access,
       scope: state.scope,
@@ -908,14 +921,7 @@ export function ExternalFileAccess(props: { file: ContextFile; active: boolean; 
               without an approved folder grant.
             </p>
           </div>
-          <Show
-            when={sessionID()}
-            fallback={
-              <p role="status" style={alert()}>
-                Start a research session to request access.
-              </p>
-            }
-          >
+          <div style={{ display: "grid", gap: "12px" }}>
             <div style={fieldGrid()}>
               <div style={field()}>
                 <span>Access</span>
@@ -954,7 +960,12 @@ export function ExternalFileAccess(props: { file: ContextFile; active: boolean; 
             <button type="button" onClick={request} disabled={state.busy} style={primary()}>
               {state.busy ? "Requesting…" : "Request access"}
             </button>
-          </Show>
+            <Show when={!sessionID()}>
+              <p role="status" style={note()}>
+                A research session will start automatically when access is requested.
+              </p>
+            </Show>
+          </div>
           <button type="button" onClick={props.onClose} style={secondary()}>
             Back to file sources
           </button>

--- a/frontend/workspace/src/atlas/KernelCard.test.tsx
+++ b/frontend/workspace/src/atlas/KernelCard.test.tsx
@@ -74,11 +74,11 @@ describe("KernelCard lifecycle controls", () => {
       }),
     )
 
-    expect(host.textContent).toContain("runtime active")
+    expect(host.querySelector(".kernel-card__state")?.textContent).toContain("ready")
     expect(host.textContent).toContain("r4")
     expect(host.textContent).toContain("8234")
     expect(host.textContent).toContain("PID and process start verified")
-    expect(button(host, "Interrupt analysis.ipynb")?.disabled).toBe(true)
+    expect(button(host, "Interrupt analysis.ipynb")).toBeNull()
     expect(button(host, "Restart analysis.ipynb")?.disabled).toBe(false)
     expect(button(host, "Stop analysis.ipynb")?.disabled).toBe(false)
 
@@ -102,9 +102,7 @@ describe("KernelCard lifecycle controls", () => {
     expect(button(host, "Restart analysis.ipynb")?.title).toContain(
       "All in-memory variables and queued cells will be lost",
     )
-    expect(host.querySelector(".kernel-card__control-note")?.textContent).toContain(
-      "every in-memory variable and queued cell is lost",
-    )
+    expect(host.querySelector(".kernel-card__control-note")).toBeNull()
     button(host, "Interrupt analysis.ipynb")?.click()
     expect(calls).toEqual(["interrupt"])
   })
@@ -130,15 +128,15 @@ describe("KernelCard lifecycle controls", () => {
       }),
     )
 
-    expect(host.textContent).toContain("R environment")
-    expect(button(host, "Restart analysis.ipynb")?.disabled).toBe(false)
-    expect(button(host, "Stop analysis.ipynb")?.disabled).toBe(true)
+    expect(host.textContent).toContain("R · Local")
+    expect(button(host, "Start runtime analysis.ipynb")?.disabled).toBe(false)
+    expect(button(host, "Stop analysis.ipynb")).toBeNull()
     expect(button(host, "Forget analysis.ipynb")?.disabled).toBe(false)
     button(host, "Forget analysis.ipynb")?.click()
     expect(calls).toEqual(["delete"])
   })
 
-  test("shows the local target with sampled usage and an unavailable fallback, never zero", () => {
+  test("shows only metrics the host actually reports", () => {
     const sampled = mount(() =>
       subject.KernelCard({
         kernel: kernel({ resources: { cpu_percent: 12.34, memory_bytes: 412_000_000 } }),
@@ -147,14 +145,15 @@ describe("KernelCard lifecycle controls", () => {
         onControl: () => {},
       }),
     )
-    const usage = sampled.querySelector(".kernel-card__metrics--usage")
+    const usage = sampled.querySelector(".kernel-card__metrics")
     expect(usage?.textContent).toContain("Target")
     expect(usage?.textContent).toContain("Local")
     expect(usage?.textContent).toContain("12.3%")
     expect(usage?.textContent).toContain("412 MB")
     expect(usage?.textContent).toContain("Uptime")
-    expect(usage?.textContent).toContain("GPU")
-    expect(usage?.textContent).toContain("VRAM")
+    expect(usage?.textContent).not.toContain("GPU")
+    expect(usage?.textContent).not.toContain("VRAM")
+    expect(usage?.textContent).not.toContain("Unavailable")
 
     const partial = mount(() =>
       subject.KernelCard({
@@ -164,9 +163,9 @@ describe("KernelCard lifecycle controls", () => {
         onControl: () => {},
       }),
     )
-    const half = partial.querySelector(".kernel-card__metrics--usage")
+    const half = partial.querySelector(".kernel-card__metrics")
     expect(half?.textContent).toContain("3.0%")
-    expect(half?.textContent?.match(/Unavailable/g)?.length).toBe(3)
+    expect(half?.textContent).not.toContain("Unavailable")
     expect(half?.textContent).not.toContain("0 B")
 
     const bare = mount(() =>
@@ -177,10 +176,10 @@ describe("KernelCard lifecycle controls", () => {
         onControl: () => {},
       }),
     )
-    const empty = bare.querySelector(".kernel-card__metrics--usage")
+    const empty = bare.querySelector(".kernel-card__metrics")
     expect(empty?.textContent).toContain("Local")
     expect(empty?.textContent).not.toContain("%")
-    expect(empty?.textContent?.match(/Unavailable/g)?.length).toBe(4)
+    expect(empty?.textContent).not.toContain("Unavailable")
   })
 
   test("keeps the lazy named session kernel restartable but not deletable", () => {
@@ -204,7 +203,7 @@ describe("KernelCard lifecycle controls", () => {
     )
 
     expect(host.textContent).toContain("No process is running")
-    expect(button(host, "Restart Python analysis")?.disabled).toBe(false)
+    expect(button(host, "Start runtime Python analysis")?.disabled).toBe(false)
     expect(button(host, "Forget Python analysis")).toBeNull()
   })
 

--- a/frontend/workspace/src/atlas/KernelCard.test.tsx
+++ b/frontend/workspace/src/atlas/KernelCard.test.tsx
@@ -128,7 +128,8 @@ describe("KernelCard lifecycle controls", () => {
       }),
     )
 
-    expect(host.textContent).toContain("R · Local")
+    expect(host.textContent).toContain("R · This session")
+    expect(host.querySelector(".kernel-card__metrics")?.textContent).toContain("TargetLocal")
     expect(button(host, "Start runtime analysis.ipynb")?.disabled).toBe(false)
     expect(button(host, "Stop analysis.ipynb")).toBeNull()
     expect(button(host, "Forget analysis.ipynb")?.disabled).toBe(false)

--- a/frontend/workspace/src/atlas/KernelCard.tsx
+++ b/frontend/workspace/src/atlas/KernelCard.tsx
@@ -80,16 +80,15 @@ export function KernelCard(props: {
               : props.kernel.language.slice(0, 2)}
         </span>
         <div class="kernel-card__title">
-          <strong title={kernelLabel(props.kernel)}>{kernelLabel(props.kernel)}</strong>
+          <div class="kernel-card__name">
+            <strong title={kernelLabel(props.kernel)}>{kernelLabel(props.kernel)}</strong>
+            <span class="kernel-card__state" data-tone={kernelTone(props.kernel.state)}>
+              <span class="kernel-card__state-dot" aria-hidden="true" />
+              <strong>{kernelStateLabel(props.kernel.state)}</strong>
+            </span>
+          </div>
           <span>
-            {kernelLanguageLabel(props.kernel)} · {kernelTargetLabel(props.kernel)}
-          </span>
-        </div>
-        <div class="kernel-card__meta">
-          <span class="kernel-card__owner">{owner()}</span>
-          <span class="kernel-card__state" data-tone={kernelTone(props.kernel.state)}>
-            <span class="kernel-card__state-dot" aria-hidden="true" />
-            <strong>{kernelStateLabel(props.kernel.state)}</strong>
+            {kernelLanguageLabel(props.kernel)} · {owner()}
           </span>
         </div>
       </div>
@@ -103,7 +102,9 @@ export function KernelCard(props: {
         <For each={metrics()}>{(metric) => <Metric label={metric.label} value={metric.value} />}</For>
       </div>
 
-      <p class="kernel-card__recovery">{kernelRecoveryLabel(props.kernel)}</p>
+      <Show when={props.kernel.state !== "idle" || props.kernel.queue_depth > 0}>
+        <p class="kernel-card__recovery">{kernelRecoveryLabel(props.kernel)}</p>
+      </Show>
 
       <div class="kernel-card__controls">
         <Show when={kernelCanInterrupt(props.kernel)}>
@@ -159,7 +160,7 @@ export function KernelCard(props: {
       </div>
 
       <details class="kernel-card__identity">
-        <summary>Runtime details</summary>
+        <summary>Details</summary>
         <div>
           <Show when={props.kernel.environment}>
             <section class="kernel-card__environment" aria-label={`${kernelLanguageLabel(props.kernel)} environment`}>

--- a/frontend/workspace/src/atlas/KernelCard.tsx
+++ b/frontend/workspace/src/atlas/KernelCard.tsx
@@ -1,4 +1,4 @@
-import { Show, type JSX } from "solid-js"
+import { For, Show, type JSX } from "solid-js"
 import {
   kernelAtlasLabel,
   kernelCanForget,
@@ -47,6 +47,23 @@ export function KernelCard(props: {
 }): JSX.Element {
   const owner = () => kernelOwnershipLabel(props.kernel, props.routeID)
   const busy = (action: KernelAction) => props.action === `${props.kernel.id}:${action}`
+  const launch = () => (props.kernel.active ? "Restart" : "Start runtime")
+  const metrics = () =>
+    [
+      { label: "Target", value: kernelTargetLabel(props.kernel) },
+      { label: "Runs", value: String(props.kernel.execution_count) },
+      { label: "Queued", value: props.kernel.queue_depth > 0 ? String(props.kernel.queue_depth) : "Unavailable" },
+      {
+        label: "Runtime",
+        value:
+          props.kernel.active && props.kernel.incarnation !== null ? `r${props.kernel.incarnation}` : "Unavailable",
+      },
+      { label: "Uptime", value: kernelUptimeLabel(props.kernel) },
+      { label: "CPU", value: kernelCpuLabel(props.kernel.resources?.cpu_percent) },
+      { label: "Memory", value: kernelMemoryLabel(props.kernel.resources?.memory_bytes) },
+      { label: "GPU", value: kernelGpuLabel(props.kernel.resources?.gpu_percent) },
+      { label: "VRAM", value: kernelVramLabel(props.kernel.resources?.vram_bytes) },
+    ].filter((metric) => metric.value !== "Unavailable")
   return (
     <article
       class="kernel-card"
@@ -64,105 +81,70 @@ export function KernelCard(props: {
         </span>
         <div class="kernel-card__title">
           <strong title={kernelLabel(props.kernel)}>{kernelLabel(props.kernel)}</strong>
-          <span>{kernelLanguageLabel(props.kernel)} environment</span>
+          <span>
+            {kernelLanguageLabel(props.kernel)} · {kernelTargetLabel(props.kernel)}
+          </span>
         </div>
-        <span class="kernel-card__owner">{owner()}</span>
-      </div>
-
-      <div class="kernel-card__state" data-tone={kernelTone(props.kernel.state)}>
-        <span class="kernel-card__state-dot" aria-hidden="true" />
-        <strong>{kernelStateLabel(props.kernel.state)}</strong>
-        <span>{props.kernel.active ? "runtime active" : "runtime inactive"}</span>
-      </div>
-
-      <div class="kernel-card__metrics">
-        <Metric label="Lifecycle" value={kernelStateLabel(props.kernel.state)} />
-        <Metric label="Executions" value={String(props.kernel.execution_count)} />
-        <Metric label="Queued" value={String(props.kernel.queue_depth)} />
-        <Metric
-          label="Runtime"
-          value={props.kernel.incarnation === null ? "Unavailable" : `r${props.kernel.incarnation}`}
-        />
+        <div class="kernel-card__meta">
+          <span class="kernel-card__owner">{owner()}</span>
+          <span class="kernel-card__state" data-tone={kernelTone(props.kernel.state)}>
+            <span class="kernel-card__state-dot" aria-hidden="true" />
+            <strong>{kernelStateLabel(props.kernel.state)}</strong>
+          </span>
+        </div>
       </div>
 
       <div
-        class="kernel-card__metrics kernel-card__metrics--usage"
+        class="kernel-card__metrics"
         role="group"
-        aria-label="Target and live usage, sampled on each refresh"
-        title="CPU and memory are sampled by the server on each refresh. Unavailable means the platform did not report a value."
+        aria-label="Kernel summary and available live usage"
+        title="Live usage appears only when the host reports it."
       >
-        <Metric label="Target" value={kernelTargetLabel(props.kernel)} />
-        <Metric label="Uptime" value={kernelUptimeLabel(props.kernel)} />
-        <Metric label="CPU" value={kernelCpuLabel(props.kernel.resources?.cpu_percent)} />
-        <Metric label="Memory" value={kernelMemoryLabel(props.kernel.resources?.memory_bytes)} />
-        <Metric label="GPU" value={kernelGpuLabel(props.kernel.resources?.gpu_percent)} />
-        <Metric label="VRAM" value={kernelVramLabel(props.kernel.resources?.vram_bytes)} />
+        <For each={metrics()}>{(metric) => <Metric label={metric.label} value={metric.value} />}</For>
       </div>
-
-      <section class="kernel-card__environment" aria-label={`${kernelLanguageLabel(props.kernel)} environment`}>
-        <div class="kernel-card__environment-header">
-          <strong>{kernelLanguageLabel(props.kernel)} environment</strong>
-          <span data-tone={kernelEnvironmentTone(props.kernel)}>{kernelEnvironmentLabel(props.kernel)}</span>
-        </div>
-        <Show when={props.kernel.environment?.cwd}>
-          {(cwd) => (
-            <div class="kernel-card__environment-row">
-              <span>Working directory</span>
-              <code title={cwd()}>{cwd()}</code>
-            </div>
-          )}
-        </Show>
-        <Show when={props.kernel.environment?.atlas}>
-          <div class="kernel-card__environment-row">
-            <span>Atlas boundary</span>
-            <p>{kernelAtlasLabel(props.kernel)}</p>
-          </div>
-        </Show>
-      </section>
 
       <p class="kernel-card__recovery">{kernelRecoveryLabel(props.kernel)}</p>
 
       <div class="kernel-card__controls">
+        <Show when={kernelCanInterrupt(props.kernel)}>
+          <button
+            type="button"
+            aria-label={`Interrupt ${kernelLabel(props.kernel)}`}
+            title="Interrupt the executing cell. The runtime will preserve state when supported."
+            disabled={!!props.action}
+            onClick={() => props.onControl("interrupt")}
+          >
+            {busy("interrupt") ? "Interrupting…" : "Interrupt"}
+          </button>
+        </Show>
         <button
           type="button"
-          aria-label={`Interrupt ${kernelLabel(props.kernel)}`}
-          title={
-            kernelCanInterrupt(props.kernel)
-              ? "Interrupt the executing cell. The runtime will preserve state when supported."
-              : "Interrupt is available while this kernel is executing."
-          }
-          disabled={!!props.action || !kernelCanInterrupt(props.kernel)}
-          onClick={() => props.onControl("interrupt")}
-        >
-          {busy("interrupt") ? "Interrupting…" : "Interrupt"}
-        </button>
-        <button
-          type="button"
-          aria-label={`Restart ${kernelLabel(props.kernel)}`}
+          class="kernel-card__primary"
+          aria-label={`${launch()} ${kernelLabel(props.kernel)}`}
           title={
             props.restartDisabled
               ? props.restartTitle
-              : "Replace this runtime now. All in-memory variables and queued cells will be lost."
+              : props.kernel.active
+                ? "Replace this runtime now. All in-memory variables and queued cells will be lost."
+                : "Start this kernel in a fresh runtime."
           }
           disabled={!!props.action || props.restartDisabled}
           onClick={() => props.onControl("restart")}
         >
-          {busy("restart") ? "Restarting…" : "Restart"}
+          {busy("restart") ? (props.kernel.active ? "Restarting…" : "Starting…") : launch()}
         </button>
-        <button
-          type="button"
-          class="kernel-card__stop"
-          aria-label={`Stop ${kernelLabel(props.kernel)}`}
-          title={
-            kernelCanStop(props.kernel)
-              ? "Stop the runtime and clear its in-memory state."
-              : "This runtime is already stopped."
-          }
-          disabled={!!props.action || !kernelCanStop(props.kernel)}
-          onClick={() => props.onControl("stop")}
-        >
-          {busy("stop") ? "Stopping…" : "Stop"}
-        </button>
+        <Show when={kernelCanStop(props.kernel)}>
+          <button
+            type="button"
+            class="kernel-card__stop"
+            aria-label={`Stop ${kernelLabel(props.kernel)}`}
+            title="Stop the runtime and clear its in-memory state."
+            disabled={!!props.action}
+            onClick={() => props.onControl("stop")}
+          >
+            {busy("stop") ? "Stopping…" : "Stop"}
+          </button>
+        </Show>
         <Show when={kernelCanForget(props.kernel)}>
           <button
             type="button"
@@ -175,28 +157,50 @@ export function KernelCard(props: {
           </button>
         </Show>
       </div>
-      <p class="kernel-card__control-note">
-        Interrupt targets the active cell. Restart replaces the runtime immediately; every in-memory variable and queued
-        cell is lost. Stop clears state without starting a replacement.
-      </p>
 
       <details class="kernel-card__identity">
-        <summary>Runtime identity</summary>
+        <summary>Runtime details</summary>
         <div>
+          <Show when={props.kernel.environment}>
+            <section class="kernel-card__environment" aria-label={`${kernelLanguageLabel(props.kernel)} environment`}>
+              <div class="kernel-card__environment-header">
+                <strong>{kernelLanguageLabel(props.kernel)} environment</strong>
+                <span data-tone={kernelEnvironmentTone(props.kernel)}>{kernelEnvironmentLabel(props.kernel)}</span>
+              </div>
+              <Show when={props.kernel.environment?.cwd}>
+                {(cwd) => (
+                  <div class="kernel-card__environment-row">
+                    <span>Working directory</span>
+                    <code title={cwd()}>{cwd()}</code>
+                  </div>
+                )}
+              </Show>
+              <Show when={props.kernel.environment?.atlas}>
+                <div class="kernel-card__environment-row">
+                  <span>Atlas boundary</span>
+                  <p>{kernelAtlasLabel(props.kernel)}</p>
+                </div>
+              </Show>
+            </section>
+          </Show>
           <Identity label="Runtime ID" value={props.kernel.id} />
           <Identity label="Session ID" value={props.kernel.sessionID} />
           <Identity label="Project ID" value={props.kernel.projectID} />
-          <Identity
-            label="Process ID"
-            value={props.kernel.process_id === null ? "Unavailable" : String(props.kernel.process_id)}
-          />
-          <Identity
-            label="Process identity"
-            value={props.kernel.process_identity_verified ? "PID and process start verified" : "Unavailable"}
-          />
-          <Identity label="Process started" value={date(props.kernel.process_started_at)} />
-          <Identity label="Started" value={date(props.kernel.started_at)} />
-          <Identity label="Last activity" value={time(props.kernel.last_activity_at)} />
+          <Show when={props.kernel.process_id !== null}>
+            <Identity label="Process ID" value={String(props.kernel.process_id)} />
+          </Show>
+          <Show when={props.kernel.process_identity_verified}>
+            <Identity label="Process identity" value="PID and process start verified" />
+          </Show>
+          <Show when={props.kernel.process_started_at}>
+            <Identity label="Process started" value={date(props.kernel.process_started_at)} />
+          </Show>
+          <Show when={props.kernel.started_at}>
+            <Identity label="Started" value={date(props.kernel.started_at)} />
+          </Show>
+          <Show when={props.kernel.last_activity_at}>
+            <Identity label="Last activity" value={time(props.kernel.last_activity_at)} />
+          </Show>
         </div>
       </details>
     </article>

--- a/frontend/workspace/src/atlas/KernelPanel.test.ts
+++ b/frontend/workspace/src/atlas/KernelPanel.test.ts
@@ -18,11 +18,11 @@ describe("kernel control room", () => {
     expect(panel).toContain("kernel.id")
   })
 
-  test("keeps ownership guidance collapsed by default", () => {
+  test("keeps ownership data available without a redundant help disclosure", () => {
     const panel = source()
 
-    expect(panel).toContain("<summary>About kernels</summary>")
-    expect(panel).toContain("Kernels belong to this session.")
+    expect(panel).not.toContain("<summary>About kernels</summary>")
+    expect(panel).not.toContain("Kernels belong to this session.")
     expect(panel).not.toContain("Project inventory")
   })
 
@@ -77,16 +77,17 @@ describe("kernel control room", () => {
     expect(runtime).toContain("process_identity_verified: boolean | null")
   })
 
-  test("keeps the invoked compute control room compact and softly grouped", () => {
+  test("keeps the invoked compute control room quiet and compact", () => {
     const css = styles()
 
-    expect(css).toMatch(/\.compute-surface \.kernel-panel__header\s*\{[^}]*min-height: 44px/s)
-    expect(css).toMatch(/\.compute-surface \.kernel-panel__heading strong\s*\{[^}]*font-size: 14px/s)
-    expect(css).toMatch(/\.compute-surface \.kernel-panel__scope\s*\{[^}]*background: none/s)
-    expect(css).toMatch(/\.compute-surface \.kernel-card\s*\{[^}]*padding: 11px/s)
-    expect(css).toMatch(/\.compute-surface \.kernel-card\s*\{[^}]*border-radius: 12px/s)
+    expect(css).toMatch(/\.compute-surface__tabs\s*\{[^}]*border-bottom: 1px solid/s)
+    expect(css).toMatch(/\.compute-surface \.kernel-panel__header\s*\{[^}]*min-height: 42px/s)
+    expect(css).toMatch(/\.compute-surface \.kernel-panel__create\s*\{[^}]*grid-template-columns/s)
+    expect(css).toMatch(/\.compute-surface \.kernel-card\s*\{[^}]*padding: 12px/s)
+    expect(css).toMatch(/\.compute-surface \.kernel-card\s*\{[^}]*border-radius: var\(--compute-radius\)/s)
     expect(css).toMatch(/\.compute-surface \.kernel-card\s*\{[^}]*box-shadow: none/s)
-    expect(css).toMatch(/\.compute-surface \.kernel-card__metric\s*\{[^}]*min-height: 0/s)
+    expect(css).toMatch(/\.compute-surface \.kernel-card__metrics\s*\{[^}]*border: 0/s)
+    expect(css).toContain(".compute-surface .kernel-card__name")
   })
 
   test("materializes a new session and refreshes only while kernels are active", () => {

--- a/frontend/workspace/src/atlas/KernelPanel.test.ts
+++ b/frontend/workspace/src/atlas/KernelPanel.test.ts
@@ -18,10 +18,11 @@ describe("kernel control room", () => {
     expect(panel).toContain("kernel.id")
   })
 
-  test("keeps ownership guidance compact and inline", () => {
+  test("keeps ownership guidance collapsed by default", () => {
     const panel = source()
 
-    expect(panel).toContain("<strong>Session-owned kernels.</strong>")
+    expect(panel).toContain("<summary>About kernels</summary>")
+    expect(panel).toContain("Kernels belong to this session.")
     expect(panel).not.toContain("Project inventory")
   })
 
@@ -34,7 +35,7 @@ describe("kernel control room", () => {
     expect(panel).toContain("kernelCanInterrupt")
     expect(panel).toContain("kernelCanStop")
     expect(panel).toContain("kernelCanForget")
-    expect(panel).toContain("aria-label={`Restart ${kernelLabel(props.kernel)}`}")
+    expect(panel).toContain("aria-label={`${launch()} ${kernelLabel(props.kernel)}`}")
     expect(panel).toContain("aria-label={`Stop ${kernelLabel(props.kernel)}`}")
     expect(panel).toContain("aria-label={`Forget ${kernelLabel(props.kernel)}`}")
     expect(panel).toContain('request<KernelStatus>("/notebook/kernels"')
@@ -50,8 +51,8 @@ describe("kernel control room", () => {
     expect(panel).toContain('action === "restart" && !authority.allowed()')
     expect(panel).toContain("restartDisabled={!authority.allowed()}")
     expect(panel).toContain("disabled={!!props.action || props.restartDisabled}")
-    expect(panel).toContain("disabled={!!props.action || !kernelCanStop(props.kernel)}")
-    expect(panel).toContain("disabled={!!props.action || !kernelCanInterrupt(props.kernel)}")
+    expect(panel).toContain("<Show when={kernelCanStop(props.kernel)}>")
+    expect(panel).toContain("<Show when={kernelCanInterrupt(props.kernel)}>")
   })
 
   test("explains state preservation and recovery after controls complete", () => {
@@ -59,8 +60,7 @@ describe("kernel control room", () => {
 
     expect(panel).toContain("Runtime state was preserved.")
     expect(panel).toContain("Previous in-memory variables and queued work were cleared.")
-    expect(panel).toContain("every in-memory variable and queued")
-    expect(panel).toContain("cell is lost")
+    expect(panel).toContain("All in-memory variables and queued cells will be lost.")
     expect(panel).toContain('class="kernel-card__recovery"')
     expect(panel).toContain('role="status"')
   })
@@ -80,13 +80,13 @@ describe("kernel control room", () => {
   test("keeps the invoked compute control room compact and softly grouped", () => {
     const css = styles()
 
-    expect(css).toMatch(/\.compute-surface \.kernel-panel__header\s*\{[^}]*min-height: 48px/s)
-    expect(css).toMatch(/\.compute-surface \.kernel-panel__heading strong\s*\{[^}]*font-size: 15px/s)
-    expect(css).toMatch(/\.compute-surface \.kernel-panel__scope\s*\{[^}]*background: transparent/s)
-    expect(css).toMatch(/\.compute-surface \.kernel-card\s*\{[^}]*padding: 12px/s)
+    expect(css).toMatch(/\.compute-surface \.kernel-panel__header\s*\{[^}]*min-height: 44px/s)
+    expect(css).toMatch(/\.compute-surface \.kernel-panel__heading strong\s*\{[^}]*font-size: 14px/s)
+    expect(css).toMatch(/\.compute-surface \.kernel-panel__scope\s*\{[^}]*background: none/s)
+    expect(css).toMatch(/\.compute-surface \.kernel-card\s*\{[^}]*padding: 11px/s)
     expect(css).toMatch(/\.compute-surface \.kernel-card\s*\{[^}]*border-radius: 12px/s)
     expect(css).toMatch(/\.compute-surface \.kernel-card\s*\{[^}]*box-shadow: none/s)
-    expect(css).toMatch(/\.compute-surface \.kernel-card__metric\s*\{[^}]*min-height: 40px/s)
+    expect(css).toMatch(/\.compute-surface \.kernel-card__metric\s*\{[^}]*min-height: 0/s)
   })
 
   test("materializes a new session and refreshes only while kernels are active", () => {

--- a/frontend/workspace/src/atlas/KernelPanel.tsx
+++ b/frontend/workspace/src/atlas/KernelPanel.tsx
@@ -64,6 +64,14 @@ export function KernelPanel(props: { onEnsureSession?: () => Promise<string | un
   const [data, api] = createResource(load)
   const kernels = () => data()?.kernels ?? []
   const summary = createMemo(() => summarizeKernels(kernels()))
+  const overview = createMemo(() => {
+    if (summary().running > 0) {
+      return `${summary().running} running${summary().queued > 0 ? ` · ${summary().queued} queued` : ""}`
+    }
+    if (summary().live > 0) return `${summary().live} ready`
+    const count = kernels().length
+    return `${count} saved ${count === 1 ? "kernel" : "kernels"} · none running`
+  })
   const ensureSession = async () => {
     if (params.id && params.id !== "new") return params.id
     return props.onEnsureSession?.()
@@ -159,11 +167,8 @@ export function KernelPanel(props: { onEnsureSession?: () => Promise<string | un
     <section aria-label="Session kernel control room" data-testid="kernel-panel" class="kernel-panel">
       <header class="kernel-panel__header">
         <div class="kernel-panel__heading">
-          <span class="kernel-panel__eyebrow">Compute</span>
-          <strong>Session kernels</strong>
-          <span>
-            {summary().live} live · {summary().running} running · {summary().queued} queued
-          </span>
+          <strong>Kernels</strong>
+          <span>{overview()}</span>
         </div>
         <div class="kernel-panel__refresh">
           <Show when={view.updated}>
@@ -232,15 +237,13 @@ export function KernelPanel(props: { onEnsureSession?: () => Promise<string | un
           </form>
         </Show>
 
-        <section class="kernel-panel__scope" aria-label="Kernel ownership model">
-          <span class="kernel-panel__scope-icon" aria-hidden="true">
-            <IconCpu size={13} strokeWidth={1.5} />
-          </span>
+        <details class="kernel-panel__scope">
+          <summary>About kernels</summary>
           <p>
-            <strong>Session-owned kernels.</strong> Named records survive app restarts; live variables persist only
-            while their backend process remains alive.
+            Kernels belong to this session. Named records survive app restarts; live variables last only while the
+            runtime is active.
           </p>
-        </section>
+        </details>
 
         <Show when={authority.message()}>
           {(message) => (
@@ -271,8 +274,8 @@ export function KernelPanel(props: { onEnsureSession?: () => Promise<string | un
               <span aria-hidden="true">
                 <IconCpu size={15} strokeWidth={1.4} />
               </span>
-              <strong>No active kernels</strong>
-              <p>A real session exposes its default Python record here before starting a process.</p>
+              <strong>No kernels yet</strong>
+              <p>Create a named Python or R runtime for work that needs its own in-memory state.</p>
             </div>
           }
         >

--- a/frontend/workspace/src/atlas/KernelPanel.tsx
+++ b/frontend/workspace/src/atlas/KernelPanel.tsx
@@ -167,7 +167,6 @@ export function KernelPanel(props: { onEnsureSession?: () => Promise<string | un
     <section aria-label="Session kernel control room" data-testid="kernel-panel" class="kernel-panel">
       <header class="kernel-panel__header">
         <div class="kernel-panel__heading">
-          <strong>Kernels</strong>
           <span>{overview()}</span>
         </div>
         <div class="kernel-panel__refresh">
@@ -236,14 +235,6 @@ export function KernelPanel(props: { onEnsureSession?: () => Promise<string | un
             </div>
           </form>
         </Show>
-
-        <details class="kernel-panel__scope">
-          <summary>About kernels</summary>
-          <p>
-            Kernels belong to this session. Named records survive app restarts; live variables last only while the
-            runtime is active.
-          </p>
-        </details>
 
         <Show when={authority.message()}>
           {(message) => (

--- a/frontend/workspace/src/atlas/RightPane.tsx
+++ b/frontend/workspace/src/atlas/RightPane.tsx
@@ -366,6 +366,7 @@ export function RightPane(
                       <ExternalFileAccess
                         file={file}
                         active={context() === "files" || context() === "artifact"}
+                        onEnsureSession={props.onEnsureSession}
                         onClose={() => uiStore.closeFile()}
                       />
                     }
@@ -389,7 +390,7 @@ export function RightPane(
                 {(current) => <StoredArtifactView artifact={current()} />}
               </Match>
               <Match when={context() === "files" && !uiStore.file() && !uiStore.saved()}>
-                <FileExplorer />
+                <FileExplorer onEnsureSession={props.onEnsureSession} />
               </Match>
               <Match when={context() === "terminal"}>
                 <TerminalSurface />

--- a/frontend/workspace/src/atlas/file-location-menu.test.ts
+++ b/frontend/workspace/src/atlas/file-location-menu.test.ts
@@ -1,4 +1,6 @@
 import { afterAll, afterEach, describe, expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
 import type { JSX } from "solid-js"
 import { createServer } from "vite"
 import solid from "vite-plugin-solid"
@@ -96,6 +98,7 @@ const setup = (
     trash?: StoredArtifact[]
     onRestoreArtifact?: (artifact: StoredArtifact) => void
     onChoose?: (kind: "folder" | "file") => Promise<string | undefined>
+    sessionReady?: boolean
   } = {},
 ) =>
   mount(() =>
@@ -104,7 +107,7 @@ const setup = (
       trash: options.trash ?? [],
       grants,
       projectRoot: "/Users/aayam/kras-speedrun",
-      sessionReady: true,
+      sessionReady: options.sessionReady ?? true,
       onOpenProject: () => {},
       onOpenSession: () => {},
       onOpenArtifact: () => {},
@@ -184,6 +187,23 @@ describe("Files sources", () => {
     form?.dispatchEvent(new SubmitEvent("submit", { bubbles: true, cancelable: true }))
 
     expect(requests).toEqual([{ path: "/outside/lab", access: "read", scope: "session" }])
+  })
+
+  test("allows picking a connection before a session exists", () => {
+    const host = setup({ sessionReady: false })
+    const connect = host.querySelector<HTMLButtonElement>('[aria-label="Connect another location"]')
+
+    expect(connect?.disabled).toBe(false)
+    expect(host.textContent).toContain("A research session will start automatically")
+    connect?.click()
+    expect(host.querySelector('[aria-label="Connect file or folder access"]')).not.toBeNull()
+  })
+
+  test("creates the required session only when the connection is submitted", () => {
+    const source = readFileSync(fileURLToPath(new URL("./FileExplorer.tsx", import.meta.url)), "utf8")
+
+    expect(source).toContain("sessionID() ?? (await props.onEnsureSession?.())")
+    expect(source).toContain("const current = identity(session)")
   })
 
   test("shows trashed artifacts as recoverable for 30 days", () => {

--- a/frontend/workspace/src/components/settings/Storage.tsx
+++ b/frontend/workspace/src/components/settings/Storage.tsx
@@ -57,13 +57,7 @@ export const Storage: Component = () => {
     if (busy()) return
     setError(undefined)
     setStatus(undefined)
-    let target: string | undefined
-    if (platform.openDirectoryPickerDialog) {
-      const picked = await platform.openDirectoryPickerDialog({ title: "Choose a new data location" }).catch(() => null)
-      target = Array.isArray(picked) ? picked[0] : (picked ?? undefined)
-    } else {
-      target = window.prompt("New absolute path for the data directory:") ?? undefined
-    }
+    const target = window.prompt("New absolute path for the data directory:") ?? undefined
     if (!target?.trim()) return
     setBusy(true)
     try {

--- a/frontend/workspace/src/components/settings/truth-pass.test.ts
+++ b/frontend/workspace/src/components/settings/truth-pass.test.ts
@@ -60,6 +60,13 @@ describe("launch settings truth pass", () => {
     expect(source("Storage.tsx")).not.toContain("manage cloud credentials")
   })
 
+  test("keeps storage relocation as an explicit absolute path", () => {
+    const storage = source("Storage.tsx")
+
+    expect(storage).toContain('window.prompt("New absolute path for the data directory:")')
+    expect(storage).not.toContain("openDirectoryPickerDialog")
+  })
+
   test("connectors persist enablement and inspect real server capabilities", () => {
     const connectors = source("Connectors.tsx")
 

--- a/frontend/workspace/src/context/platform.tsx
+++ b/frontend/workspace/src/context/platform.tsx
@@ -26,11 +26,19 @@ export type Platform = {
   /** Send a system notification (optional deep link) */
   notify(title: string, description?: string, href?: string): Promise<void>
 
-  /** Open directory picker dialog (native on Tauri, server-backed on web) */
-  openDirectoryPickerDialog?(opts?: { title?: string; multiple?: boolean }): Promise<string | string[] | null>
+  /** Open an OS-native directory picker. Undefined means the current platform cannot provide one. */
+  openDirectoryPickerDialog?(opts?: {
+    title?: string
+    multiple?: boolean
+    server?: string
+  }): Promise<string | string[] | null | undefined>
 
-  /** Open native file picker dialog (Tauri only) */
-  openFilePickerDialog?(opts?: { title?: string; multiple?: boolean }): Promise<string | string[] | null>
+  /** Open an OS-native file picker. Undefined means the current platform cannot provide one. */
+  openFilePickerDialog?(opts?: {
+    title?: string
+    multiple?: boolean
+    server?: string
+  }): Promise<string | string[] | null | undefined>
 
   /** Save file picker dialog (Tauri only) */
   saveFilePickerDialog?(opts?: { title?: string; defaultPath?: string }): Promise<string | null>

--- a/frontend/workspace/src/entry.tsx
+++ b/frontend/workspace/src/entry.tsx
@@ -5,6 +5,7 @@ import { Platform, PlatformProvider } from "@/context/platform"
 import { dict as en } from "@/i18n/en"
 import { dict as zh } from "@/i18n/zh"
 import { openscienceFetch } from "@/utils/openscience-fetch"
+import { openNativePicker } from "@/utils/native-picker"
 import { URLS } from "@/config/urls"
 import pkg from "../package.json"
 
@@ -67,6 +68,8 @@ const platform: Platform = {
       })
       .catch(() => undefined)
   },
+  openDirectoryPickerDialog: (options) => openNativePicker("folder", options, openscienceFetch),
+  openFilePickerDialog: (options) => openNativePicker("file", options, openscienceFetch),
   checkUpdate: async () => {
     const response = await openscienceFetch("/settings/updates", { headers: { Accept: "application/json" } })
     if (!response.ok) throw new Error(`Update check failed (${response.status})`)

--- a/frontend/workspace/src/pages/home.tsx
+++ b/frontend/workspace/src/pages/home.tsx
@@ -114,9 +114,12 @@ export default function Home(): JSX.Element {
       const result = await platform.openDirectoryPickerDialog({
         title: language.t("command.project.open"),
         multiple: true,
+        server: sdk.url,
       })
-      resolve(result)
-      return
+      if (result !== undefined) {
+        resolve(result)
+        return
+      }
     }
 
     dialog.show(() => <FolderPicker onSelect={resolve} />, {
@@ -145,9 +148,15 @@ export default function Home(): JSX.Element {
 
   async function chooseProjectSources() {
     if (platform.openDirectoryPickerDialog && server.isLocal()) {
-      const result = await platform.openDirectoryPickerDialog({ title: "Add source folders", multiple: true })
-      mergeSources(result)
-      return
+      const result = await platform.openDirectoryPickerDialog({
+        title: "Add source folders",
+        multiple: true,
+        server: sdk.url,
+      })
+      if (result !== undefined) {
+        mergeSources(result)
+        return
+      }
     }
 
     const selection = { result: null as string | string[] | null }

--- a/frontend/workspace/src/pages/session-shell.test.ts
+++ b/frontend/workspace/src/pages/session-shell.test.ts
@@ -117,6 +117,14 @@ describe("focused workspace shell", () => {
     expect(session).not.toContain(">Inspector</span>")
   })
 
+  test("shows Atlas from the saved workspace preference without requiring an account session", () => {
+    const session = read("./session.tsx")
+
+    expect(session).toContain("const atlasAvailable = productPreferences.atlas")
+    expect(session).not.toContain("atlasConnected")
+    expect(session).not.toContain("fetchSetupSession")
+  })
+
   test("derives Files and contextual selection from the surfaces they open", () => {
     const session = read("./session.tsx")
     const action = read("./session-sidebar-action.tsx")
@@ -210,6 +218,8 @@ describe("focused workspace shell", () => {
     expect(pane).toContain('class="research-inspector__header"')
     expect(pane).toContain('class="research-inspector__context"')
     expect(pane).toContain("<TerminalSurface />")
+    expect(pane).toContain("<FileExplorer onEnsureSession={props.onEnsureSession} />")
+    expect(pane).toContain("onEnsureSession={props.onEnsureSession}")
     expect(pane).toContain("narrow() ? uiStore.closeContext() : uiStore.closeWorkTab()")
     expect(pane).toContain("<WorkTabStrip")
     expect(pane).not.toContain('class="research-inspector__tabs"')

--- a/frontend/workspace/src/pages/session.tsx
+++ b/frontend/workspace/src/pages/session.tsx
@@ -58,7 +58,6 @@ import { StatusDot } from "@/atlas/shared/StatusDot"
 import { IconTrash } from "@/atlas/shared/Icon"
 import { toast } from "@/atlas/Toast"
 import { artifactContext } from "@/artifacts/context"
-import { fetchSetupSession } from "@/atlas/setup-session"
 import { createSessionTabs } from "@/atlas/store/sessionTabs"
 import { ProjectTrustControl } from "@/atlas/ProjectTrust"
 import { projectTrustApi, type ProjectTrustApi } from "@/atlas/project-trust"
@@ -106,21 +105,7 @@ export default function Page(): JSX.Element {
   const pending: { value?: Promise<string | undefined>; context?: SessionContext } = {}
   const [mobileSessionsOpen, setMobileSessionsOpen] = createSignal(false)
   const [sessionsCollapsed, setSessionsCollapsed] = createSignal(readSessionSidebar())
-  const [atlasConnected, setAtlasConnected] = createSignal(false)
   const sessionTabs = createSessionTabs()
-
-  createEffect(
-    on(
-      () => server.url,
-      (url) => {
-        setAtlasConnected(false)
-        if (!url) return
-        void fetchSetupSession(url, platform.fetch ?? fetch)
-          .then(setAtlasConnected)
-          .catch(() => setAtlasConnected(false))
-      },
-    ),
-  )
 
   createEffect(
     on(
@@ -177,7 +162,7 @@ export default function Page(): JSX.Element {
     return task
   }
 
-  const atlasAvailable = () => atlasConnected() && productPreferences.atlas()
+  const atlasAvailable = productPreferences.atlas
 
   createEffect(() => {
     if (productPreferences.atlas()) return

--- a/frontend/workspace/src/utils/native-picker.ts
+++ b/frontend/workspace/src/utils/native-picker.ts
@@ -1,0 +1,42 @@
+import { resolveServerRoute } from "@/config/server-url"
+
+export type NativePickerOptions = {
+  title?: string
+  multiple?: boolean
+  server?: string
+}
+
+type NativePickerResult = {
+  paths?: unknown
+  error?: unknown
+  unsupported?: unknown
+}
+
+export async function openNativePicker(
+  kind: "folder" | "file",
+  options: NativePickerOptions = {},
+  request: typeof fetch = fetch,
+): Promise<string | string[] | null | undefined> {
+  const route = options.server
+    ? resolveServerRoute("/api/resolve-folder/dialog", options.server, window.location.origin)
+    : "/api/resolve-folder/dialog"
+  const response = await request(route, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ kind, title: options.title, multiple: options.multiple ?? false }),
+  })
+
+  if (response.status === 501) return undefined
+
+  const result = (await response.json().catch(() => ({}))) as NativePickerResult
+  if (result.error === "cancelled") return null
+  if (!response.ok)
+    throw new Error(typeof result.error === "string" ? result.error : `Picker failed (${response.status})`)
+
+  const paths = Array.isArray(result.paths)
+    ? result.paths.filter((value): value is string => typeof value === "string")
+    : []
+  if (paths.length === 0) return null
+  if (options.multiple) return paths
+  return paths[0]
+}


### PR DESCRIPTION
## Summary

- restore host-native macOS and Windows pickers for project imports, source folders, and direct file/folder connections
- keep Storage relocation on the explicit absolute-path flow
- make Atlas navigation follow the saved General toggle immediately, without requiring an account-session probe
- allow file and folder connections before a session exists by creating the required session on demand
- simplify the kernel panel into a quiet compact surface with underline tabs, flat metrics, a responsive creation form, and collapsed details
- launch sandboxed zsh terminals without user startup files and with a clean project prompt
- preserve each queued notebook cell execution count while kernel state persists concurrently

## Verification

- root typecheck: 7 packages passed
- focused frontend tests: 40 passed
- focused Compute browser E2E: passed
- production frontend build: passed
- isolated local browser verification: Atlas toggle/nav, pre-session file connection, compact Compute card/form, no browser warnings or errors
- npm test publish: `2.0.2-test.76.1`
- packaged browser E2E: passed
- npm package smoke: Linux x64, Linux ARM64, macOS, and Windows passed
- test-publish run: https://github.com/synthetic-sciences/openscience/actions/runs/30813082835

This PR is intentionally left unmerged. Nothing was published to npm `latest` or production.