### PR TITLE
fix: stabilize model picker navigation

### DIFF
--- a/frontend/workspace/e2e/model-picker.spec.ts
+++ b/frontend/workspace/e2e/model-picker.spec.ts
@@ -24,3 +24,46 @@ test("smoke model selection updates the composer trigger", async ({ page, gotoSe
   await expect(picker).toBeHidden()
   await expect(trigger).toContainText(name)
 })
+
+test("effort back-navigation stays compact and Manage models opens Customize", async ({ page, gotoSession }) => {
+  await page.setViewportSize({ width: 1280, height: 720 })
+  await gotoSession()
+
+  const trigger = page.locator(modelTriggerSelector)
+  const picker = page.locator(modelPopoverSelector)
+  await trigger.click()
+  await picker.locator('[data-model-menu-row="effort"]').click()
+  await picker.locator('[data-model-option="effort"][data-model-option-id="high"]').click()
+
+  await expect(picker).toHaveAttribute("data-model-settings-view", "root")
+  await expect(picker.getByText("Quick models", { exact: true })).toBeVisible()
+  expect(await picker.locator("[data-model-quick]").count()).toBeLessThanOrEqual(4)
+  await expect.poll(() => picker.evaluate((element) => element.scrollTop)).toBe(0)
+
+  await picker.locator('[data-model-menu-row="model"]').click()
+  await expect(picker).toHaveAttribute("data-model-settings-view", "models")
+  const manage = picker.getByRole("button", { name: "Manage models", exact: true })
+  await expect(manage).toBeVisible()
+
+  const layout = await picker.evaluate((element) => {
+    const footer = element.querySelector<HTMLElement>(".model-settings-manage")
+    const catalog = element.querySelector<HTMLElement>(".model-settings-catalog")
+    const frame = element.getBoundingClientRect()
+    const bounds = footer?.getBoundingClientRect()
+    return {
+      outerOverflow: element.scrollHeight - element.clientHeight,
+      footerVisible: Boolean(bounds && bounds.top >= frame.top && bounds.bottom <= frame.bottom),
+      catalogScrolls: Boolean(catalog && catalog.scrollHeight >= catalog.clientHeight),
+    }
+  })
+  expect(layout.outerOverflow).toBeLessThanOrEqual(1)
+  expect(layout.footerVisible).toBe(true)
+  expect(layout.catalogScrolls).toBe(true)
+
+  await manage.click()
+  await expect(picker).toBeHidden()
+  const dialog = page.getByRole("dialog")
+  await expect(dialog).toBeVisible()
+  await expect(dialog.locator("header").getByText("Models", { exact: true })).toBeVisible()
+  await expect(dialog.getByRole("heading", { name: "Composer models", exact: true })).toBeVisible()
+})

--- a/frontend/workspace/src/components/model-settings-popover.css
+++ b/frontend/workspace/src/components/model-settings-popover.css
@@ -97,7 +97,10 @@ html[data-color-scheme="dark"]
 }
 
 [data-model-settings-popover] {
+  box-sizing: border-box;
   width: min(320px, calc(100vw - 24px)) !important;
+  max-height: min(72dvh, 440px);
+  overflow: hidden;
   padding: 6px !important;
   border: 1px solid var(--model-control-border-strong) !important;
   border-radius: 12px !important;
@@ -190,6 +193,21 @@ html[data-color-scheme="dark"]
 .model-settings-browser {
   min-height: 0;
   display: flex;
+  flex: 1;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+[data-model-settings-view="models"] {
+  height: min(72dvh, 440px);
+  display: flex;
+  flex-direction: column;
+}
+
+[data-model-settings-view="models"] .mobile-model-settings__body {
+  min-height: 0;
+  display: flex;
+  flex: 1;
   flex-direction: column;
 }
 
@@ -225,8 +243,8 @@ html[data-color-scheme="dark"]
 }
 
 .model-settings-catalog {
-  min-height: 80px;
-  max-height: min(310px, calc(72dvh - 132px));
+  min-height: 0;
+  flex: 1;
   overflow-y: auto;
   overscroll-behavior: contain;
   scrollbar-width: thin;
@@ -252,6 +270,8 @@ html[data-color-scheme="dark"]
 
 .model-settings-manage {
   min-height: 38px !important;
+  flex: 0 0 38px;
+  background: var(--model-control-surface);
 }
 
 [data-model-menu-value] {

--- a/frontend/workspace/src/components/model-settings-popover.tsx
+++ b/frontend/workspace/src/components/model-settings-popover.tsx
@@ -164,7 +164,7 @@ export const ModelSettingsPopover: Component<{ trigger?: "label" | "icon" }> = (
   const quick = createMemo(() => {
     // Pins are explicit. New installations instead see a calm recommended trio
     // with the current model retained when it falls outside that set.
-    const models = [...local.model.pinned(), ...recommended(), current(), ...local.model.recent()].filter(
+    const models = [...local.model.pinned(), ...recommended(), current()].filter(
       (model): model is NonNullable<typeof model> => Boolean(model),
     )
     const seen = new Set<string>()
@@ -237,7 +237,11 @@ export const ModelSettingsPopover: Component<{ trigger?: "label" | "icon" }> = (
     if (view() === "speed" && !value.speed) setView("root")
   })
 
-  const focus = (selector: string) => queueMicrotask(() => refs.content?.querySelector<HTMLElement>(selector)?.focus())
+  const focus = (selector: string, reset = false) =>
+    queueMicrotask(() => {
+      if (reset && refs.content) refs.content.scrollTop = 0
+      refs.content?.querySelector<HTMLElement>(selector)?.focus({ preventScroll: true })
+    })
 
   const show = (next: "effort" | "speed") => {
     setView(next)
@@ -246,13 +250,13 @@ export const ModelSettingsPopover: Component<{ trigger?: "label" | "icon" }> = (
 
   const root = (next: "effort" | "speed") => {
     setView("root")
-    focus(`[data-model-menu-row="${next}"]`)
+    focus(`[data-model-menu-row="${next}"]`, true)
   }
 
   const choose = () => {
     setQuery("")
     setView("models")
-    focus("[data-model-catalog-search]")
+    focus("[data-model-catalog-search]", true)
   }
 
   const manage = () => {
@@ -344,7 +348,8 @@ export const ModelSettingsPopover: Component<{ trigger?: "label" | "icon" }> = (
         <Kobalte.Content
           ref={(element) => (refs.content = element)}
           data-model-settings-popover
-          class="z-50 max-h-[min(72dvh,440px)] overflow-y-auto outline-none"
+          data-model-settings-view={view()}
+          class="z-50 outline-none"
           onKeyDown={onMenuKeyDown}
         >
           <header class="mobile-model-settings__header">


### PR DESCRIPTION
## What changed

- keep the quick model menu compact by dropping transient recent-model entries
- reset popover scroll and focus state when returning from effort or entering the catalog
- make the model catalog the only scrolling region so Manage models remains fully visible
- route Manage models cleanly into Customize on the Models panel
- add an end-to-end regression covering effort back-navigation, layout geometry, and Customize navigation

## Root cause

The outer popover and inner catalog were both scroll containers. Changing views retained outer scroll state, while the Manage models footer participated in the wrong scrolling layer. Recent models also expanded the quick list beyond its intended compact set.

## Validation

- `npm test`: 1,840 passed, 2 skipped, 0 failed
- full workspace E2E: 80 passed, 1 skipped, 0 failed
- workspace typecheck: 7/7 packages passed
- focused model-picker and effort E2E: 3 passed
- focused component tests: 7 passed
