### PR TITLE
fix: preserve web metadata in production builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -75,7 +75,9 @@ jobs:
       - name: Cache CLI build
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: backend/cli/dist
+          path: |
+            backend/cli/dist
+            frontend/workspace/dist/version.json
           key: cli-build-${{ github.run_id }}
 
     outputs:
@@ -109,7 +111,9 @@ jobs:
       - name: Restore CLI build
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: backend/cli/dist
+          path: |
+            backend/cli/dist
+            frontend/workspace/dist/version.json
           key: cli-build-${{ github.run_id }}
           fail-on-cache-miss: true
 
@@ -162,7 +166,9 @@ jobs:
       - name: Restore CLI build
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: backend/cli/dist
+          path: |
+            backend/cli/dist
+            frontend/workspace/dist/version.json
           key: cli-build-${{ github.run_id }}
           fail-on-cache-miss: true
 


### PR DESCRIPTION
## Summary\n\n- cache the generated web version metadata alongside the CLI build\n- restore the metadata in native verification and publish jobs\n- keep the packaged native/web version consistency check enforced\n\n## Root cause\n\nThe build job generated frontend/workspace/dist/version.json, but only backend/cli/dist was cached. Fresh verification runners therefore saw native package version 2.0.2 with missing web metadata.\n\n## Validation\n\n- workflow YAML parses successfully\n- Prettier check passes\n- git diff --check passes\n- pre-push monorepo typecheck passes