### PR TITLE
Fix Grok 4.5 (xAI BYOK): accept null usage on the Responses stream open

### DIFF
--- a/backend/cli/src/provider/provider.ts
+++ b/backend/cli/src/provider/provider.ts
@@ -398,6 +398,13 @@ export namespace Provider {
         // Responses API. The pinned chat adapter accepts only low/high and
         // rejects medium before sending a request, so route just this family
         // through responses while preserving chat behavior for older models.
+        //
+        // This responses path only works because of
+        // tooling/patches/@ai-sdk%2Fxai@2.0.51.patch. xAI opens every stream
+        // with `response.created` carrying `"usage": null`, which the pinned
+        // 2.0.51 schema rejects (it marks usage optional, not nullable), so
+        // Grok 4.5 died on its first SSE event. @ai-sdk/xai@4.0.25 ships the
+        // same fix upstream; drop the patch when the @ai-sdk major bump lands.
         async getModel(sdk: any, modelID: string) {
           return /grok-4[.-]5\b/i.test(modelID) ? sdk.responses(modelID) : sdk.languageModel(modelID)
         },

--- a/backend/cli/test/provider/xai-responses-usage.test.ts
+++ b/backend/cli/test/provider/xai-responses-usage.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test"
+import { createXai } from "@ai-sdk/xai"
+import { streamText } from "ai"
+
+/** A Grok 4.5 turn replayed from the wire. xAI opens every Responses stream
+ *  with `response.created` carrying `"usage": null`; @ai-sdk/xai@2.0.51 marked
+ *  that field optional (accepts *absent*) rather than nullable, so the first
+ *  SSE event failed every branch of the chunk union and the turn died before
+ *  any content. tooling/patches/@ai-sdk%2Fxai@2.0.51.patch makes it nullish,
+ *  matching the upstream fix in @ai-sdk/xai@4.0.25. */
+const events = [
+  {
+    sequence_number: 0,
+    type: "response.created",
+    response: {
+      created_at: 1785764408,
+      id: "55a979f0-880b-9e72-85bd-0e7211a8ea43",
+      model: "grok-4.5",
+      object: "response",
+      output: [],
+      usage: null,
+      status: "in_progress",
+    },
+  },
+  {
+    type: "response.output_item.added",
+    output_index: 0,
+    item: { type: "message", role: "assistant", content: [], id: "msg-1", status: "in_progress" },
+  },
+  {
+    type: "response.content_part.added",
+    item_id: "msg-1",
+    output_index: 0,
+    content_index: 0,
+    part: { type: "output_text", text: "" },
+  },
+  { type: "response.output_text.delta", item_id: "msg-1", output_index: 0, content_index: 0, delta: "OK" },
+  { type: "response.output_text.done", item_id: "msg-1", output_index: 0, content_index: 0, text: "OK" },
+  {
+    type: "response.content_part.done",
+    item_id: "msg-1",
+    output_index: 0,
+    content_index: 0,
+    part: { type: "output_text", text: "OK" },
+  },
+  {
+    type: "response.output_item.done",
+    output_index: 0,
+    item: {
+      type: "message",
+      role: "assistant",
+      content: [{ type: "output_text", text: "OK" }],
+      id: "msg-1",
+      status: "completed",
+    },
+  },
+  {
+    type: "response.completed",
+    response: {
+      created_at: 1785764408,
+      id: "55a979f0-880b-9e72-85bd-0e7211a8ea43",
+      model: "grok-4.5",
+      object: "response",
+      output: [
+        {
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: "OK" }],
+          id: "msg-1",
+          status: "completed",
+        },
+      ],
+      usage: { input_tokens: 9, output_tokens: 2, total_tokens: 11 },
+      status: "completed",
+    },
+  },
+]
+
+/** Canned SSE body: data, not a mock. Nothing inside the provider is stubbed —
+ *  the real @ai-sdk/xai Responses model parses these bytes. */
+function replay() {
+  const body = events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")
+  const fetch = async () => new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } })
+  return fetch as unknown as typeof globalThis.fetch
+}
+
+describe("xAI Responses stream tolerates a null usage on response.created", () => {
+  test("Grok 4.5 streams its text instead of aborting on the opening chunk", async () => {
+    const sdk = createXai({ apiKey: "test", baseURL: "https://xai.test/v1", fetch: replay() })
+    const result = streamText({ model: sdk.responses("grok-4.5"), prompt: "Reply with exactly: OK" })
+
+    const errors: unknown[] = []
+    const text: string[] = []
+    for await (const part of result.fullStream) {
+      if (part.type === "error") errors.push(part.error)
+      if (part.type === "text-delta") text.push(part.text)
+    }
+
+    expect(errors).toEqual([])
+    expect(text.join("")).toBe("OK")
+  })
+})

--- a/bun.lock
+++ b/bun.lock
@@ -296,6 +296,7 @@
   ],
   "patchedDependencies": {
     "@ai-sdk/openai@2.0.89": "tooling/patches/@ai-sdk%2Fopenai@2.0.89.patch",
+    "@ai-sdk/xai@2.0.51": "tooling/patches/@ai-sdk%2Fxai@2.0.51.patch",
     "@ai-sdk/anthropic@2.0.57": "tooling/patches/@ai-sdk%2Fanthropic@2.0.57.patch",
     "ghostty-web@0.3.0": "tooling/patches/ghostty-web@0.3.0.patch",
   },

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
   "patchedDependencies": {
     "ghostty-web@0.3.0": "tooling/patches/ghostty-web@0.3.0.patch",
     "@ai-sdk/anthropic@2.0.57": "tooling/patches/@ai-sdk%2Fanthropic@2.0.57.patch",
-    "@ai-sdk/openai@2.0.89": "tooling/patches/@ai-sdk%2Fopenai@2.0.89.patch"
+    "@ai-sdk/openai@2.0.89": "tooling/patches/@ai-sdk%2Fopenai@2.0.89.patch",
+    "@ai-sdk/xai@2.0.51": "tooling/patches/@ai-sdk%2Fxai@2.0.51.patch"
   }
 }

--- a/tooling/patches/@ai-sdk%2Fxai@2.0.51.patch
+++ b/tooling/patches/@ai-sdk%2Fxai@2.0.51.patch
@@ -1,0 +1,41 @@
+Make `usage` nullish in xAI's Responses stream schema.
+
+xAI's first SSE event (`response.created`) carries `"usage": null`. Upstream
+2.0.51 wrote `xaiResponsesResponseSchema.partial({ usage: true })`, which makes
+the field *optional* (accepts absent) but not *nullable* — so every union branch
+of `xaiResponsesChunkSchema` fails with `["response","usage"]: expected object,
+received null` and the stream aborts before any content. Only Grok 4.5 is hit,
+because provider.ts routes just that family through `sdk.responses()`.
+
+@ai-sdk/xai@4.0.25 fixes this upstream with exactly this change
+(`usage: xaiResponsesUsageSchema.nullish()`). We cannot take 4.x yet: it needs
+@ai-sdk/provider@4.0.4 against our pinned 2.0.1, two majors of the shared spec.
+
+DELETE THIS PATCH when the @ai-sdk major migration lands.
+
+diff --git a/dist/index.js b/dist/index.js
+index 0cc2af9842b698c0a29ae2bbebf9c72f17bf3253..cfccbdebee98cafea6cb13e5a91fc46494cecb6c 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -964,7 +964,7 @@ var xaiResponsesResponseSchema = import_v44.z.object({
+   model: import_v44.z.string().nullish(),
+   object: import_v44.z.literal("response"),
+   output: import_v44.z.array(outputItemSchema),
+-  usage: xaiResponsesUsageSchema,
++  usage: xaiResponsesUsageSchema.nullish(),
+   status: import_v44.z.string()
+ });
+ var xaiResponsesChunkSchema = import_v44.z.union([
+diff --git a/dist/index.mjs b/dist/index.mjs
+index 72ffc7ff8cb2c364e8967ae03d7c3d226cc8d2b0..66f90ce51b5c8eeb942806a59991d1eec2657be7 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -959,7 +959,7 @@ var xaiResponsesResponseSchema = z4.object({
+   model: z4.string().nullish(),
+   object: z4.literal("response"),
+   output: z4.array(outputItemSchema),
+-  usage: xaiResponsesUsageSchema,
++  usage: xaiResponsesUsageSchema.nullish(),
+   status: z4.string()
+ });
+ var xaiResponsesChunkSchema = z4.union([


### PR DESCRIPTION
### What does this PR do?

Fixes Grok 4.5 (xAI BYOK), which failed on **every** prompt with `AI_TypeValidationError` before emitting any content. Grok 4.2 and every other xAI model were unaffected.

`provider.ts:394` routes only Grok 4.5 through xAI's **Responses API** (`sdk.responses()`); everything else uses `sdk.languageModel()` (chat). So only 4.5 is validated against the Responses schema.

xAI opens every stream with:

```json
{"type":"response.created","response":{ …, "usage": null, "status":"in_progress", … }}
```

`@ai-sdk/xai@2.0.51` declares that field as **required**, and the `response.created` / `response.in_progress` union members relax it with `.partial({ usage: true })`:

```js
usage: xaiResponsesUsageSchema,   // required
…
response: xaiResponsesResponseSchema.partial({ usage: true, status: true })
```

`.partial()` makes a field **optional** — it accepts *absent*. xAI sends it **present and null**, and Zod's `.optional()` does not accept `null`; that needs `.nullable()`/`.nullish()`. So the very first SSE event fails every branch of the chunk union with `path: ["response","usage"] — expected object, received null`, and the stream aborts. That is why the failure was immediate and why the UI showed an empty / compacted context.

**This is fixed upstream.** `@ai-sdk/xai@4.0.25` changes exactly one thing in that schema:

```ts
usage: xaiResponsesUsageSchema.nullish(),
```

This PR applies that same one-line change as a pinned dependency patch, using the convention already established here — bun `patchedDependencies` with the patch under `tooling/patches/`, alongside the existing `@ai-sdk/anthropic` and `@ai-sdk/openai` patches.

### Why patch instead of upgrading the SDK?

`@ai-sdk/xai@4.x` requires `@ai-sdk/provider@4.0.4` against the pinned `2.0.1` — **two majors of the interface every provider implements** — dragging ~20 `@ai-sdk/*` packages plus `ai` core, and anything implementing the model interfaces (`transform.ts`, the custom loaders in `provider.ts`).

That upgrade is worth doing and is being scheduled separately. It should not be the vehicle for a user-facing regression fix: bundling them makes the fix unverifiable (a regression in, say, Bedrock could not be attributed), and Grok 4.5 stays broken for the length of the migration.

The patch header and a comment at `provider.ts:394` both record that 4.0.25 fixes this upstream and that **the patch should be deleted when the SDK migration lands**.

### How did you verify your code works?

**Live, against a real xAI key**, rebuilt binary, isolated config and data:

```
openscience run -m xai/grok-4.5 "Reply with exactly: OK"
```

- **Before:** `AI_TypeValidationError` naming `["response","usage"]`, exit 1.
- **After:** `OK`, exit 0.

Confirmed twice — once by the implementer, once independently from a fresh build.

Chat path unaffected: the same probe against a non-4.5 xAI model succeeds before and after.

**Offline regression test** (`backend/cli/test/provider/xai-responses-usage.test.ts`) feeds a `response.created` chunk carrying `"usage": null` through the real provider via a stubbed `fetch` — no network, no key. **Mutation-verified:** with the patch reverted it fails with exactly the production error; restored, it passes.

Suite: 1723 pass / 2 fail — both on the repo's known pre-existing list (`npm selects every supported native package contract…`, and `killTree SIGKILLs a detached group`, re-verified passing standalone). Typecheck 7/7 green.

### Notes for the reviewer

- **`patchedDependencies` keys on the exact version string** (`@ai-sdk/xai@2.0.51`). Any bump within 2.x silently drops the patch with no install-time error, and Grok 4.5 breaks again. The regression test is the only guard — worth remembering when the SDK migration is planned.
- The patch matches upstream 4.0.25 exactly rather than narrowing to `response.created`, so it also loosens `response.done` / `response.completed`. Consequence: a null `usage` on a *terminal* event would degrade to zero-usage rather than erroring. Deliberate — staying identical to upstream keeps the eventual migration a clean deletion.
- Live coverage is a single-turn prompt: no tool calls, reasoning summaries, or web search. Those exercise other parts of the Responses schema, and since this bug was a schema mismatch on the very first event, further mismatches may exist deeper in a stream.
- The patch was verified to survive a from-scratch `bun install --frozen-lockfile`.

### Checklist

- [x] `bun run typecheck` passes
- [x] `bun test` (in `backend/cli`) passes — modulo the pre-existing failures noted above
- [x] `bunx prettier --check` is clean on changed files
- [ ] Linked an issue — the report this came from is not filed as a GitHub issue
- [ ] Screenshots for UI changes — none; backend only
