### PR TITLE
fix(kernel): publish a booting kernel only once its cell holds the queue slot

### DIFF
--- a/backend/cli/src/science/kernel/registry.ts
+++ b/backend/cli/src/science/kernel/registry.ts
@@ -470,11 +470,16 @@ export namespace KernelRuntime {
     value.lastActivityAt = startedAt
     return kernel.execute(code, options).then(
       async (result) => {
-        value.executionCount = result.executionCount ?? value.executionCount + 1
+        // The count belongs to this cell, so capture it before the awaits below.
+        // `value.executionCount` is the kernel's running total and every cell
+        // queued behind this one advances it — reading it back after the persist
+        // reported the count of whichever cell had most recently finished.
+        const count = result.executionCount ?? value.executionCount + 1
+        value.executionCount = count
         const completedAt = Date.now()
         value.lastActivityAt = completedAt
         await persist(value)
-        const complete = { ...result, executionCount: value.executionCount }
+        const complete = { ...result, executionCount: count }
         const node = await provenance(
           identity,
           value,

--- a/backend/cli/src/science/kernel/registry.ts
+++ b/backend/cli/src/science/kernel/registry.ts
@@ -362,37 +362,54 @@ const entry = async (identity: KernelIdentity, _options?: KernelStartOptions) =>
   value.startedAt = null
   value.lastActivityAt = Date.now()
   value.authority = authority
-  await persist(value)
-  const start = value.manager
-    .get(value.key, {
+  const drop = () => {
+    if (records().starts.get(value.key)?.ticket === ticket) records().starts.delete(value.key)
+  }
+  const stale = () => ticket.cancelled || records().entries.get(value.key) !== value
+  const abort = async () => {
+    drop()
+    await value.manager.release(value.key)
+    throw new KernelStartupCancelled()
+  }
+  // Booting runs inside a call so the pending-start record below is claimed in
+  // this same synchronous block. The boot awaits (persist, then the process
+  // spawn), and a cell that arrives during one of them has to find the in-flight
+  // start to queue behind — publishing the record after those awaits let it
+  // instead see an entry with no start and boot a second incarnation of its own.
+  const start = (async () => {
+    await persist(value)
+    return value.manager.get(value.key, {
       sessionID: identity.sessionID,
       cwd: authority.workspace,
     })
-    .then(
-      async (kernel) => {
-        if (records().starts.get(value.key)?.ticket === ticket) records().starts.delete(value.key)
-        if (ticket.cancelled || records().entries.get(value.key) !== value) {
-          await value.manager.release(value.key)
-          throw new KernelStartupCancelled()
-        }
-        value.kernel = kernel
-        value.environment = kernel.environment ?? null
-        value.authority = authority
-        value.startedAt = kernel.process?.startedAt ?? Date.now()
-        value.lastActivityAt = value.startedAt
-        await persist(value)
-        return value
-      },
-      async (error) => {
-        if (records().starts.get(value.key)?.ticket === ticket) records().starts.delete(value.key)
-        value.kernel = undefined
-        value.authority = authority
-        value.state = ticket.cancelled ? "stopped" : "crashed"
-        await persist(value)
-        if (ticket.cancelled) throw new KernelStartupCancelled()
-        throw error
-      },
-    )
+  })().then(
+    async (kernel) => {
+      if (stale()) return abort()
+      value.environment = kernel.environment ?? null
+      value.authority = authority
+      value.startedAt = kernel.process?.startedAt ?? Date.now()
+      value.lastActivityAt = value.startedAt
+      await persist(value)
+      if (stale()) return abort()
+      // Handing the kernel over is the last, synchronous step of the boot.
+      // `/status` and the ready fast path above both read `value.kernel`, so
+      // publishing it before the persist above advertised an idle, ready kernel
+      // while the cell whose request booted it had not reached the execution
+      // queue yet — a cell arriving in that window took the free slot first.
+      drop()
+      value.kernel = kernel
+      return value
+    },
+    async (error) => {
+      drop()
+      value.kernel = undefined
+      value.authority = authority
+      value.state = ticket.cancelled ? "stopped" : "crashed"
+      await persist(value)
+      if (ticket.cancelled) throw new KernelStartupCancelled()
+      throw error
+    },
+  )
   records().starts.set(value.key, {
     identity,
     key: value.key,

--- a/backend/cli/test/server/notebook.test.ts
+++ b/backend/cli/test/server/notebook.test.ts
@@ -603,12 +603,14 @@ describe("/notebook routes", () => {
         // Sample the value `/status` serves on every macrotask turn. Polling the
         // route instead would do enough I/O per attempt to step straight over the
         // window this pins, which is what let the defect stay invisible.
-        const ready = async (attempt = 0): Promise<ReturnType<typeof KernelRuntime.status>> => {
-          const status = KernelRuntime.status(id)
-          if (status.active) return status
-          if (attempt >= 500_000) throw new Error("kernel did not start")
-          await Bun.sleep(0)
-          return ready(attempt + 1)
+        const deadline = Date.now() + 20_000
+        const ready = async () => {
+          while (Date.now() < deadline) {
+            const status = KernelRuntime.status(id)
+            if (status.active) return status
+            await Bun.sleep(0)
+          }
+          throw new Error("kernel did not start")
         }
         // A client that waits for the kernel and then sends its next cell must not
         // be able to overtake the cell that booted it, so the kernel may not turn

--- a/backend/cli/test/server/notebook.test.ts
+++ b/backend/cli/test/server/notebook.test.ts
@@ -6,6 +6,7 @@ import { Provenance } from "../../src/science/provenance/store"
 import { Session } from "../../src/session"
 import { Identifier } from "../../src/id/id"
 import { Server } from "../../src/server/server"
+import { KernelRuntime } from "../../src/science/kernel/registry"
 import { Sandbox } from "../../src/sandbox/sandbox"
 
 const alive = (pid: number) => {
@@ -570,6 +571,99 @@ describe("/notebook routes", () => {
             id: "analysis.ipynb",
             language: "python",
           }),
+        })
+      },
+    })
+  }, 30_000)
+
+  test("holds the queue slot of the booting cell before the kernel reports active", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await trustProject()
+        const app = NotebookRoutes()
+        const session = await Session.create({})
+        const id = {
+          projectID: Instance.project.id,
+          sessionID: session.id,
+          name: "notebook:analysis.ipynb",
+          language: "python" as const,
+        }
+        const cell = app.request("/execute", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            sessionID: session.id,
+            id: "analysis.ipynb",
+            language: "python",
+            code: "(__import__('time').sleep(0.5), 'first')[-1]",
+          }),
+        })
+        // Sample the value `/status` serves on every macrotask turn. Polling the
+        // route instead would do enough I/O per attempt to step straight over the
+        // window this pins, which is what let the defect stay invisible.
+        const ready = async (attempt = 0): Promise<ReturnType<typeof KernelRuntime.status>> => {
+          const status = KernelRuntime.status(id)
+          if (status.active) return status
+          if (attempt >= 500_000) throw new Error("kernel did not start")
+          await Bun.sleep(0)
+          return ready(attempt + 1)
+        }
+        // A client that waits for the kernel and then sends its next cell must not
+        // be able to overtake the cell that booted it, so the kernel may not turn
+        // reachable until that cell already occupies the queue.
+        expect((await ready()).state).toBe("running")
+        const result = (await (await cell).json()) as { execution_count: number }
+        expect(result.execution_count).toBe(1)
+
+        await app.request("/stop", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ sessionID: session.id, id: "analysis.ipynb", language: "python" }),
+        })
+      },
+    })
+  }, 30_000)
+
+  test("boots one incarnation when a second cell arrives during startup", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await trustProject()
+        const app = NotebookRoutes()
+        const session = await Session.create({})
+        const execute = (code: string) =>
+          app.request("/execute", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              sessionID: session.id,
+              id: "analysis.ipynb",
+              language: "python",
+              code,
+            }),
+          })
+
+        // Both cells are in flight before the kernel process exists, so the second
+        // has to find the startup already in flight and wait on it. Without that
+        // record it opened a startup of its own and burned an extra incarnation.
+        await Promise.all([execute("boot = 1"), execute("boot = 2")])
+        const status = await app.request(
+          `/status?sessionID=${encodeURIComponent(session.id)}&id=analysis.ipynb&language=python`,
+        )
+        expect(await status.json()).toMatchObject({
+          active: true,
+          state: "idle",
+          incarnation: 1,
+          execution_count: 2,
+        })
+
+        await app.request("/stop", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ sessionID: session.id, id: "analysis.ipynb", language: "python" }),
         })
       },
     })

--- a/backend/cli/test/server/notebook.test.ts
+++ b/backend/cli/test/server/notebook.test.ts
@@ -628,6 +628,62 @@ describe("/notebook routes", () => {
     })
   }, 30_000)
 
+  test("reports each queued cell its own execution count", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await trustProject()
+        const app = NotebookRoutes()
+        const session = await Session.create({})
+        const execute = (code: string) =>
+          app.request("/execute", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              sessionID: session.id,
+              id: "analysis.ipynb",
+              language: "python",
+              code,
+            }),
+          })
+
+        // Every cell reports the position it actually ran at, straight out of the
+        // kernel namespace, so the assertion never assumes which HTTP request
+        // reached the queue first. A slow lead cell makes the rest pile up behind
+        // it and drain back to back, which is when the counts got crossed: the
+        // entry keeps a running total that each completion advances, and reading
+        // that shared total back after a persist handed a cell whichever count
+        // had landed last rather than its own.
+        const position = "globals().setdefault('order', []).append(1), len(globals()['order'])"
+        const lead = execute(`(__import__('time').sleep(0.5), ${position})[-1]`)
+        const rest = Array.from({ length: 12 }, () => execute(`(${position})[-1]`))
+        const counts = await Promise.all(
+          [lead, ...rest].map(async (pending) => {
+            const body = (await (await pending).json()) as {
+              execution_count: number
+              outputs: Array<{ data?: Record<string, string> }>
+            }
+            const ran = body.outputs.find((value) => value.data?.["text/plain"])?.data?.["text/plain"]
+            return { ran: Number(ran), reported: body.execution_count }
+          }),
+        )
+        // Each response carries the count of the cell it answers, and the kernel
+        // ran all thirteen exactly once.
+        for (const count of counts) expect(count.reported).toBe(count.ran)
+        expect(counts.map((count) => count.ran).sort((a, b) => a - b)).toEqual(
+          Array.from({ length: 13 }, (_, index) => index + 1),
+        )
+
+        await app.request("/stop", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ sessionID: session.id, id: "analysis.ipynb", language: "python" }),
+        })
+      },
+    })
+  }, 30_000)
+
   test("boots one incarnation when a second cell arrives during startup", async () => {
     await using tmp = await tmpdir({ git: true })
     await Instance.provide({


### PR DESCRIPTION
### What does this PR do?

Fixes a pre-existing concurrency race in the notebook kernel registry. A cell could execute **ahead of the cell that booted the kernel**, and — the defect that actually broke CI — a cell could be handed **another cell's execution count**.

**This is a product bug, not a test bug.** The queue genuinely promises arrival-order serialization and the product broke that promise:

- `KernelQueue` is a strict FIFO whose position is fixed by `run()` call order — the only ordering mechanism in the system.
- The public HTTP contract models the queue explicitly: `KernelStatus` exposes `queue_depth`, and `/notebook/status` reports `running` vs `idle`. `queue_depth` is meaningless under an "order unspecified" contract.
- `execution_count` is returned per cell and persisted into the saved `.ipynb` (`NotebookView.tsx` writes `result.execution_count` onto the cell), so it is user-visible and durable.
- The decisive evidence is behavioural. With the ordering window widened to 50 ms, the later cell ran **first** and returned no result at all — it raised `NameError` on the variable the earlier cell was about to define. Run cell A, quickly run cell B, and B executes first and fails on A's state.

#### Mechanism

Three windows, all the same shape: **shared registry state read or published across an `await`**.

**Window A — pre-boot.** `records().starts.set(...)` (the "a start is in flight" marker) was published only *after* the pre-boot `persist` and after `manager.get()` was called. A cell arriving during that write found no start in flight, so it allocated a **second incarnation** and reset `executionCount`. Two cells issued back to back reported `incarnation: 2` for a single boot, 5/5 runs.

**Window B — post-boot.** `value.kernel = kernel` was assigned *before* the boot's final `await persist(value)`. Both `/status.active` and the ready fast path in `entry()` read `value.kernel`, so the kernel advertised itself as reachable and `idle` while the cell whose request booted it had not yet reached `kernel.execute()`. Any client that waits for `active` and then sends its next cell — `waitForKernel()` in the tests, the workspace UI polling `/notebook/status` — drops into the free slot and runs first. Sampling the value `/status` serves on every macrotask turn, 5/5:

```
... false:starting:0 | false:starting:0 | true:idle:0
```

**Window C — the one that actually broke CI.** My first push fixed A and B; CI *still* failed the original assertion. That was decisive: both new tests passed on CI, so ordering was correct, yet `firstResult.execution_count` was still 2. A third, independent defect produces the identical symptom without any reordering:

```ts
value.executionCount = result.executionCount ?? value.executionCount + 1
...
await persist(value)
const complete = { ...result, executionCount: value.executionCount }  // shared read
```

The cell's own count is `result.executionCount`. `value.executionCount` is the entry's **running total**, advanced by every cell queued behind this one — and the response is built by reading it back *after* an await. Once a slow cell releases the queue the rest drain back to back, so the next cell only has to finish its kernel round trip before the previous cell's `persist` resolves. On a fast local disk the persist wins and counts look right; on a slower runner it loses. Outputs were correct throughout — only the counts were crossed, which is why this looked like a reordering and was not one.

#### Fix

- Boot runs inside an immediately-invoked async call, so the pending-start record is claimed in the **same synchronous block** — a cell arriving during either boot await finds the in-flight start and queues behind it.
- Handing over `value.kernel` is the **last, synchronous step** after every await. Publication and the booting cell's enqueue are separated only by microtasks, which drain fully before the next macrotask, so nothing can interleave.
- Cancellation is re-checked after the newly relevant await, so a `release()` landing mid-publish yields `KernelStartupCancelled` (409) rather than a killed kernel.
- The execution count is captured into a local before the awaits, so a response carries the count of the cell it answers.

No sleeps, retries, or timing slop; no assertion loosened; nothing skipped.

#### Pre-existing and latent

All three defects predate this branch and fire only when one side of a filesystem write loses a race — Bun's parallel test scheduling and runner disk speed decide that. **PR #249 (`fix/grok-45-responses-usage-null`, an unrelated xAI schema patch) was blocked by it**: its Test job failed twice, and an otherwise-identical probe branch with its one unrelated new test file removed went green. Adding a single file shifts which files run alongside `notebook.test.ts`. `main` passing today is scheduling luck, not correctness.

#### Scope note

Two cells submitted simultaneously with no happens-before between them remain unordered: the route preamble (`owner()` → `Session.get`, `SessionFilesystem.workspace()`) races before either reaches the runtime. That is inherent to concurrent HTTP submission. The guarantee fixed here is the meaningful one: once a cell's execution is observable, a later request cannot overtake it.

### How did you verify your code works?

Three new tests in `backend/cli/test/server/notebook.test.ts` — real Python kernel, real registry, real storage, no mocks:

1. `holds the queue slot of the booting cell before the kernel reports active` — samples the value `/status` serves on every macrotask turn and asserts the first `active: true` observation reports `state: "running"`. Deterministic by JS semantics: pre-fix the booting cell is parked on a real file write, guaranteeing a macrotask turn where the kernel is reachable and unqueued. The route is deliberately not polled — each HTTP status request does enough I/O to step over the window, which is exactly what kept this invisible.
2. `boots one incarnation when a second cell arrives during startup` — two cells in flight before the process exists; asserts `incarnation: 1`.
3. `reports each queued cell its own execution count` — thirteen cells behind a slow lead, each returning the position it actually ran at from the kernel namespace, so the assertion never assumes which HTTP request reached the queue first.

**Mutation verification** (fix reverted, tests kept):

| test | fix reverted | fix restored |
| --- | --- | --- |
| holds the queue slot… | **fail 3/3** — `Expected: "running"  Received: "idle"` | pass 3/3 |
| boots one incarnation… | **fail 3/3** — `"incarnation": 1` vs `+ "incarnation": 2` | pass 3/3 |
| reports each queued cell… | passed 5/5 locally — see caveat | pass 3/3 |

**Honest caveat on test 3.** It did *not* fail locally with its fix reverted, so I am not claiming it pins window C on this machine — local tmpfs makes `persist` beat the kernel round trip nearly every time. What I did watch fail:

- **CI, twice.** Runs `30838948158` and `30839183114` both carry the ordering fix without the count fix, and both failed the Test job on exactly `Expected: 1 / Received: 2`. That is the mutation experiment run in the environment where the defect fires.
- **Locally under storage contention** (6 notebooks × 13 cells, throwaway probe): 1 mismatched count in 78 cells on 2 of 3 runs with the fix reverted (`ran=12 reported=13`, `ran=7 reported=8`); 0/78 on 3/3 runs with it restored.
- **Locally with the window widened** by 50 ms: the exact CI symptom, 3/3.

Robustness: re-injecting a 50 ms stall *inside* the now-protected boot window — the same stall that broke ordering 3/3 pre-fix — leaves ordering, incarnation, and status correct 3/3.

Also run:

- `bun test test/server/notebook.test.ts` — 23 pass, 0 fail
- `bun test` (full suite) — 1725 pass, 2 fail, both pre-existing and unrelated to kernel code: `killTree SIGKILLs a detached group` (passes standalone: 3 pass, 0 fail) and `npm selects every supported native package contract with lifecycle scripts disabled`
- `bunx turbo typecheck --force` — 7/7 successful
- `bunx prettier --check` on both changed files — clean
- Scheduling perturbation: a throwaway extra test file was added on a separate probe branch to shift Bun's parallel scheduling the way #249's did, CI dispatched there, then the branch deleted. The PR branch never carried the file.

### Checklist

- [x] `bun run typecheck` passes
- [ ] `bun test` (in `backend/cli`) passes — 1725 pass, 2 pre-existing unrelated failures (see above)
- [ ] `bunx prettier --check .` is clean — verified on the two changed files only, not the whole tree
- [ ] Linked an issue (e.g. `Fixes #123`)
- [ ] Screenshots or a short video for UI changes
