### PR TITLE
fix: repair test publish validation

### DIFF
--- a/backend/cli/src/compute/modal/plan.ts
+++ b/backend/cli/src/compute/modal/plan.ts
@@ -96,26 +96,28 @@ export namespace ModalPlan {
   }
 
   async function inputs(root: string, patterns: string[]) {
+    const project = await Filesystem.canonical(root)
+    if (!project) throw new Error(`Modal project directory is unavailable: ${root}`)
     const files = new Map<string, ModalAdapter.File>()
     const found = new Set<string>()
     for (const pattern of patterns) {
       if (path.isAbsolute(pattern) || pattern.split(/[\\/]/).includes("..")) {
         throw new Error(`Modal upload pattern must stay inside the project: ${pattern}`)
       }
-      const scan = new Bun.Glob(pattern).scan({ cwd: root, dot: true, onlyFiles: true, followSymlinks: true })
+      const scan = new Bun.Glob(pattern).scan({ cwd: project, dot: true, onlyFiles: true, followSymlinks: true })
       for await (const file of scan) found.add(posix(file))
     }
-    const excludes = await ignored(root, [...found])
+    const excludes = await ignored(project, [...found])
     for (const relative of found) {
       if (excludes.has(relative)) continue
       if (forbidden(relative)) throw new Error(`Modal upload policy denied: ${relative}`)
-      const canonical = await Filesystem.canonical(path.resolve(root, relative))
-      if (!canonical || !Filesystem.contains(root, canonical)) {
+      const canonical = await Filesystem.canonical(path.resolve(project, relative))
+      if (!canonical || !Filesystem.contains(project, canonical)) {
         throw new Error(`Modal upload escaped the project: ${relative}`)
       }
-      const resolved = posix(path.relative(root, canonical))
+      const resolved = posix(path.relative(project, canonical))
       const canonicalIgnored =
-        resolved === relative ? excludes.has(resolved) : (await ignored(root, [resolved])).has(resolved)
+        resolved === relative ? excludes.has(resolved) : (await ignored(project, [resolved])).has(resolved)
       if (canonicalIgnored) continue
       if (forbidden(resolved)) throw new Error(`Modal upload policy denied: ${relative}`)
       const info = await fs.stat(canonical)

--- a/backend/cli/test/compute/modal-adapter.test.ts
+++ b/backend/cli/test/compute/modal-adapter.test.ts
@@ -38,16 +38,12 @@ describe("ModalAdapter sandbox lifecycle", () => {
     )
     await Bun.write(path.join(root, ".openscience-ready"), "approved\n")
     const result = path.join(root, ".openscience-exit-code")
-    const wait = async (attempts = 100): Promise<string> => {
-      if (await Bun.file(result).exists()) return Bun.file(result).text()
-      if (!attempts) throw new Error("Modal wrapper did not record the command result")
-      await Bun.sleep(20)
-      return wait(attempts - 1)
-    }
-    expect(await wait()).toBe("0\n")
+    const timeout = setTimeout(() => child.kill(), 10_000)
+    const code = await child.exited.finally(() => clearTimeout(timeout))
+    expect(code).toBe(0)
+    expect(await Bun.file(result).text()).toBe("0\n")
     expect(await Bun.file(path.join(root, "result.txt")).text()).toBe("artifact")
     expect(await Bun.file(path.join(root, ".openscience-run.log")).text()).toBe("completed\n")
-    expect(await child.exited).toBe(0)
     await fs.rm(root, { recursive: true, force: true })
   })
 

--- a/backend/cli/test/compute/modal-plan.test.ts
+++ b/backend/cli/test/compute/modal-plan.test.ts
@@ -57,6 +57,17 @@ describe("ModalPlan", () => {
     )
   })
 
+  test("accepts a project root reached through a symlink", async () => {
+    const root = await project()
+    const alias = `${root}-alias`
+    roots.push(alias)
+    await fs.symlink(root, alias)
+
+    const prepared = await ModalPlan.prepare(input(alias))
+
+    expect(prepared.plan.uploads.map((file) => file.path)).toEqual(["src/train.py"])
+  })
+
   test("denies secrets, control directories, and paths outside the project", async () => {
     const root = await project()
     await fs.writeFile(path.join(root, ".env"), "MODAL_TOKEN_SECRET=secret\n")

--- a/backend/cli/test/compute/modal-volume.test.ts
+++ b/backend/cli/test/compute/modal-volume.test.ts
@@ -162,7 +162,7 @@ describe("ModalVolume", () => {
       path.join(alias, "staging"),
     )
 
-    expect(downloaded[0]?.staging).toBe(path.join(real, "staging", "outputs", "model.bin"))
+    expect(downloaded[0]?.staging).toBe(await fs.realpath(path.join(real, "staging", "outputs", "model.bin")))
     expect(await Bun.file(downloaded[0]!.staging).text()).toBe("weights")
   })
 })

--- a/frontend/workspace/e2e/setup-gate.spec.ts
+++ b/frontend/workspace/e2e/setup-gate.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "./fixtures"
+import { openSettings } from "./utils"
 
-test("first-run setup offers every path and remembers dismissal", async ({ page, gotoSession }) => {
+test("an unconfigured first run stays local and exposes model setup in Customize", async ({ page, gotoSession }) => {
   await page.route("**/provider", (route) =>
     route.fulfill({
       status: 200,
@@ -17,24 +18,12 @@ test("first-run setup offers every path and remembers dismissal", async ({ page,
 
   await gotoSession()
 
-  const dialog = page.getByRole("dialog", { name: "Set up models" })
-  await expect(dialog).toBeVisible()
-  await expect(dialog.getByRole("button", { name: /Atlas managed/ })).toBeVisible()
-  await expect(dialog.getByRole("button", { name: /Your own keys/ })).toBeVisible()
-  await expect(dialog.getByRole("button", { name: /Not now/ })).toBeVisible()
-
-  await dialog.getByRole("button", { name: /Your own keys/ }).click()
-  await expect(dialog.getByText("Add a provider key.", { exact: false })).toBeVisible()
-  await expect(dialog.getByRole("button", { name: "Anthropic", exact: true })).toBeVisible()
-  await expect(dialog.getByRole("button", { name: "OpenAI", exact: true })).toBeVisible()
-  await expect(dialog.getByRole("button", { name: "Google Gemini", exact: true })).toBeVisible()
-  await expect(dialog.getByRole("button", { name: "save key", exact: true })).toBeDisabled()
-
-  await dialog.getByRole("button", { name: "back", exact: true }).click()
-  await dialog.getByRole("button", { name: /Not now/ }).click()
-  await expect(dialog).toHaveCount(0)
-  await expect.poll(() => page.evaluate(() => localStorage.getItem("openscience.setup.dismissed"))).toBe("1")
-
-  await page.reload()
   await expect(page.getByRole("dialog", { name: "Set up models" })).toHaveCount(0)
+  await expect.poll(() => page.evaluate(() => localStorage.getItem("openscience.setup.dismissed"))).toBeNull()
+
+  const dialog = await openSettings(page)
+  await expect(dialog.getByRole("heading", { name: "Models", exact: true })).toBeVisible()
+  await expect(dialog.getByRole("heading", { name: "ChatGPT / Codex" })).toBeVisible()
+  await expect(dialog.getByRole("heading", { name: "Provider keys" })).toBeVisible()
+  await expect(dialog.getByRole("button", { name: "save key", exact: true })).toBeDisabled()
 })


### PR DESCRIPTION
## Summary

- update the packaged first-run E2E contract for offline-first model setup in Customize
- canonicalize Modal upload roots so macOS `/var` aliases and symlinked project paths remain inside the approved project
- make Modal lifecycle validation wait for the wrapper process instead of a fixed two-second poll

## Validation

- `npm test` — 1,840 passed, 2 skipped, 0 failed
- `bun run typecheck` — 7/7 targets passed
- `bun script/e2e-local.ts e2e/setup-gate.spec.ts` — passed
- focused Modal and SPA tests — 21/21 passed