### PR TITLE
fix(files): make Modal Volume browsing and previews work

### DIFF
--- a/frontend/workspace/src/atlas/FilesPane.test.ts
+++ b/frontend/workspace/src/atlas/FilesPane.test.ts
@@ -326,6 +326,50 @@ describe("files pane", () => {
 
   // A Volume file has no path on this machine, so a previewable one opens a tab
   // backed by its bytes rather than by a path.
+  // A Volume listing spawns a Modal process and takes seconds. The rows still on
+  // screen describe the folder being left, so clicking a second one appended its
+  // name to the path the first click had already set -- asking the server for a
+  // folder inside a folder that was never opened, which came back as a NOT_FOUND
+  // traceback.
+  test("refuses clicks on a listing that is being replaced", async () => {
+    const asked: string[] = []
+    let release: ((value: Response) => void) | undefined
+    const request = async (path: string, _init?: RequestInit, query?: Record<string, string>) => {
+      if (path === "/settings/compute") return listing({ providers: [{ id: "modal", connected: true, enabled: true }] })
+      if (path === "/settings/compute/modal/volumes") return listing([{ name: "weights" }])
+      if (path.includes("/volumes/") && path.endsWith("/files")) {
+        asked.push(query?.path ?? "")
+        // The second listing never resolves, so the pane stays mid-flight.
+        if (asked.length > 1) return new Promise<Response>((resolve) => (release = resolve))
+        return listing([
+          { path: "alpha", type: "directory", size: 0 },
+          { path: "beta", type: "directory", size: 0 },
+        ])
+      }
+      if (path.startsWith("/file/artifact-store")) return listing([])
+      return listing([])
+    }
+    const host = mount(() => subject.FilesPane({ request }))
+    await settle()
+    await enterModal(host)
+    host.querySelector<HTMLButtonElement>('[data-file-row="weights"]')?.click()
+    await settle()
+
+    host.querySelector<HTMLButtonElement>('[data-file-row="alpha"]')?.click()
+    await settle()
+
+    expect(host.querySelector("[data-files-loading]")).not.toBeNull()
+    expect(host.querySelector<HTMLButtonElement>('[data-file-row="beta"]')?.disabled).toBe(true)
+
+    // The click that used to produce volume/alpha/beta.
+    host.querySelector<HTMLButtonElement>('[data-file-row="beta"]')?.click()
+    await settle()
+
+    expect(asked).not.toContain("/alpha/beta")
+    expect(asked.at(-1)).toBe("/alpha")
+    release?.(listing([]))
+  })
+
   test("previews a Volume file of a format worth showing", async () => {
     const { calls, request } = modal({
       files: [

--- a/frontend/workspace/src/atlas/FilesPane.tsx
+++ b/frontend/workspace/src/atlas/FilesPane.tsx
@@ -72,6 +72,30 @@ const errorMessage = (value: unknown) => {
   return String(value || "Request failed")
 }
 
+/**
+ * One line a person can act on.
+ *
+ * A failure from the compute routes arrives as a JSON envelope wrapping a
+ * multi-kilobyte Python traceback, and putting that in the pane buries the
+ * screen in stack frames. Unwrap what we can, keep the first line, and cap it.
+ */
+const concise = (value: unknown) => {
+  const raw = errorMessage(value)
+  const unwrapped = (() => {
+    try {
+      const parsed = JSON.parse(raw) as { data?: { message?: string }; message?: string; error?: string }
+      return parsed.data?.message ?? parsed.message ?? parsed.error ?? raw
+    } catch {
+      return raw
+    }
+  })()
+  const line = unwrapped
+    .split("\n")[0]!
+    .replace(/^Error:\s*/, "")
+    .trim()
+  return line.length > 160 ? `${line.slice(0, 159)}…` : line
+}
+
 // FileExplorer.tsx:57-77 keeps equivalent readAccess/grantAccess/revokeAccess
 // helpers, but they are private, unexported, and typed against ProjectRequest
 // (which carries a .url this pane's injected transport does not). They are
@@ -356,7 +380,7 @@ export function FilesPane(
             }))
           })
           .catch((value) => {
-            setError(`Modal Volumes could not be listed. ${errorMessage(value)}`)
+            setError(`Modal Volumes could not be listed. ${concise(value)}`)
             return [] as FileRow[]
           })
       }
@@ -375,7 +399,7 @@ export function FilesPane(
           }))
         })
         .catch((value) => {
-          setError(`${volume} could not be read. ${errorMessage(value)}`)
+          setError(`${volume} could not be read. ${concise(value)}`)
           return [] as FileRow[]
         })
     }
@@ -528,7 +552,7 @@ export function FilesPane(
         anchor.remove()
         setTimeout(() => URL.revokeObjectURL(url), 0)
       })
-      .catch((value) => setError(`${row.name} could not be downloaded. ${errorMessage(value)}`))
+      .catch((value) => setError(`${row.name} could not be downloaded. ${concise(value)}`))
       .finally(() => setBusy(false))
   }
 
@@ -760,6 +784,17 @@ export function FilesPane(
         />
       </div>
 
+      {/* A Volume listing spawns a Modal process and takes seconds. Without this
+          the pane looks frozen, and the rows still on screen describe the folder
+          being left -- which is how clicking a second one asked for a folder
+          inside a folder that was never opened. */}
+      <Show when={entries.loading}>
+        <div class="files-loading" role="status" data-files-loading>
+          <span class="files-loading__spark" aria-hidden="true" />
+          Loading {current().name}…
+        </div>
+      </Show>
+
       <Show when={error()}>
         <div class="files-notice" role="status">
           {error()}
@@ -792,6 +827,7 @@ export function FilesPane(
           <FileTable
             rows={rows()}
             depth={path().length}
+            busy={entries.loading}
             onUp={() => {
               setPath(path().slice(0, -1))
               // Symmetric with descending: a query typed for the folder being

--- a/frontend/workspace/src/atlas/files/FileTable.tsx
+++ b/frontend/workspace/src/atlas/files/FileTable.tsx
@@ -19,6 +19,13 @@ export function FileTable(props: {
   depth: number
   onOpen: (row: FileRow) => void
   onUp: () => void
+  /**
+   * A listing is in flight. The rows on screen still describe the folder being
+   * left, so they are shown but not clickable: clicking one would append its
+   * name to the path the previous click already set, asking the server for a
+   * folder inside a folder that was never opened.
+   */
+  busy?: boolean
 }): JSX.Element {
   const sorted = createMemo(() =>
     [...props.rows].sort((a, b) =>
@@ -27,9 +34,15 @@ export function FileTable(props: {
   )
 
   return (
-    <div class="files-table">
+    <div class="files-table" classList={{ "files-table--busy": props.busy }} aria-busy={props.busy}>
       <Show when={props.depth > 0}>
-        <button type="button" class="files-row files-row--up" data-file-up onClick={() => props.onUp()}>
+        <button
+          type="button"
+          class="files-row files-row--up"
+          data-file-up
+          disabled={props.busy}
+          onClick={() => props.onUp()}
+        >
           <span class="files-row__glyph" aria-hidden="true">
             ↑
           </span>
@@ -46,6 +59,7 @@ export function FileTable(props: {
               class="files-row"
               classList={{ "files-row--ignored": row.ignored }}
               data-file-row={row.name}
+              disabled={props.busy}
               onClick={() => props.onOpen(row)}
             >
               <span class="files-row__glyph" aria-hidden="true">

--- a/frontend/workspace/src/atlas/files/FilesPane.css
+++ b/frontend/workspace/src/atlas/files/FilesPane.css
@@ -1013,3 +1013,40 @@
   color: var(--color-text-faint);
   font-size: 12px;
 }
+
+.files-loading {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px 8px;
+  color: var(--color-text-muted);
+  font-size: 12.5px;
+}
+.files-loading__spark {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--color-text-faint);
+  animation: files-pulse 1s ease-in-out infinite;
+}
+@keyframes files-pulse {
+  0%,
+  100% {
+    opacity: 0.25;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .files-loading__spark {
+    animation: none;
+    opacity: 0.6;
+  }
+}
+
+/* Shown but not actionable: the rows describe the folder being left. */
+.files-table--busy .files-row {
+  opacity: 0.5;
+  cursor: default;
+}

--- a/frontend/workspace/src/atlas/files/RemoteFileView.test.ts
+++ b/frontend/workspace/src/atlas/files/RemoteFileView.test.ts
@@ -33,8 +33,9 @@ const mount = (view: () => JSX.Element) => {
 
 const settle = (ms = 40) => new Promise((resolve) => setTimeout(resolve, ms))
 
+let unique = 0
 const props = (over: Record<string, unknown> = {}) => ({
-  file: { name: "notes.md", path: "notes.md", volume: "weights", size: 12 },
+  file: { name: "notes.md", path: `notes-${(unique += 1)}.md`, volume: "weights", size: 12 },
   read: async () => new Blob(["# Objective"], { type: "text/markdown" }),
   onDownload: () => {},
   onClose: () => {},
@@ -180,5 +181,63 @@ describe("remote file view", () => {
     host.querySelector<HTMLButtonElement>('[aria-label="Close notes.md"]')!.click()
 
     expect(events).toEqual(["download", "close"])
+  })
+
+  // Switching tabs unmounts this viewer, so without a cache every switch went
+  // back to Modal for bytes already in hand.
+  test("does not re-fetch a file it has already pulled down", async () => {
+    let reads = 0
+    const file = { name: "shared.md", path: "shared.md", volume: "weights", size: 12 }
+    const view = () =>
+      subject.RemoteFileView(
+        props({
+          file,
+          read: async () => {
+            reads += 1
+            return new Blob(["# Objective"], { type: "text/markdown" })
+          },
+        }) as never,
+      )
+
+    const first = mount(view)
+    await settle()
+    expect(first.querySelector("[data-remote-text]")?.textContent).toContain("# Objective")
+    expect(reads).toBe(1)
+
+    cleanups.splice(0).forEach((fn) => fn())
+    document.body.replaceChildren()
+
+    const second = mount(view)
+    await settle()
+
+    expect(second.querySelector("[data-remote-text]")?.textContent).toContain("# Objective")
+    expect(reads).toBe(1)
+  })
+
+  // A Volume file can change, unlike an artifact version; the size a listing
+  // reports is the cheapest signal of that.
+  test("fetches again when the file has changed size", async () => {
+    let reads = 0
+    const read = async () => {
+      reads += 1
+      return new Blob(["# Objective"], { type: "text/markdown" })
+    }
+    mount(() =>
+      subject.RemoteFileView(
+        props({ file: { name: "grew.md", path: "grew.md", volume: "weights", size: 12 }, read }) as never,
+      ),
+    )
+    await settle()
+    cleanups.splice(0).forEach((fn) => fn())
+    document.body.replaceChildren()
+
+    mount(() =>
+      subject.RemoteFileView(
+        props({ file: { name: "grew.md", path: "grew.md", volume: "weights", size: 4096 }, read }) as never,
+      ),
+    )
+    await settle()
+
+    expect(reads).toBe(2)
   })
 })

--- a/frontend/workspace/src/atlas/files/RemoteFileView.test.ts
+++ b/frontend/workspace/src/atlas/files/RemoteFileView.test.ts
@@ -66,9 +66,10 @@ describe("remote file view", () => {
     expect(host.querySelector("[data-remote-text]")?.textContent).toContain("# Objective")
   })
 
-  // The route answers with Content-Disposition: attachment, which a browser may
-  // honour by downloading rather than rendering, so bytes go through a blob.
-  test("renders an image from a blob rather than the route", async () => {
+  // The app's CSP is img-src 'self' data: https: -- no blob: -- so an image
+  // rendered from a blob: URL never decodes. Verified in the running app: the
+  // same PNG loads as data: and fails as blob:.
+  test("renders an image from a data URL, which the CSP allows", async () => {
     const host = mount(() =>
       subject.RemoteFileView(
         props({
@@ -79,7 +80,35 @@ describe("remote file view", () => {
     )
     await settle()
 
-    expect(host.querySelector("[data-remote-image]")?.getAttribute("src")).toStartWith("blob:")
+    expect(host.querySelector("[data-remote-image]")?.getAttribute("src")).toStartWith("data:image/png")
+  })
+
+  // frame-src does allow blob:, so a PDF keeps it -- but the bytes arrive as
+  // application/octet-stream, and an <iframe> handed that downloads the file
+  // instead of displaying it.
+  test("renders a PDF from a blob typed as a PDF", async () => {
+    let seen: string | undefined
+    const create = URL.createObjectURL.bind(URL)
+    URL.createObjectURL = (blob: Blob) => {
+      seen = (blob as Blob).type
+      return create(blob)
+    }
+    try {
+      const host = mount(() =>
+        subject.RemoteFileView(
+          props({
+            file: { name: "paper.pdf", path: "paper.pdf", volume: "weights", size: 40 },
+            read: async () => new Blob([new Uint8Array([37, 80, 68, 70])], { type: "application/octet-stream" }),
+          }) as never,
+        ),
+      )
+      await settle()
+
+      expect(seen).toBe("application/pdf")
+      expect(host.querySelector("[data-remote-pdf]")?.getAttribute("src")).toStartWith("blob:")
+    } finally {
+      URL.createObjectURL = create
+    }
   })
 
   test("offers download instead of guessing at a format it cannot render", async () => {

--- a/frontend/workspace/src/atlas/files/RemoteFileView.tsx
+++ b/frontend/workspace/src/atlas/files/RemoteFileView.tsx
@@ -25,6 +25,41 @@ export interface RemoteFileViewProps {
 const shared = (code: string, lang: string) =>
   import("@synsci/ui/context/marked").then((module) => module.highlightSnippet(code, lang))
 
+interface Cached {
+  bytes: number
+  text?: { body: string; html?: string }
+  /** Images keep their data: URL, which needs no revoking and can be reused. */
+  dataUrl?: string
+  /** PDFs keep the typed bytes; the object URL is remade per mount and revoked. */
+  blob?: Blob
+}
+
+/**
+ * Files already fetched out of a Volume.
+ *
+ * Switching tabs unmounts this viewer, so without it every switch went back to
+ * Modal -- seconds each time for bytes already in hand. Keyed by volume, path
+ * and size: a Volume file can change, unlike an artifact version, and the size
+ * is the cheapest signal of that a listing gives us. A file edited in place to
+ * exactly the same length serves the previous bytes until the pane reloads.
+ */
+const fetched = new Map<string, Cached>()
+const CACHE_BUDGET = 32 * 1024 * 1024
+
+const cacheKey = (file: RemoteFile) => `${file.volume}\u0000${file.path}\u0000${file.size ?? "?"}`
+
+const keep = (key: string, entry: Cached) => {
+  let held = entry.bytes
+  for (const value of fetched.values()) held += value.bytes
+  // Oldest out first; a preview is worth re-fetching, a wedged tab is not.
+  for (const [oldest, value] of fetched) {
+    if (held <= CACHE_BUDGET) break
+    fetched.delete(oldest)
+    held -= value.bytes
+  }
+  fetched.set(key, entry)
+}
+
 export function RemoteFileView(props: RemoteFileViewProps): JSX.Element {
   const [text, setText] = createSignal<{ body: string; html?: string }>()
   const [url, setUrl] = createSignal<string>()
@@ -52,6 +87,18 @@ export function RemoteFileView(props: RemoteFileViewProps): JSX.Element {
       if (revoke) URL.revokeObjectURL(revoke)
     })
 
+    const key = cacheKey(file)
+    const hit = fetched.get(key)
+    if (hit) {
+      if (hit.text) setText(hit.text)
+      if (hit.dataUrl) setUrl(hit.dataUrl)
+      if (hit.blob) {
+        revoke = URL.createObjectURL(hit.blob)
+        setUrl(revoke)
+      }
+      return
+    }
+
     void (async () => {
       try {
         const blob = await props.read(file)
@@ -59,6 +106,7 @@ export function RemoteFileView(props: RemoteFileViewProps): JSX.Element {
         if (shape === "text") {
           const body = await blob.text()
           const html = await (props.highlight ?? shared)(body, thumbLanguage(file.name)).catch(() => undefined)
+          keep(key, { bytes: blob.size, text: { body, html } })
           if (live) setText({ body, html })
           return
         }
@@ -73,17 +121,20 @@ export function RemoteFileView(props: RemoteFileViewProps): JSX.Element {
         // as application/octet-stream, and an <iframe> handed that downloads the
         // file instead of displaying it.
         const mime = remoteMime(file.name)
+        const typed = mime && blob.type !== mime ? new Blob([blob], { type: mime }) : blob
         if (shape === "image") {
           const encoded = await new Promise<string>((resolve, reject) => {
             const reader = new FileReader()
             reader.onload = () => resolve(String(reader.result))
             reader.onerror = () => reject(reader.error ?? new Error("could not decode the image"))
-            reader.readAsDataURL(mime ? new Blob([blob], { type: mime }) : blob)
+            reader.readAsDataURL(typed)
           })
+          keep(key, { bytes: typed.size, dataUrl: encoded })
           if (live) setUrl(encoded)
           return
         }
-        revoke = URL.createObjectURL(mime && blob.type !== mime ? new Blob([blob], { type: mime }) : blob)
+        keep(key, { bytes: typed.size, blob: typed })
+        revoke = URL.createObjectURL(typed)
         if (live) setUrl(revoke)
       } catch (error) {
         if (live) setFailed(error instanceof Error ? error.message : String(error))

--- a/frontend/workspace/src/atlas/files/RemoteFileView.tsx
+++ b/frontend/workspace/src/atlas/files/RemoteFileView.tsx
@@ -2,7 +2,7 @@ import { Match, Show, Switch, createEffect, createSignal, onCleanup, type JSX } 
 import { IconDownload, IconX } from "@/atlas/shared/Icon"
 import { bytes } from "./bytes"
 import { thumbLanguage } from "./artifact-thumb"
-import { remotePreview, type RemotePreview } from "./remote-preview"
+import { remoteMime, remotePreview, type RemotePreview } from "./remote-preview"
 
 export interface RemoteFile {
   name: string
@@ -62,10 +62,28 @@ export function RemoteFileView(props: RemoteFileViewProps): JSX.Element {
           if (live) setText({ body, html })
           return
         }
-        // Fetched to a blob rather than pointed at the route: the endpoint
-        // answers with Content-Disposition: attachment, which a browser may
-        // honour by downloading instead of rendering.
-        revoke = URL.createObjectURL(blob)
+        // The app's CSP is img-src 'self' data: https: and frame-src 'self' blob:
+        // (server.ts), so the two shapes need different carriers:
+        //
+        // An image cannot come from a blob: URL at all -- verified in the app,
+        // where a valid PNG decodes as data: and fails as blob: -- so its bytes
+        // become a data: URL.
+        //
+        // A PDF may use blob:, but only once it is re-typed: these bytes arrive
+        // as application/octet-stream, and an <iframe> handed that downloads the
+        // file instead of displaying it.
+        const mime = remoteMime(file.name)
+        if (shape === "image") {
+          const encoded = await new Promise<string>((resolve, reject) => {
+            const reader = new FileReader()
+            reader.onload = () => resolve(String(reader.result))
+            reader.onerror = () => reject(reader.error ?? new Error("could not decode the image"))
+            reader.readAsDataURL(mime ? new Blob([blob], { type: mime }) : blob)
+          })
+          if (live) setUrl(encoded)
+          return
+        }
+        revoke = URL.createObjectURL(mime && blob.type !== mime ? new Blob([blob], { type: mime }) : blob)
         if (live) setUrl(revoke)
       } catch (error) {
         if (live) setFailed(error instanceof Error ? error.message : String(error))

--- a/frontend/workspace/src/atlas/files/remote-preview.test.ts
+++ b/frontend/workspace/src/atlas/files/remote-preview.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { REMOTE_PREVIEW_LIMIT, remotePreview } from "./remote-preview"
+import { REMOTE_PREVIEW_LIMIT, remoteMime, remotePreview } from "./remote-preview"
 
 describe("remote file previews", () => {
   test("previews the formats a viewer can actually render", () => {
@@ -36,5 +36,20 @@ describe("remote file previews", () => {
   test("is case-insensitive about the extension", () => {
     expect(remotePreview("NOTES.MD")).toBe("text")
     expect(remotePreview("Figure.PNG")).toBe("image")
+  })
+
+  // The route answers every download as application/octet-stream, and a blob:
+  // URL serves the Blob's own type -- an <img> given octet-stream shows a broken
+  // image, and an <iframe> given it downloads the file instead of rendering it.
+  test("names a content type for everything it renders from bytes", () => {
+    expect(remoteMime("fit.png")).toBe("image/png")
+    expect(remoteMime("photo.JPEG")).toBe("image/jpeg")
+    expect(remoteMime("plot.svg")).toBe("image/svg+xml")
+    expect(remoteMime("paper.pdf")).toBe("application/pdf")
+  })
+
+  test("names none for what it never turns into a blob", () => {
+    expect(remoteMime("notes.md")).toBeUndefined()
+    expect(remoteMime("model.safetensors")).toBeUndefined()
   })
 })

--- a/frontend/workspace/src/atlas/files/remote-preview.ts
+++ b/frontend/workspace/src/atlas/files/remote-preview.ts
@@ -63,6 +63,30 @@ const TEXT = new Set([
 
 const IMAGE = new Set(["png", "jpg", "jpeg", "gif", "webp", "svg", "bmp", "avif"])
 
+const MIME: Record<string, string> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+  svg: "image/svg+xml",
+  bmp: "image/bmp",
+  avif: "image/avif",
+  pdf: "application/pdf",
+}
+
+/**
+ * The content type a previewed file's bytes should carry.
+ *
+ * The route answers every download as `application/octet-stream`, and a blob:
+ * URL serves the Blob's recorded type -- so an <img> given octet-stream shows a
+ * broken image and an <iframe> given it downloads the file instead of rendering
+ * it. The bytes are re-typed from the extension before the URL is made.
+ */
+export function remoteMime(filename: string): string | undefined {
+  return MIME[extension(filename)]
+}
+
 /**
  * What a remote file may be previewed as, or undefined when it may not be.
  *


### PR DESCRIPTION
Follow-up to #255, from driving the merged build against a real Modal account. Four defects, all in the Modal Volumes path.

## A slow listing produced an impossible path

A Volume listing spawns a Modal process and takes seconds. During that time the pane looked frozen, and the rows still on screen described the folder being **left** — so clicking a second folder appended its name to the path the first click had already set. The pane asked for a folder inside a folder that was never opened, and Modal answered `NOT_FOUND`.

The pane now says it is loading, and a listing being replaced no longer takes clicks. The guard is mutation-tested: re-enabling those rows fails the test.

## …and then filled the pane with the traceback

Failures from the compute routes arrive as a JSON envelope wrapping a multi-kilobyte Python stack, and the pane rendered it raw — burying the surface in frames from `grpclib`. Unwrapped to one line and capped at 160 characters.

## Images and PDFs did not render

Both previews failed, and the app's own CSP is why:

```
img-src   'self' data: https:      ← no blob:
frame-src 'self' blob:
```

An image from a `blob:` URL can never decode. Verified in the running app: the same PNG loads as `data:` and fails as `blob:`. Images now carry a `data:` URL.

A PDF may use `blob:`, but the bytes arrive as `application/octet-stream`, and an `<iframe>` handed that **downloads the file instead of displaying it** — which is exactly what happened. It is re-typed from the extension before the URL is made.

## Switching tabs re-fetched from the cloud

Switching tabs unmounts the viewer, so its effect re-ran and went back to Modal for bytes already in hand. Fetched files are kept now, as artifact previews already are.

Keyed by volume, path and **size**, because a Volume file can change — unlike an artifact version, which is immutable by construction — and size is the cheapest signal of that a listing gives us. A file edited in place to exactly the same length serves the previous bytes until the pane reloads. The cache holds 32 MB, oldest out first. Images keep their `data:` URL, which needs no revoking; PDFs keep the typed bytes and mint a fresh object URL per mount, since the previous one is revoked on the way out.

## Verification

Measured against a real Modal account, on `fno-wave2-results`:

| | |
| --- | --- |
| `nrmse_dist.png` | `data:image/png…`, decoded 1476×726 |
| `nrmse_dist.pdf` | renders in the frame, no download |
| Open PNG, then PDF | 2 fetches |
| Switch between both tabs | **0 further fetches**, image back in 4ms |
| `fno-wave2-results` | lists cleanly — it is the volume that produced the traceback |

`bun test src/atlas` is 300 pass / 0 fail against this branch's base; typecheck clean.

## Note

Cherry-picked onto current `main` rather than pushed from the #255 branch: that PR was squash-merged, so its branch no longer shares a merge base and would have re-shown ~6.7k already-merged lines. Applies cleanly over #256 and #257.
