### PR TITLE
fix: import legacy OpenScience data on upgrade

### DIFF
--- a/backend/cli/src/cli/onboard.ts
+++ b/backend/cli/src/cli/onboard.ts
@@ -231,9 +231,19 @@ export const DoctorCommand = cmd({
     prompts.log.info(`State root: ${Global.Path.state}`)
 
     if (Global.DataMigration.migrated) {
+      const done = Global.DataMigration.migrated
+      // Each count is a distinct kind of import, so name them separately
+      // rather than folding them into one "files" total that matches none of
+      // them. `deferred` is the one a user can act on: those files are still
+      // in the previous directory and the next launch will try again.
       prompts.log.success(
-        `Legacy data imported into ~/.openscience and verified (${Global.DataMigration.migrated.files} files, ${Global.DataMigration.migrated.merged} credential stores merged, ${Global.DataMigration.migrated.artifacts} artifacts restored). Existing OpenScience data was kept, and the previous XDG directory remains as a safety copy.`,
+        `Legacy data imported into ~/.openscience and verified: ${done.files} file(s) copied, ` +
+          `${done.merged} credential store(s) merged, ${done.artifacts} artifact record(s) restored, ` +
+          `${done.skipped} already present. Existing OpenScience data was kept, and ${done.source} ` +
+          `remains as a safety copy.`,
       )
+      if (done.deferred > 0)
+        prompts.log.warn(`${done.deferred} file(s) could not be read this run; the next launch will retry them.`)
     }
     if (Global.DataMigration.warning) {
       prompts.log.warn(Global.DataMigration.warning)

--- a/backend/cli/src/cli/onboard.ts
+++ b/backend/cli/src/cli/onboard.ts
@@ -235,6 +235,9 @@ export const DoctorCommand = cmd({
         `Legacy data imported into ~/.openscience and verified (${Global.DataMigration.migrated.files} files, ${Global.DataMigration.migrated.merged} credential stores merged, ${Global.DataMigration.migrated.artifacts} artifacts restored). Existing OpenScience data was kept, and the previous XDG directory remains as a safety copy.`,
       )
     }
+    if (Global.DataMigration.warning) {
+      prompts.log.warn(Global.DataMigration.warning)
+    }
     if (Global.DataMigration.error) {
       prompts.log.warn(
         `Data migration to ~/.openscience did not complete; OpenScience is using ${Global.DataMigration.path}. ${Global.DataMigration.error}`,

--- a/backend/cli/src/cli/onboard.ts
+++ b/backend/cli/src/cli/onboard.ts
@@ -232,12 +232,12 @@ export const DoctorCommand = cmd({
 
     if (Global.DataMigration.migrated) {
       prompts.log.success(
-        `Data copied to ~/.openscience and verified (${Global.DataMigration.migrated.files} files). The previous XDG directory remains as a safety copy.`,
+        `Legacy data imported into ~/.openscience and verified (${Global.DataMigration.migrated.files} files, ${Global.DataMigration.migrated.merged} credential stores merged, ${Global.DataMigration.migrated.artifacts} artifacts restored). Existing OpenScience data was kept, and the previous XDG directory remains as a safety copy.`,
       )
     }
     if (Global.DataMigration.error) {
       prompts.log.warn(
-        `Data migration to ~/.openscience did not complete; OpenScience is still using the previous directory. ${Global.DataMigration.error}`,
+        `Data migration to ~/.openscience did not complete; OpenScience is using ${Global.DataMigration.path}. ${Global.DataMigration.error}`,
       )
     }
 

--- a/backend/cli/src/global/data-dir.ts
+++ b/backend/cli/src/global/data-dir.ts
@@ -6,6 +6,9 @@ import path from "node:path"
 import { JsonStore } from "../util/jsonstore"
 
 const marker = ".xdg-data-migration-v2.json"
+/** Suffix for a copy in flight. Never collides with a real name, and marks
+ *  leftovers from a killed process as safe to overwrite. */
+const pending = ".openscience-import"
 // Top-level names the import never reads or writes. `log` is disposable and is
 // the one tree a still-running older instance appends to throughout the import,
 // so copying it buys nothing and costs a full SHA-256 pass over tens of MB on
@@ -32,8 +35,8 @@ export interface DataResolution {
     artifacts: number
     /** Already in the target — settled, never retried. */
     skipped: number
-    /** Unreadable or unverifiable this run — the marker is withheld so the
-     *  next launch tries again. */
+    /** Unreadable or unverifiable this run — named in the marker's `pending`
+     *  list so the next launch retries just these. */
     deferred: number
   }
   warning?: string
@@ -75,6 +78,28 @@ async function inventory(root: string) {
     }
   }
   return files.sort((a, b) => a.path.localeCompare(b.path))
+}
+
+/** A marker's `pending` list is on-disk data a user can edit, so treat it as
+ *  untrusted: only plain relative paths that stay inside the root. */
+function isRelative(value: unknown): value is string {
+  if (typeof value !== "string" || !value) return false
+  if (path.isAbsolute(value)) return false
+  return !path.normalize(value).split(/[\\/]/).includes("..")
+}
+
+/** Re-stat named paths so a resumed import works from what is on disk now,
+ *  not from what the previous run recorded. Anything gone is dropped. */
+async function describe(root: string, names: string[]) {
+  const files = await Promise.all(
+    names.map((name) =>
+      fs
+        .stat(path.join(root, name))
+        .then((stat) => (stat.isFile() ? { path: name, bytes: stat.size, mode: stat.mode & 0o777 } : undefined))
+        .catch(() => undefined),
+    ),
+  )
+  return files.filter((file) => file !== undefined).sort((a, b) => a.path.localeCompare(b.path))
 }
 
 /** Whether both roots seal credentials.json with the same machine key — true
@@ -195,17 +220,34 @@ export async function resolveDataDirectory(input: {
 
   const target = path.join(path.resolve(input.home), ".openscience")
   const legacy = path.resolve(input.legacy)
-  const migrated = await fs
-    .stat(path.join(target, marker))
-    .then((stat) => stat.isFile())
-    .catch(() => false)
-  if (migrated) return { path: target }
+  // A sealed marker with nothing outstanding is the steady state for every
+  // user after their first upgrade, so it has to be the cheapest path here:
+  // one stat, no walk.
+  const sealed = await Bun.file(path.join(target, marker))
+    .json()
+    .then((value) => (value && typeof value === "object" ? (value as { pending?: unknown }) : undefined))
+    .catch(() => undefined)
+  const outstanding = Array.isArray(sealed?.pending) ? (sealed.pending as unknown[]).filter(isRelative) : []
+  if (sealed && outstanding.length === 0) return { path: target }
   if (legacy === target) return { path: target }
 
-  const source = (await inventory(legacy)).filter(
-    (file) => !reserved.has(file.path.split(path.sep)[0]) && !transient.test(file.path),
-  )
-  if (source.length === 0) return { path: target }
+  // A resumed import revisits only the paths the previous run named. The rest
+  // of the tree was settled then, and re-walking it to rediscover that is what
+  // made a single unreadable file expensive on every launch.
+  const source = sealed
+    ? await describe(legacy, outstanding)
+    : (await inventory(legacy)).filter(
+        (file) => !reserved.has(file.path.split(path.sep)[0]) && !transient.test(file.path),
+      )
+  if (source.length === 0) {
+    // Nothing left to fetch — the stragglers are gone from the legacy root
+    // too. Clear the list so the next launch takes the one-stat path.
+    if (sealed)
+      await Bun.write(path.join(target, marker), `${JSON.stringify({ ...sealed, pending: [] }, null, 2)}\n`, {
+        mode: 0o600,
+      }).catch(() => undefined)
+    return { path: target }
+  }
 
   const occupied = (await entries(target)).some((entry) => !reserved.has(entry.name))
 
@@ -215,16 +257,16 @@ export async function resolveDataDirectory(input: {
   // one while its server writes the other, which is the failure this import
   // exists to end.
   const landed = { value: false }
-  const stage = await fs.mkdtemp(path.join(path.resolve(input.home), ".openscience-migrate-"))
   const result = await (async () => {
-    const staged = [] as typeof source
+    const copied = [] as typeof source
     // Two different reasons to not carry a file, with opposite consequences.
     // `present` means the target already has its own copy — settled forever,
     // and the whole point of never overwriting. `deferred` means this run
     // could not read or verify the source: a permission error, a file being
-    // rewritten underneath us, a disk hiccup. Sealing the import with a marker
-    // while anything is deferred would strand those files permanently, so the
-    // two must not be counted together.
+    // rewritten underneath us, a disk hiccup. Those go into the marker's
+    // `pending` list to be retried by name, so the two must not be counted
+    // together: folding them would either strand the second permanently or
+    // send the next launch chasing the first.
     const present: string[] = []
     const deferred: string[] = []
     const carried = new Set<string>()
@@ -245,58 +287,58 @@ export async function resolveDataDirectory(input: {
         present.push(file.path)
         continue
       }
+      // Staged beside its destination rather than in a scratch directory that
+      // is later copied across. Going through a staging root meant writing
+      // every byte twice and needing twice the free space before the CLI would
+      // start — and on a nearly full disk the second write is what fails, so
+      // the cost also bought a failure mode. Here the bytes are written once
+      // and the file is linked into place.
+      //
       // One unreadable file must cost that file and nothing else. Letting the
-      // copy throw here abandoned the entire import — credentials, session,
-      // and history included — over a single chmod 000 leftover.
-      const temporary = path.join(stage, file.path)
+      // copy throw abandoned the entire import — credentials, session, and
+      // history included — over a single chmod 000 leftover.
+      const temporary = `${destination}.${process.pid}${pending}`
       const ready = await fs
-        .mkdir(path.dirname(temporary), { recursive: true })
+        .mkdir(path.dirname(destination), { recursive: true })
         .then(() => fs.copyFile(path.join(legacy, file.path), temporary))
         .then(() => fs.chmod(temporary, file.mode))
-        .then(() => true)
+        // Verify the copy against a fresh hash of its source, so a file being
+        // rewritten underneath us is dropped alone rather than silently landing
+        // half old and half new.
+        .then(async () => {
+          const [copy, origin] = await Promise.all([hash(temporary), hash(path.join(legacy, file.path))])
+          return copy === origin
+        })
         .catch(() => false)
       if (!ready) {
+        await fs.rm(temporary, { force: true }).catch(() => undefined)
         deferred.push(file.path)
         continue
       }
-      carried.add(file.path)
-      staged.push(file)
-    }
-
-    // Verify each copy against a fresh hash of its source and drop only the
-    // files that disagree. Comparing whole-tree manifests instead meant one
-    // file changing mid-copy — a session an already-running instance was
-    // still writing — discarded the entire import, credentials and history
-    // included, and left the user signed out for the sake of one stale byte.
-    const verified = [] as typeof staged
-    for (const file of staged) {
-      const [copy, origin] = await Promise.all([
-        hash(path.join(stage, file.path)).catch(() => undefined),
-        hash(path.join(legacy, file.path)).catch(() => undefined),
-      ])
-      if (!copy || copy !== origin) {
-        deferred.push(file.path)
-        continue
-      }
-      verified.push(file)
-    }
-
-    const copied = [] as typeof staged
-    for (const file of verified) {
-      const destination = path.join(target, file.path)
-      await fs.mkdir(path.dirname(destination), { recursive: true })
-      // EXCL is what makes two concurrently booting processes safe: whoever
-      // loses the race is told EEXIST rather than overwriting the winner.
+      // link() is the atomic create-if-absent that makes two concurrently
+      // booting processes safe: the loser is told EEXIST rather than
+      // overwriting the winner. Filesystems without hardlinks fall back to a
+      // copy with the same exclusive semantics.
       const created = await fs
-        .copyFile(path.join(stage, file.path), destination, constants.COPYFILE_EXCL)
+        .link(temporary, destination)
         .then(() => "created" as const)
-        .catch((error: NodeJS.ErrnoException) => (error.code === "EEXIST" ? ("present" as const) : ("failed" as const)))
+        .catch((error: NodeJS.ErrnoException) =>
+          error.code === "EEXIST"
+            ? ("present" as const)
+            : fs
+                .copyFile(temporary, destination, constants.COPYFILE_EXCL)
+                .then(() => "created" as const)
+                .catch((fallback: NodeJS.ErrnoException) =>
+                  fallback.code === "EEXIST" ? ("present" as const) : ("failed" as const),
+                ),
+        )
+      await fs.rm(temporary, { force: true }).catch(() => undefined)
       if (created !== "created") {
         ;(created === "present" ? present : deferred).push(file.path)
         continue
       }
-      await fs.chmod(destination, file.mode).catch(() => undefined)
       landed.value = true
+      carried.add(file.path)
       copied.push(file)
     }
 
@@ -344,10 +386,15 @@ export async function resolveDataDirectory(input: {
     // not a database". Recovering a user's credentials and history must not
     // hinge on that — record the reason and finish the import without it,
     // rather than throwing away everything already verified.
-    const artifacts = await mergeArtifacts(legacy, target).catch((error: unknown) => {
-      notes.push(`legacy artifact store not imported: ${error instanceof Error ? error.message : String(error)}`)
-      return 0
-    })
+    // Only on a first import. A resume is chasing a handful of named files;
+    // replaying every artifact row to re-discover that they are all already
+    // there would cost more than the retry it is part of.
+    const artifacts = sealed
+      ? 0
+      : await mergeArtifacts(legacy, target).catch((error: unknown) => {
+          notes.push(`legacy artifact store not imported: ${error instanceof Error ? error.message : String(error)}`)
+          return 0
+        })
     const bytes = copied.reduce((total, file) => total + file.bytes, 0)
     const migration = {
       source: legacy,
@@ -360,19 +407,21 @@ export async function resolveDataDirectory(input: {
       deferred: deferred.length,
     }
     await fs.mkdir(target, { recursive: true })
-    // The marker short-circuits every later boot, so writing it is a promise
-    // that nothing is left to fetch. Anything deferred — unreadable, or moving
-    // under the copy — would be stranded for good, so leave the import open and
-    // let the next launch finish the job. Retries are cheap: files already in
-    // the target are skipped before they are ever hashed.
-    if (deferred.length === 0)
-      await Bun.write(
-        path.join(target, marker),
-        `${JSON.stringify({ ...migration, migratedAt: Date.now() }, null, 2)}\n`,
-        { mode: 0o600 },
-      )
+    // Always seal, and carry the outstanding paths inside the marker. Leaving
+    // the marker unwritten instead made every later launch re-walk and re-stat
+    // the whole legacy tree — `--version` included — for as long as one file
+    // stayed unreadable, which for a root-owned leftover is forever. Naming
+    // the stragglers means the retry costs one stat each and the common case
+    // still short-circuits on the first line of the function.
+    // A resume keeps the original import's record and only updates what is
+    // still outstanding — overwriting it with a retry's counts would erase the
+    // one account of what actually moved.
+    const record = sealed
+      ? { ...sealed, pending: deferred, resumedAt: Date.now() }
+      : { ...migration, migratedAt: Date.now(), pending: deferred }
+    await Bun.write(path.join(target, marker), `${JSON.stringify(record, null, 2)}\n`, { mode: 0o600 })
     if (deferred.length > 0)
-      notes.push(`${deferred.length} file(s) could not be read from ${legacy} and will be retried on the next launch`)
+      notes.push(`${deferred.length} file(s) could not be read from ${legacy}; the next launch will retry them`)
     return {
       path: target,
       migrated: migration,
@@ -384,6 +433,5 @@ export async function resolveDataDirectory(input: {
       error: error instanceof Error ? error.message : String(error),
     } satisfies DataResolution
   })
-  await fs.rm(stage, { recursive: true, force: true })
   return result
 }

--- a/backend/cli/src/global/data-dir.ts
+++ b/backend/cli/src/global/data-dir.ts
@@ -12,10 +12,14 @@ const marker = ".xdg-data-migration-v2.json"
 // the boot path.
 const reserved = new Set(["bin", "log", ".xdg-data-migration-v1.json", marker])
 const stores = new Set(["auth.json", "credentials.json", "mcp-auth.json"])
-// Per-process scratch that must not be transplanted. A SQLite -wal/-shm belongs
-// to the legacy database specifically; landing one beside the target's own
-// artifacts.db pairs a journal with a database it never described.
-const transient = /(?:-wal|-shm|\.tmp|\.lock)$/
+// Per-process scratch that must not be transplanted.
+const transient = /(?:\.tmp|\.lock)$/
+// A SQLite -wal/-shm is only meaningful beside the exact database it was
+// written for. Landing one next to the target's own artifacts.db pairs a
+// journal with a database it never described; dropping it when the database
+// IS being carried loses every transaction still in the log. So it travels
+// with its database and only with its database.
+const journal = /(?:-wal|-shm)$/
 
 export interface DataResolution {
   path: string
@@ -26,9 +30,12 @@ export interface DataResolution {
     bytes: number
     merged: number
     artifacts: number
+    /** Already in the target — settled, never retried. */
     skipped: number
+    /** Unreadable or unverifiable this run — the marker is withheld so the
+     *  next launch tries again. */
+    deferred: number
   }
-  conflict?: { legacy: string; current: string }
   warning?: string
   error?: string
 }
@@ -57,11 +64,28 @@ async function inventory(root: string) {
         continue
       }
       if (!entry.isFile()) continue
-      const stat = await fs.stat(full)
+      // A file can vanish between the readdir and the stat — a still-running
+      // instance rotating a log, or JsonStore renaming its `.tmp` over the
+      // real store. This walk runs at module scope behind a top-level await,
+      // so letting ENOENT escape here does not fail the import, it stops the
+      // CLI from booting at all.
+      const stat = await fs.stat(full).catch(() => undefined)
+      if (!stat) continue
       files.push({ path: path.relative(root, full), bytes: stat.size, mode: stat.mode & 0o777 })
     }
   }
   return files.sort((a, b) => a.path.localeCompare(b.path))
+}
+
+/** Whether both roots seal credentials.json with the same machine key — true
+ *  only when the legacy key was the one carried across, i.e. the target had
+ *  none of its own. */
+async function sameKey(legacy: string, target: string) {
+  const [old, current] = await Promise.all(
+    [legacy, target].map((root) => fs.readFile(path.join(root, "credentials.key")).catch(() => undefined)),
+  )
+  if (!old) return true
+  return !!current && old.equals(current)
 }
 
 async function object(file: string) {
@@ -89,8 +113,20 @@ async function mergeArtifacts(legacy: string, target: string) {
     .then(() => {
       db.exec("PRAGMA foreign_keys = ON")
       db.exec("PRAGMA busy_timeout = 5000")
-      const columns = old.query("PRAGMA table_info(artifacts)").all() as Array<{ name: string }>
-      const trashed = columns.some((column) => column.name === "trashed_at") ? "trashed_at" : "NULL"
+      // `trashed_at` has to exist on BOTH sides. A target written by an older
+      // build has not been through ArtifactStore.prepare()'s ALTER TABLE yet
+      // in this process, and inserting into a column it lacks fails the whole
+      // merge with "no such column".
+      const has = (handle: Database) =>
+        (handle.query("PRAGMA table_info(artifacts)").all() as Array<{ name: string }>).some(
+          (column) => column.name === "trashed_at",
+        )
+      // Both the read and the write have to drop the column together: naming
+      // it only in the INSERT fails just as hard as selecting it from a source
+      // that lacks it.
+      const trashed = has(db)
+      const select = trashed ? (has(old) ? "trashed_at" : "NULL") : undefined
+      const column = trashed ? "trashed_at, " : ""
       const before = db.query("SELECT count(*) AS value FROM main.artifacts").get() as { value: number }
       const copy = (select: string, insert: string, keep?: (row: SQLQueryBindings[]) => boolean) => {
         const statement = db.query<unknown, SQLQueryBindings[]>(insert)
@@ -106,10 +142,10 @@ async function mergeArtifacts(legacy: string, target: string) {
         )
         copy(
           `SELECT id, schema_version, project_id, source_key, title, kind, current_version_id, state,
-                  ${trashed}, created_at, updated_at FROM artifacts`,
+                  ${select ? `${select},` : ""} created_at, updated_at FROM artifacts`,
           `INSERT OR IGNORE INTO artifacts
-            (id, schema_version, project_id, source_key, title, kind, current_version_id, state, trashed_at,
-             created_at, updated_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)`,
+            (id, schema_version, project_id, source_key, title, kind, current_version_id, state, ${column}
+             created_at, updated_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10${trashed ? ", ?11" : ""})`,
         )
         const artifacts = new Set(db.query("SELECT id FROM artifacts").values().flat())
         copy(
@@ -182,7 +218,16 @@ export async function resolveDataDirectory(input: {
   const stage = await fs.mkdtemp(path.join(path.resolve(input.home), ".openscience-migrate-"))
   const result = await (async () => {
     const staged = [] as typeof source
-    const skipped: string[] = []
+    // Two different reasons to not carry a file, with opposite consequences.
+    // `present` means the target already has its own copy — settled forever,
+    // and the whole point of never overwriting. `deferred` means this run
+    // could not read or verify the source: a permission error, a file being
+    // rewritten underneath us, a disk hiccup. Sealing the import with a marker
+    // while anything is deferred would strand those files permanently, so the
+    // two must not be counted together.
+    const present: string[] = []
+    const deferred: string[] = []
+    const carried = new Set<string>()
     for (const file of source) {
       if (stores.has(file.path)) continue
       const destination = path.join(target, file.path)
@@ -191,13 +236,30 @@ export async function resolveDataDirectory(input: {
         .then(() => true)
         .catch(() => false)
       if (exists) {
-        skipped.push(file.path)
+        present.push(file.path)
         continue
       }
+      // Source order is sorted, so a database sorts before its -wal/-shm and
+      // `carried` is already decided by the time the journal is considered.
+      if (journal.test(file.path) && !carried.has(file.path.replace(journal, ""))) {
+        present.push(file.path)
+        continue
+      }
+      // One unreadable file must cost that file and nothing else. Letting the
+      // copy throw here abandoned the entire import — credentials, session,
+      // and history included — over a single chmod 000 leftover.
       const temporary = path.join(stage, file.path)
-      await fs.mkdir(path.dirname(temporary), { recursive: true })
-      await fs.copyFile(path.join(legacy, file.path), temporary)
-      await fs.chmod(temporary, file.mode)
+      const ready = await fs
+        .mkdir(path.dirname(temporary), { recursive: true })
+        .then(() => fs.copyFile(path.join(legacy, file.path), temporary))
+        .then(() => fs.chmod(temporary, file.mode))
+        .then(() => true)
+        .catch(() => false)
+      if (!ready) {
+        deferred.push(file.path)
+        continue
+      }
+      carried.add(file.path)
       staged.push(file)
     }
 
@@ -213,7 +275,7 @@ export async function resolveDataDirectory(input: {
         hash(path.join(legacy, file.path)).catch(() => undefined),
       ])
       if (!copy || copy !== origin) {
-        skipped.push(file.path)
+        deferred.push(file.path)
         continue
       }
       verified.push(file)
@@ -223,35 +285,54 @@ export async function resolveDataDirectory(input: {
     for (const file of verified) {
       const destination = path.join(target, file.path)
       await fs.mkdir(path.dirname(destination), { recursive: true })
+      // EXCL is what makes two concurrently booting processes safe: whoever
+      // loses the race is told EEXIST rather than overwriting the winner.
       const created = await fs
         .copyFile(path.join(stage, file.path), destination, constants.COPYFILE_EXCL)
-        .then(() => true)
-        .catch((error: NodeJS.ErrnoException) => {
-          if (error.code === "EEXIST") return false
-          throw error
-        })
-      if (!created) {
-        skipped.push(file.path)
+        .then(() => "created" as const)
+        .catch((error: NodeJS.ErrnoException) => (error.code === "EEXIST" ? ("present" as const) : ("failed" as const)))
+      if (created !== "created") {
+        ;(created === "present" ? present : deferred).push(file.path)
         continue
       }
-      await fs.chmod(destination, file.mode)
+      await fs.chmod(destination, file.mode).catch(() => undefined)
       landed.value = true
       copied.push(file)
     }
 
     const merged: string[] = []
+    const notes: string[] = []
     for (const name of stores) {
       const old = source.find((file) => file.path === name)
       if (!old) continue
-      const previous = await JsonStore.read(path.join(target, name))
-      const legacyData = await object(path.join(legacy, name))
-      if (!Object.keys(legacyData).some((key) => !(key in previous))) continue
-      const count = { value: 0 }
-      await JsonStore.update(path.join(target, name), (current) => {
-        count.value = Object.keys(legacyData).filter((key) => !(key in current)).length
-        return { ...legacyData, ...current }
+      // Entries in credentials.json are AES-256-GCM ciphertexts sealed with
+      // the machine-local credentials.key. Importing them under a different
+      // key produces entries the UI reports as "set" while decryptFields
+      // silently drops every one — the user sees a configured GitHub token
+      // and gets no GITHUB_TOKEN. Only carry them when the key came across
+      // too, which is exactly when the target had none of its own.
+      if (name === "credentials.json" && !(await sameKey(legacy, target))) {
+        notes.push("legacy credentials.json not imported: it is sealed with a different machine key")
+        continue
+      }
+      // A corrupt legacy store must cost that store, not the import. Left
+      // unguarded this threw past the marker write, so every later boot
+      // re-ran the whole import and failed at the same byte, forever.
+      const outcome = await (async () => {
+        const previous = await JsonStore.read(path.join(target, name))
+        const legacyData = await object(path.join(legacy, name))
+        if (!Object.keys(legacyData).some((key) => !(key in previous))) return 0
+        const count = { value: 0 }
+        await JsonStore.update(path.join(target, name), (current) => {
+          count.value = Object.keys(legacyData).filter((key) => !(key in current)).length
+          return { ...legacyData, ...current }
+        })
+        return count.value
+      })().catch((error: unknown) => {
+        notes.push(`legacy ${name} not imported: ${error instanceof Error ? error.message : String(error)}`)
+        return 0
       })
-      if (count.value > 0) {
+      if (outcome > 0) {
         landed.value = true
         merged.push(name)
       }
@@ -263,37 +344,40 @@ export async function resolveDataDirectory(input: {
     // not a database". Recovering a user's credentials and history must not
     // hinge on that — record the reason and finish the import without it,
     // rather than throwing away everything already verified.
-    const outcome = await mergeArtifacts(legacy, target).then(
-      (count) => ({ count, warning: undefined as string | undefined }),
-      (error: unknown) => ({
-        count: 0,
-        warning: `legacy artifact store not imported: ${error instanceof Error ? error.message : String(error)}`,
-      }),
-    )
-    const artifacts = outcome.count
-    const imported = copied.length + merged.length + (artifacts > 0 ? 1 : 0)
-    const bytes = [...copied, ...source.filter((file) => merged.includes(file.path))].reduce(
-      (total, file) => total + file.bytes,
-      0,
-    )
+    const artifacts = await mergeArtifacts(legacy, target).catch((error: unknown) => {
+      notes.push(`legacy artifact store not imported: ${error instanceof Error ? error.message : String(error)}`)
+      return 0
+    })
+    const bytes = copied.reduce((total, file) => total + file.bytes, 0)
     const migration = {
       source: legacy,
       target,
-      files: imported,
+      files: copied.length,
       bytes,
       merged: merged.length,
       artifacts,
-      skipped: skipped.length,
+      skipped: present.length,
+      deferred: deferred.length,
     }
     await fs.mkdir(target, { recursive: true })
-    await Bun.write(
-      path.join(target, marker),
-      `${JSON.stringify({ ...migration, migratedAt: Date.now() }, null, 2)}\n`,
-      {
-        mode: 0o600,
-      },
-    )
-    return { path: target, migrated: migration, warning: outcome.warning } satisfies DataResolution
+    // The marker short-circuits every later boot, so writing it is a promise
+    // that nothing is left to fetch. Anything deferred — unreadable, or moving
+    // under the copy — would be stranded for good, so leave the import open and
+    // let the next launch finish the job. Retries are cheap: files already in
+    // the target are skipped before they are ever hashed.
+    if (deferred.length === 0)
+      await Bun.write(
+        path.join(target, marker),
+        `${JSON.stringify({ ...migration, migratedAt: Date.now() }, null, 2)}\n`,
+        { mode: 0o600 },
+      )
+    if (deferred.length > 0)
+      notes.push(`${deferred.length} file(s) could not be read from ${legacy} and will be retried on the next launch`)
+    return {
+      path: target,
+      migrated: migration,
+      warning: notes.length ? notes.join("; ") : undefined,
+    } satisfies DataResolution
   })().catch((error: unknown) => {
     return {
       path: occupied || landed.value ? target : legacy,

--- a/backend/cli/src/global/data-dir.ts
+++ b/backend/cli/src/global/data-dir.ts
@@ -1,13 +1,25 @@
 import fs from "fs/promises"
+import { Database, type SQLQueryBindings } from "bun:sqlite"
 import { createHash } from "node:crypto"
-import { createReadStream } from "node:fs"
+import { constants, createReadStream } from "node:fs"
 import path from "node:path"
+import { JsonStore } from "../util/jsonstore"
 
-const reserved = new Set(["bin", ".xdg-data-migration-v1.json"])
+const marker = ".xdg-data-migration-v2.json"
+const reserved = new Set(["bin", ".xdg-data-migration-v1.json", marker])
+const stores = new Set(["auth.json", "credentials.json", "mcp-auth.json"])
 
 export interface DataResolution {
   path: string
-  migrated?: { source: string; target: string; files: number; bytes: number }
+  migrated?: {
+    source: string
+    target: string
+    files: number
+    bytes: number
+    merged: number
+    artifacts: number
+    skipped: number
+  }
   conflict?: { legacy: string; current: string }
   error?: string
 }
@@ -22,9 +34,9 @@ async function hash(file: string) {
   return value.digest("hex")
 }
 
-async function manifest(root: string) {
+async function inventory(root: string) {
   const stack = [root]
-  const files: Array<{ path: string; bytes: number; sha256: string }> = []
+  const files: Array<{ path: string; bytes: number; mode: number }> = []
   while (stack.length) {
     const dir = stack.pop()
     if (!dir) continue
@@ -37,22 +49,105 @@ async function manifest(root: string) {
       }
       if (!entry.isFile()) continue
       const stat = await fs.stat(full)
-      files.push({ path: path.relative(root, full), bytes: stat.size, sha256: await hash(full) })
+      files.push({ path: path.relative(root, full), bytes: stat.size, mode: stat.mode & 0o777 })
     }
   }
   return files.sort((a, b) => a.path.localeCompare(b.path))
 }
 
-async function copy(source: string, target: string) {
-  await fs.mkdir(target, { recursive: true })
-  for (const entry of await entries(source)) {
-    if (reserved.has(entry.name) || entry.isSymbolicLink()) continue
-    await fs.cp(path.join(source, entry.name), path.join(target, entry.name), {
-      recursive: true,
-      force: false,
-      errorOnExist: true,
+async function manifest(root: string, files?: Awaited<ReturnType<typeof inventory>>) {
+  const selected = files ?? (await inventory(root))
+  return Promise.all(
+    selected.map(async (file) => ({
+      path: file.path,
+      bytes: file.bytes,
+      sha256: await hash(path.join(root, file.path)),
+    })),
+  )
+}
+
+async function object(file: string) {
+  const value: unknown = JSON.parse(await fs.readFile(file, "utf8"))
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(`${file} is not a JSON object`)
+  return value as Record<string, unknown>
+}
+
+async function mergeArtifacts(legacy: string, target: string) {
+  const source = path.join(legacy, "artifact-store", "artifacts.db")
+  const destination = path.join(target, "artifact-store", "artifacts.db")
+  const available = await Promise.all(
+    [source, destination].map((file) =>
+      fs
+        .stat(file)
+        .then((stat) => stat.isFile())
+        .catch(() => false),
+    ),
+  )
+  if (!available.every(Boolean)) return 0
+
+  const db = new Database(destination)
+  const old = new Database(source, { readonly: true })
+  return Promise.resolve()
+    .then(() => {
+      db.exec("PRAGMA foreign_keys = ON")
+      db.exec("PRAGMA busy_timeout = 5000")
+      const columns = old.query("PRAGMA table_info(artifacts)").all() as Array<{ name: string }>
+      const trashed = columns.some((column) => column.name === "trashed_at") ? "trashed_at" : "NULL"
+      const before = db.query("SELECT count(*) AS value FROM main.artifacts").get() as { value: number }
+      const copy = (select: string, insert: string, keep?: (row: SQLQueryBindings[]) => boolean) => {
+        const statement = db.query<unknown, SQLQueryBindings[]>(insert)
+        for (const row of old.query(select).values() as SQLQueryBindings[][]) {
+          if (keep && !keep(row)) continue
+          statement.run(...row)
+        }
+      }
+      db.transaction(() => {
+        copy(
+          "SELECT sha256, size, path, created_at FROM blobs",
+          "INSERT OR IGNORE INTO blobs (sha256, size, path, created_at) VALUES (?1, ?2, ?3, ?4)",
+        )
+        copy(
+          `SELECT id, schema_version, project_id, source_key, title, kind, current_version_id, state,
+                  ${trashed}, created_at, updated_at FROM artifacts`,
+          `INSERT OR IGNORE INTO artifacts
+            (id, schema_version, project_id, source_key, title, kind, current_version_id, state, trashed_at,
+             created_at, updated_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)`,
+        )
+        const artifacts = new Set(db.query("SELECT id FROM artifacts").values().flat())
+        copy(
+          `SELECT id, artifact_id, version, filename, mime_type, size, sha256, session_id, message_id, execution_id,
+                  source_path, capture_quality, created_at FROM versions`,
+          `INSERT OR IGNORE INTO versions
+            (id, artifact_id, version, filename, mime_type, size, sha256, session_id, message_id, execution_id,
+             source_path, capture_quality, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)`,
+          (row) => artifacts.has(row[1] as string),
+        )
+        const versions = new Set(db.query("SELECT id FROM versions").values().flat())
+        copy(
+          `SELECT id, artifact_version_id, command, code, status, stdout, stderr, model, provider, effort, source,
+                  permission_snapshot, inputs, capture_quality, files, environment, created_at FROM executions`,
+          `INSERT OR IGNORE INTO executions
+            (id, artifact_version_id, command, code, status, stdout, stderr, model, provider, effort, source,
+             permission_snapshot, inputs, capture_quality, files, environment, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)`,
+          (row) => versions.has(row[1] as string),
+        )
+      })()
+      const after = db.query("SELECT count(*) AS value FROM main.artifacts").get() as { value: number }
+      return after.value - before.value
     })
-  }
+    .then(
+      (result) => {
+        old.close()
+        db.close()
+        return result
+      },
+      (error) => {
+        old.close()
+        db.close()
+        throw error
+      },
+    )
 }
 
 export async function resolveDataDirectory(input: {
@@ -67,54 +162,107 @@ export async function resolveDataDirectory(input: {
   const target = path.join(path.resolve(input.home), ".openscience")
   const legacy = path.resolve(input.legacy)
   const migrated = await fs
-    .stat(path.join(target, ".xdg-data-migration-v1.json"))
+    .stat(path.join(target, marker))
     .then((stat) => stat.isFile())
     .catch(() => false)
   if (migrated) return { path: target }
-  const source = await entries(legacy)
-  if (source.length === 0 || legacy === target) return { path: target }
+  if (legacy === target) return { path: target }
 
-  const occupied = (await entries(target)).filter((entry) => !reserved.has(entry.name))
-  if (occupied.length > 0) {
-    return { path: target, conflict: { legacy, current: target } }
-  }
+  const source = (await inventory(legacy)).filter((file) => !reserved.has(file.path.split(path.sep)[0]))
+  if (source.length === 0) return { path: target }
+
+  const occupied = (await entries(target)).some((entry) => !reserved.has(entry.name))
 
   const stage = await fs.mkdtemp(path.join(path.resolve(input.home), ".openscience-migrate-"))
-  const moved: string[] = []
-  const result = await copy(legacy, stage)
-    .then(async () => {
-      const before = await manifest(stage)
-      const original = (await manifest(legacy)).filter((file) => !reserved.has(file.path.split(path.sep)[0]))
-      if (JSON.stringify(before) !== JSON.stringify(original)) throw new Error("checksum verification failed")
-      await fs.mkdir(target, { recursive: true })
-      for (const entry of await entries(stage)) {
-        await fs.rename(path.join(stage, entry.name), path.join(target, entry.name))
-        moved.push(entry.name)
+  const result = await (async () => {
+    const staged = [] as typeof source
+    const skipped: string[] = []
+    for (const file of source) {
+      if (stores.has(file.path)) continue
+      const destination = path.join(target, file.path)
+      const exists = await fs
+        .lstat(destination)
+        .then(() => true)
+        .catch(() => false)
+      if (exists) {
+        skipped.push(file.path)
+        continue
       }
-      const bytes = before.reduce((total, file) => total + file.bytes, 0)
-      const migrated = { source: legacy, target, files: before.length, bytes }
-      await Bun.write(
-        path.join(target, ".xdg-data-migration-v1.json"),
-        `${JSON.stringify({ ...migrated, migratedAt: Date.now() }, null, 2)}\n`,
-        { mode: 0o600 },
-      )
-      return { path: target, migrated } satisfies DataResolution
-    })
-    .catch(async (error: unknown) => {
-      await Promise.all(
-        moved
-          .reverse()
-          .map((name) =>
-            fs
-              .rename(path.join(target, name), path.join(stage, name))
-              .catch(() => fs.rm(path.join(target, name), { recursive: true, force: true })),
-          ),
-      )
-      return {
-        path: legacy,
-        error: error instanceof Error ? error.message : String(error),
+      const temporary = path.join(stage, file.path)
+      await fs.mkdir(path.dirname(temporary), { recursive: true })
+      await fs.copyFile(path.join(legacy, file.path), temporary)
+      await fs.chmod(temporary, file.mode)
+      staged.push(file)
+    }
+
+    const before = await manifest(stage)
+    const original = await manifest(legacy, staged)
+    if (JSON.stringify(before) !== JSON.stringify(original)) throw new Error("checksum verification failed")
+
+    const copied = [] as typeof staged
+    for (const file of staged) {
+      const destination = path.join(target, file.path)
+      await fs.mkdir(path.dirname(destination), { recursive: true })
+      const created = await fs
+        .copyFile(path.join(stage, file.path), destination, constants.COPYFILE_EXCL)
+        .then(() => true)
+        .catch((error: NodeJS.ErrnoException) => {
+          if (error.code === "EEXIST") return false
+          throw error
+        })
+      if (!created) {
+        skipped.push(file.path)
+        continue
       }
-    })
+      await fs.chmod(destination, file.mode)
+      copied.push(file)
+    }
+
+    const merged: string[] = []
+    for (const name of stores) {
+      const old = source.find((file) => file.path === name)
+      if (!old) continue
+      const previous = await JsonStore.read(path.join(target, name))
+      const legacyData = await object(path.join(legacy, name))
+      if (!Object.keys(legacyData).some((key) => !(key in previous))) continue
+      const count = { value: 0 }
+      await JsonStore.update(path.join(target, name), (current) => {
+        count.value = Object.keys(legacyData).filter((key) => !(key in current)).length
+        return { ...legacyData, ...current }
+      })
+      if (count.value > 0) merged.push(name)
+    }
+
+    const artifacts = await mergeArtifacts(legacy, target)
+    const imported = copied.length + merged.length + (artifacts > 0 ? 1 : 0)
+    const bytes = [...copied, ...source.filter((file) => merged.includes(file.path))].reduce(
+      (total, file) => total + file.bytes,
+      0,
+    )
+    const migration = {
+      source: legacy,
+      target,
+      files: imported,
+      bytes,
+      merged: merged.length,
+      artifacts,
+      skipped: skipped.length,
+    }
+    await fs.mkdir(target, { recursive: true })
+    await Bun.write(
+      path.join(target, marker),
+      `${JSON.stringify({ ...migration, migratedAt: Date.now() }, null, 2)}\n`,
+      {
+        mode: 0o600,
+      },
+    )
+    return { path: target, migrated: migration } satisfies DataResolution
+  })().catch((error: unknown) => {
+    return {
+      path: occupied ? target : legacy,
+      error: error instanceof Error ? error.message : String(error),
+    } satisfies DataResolution
+  })
   await fs.rm(stage, { recursive: true, force: true })
   return result
 }

--- a/backend/cli/src/global/data-dir.ts
+++ b/backend/cli/src/global/data-dir.ts
@@ -6,8 +6,16 @@ import path from "node:path"
 import { JsonStore } from "../util/jsonstore"
 
 const marker = ".xdg-data-migration-v2.json"
-const reserved = new Set(["bin", ".xdg-data-migration-v1.json", marker])
+// Top-level names the import never reads or writes. `log` is disposable and is
+// the one tree a still-running older instance appends to throughout the import,
+// so copying it buys nothing and costs a full SHA-256 pass over tens of MB on
+// the boot path.
+const reserved = new Set(["bin", "log", ".xdg-data-migration-v1.json", marker])
 const stores = new Set(["auth.json", "credentials.json", "mcp-auth.json"])
+// Per-process scratch that must not be transplanted. A SQLite -wal/-shm belongs
+// to the legacy database specifically; landing one beside the target's own
+// artifacts.db pairs a journal with a database it never described.
+const transient = /(?:-wal|-shm|\.tmp|\.lock)$/
 
 export interface DataResolution {
   path: string
@@ -21,6 +29,7 @@ export interface DataResolution {
     skipped: number
   }
   conflict?: { legacy: string; current: string }
+  warning?: string
   error?: string
 }
 
@@ -53,17 +62,6 @@ async function inventory(root: string) {
     }
   }
   return files.sort((a, b) => a.path.localeCompare(b.path))
-}
-
-async function manifest(root: string, files?: Awaited<ReturnType<typeof inventory>>) {
-  const selected = files ?? (await inventory(root))
-  return Promise.all(
-    selected.map(async (file) => ({
-      path: file.path,
-      bytes: file.bytes,
-      sha256: await hash(path.join(root, file.path)),
-    })),
-  )
 }
 
 async function object(file: string) {
@@ -168,11 +166,19 @@ export async function resolveDataDirectory(input: {
   if (migrated) return { path: target }
   if (legacy === target) return { path: target }
 
-  const source = (await inventory(legacy)).filter((file) => !reserved.has(file.path.split(path.sep)[0]))
+  const source = (await inventory(legacy)).filter(
+    (file) => !reserved.has(file.path.split(path.sep)[0]) && !transient.test(file.path),
+  )
   if (source.length === 0) return { path: target }
 
   const occupied = (await entries(target)).some((entry) => !reserved.has(entry.name))
 
+  // Once a single file has landed in the target this process must keep using
+  // the target, whatever fails afterwards. Falling back to the legacy root at
+  // that point splits a single launch across two data roots — the CLI reading
+  // one while its server writes the other, which is the failure this import
+  // exists to end.
+  const landed = { value: false }
   const stage = await fs.mkdtemp(path.join(path.resolve(input.home), ".openscience-migrate-"))
   const result = await (async () => {
     const staged = [] as typeof source
@@ -195,12 +201,26 @@ export async function resolveDataDirectory(input: {
       staged.push(file)
     }
 
-    const before = await manifest(stage)
-    const original = await manifest(legacy, staged)
-    if (JSON.stringify(before) !== JSON.stringify(original)) throw new Error("checksum verification failed")
+    // Verify each copy against a fresh hash of its source and drop only the
+    // files that disagree. Comparing whole-tree manifests instead meant one
+    // file changing mid-copy — a session an already-running instance was
+    // still writing — discarded the entire import, credentials and history
+    // included, and left the user signed out for the sake of one stale byte.
+    const verified = [] as typeof staged
+    for (const file of staged) {
+      const [copy, origin] = await Promise.all([
+        hash(path.join(stage, file.path)).catch(() => undefined),
+        hash(path.join(legacy, file.path)).catch(() => undefined),
+      ])
+      if (!copy || copy !== origin) {
+        skipped.push(file.path)
+        continue
+      }
+      verified.push(file)
+    }
 
     const copied = [] as typeof staged
-    for (const file of staged) {
+    for (const file of verified) {
       const destination = path.join(target, file.path)
       await fs.mkdir(path.dirname(destination), { recursive: true })
       const created = await fs
@@ -215,6 +235,7 @@ export async function resolveDataDirectory(input: {
         continue
       }
       await fs.chmod(destination, file.mode)
+      landed.value = true
       copied.push(file)
     }
 
@@ -230,10 +251,26 @@ export async function resolveDataDirectory(input: {
         count.value = Object.keys(legacyData).filter((key) => !(key in current)).length
         return { ...legacyData, ...current }
       })
-      if (count.value > 0) merged.push(name)
+      if (count.value > 0) {
+        landed.value = true
+        merged.push(name)
+      }
     }
 
-    const artifacts = await mergeArtifacts(legacy, target)
+    // Artifacts are the one part of the import that reads a foreign file
+    // format, so they are the one part that can fail on data this code never
+    // wrote: a truncated or half-written legacy artifacts.db raises "file is
+    // not a database". Recovering a user's credentials and history must not
+    // hinge on that — record the reason and finish the import without it,
+    // rather than throwing away everything already verified.
+    const outcome = await mergeArtifacts(legacy, target).then(
+      (count) => ({ count, warning: undefined as string | undefined }),
+      (error: unknown) => ({
+        count: 0,
+        warning: `legacy artifact store not imported: ${error instanceof Error ? error.message : String(error)}`,
+      }),
+    )
+    const artifacts = outcome.count
     const imported = copied.length + merged.length + (artifacts > 0 ? 1 : 0)
     const bytes = [...copied, ...source.filter((file) => merged.includes(file.path))].reduce(
       (total, file) => total + file.bytes,
@@ -256,10 +293,10 @@ export async function resolveDataDirectory(input: {
         mode: 0o600,
       },
     )
-    return { path: target, migrated: migration } satisfies DataResolution
+    return { path: target, migrated: migration, warning: outcome.warning } satisfies DataResolution
   })().catch((error: unknown) => {
     return {
-      path: occupied ? target : legacy,
+      path: occupied || landed.value ? target : legacy,
       error: error instanceof Error ? error.message : String(error),
     } satisfies DataResolution
   })

--- a/backend/cli/src/global/index.ts
+++ b/backend/cli/src/global/index.ts
@@ -71,7 +71,6 @@ const resolved = await resolveDataDirectory({
   pointer,
 })
 const data = resolved.path
-if (resolved.conflict) detectedLegacyConflicts.push(resolved.conflict)
 
 // Legacy file names inside the migrated dirs (pre-rename releases).
 migrateFile(data, "synsci-session.json", "openscience-session.json")

--- a/backend/cli/test/global/data-dir.test.ts
+++ b/backend/cli/test/global/data-dir.test.ts
@@ -103,7 +103,6 @@ describe("OpenScience data directory", () => {
     const repeated = await resolveDataDirectory({ home, legacy })
     expect(repeated.path).toBe(result.path)
     expect(repeated.migrated).toBeUndefined()
-    expect(repeated.conflict).toBeUndefined()
   })
 
   test("merges missing projects, sessions, and credentials into a populated root", async () => {
@@ -132,7 +131,7 @@ describe("OpenScience data directory", () => {
     const result = await resolveDataDirectory({ home, legacy })
 
     expect(result.path).toBe(target)
-    expect(result.conflict).toBeUndefined()
+    expect(result.error).toBeUndefined()
     expect(result.migrated?.merged).toBe(1)
     expect(await fs.readFile(path.join(target, "storage", "project", "prj_old.json"), "utf8")).toContain("old")
     expect(await fs.readFile(path.join(target, "storage", "project", "prj_new.json"), "utf8")).toContain("new")
@@ -269,5 +268,123 @@ describe("OpenScience data directory", () => {
     expect(await fs.readFile(path.join(target, "openscience-session.json"), "utf8")).toContain("kept")
     for (const id of ["a", "b", "c"])
       expect(fsSync.existsSync(path.join(target, "storage", "session", `ses_${id}.json`))).toBe(true)
+  })
+
+  test("survives a file vanishing between the walk and the copy", async () => {
+    const home = await root()
+    const legacy = path.join(home, "share", "openscience")
+    await fs.mkdir(path.join(legacy, "storage", "session"), { recursive: true })
+    await fs.writeFile(path.join(legacy, "openscience-session.json"), '{"api_key":"kept"}')
+    for (let i = 0; i < 400; i++)
+      await fs.writeFile(path.join(legacy, "storage", "session", `ses_${i}.json`), `{"i":${i}}`)
+
+    // A still-running instance deleting sessions throughout the import. This
+    // walk sits behind a top-level await in global/index.ts, so an escaping
+    // ENOENT would stop the CLI from booting at all.
+    const doomed = Array.from({ length: 400 }, (_, i) => path.join(legacy, "storage", "session", `ses_${i}.json`))
+    const killer = setInterval(() => {
+      const victim = doomed.pop()
+      if (victim) fsSync.rmSync(victim, { force: true })
+    }, 0)
+    const result = await resolveDataDirectory({ home, legacy }).finally(() => clearInterval(killer))
+
+    expect(result.path).toBe(path.join(home, ".openscience"))
+    expect(result.error).toBeUndefined()
+    expect(await fs.readFile(path.join(result.path, "openscience-session.json"), "utf8")).toContain("kept")
+  })
+
+  test("an unreadable file costs that file and nothing else", async () => {
+    const home = await root()
+    const legacy = path.join(home, "share", "openscience")
+    const target = path.join(home, ".openscience")
+    await fs.mkdir(path.join(legacy, "storage", "session"), { recursive: true })
+    await fs.writeFile(path.join(legacy, "openscience-session.json"), '{"api_key":"kept"}')
+    await fs.writeFile(path.join(legacy, "auth.json"), JSON.stringify({ "openai-codex": { access: "kept" } }))
+    await fs.writeFile(path.join(legacy, "storage", "session", "locked.json"), "{}")
+    await fs.chmod(path.join(legacy, "storage", "session", "locked.json"), 0o000)
+
+    const result = await resolveDataDirectory({ home, legacy })
+
+    expect(result.error).toBeUndefined()
+    expect(result.migrated?.deferred).toBe(1)
+    expect(await fs.readFile(path.join(target, "openscience-session.json"), "utf8")).toContain("kept")
+    expect(JSON.parse(await fs.readFile(path.join(target, "auth.json"), "utf8"))["openai-codex"].access).toBe("kept")
+    // Nothing was sealed, so the next launch retries the file it could not read.
+    expect(fsSync.existsSync(path.join(target, ".xdg-data-migration-v2.json"))).toBe(false)
+    await fs.chmod(path.join(legacy, "storage", "session", "locked.json"), 0o600)
+    const retry = await resolveDataDirectory({ home, legacy })
+    expect(retry.migrated?.deferred).toBe(0)
+    expect(fsSync.existsSync(path.join(target, "storage", "session", "locked.json"))).toBe(true)
+    expect(fsSync.existsSync(path.join(target, ".xdg-data-migration-v2.json"))).toBe(true)
+  })
+
+  test("a corrupt legacy credential store does not abort the import", async () => {
+    const home = await root()
+    const legacy = path.join(home, "share", "openscience")
+    const target = path.join(home, ".openscience")
+    await fs.mkdir(legacy, { recursive: true })
+    await fs.writeFile(path.join(legacy, "openscience-session.json"), '{"api_key":"kept"}')
+    await fs.writeFile(path.join(legacy, "auth.json"), '{"openai-codex":{"acce')
+
+    const result = await resolveDataDirectory({ home, legacy })
+
+    expect(result.path).toBe(target)
+    expect(result.error).toBeUndefined()
+    expect(result.warning).toContain("auth.json")
+    expect(await fs.readFile(path.join(target, "openscience-session.json"), "utf8")).toContain("kept")
+    // Sealed: a corrupt source is not going to parse on the next boot either,
+    // so re-running the whole import forever helps nobody.
+    expect(fsSync.existsSync(path.join(target, ".xdg-data-migration-v2.json"))).toBe(true)
+  })
+
+  test("does not import credentials sealed with a different machine key", async () => {
+    const home = await root()
+    const legacy = path.join(home, "share", "openscience")
+    const target = path.join(home, ".openscience")
+    await fs.mkdir(legacy, { recursive: true })
+    await fs.mkdir(target, { recursive: true })
+    await fs.writeFile(path.join(legacy, "credentials.key"), Buffer.alloc(32, 1))
+    await fs.writeFile(path.join(target, "credentials.key"), Buffer.alloc(32, 2))
+    await fs.writeFile(
+      path.join(legacy, "credentials.json"),
+      JSON.stringify({ github: { fields: { GITHUB_TOKEN: "ciphertext" }, updated_at: "1" } }),
+    )
+    await fs.writeFile(path.join(legacy, "auth.json"), JSON.stringify({ "openai-codex": { access: "kept" } }))
+
+    const result = await resolveDataDirectory({ home, legacy })
+
+    expect(result.warning).toContain("different machine key")
+    // Undecryptable entries would show as "set" in the UI and inject nothing.
+    expect(fsSync.existsSync(path.join(target, "credentials.json"))).toBe(false)
+    expect(await fs.readFile(path.join(target, "credentials.key"))).toEqual(Buffer.alloc(32, 2))
+    expect(JSON.parse(await fs.readFile(path.join(target, "auth.json"), "utf8"))["openai-codex"].access).toBe("kept")
+  })
+
+  test("carries a SQLite journal only alongside its own database", async () => {
+    const home = await root()
+    const legacy = path.join(home, "share", "openscience")
+    const target = path.join(home, ".openscience")
+    // `settings/memory/index.db` is the second WAL database (memory-index.ts)
+    // and nothing merges it, so what the copy decides is what survives.
+    await fs.mkdir(path.join(legacy, "settings", "memory"), { recursive: true })
+    await fs.mkdir(path.join(legacy, "settings", "notes"), { recursive: true })
+    await fs.mkdir(path.join(target, "settings", "memory"), { recursive: true })
+    await fs.writeFile(path.join(legacy, "settings", "memory", "index.db"), "legacy-index")
+    await fs.writeFile(path.join(legacy, "settings", "memory", "index.db-wal"), "memory-journal")
+    await fs.writeFile(path.join(target, "settings", "memory", "index.db"), "current-index")
+    await fs.writeFile(path.join(legacy, "settings", "notes", "index.db"), "legacy-notes")
+    await fs.writeFile(path.join(legacy, "settings", "notes", "index.db-wal"), "notes-journal")
+
+    const result = await resolveDataDirectory({ home, legacy })
+
+    expect(result.error).toBeUndefined()
+    // notes/index.db is carried, so its journal travels with it — dropping it
+    // would lose every transaction still in the log.
+    expect(await fs.readFile(path.join(target, "settings", "notes", "index.db"), "utf8")).toBe("legacy-notes")
+    expect(await fs.readFile(path.join(target, "settings", "notes", "index.db-wal"), "utf8")).toBe("notes-journal")
+    // memory/index.db is not — the target has its own — so the legacy journal
+    // must not land beside a database it never described.
+    expect(await fs.readFile(path.join(target, "settings", "memory", "index.db"), "utf8")).toBe("current-index")
+    expect(fsSync.existsSync(path.join(target, "settings", "memory", "index.db-wal"))).toBe(false)
   })
 })

--- a/backend/cli/test/global/data-dir.test.ts
+++ b/backend/cli/test/global/data-dir.test.ts
@@ -309,13 +309,63 @@ describe("OpenScience data directory", () => {
     expect(result.migrated?.deferred).toBe(1)
     expect(await fs.readFile(path.join(target, "openscience-session.json"), "utf8")).toContain("kept")
     expect(JSON.parse(await fs.readFile(path.join(target, "auth.json"), "utf8"))["openai-codex"].access).toBe("kept")
-    // Nothing was sealed, so the next launch retries the file it could not read.
-    expect(fsSync.existsSync(path.join(target, ".xdg-data-migration-v2.json"))).toBe(false)
+    // Sealed, but the straggler is named, so the retry costs one stat rather
+    // than a fresh walk of the whole legacy tree on every later launch.
+    const record = path.join(target, ".xdg-data-migration-v2.json")
+    expect(JSON.parse(await fs.readFile(record, "utf8")).pending).toEqual(["storage/session/locked.json"])
+
     await fs.chmod(path.join(legacy, "storage", "session", "locked.json"), 0o600)
     const retry = await resolveDataDirectory({ home, legacy })
     expect(retry.migrated?.deferred).toBe(0)
     expect(fsSync.existsSync(path.join(target, "storage", "session", "locked.json"))).toBe(true)
-    expect(fsSync.existsSync(path.join(target, ".xdg-data-migration-v2.json"))).toBe(true)
+    // Resuming keeps the original import's record and clears the list, so the
+    // launch after this one takes the one-stat path.
+    const after = JSON.parse(await fs.readFile(record, "utf8"))
+    expect(after.pending).toEqual([])
+    expect(after.migratedAt).toBeDefined()
+
+    const settled = await resolveDataDirectory({ home, legacy })
+    expect(settled.migrated).toBeUndefined()
+    expect(settled.path).toBe(target)
+  })
+
+  test("a straggler that disappears stops being chased", async () => {
+    const home = await root()
+    const legacy = path.join(home, "share", "openscience")
+    const target = path.join(home, ".openscience")
+    await fs.mkdir(legacy, { recursive: true })
+    await fs.writeFile(path.join(legacy, "openscience-session.json"), '{"api_key":"kept"}')
+    await fs.writeFile(path.join(legacy, "gone.json"), "{}")
+    await fs.chmod(path.join(legacy, "gone.json"), 0o000)
+
+    expect((await resolveDataDirectory({ home, legacy })).migrated?.deferred).toBe(1)
+    await fs.rm(path.join(legacy, "gone.json"), { force: true })
+
+    const retry = await resolveDataDirectory({ home, legacy })
+
+    expect(retry.path).toBe(target)
+    const record = JSON.parse(await fs.readFile(path.join(target, ".xdg-data-migration-v2.json"), "utf8"))
+    expect(record.pending).toEqual([])
+  })
+
+  test("never writes outside the target for a hand-edited pending list", async () => {
+    const home = await root()
+    const legacy = path.join(home, "share", "openscience")
+    const target = path.join(home, ".openscience")
+    await fs.mkdir(legacy, { recursive: true })
+    await fs.mkdir(target, { recursive: true })
+    await fs.writeFile(path.join(home, "secret"), "original")
+    await fs.writeFile(path.join(legacy, "openscience-session.json"), '{"api_key":"legacy"}')
+    await fs.writeFile(
+      path.join(target, ".xdg-data-migration-v2.json"),
+      JSON.stringify({ pending: ["../secret", "/etc/passwd", "openscience-session.json"] }),
+    )
+
+    const result = await resolveDataDirectory({ home, legacy })
+
+    expect(result.path).toBe(target)
+    expect(await fs.readFile(path.join(home, "secret"), "utf8")).toBe("original")
+    expect(await fs.readFile(path.join(target, "openscience-session.json"), "utf8")).toContain("legacy")
   })
 
   test("a corrupt legacy credential store does not abort the import", async () => {

--- a/backend/cli/test/global/data-dir.test.ts
+++ b/backend/cli/test/global/data-dir.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test"
+import { Database } from "bun:sqlite"
 import fs from "fs/promises"
 import os from "node:os"
 import path from "node:path"
@@ -14,6 +15,60 @@ async function root() {
   const value = await fs.mkdtemp(path.join(os.tmpdir(), "openscience-data-dir-"))
   roots.push(value)
   return value
+}
+
+async function artifact(root: string, key: string) {
+  const dir = path.join(root, "artifact-store")
+  await fs.mkdir(path.join(dir, "blobs"), { recursive: true })
+  await fs.writeFile(path.join(dir, "blobs", key), key)
+  const db = new Database(path.join(dir, "artifacts.db"), { create: true })
+  db.exec(`
+    PRAGMA foreign_keys = ON;
+    CREATE TABLE blobs (
+      sha256 TEXT PRIMARY KEY, size INTEGER NOT NULL, path TEXT NOT NULL UNIQUE, created_at INTEGER NOT NULL
+    );
+    CREATE TABLE artifacts (
+      id TEXT PRIMARY KEY, schema_version INTEGER NOT NULL, project_id TEXT NOT NULL, source_key TEXT NOT NULL,
+      title TEXT NOT NULL, kind TEXT NOT NULL, current_version_id TEXT NOT NULL, state TEXT NOT NULL,
+      trashed_at INTEGER, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL,
+      UNIQUE(project_id, source_key)
+    );
+    CREATE TABLE versions (
+      id TEXT PRIMARY KEY, artifact_id TEXT NOT NULL REFERENCES artifacts(id), version INTEGER NOT NULL,
+      filename TEXT NOT NULL, mime_type TEXT NOT NULL, size INTEGER NOT NULL,
+      sha256 TEXT NOT NULL REFERENCES blobs(sha256), session_id TEXT NOT NULL, message_id TEXT,
+      execution_id TEXT, source_path TEXT NOT NULL, capture_quality TEXT NOT NULL, created_at INTEGER NOT NULL,
+      UNIQUE(artifact_id, version)
+    );
+    CREATE TABLE executions (
+      id TEXT PRIMARY KEY, artifact_version_id TEXT NOT NULL UNIQUE REFERENCES versions(id), command TEXT, code TEXT,
+      status TEXT NOT NULL, stdout TEXT, stderr TEXT, model TEXT, provider TEXT, effort TEXT, source TEXT,
+      permission_snapshot TEXT, inputs TEXT, capture_quality TEXT NOT NULL, files TEXT NOT NULL,
+      environment TEXT, created_at INTEGER NOT NULL
+    );
+  `)
+  db.query("INSERT INTO blobs VALUES (?1, ?2, ?3, ?4)").run(key, key.length, `blobs/${key}`, 1)
+  db.query("INSERT INTO artifacts VALUES (?1, 1, ?2, ?3, ?4, 'document', ?5, 'active', NULL, 1, 1)").run(
+    `art_${key}`,
+    `prj_${key}`,
+    `/tmp/${key}.txt`,
+    key,
+    `ver_${key}`,
+  )
+  db.query("INSERT INTO versions VALUES (?1, ?2, 1, ?3, 'text/plain', ?4, ?5, ?6, NULL, ?7, ?8, 'exact', 1)").run(
+    `ver_${key}`,
+    `art_${key}`,
+    `${key}.txt`,
+    key.length,
+    key,
+    `ses_${key}`,
+    `exe_${key}`,
+    `/tmp/${key}.txt`,
+  )
+  db.query(
+    "INSERT INTO executions VALUES (?1, ?2, NULL, NULL, 'succeeded', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 'exact', '[]', NULL, 1)",
+  ).run(`exe_${key}`, `ver_${key}`)
+  db.close()
 }
 
 describe("OpenScience data directory", () => {
@@ -40,7 +95,7 @@ describe("OpenScience data directory", () => {
     expect(await fs.readFile(path.join(result.path, "storage", "session.json"), "utf8")).toContain("kept")
     expect(await fs.readFile(path.join(legacy, "storage", "session.json"), "utf8")).toContain("kept")
     expect(await fs.readFile(path.join(result.path, "bin", "openscience"), "utf8")).toBe("launcher")
-    expect(JSON.parse(await fs.readFile(path.join(result.path, ".xdg-data-migration-v1.json"), "utf8")).source).toBe(
+    expect(JSON.parse(await fs.readFile(path.join(result.path, ".xdg-data-migration-v2.json"), "utf8")).source).toBe(
       legacy,
     )
 
@@ -50,20 +105,74 @@ describe("OpenScience data directory", () => {
     expect(repeated.conflict).toBeUndefined()
   })
 
-  test("reports a conflict instead of merging two populated roots", async () => {
+  test("merges missing projects, sessions, and credentials into a populated root", async () => {
     const home = await root()
     const legacy = path.join(home, "share", "openscience")
     const target = path.join(home, ".openscience")
-    await fs.mkdir(legacy, { recursive: true })
-    await fs.mkdir(target, { recursive: true })
-    await fs.writeFile(path.join(legacy, "old.json"), "old")
-    await fs.writeFile(path.join(target, "new.json"), "new")
+    await fs.mkdir(path.join(legacy, "storage", "project"), { recursive: true })
+    await fs.mkdir(path.join(legacy, "storage", "session", "prj_old"), { recursive: true })
+    await fs.mkdir(path.join(target, "storage", "project"), { recursive: true })
+    await fs.writeFile(path.join(target, ".xdg-data-migration-v1.json"), "{}")
+    await fs.writeFile(path.join(legacy, "storage", "project", "prj_old.json"), '{"name":"old"}')
+    await fs.writeFile(path.join(legacy, "storage", "session", "prj_old", "ses_old.json"), '{"title":"old"}')
+    await fs.writeFile(path.join(target, "storage", "project", "prj_new.json"), '{"name":"new"}')
+    await fs.writeFile(path.join(legacy, "shared.json"), "legacy")
+    await fs.writeFile(path.join(target, "shared.json"), "current")
+    await fs.writeFile(path.join(legacy, "openscience-session.json"), '{"access_token":"restored"}')
+    await fs.writeFile(
+      path.join(legacy, "auth.json"),
+      JSON.stringify({ "openai-codex": { access: "old" }, anthropic: { key: "kept" } }),
+    )
+    await fs.writeFile(
+      path.join(target, "auth.json"),
+      JSON.stringify({ "openai-codex": { access: "current" }, openrouter: { key: "current" } }),
+    )
 
     const result = await resolveDataDirectory({ home, legacy })
 
     expect(result.path).toBe(target)
-    expect(result.conflict).toEqual({ legacy, current: target })
-    expect(await fs.readFile(path.join(target, "new.json"), "utf8")).toBe("new")
-    expect(await fs.readFile(path.join(legacy, "old.json"), "utf8")).toBe("old")
+    expect(result.conflict).toBeUndefined()
+    expect(result.migrated?.merged).toBe(1)
+    expect(await fs.readFile(path.join(target, "storage", "project", "prj_old.json"), "utf8")).toContain("old")
+    expect(await fs.readFile(path.join(target, "storage", "project", "prj_new.json"), "utf8")).toContain("new")
+    expect(await fs.readFile(path.join(target, "storage", "session", "prj_old", "ses_old.json"), "utf8")).toContain(
+      "old",
+    )
+    expect(await fs.readFile(path.join(target, "shared.json"), "utf8")).toBe("current")
+    expect(await fs.readFile(path.join(target, "openscience-session.json"), "utf8")).toContain("restored")
+    expect(JSON.parse(await fs.readFile(path.join(target, "auth.json"), "utf8"))).toEqual({
+      "openai-codex": { access: "current" },
+      anthropic: { key: "kept" },
+      openrouter: { key: "current" },
+    })
+    expect(await fs.readFile(path.join(legacy, "storage", "project", "prj_old.json"), "utf8")).toContain("old")
+
+    const repeated = await resolveDataDirectory({ home, legacy })
+    expect(repeated.migrated).toBeUndefined()
+  })
+
+  test("merges legacy artifact records and blobs into an existing artifact store", async () => {
+    const home = await root()
+    const legacy = path.join(home, "share", "openscience")
+    const target = path.join(home, ".openscience")
+    await artifact(legacy, "legacy")
+    await artifact(target, "current")
+
+    const result = await resolveDataDirectory({ home, legacy })
+
+    expect(result.error).toBeUndefined()
+    expect(result.migrated?.artifacts).toBe(1)
+    expect(await fs.readFile(path.join(target, "artifact-store", "blobs", "legacy"), "utf8")).toBe("legacy")
+    const current = new Database(path.join(target, "artifact-store", "artifacts.db"), { readonly: true })
+    expect(
+      (current.query("SELECT id FROM artifacts ORDER BY id").all() as Array<{ id: string }>).map((row) => row.id),
+    ).toEqual(["art_current", "art_legacy"])
+    expect((current.query("SELECT count(*) AS value FROM versions").get() as { value: number }).value).toBe(2)
+    expect((current.query("SELECT count(*) AS value FROM executions").get() as { value: number }).value).toBe(2)
+    current.close()
+
+    const source = new Database(path.join(legacy, "artifact-store", "artifacts.db"), { readonly: true })
+    expect((source.query("SELECT count(*) AS value FROM artifacts").get() as { value: number }).value).toBe(1)
+    source.close()
   })
 })

--- a/backend/cli/test/global/data-dir.test.ts
+++ b/backend/cli/test/global/data-dir.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test"
 import { Database } from "bun:sqlite"
 import fs from "fs/promises"
+import fsSync from "node:fs"
 import os from "node:os"
 import path from "node:path"
 import { resolveDataDirectory } from "@/global/data-dir"
@@ -174,5 +175,99 @@ describe("OpenScience data directory", () => {
     const source = new Database(path.join(legacy, "artifact-store", "artifacts.db"), { readonly: true })
     expect((source.query("SELECT count(*) AS value FROM artifacts").get() as { value: number }).value).toBe(1)
     source.close()
+  })
+
+  test("leaves logs and per-process sidecars behind", async () => {
+    const home = await root()
+    const legacy = path.join(home, "share", "openscience")
+    const target = path.join(home, ".openscience")
+    await artifact(legacy, "legacy")
+    await fs.mkdir(path.join(legacy, "log"), { recursive: true })
+    await fs.writeFile(path.join(legacy, "log", "2026-08-06.log"), "noise")
+    await fs.writeFile(path.join(legacy, "artifact-store", "artifacts.db-wal"), "journal")
+    await fs.writeFile(path.join(legacy, "artifact-store", "artifacts.db-shm"), "shared")
+    await fs.writeFile(path.join(legacy, "auth.json.lock"), "{}")
+    await fs.writeFile(path.join(legacy, "openscience-session.json"), '{"api_key":"kept"}')
+
+    const result = await resolveDataDirectory({ home, legacy })
+
+    expect(result.error).toBeUndefined()
+    expect(await fs.readFile(path.join(target, "openscience-session.json"), "utf8")).toContain("kept")
+    expect(fsSync.existsSync(path.join(target, "artifact-store", "artifacts.db"))).toBe(true)
+    for (const orphan of [
+      "log",
+      "artifact-store/artifacts.db-wal",
+      "artifact-store/artifacts.db-shm",
+      "auth.json.lock",
+    ])
+      expect(fsSync.existsSync(path.join(target, orphan))).toBe(false)
+  })
+
+  test("imports credentials and history even when the legacy artifact store is corrupt", async () => {
+    const home = await root()
+    const legacy = path.join(home, "share", "openscience")
+    const target = path.join(home, ".openscience")
+    await artifact(target, "current")
+    await fs.mkdir(path.join(legacy, "artifact-store"), { recursive: true })
+    await fs.writeFile(path.join(legacy, "artifact-store", "artifacts.db"), "not a database")
+    await fs.writeFile(path.join(legacy, "openscience-session.json"), '{"api_key":"kept"}')
+    await fs.writeFile(path.join(legacy, "auth.json"), JSON.stringify({ "openai-codex": { access: "kept" } }))
+
+    const result = await resolveDataDirectory({ home, legacy })
+
+    expect(result.path).toBe(target)
+    expect(result.error).toBeUndefined()
+    expect(result.warning).toContain("artifact store")
+    expect(await fs.readFile(path.join(target, "openscience-session.json"), "utf8")).toContain("kept")
+    expect(JSON.parse(await fs.readFile(path.join(target, "auth.json"), "utf8"))["openai-codex"].access).toBe("kept")
+    expect(fsSync.existsSync(path.join(target, ".xdg-data-migration-v2.json"))).toBe(true)
+  })
+
+  test("imports every other file when one changes under the copy", async () => {
+    const home = await root()
+    const legacy = path.join(home, "share", "openscience")
+    const target = path.join(home, ".openscience")
+    await fs.mkdir(path.join(legacy, "storage", "session"), { recursive: true })
+    await fs.writeFile(path.join(legacy, "openscience-session.json"), '{"api_key":"kept"}')
+    await fs.writeFile(path.join(legacy, "auth.json"), JSON.stringify({ "openai-codex": { access: "kept" } }))
+    for (const id of ["a", "b", "c"])
+      await fs.writeFile(path.join(legacy, "storage", "session", `ses_${id}.json`), `{"id":"${id}"}`)
+
+    // A still-running instance rewrites one session between the copy and its
+    // verification. Only that file may be dropped.
+    const torn = path.join(legacy, "storage", "session", "ses_b.json")
+    const original = fsSync.readFileSync(torn)
+    const watcher = setInterval(() => fsSync.writeFileSync(torn, `{"id":"b","n":${Math.random()}}`), 1)
+    const result = await resolveDataDirectory({ home, legacy }).finally(() => clearInterval(watcher))
+
+    expect(result.path).toBe(target)
+    expect(await fs.readFile(path.join(target, "openscience-session.json"), "utf8")).toContain("kept")
+    expect(JSON.parse(await fs.readFile(path.join(target, "auth.json"), "utf8"))["openai-codex"].access).toBe("kept")
+    for (const id of ["a", "c"])
+      expect(fsSync.existsSync(path.join(target, "storage", "session", `ses_${id}.json`))).toBe(true)
+    fsSync.writeFileSync(torn, original)
+  })
+
+  test("keeps concurrent boots on a single data root", async () => {
+    const home = await root()
+    const legacy = path.join(home, "share", "openscience")
+    const target = path.join(home, ".openscience")
+    await fs.mkdir(path.join(legacy, "storage", "session"), { recursive: true })
+    await fs.writeFile(path.join(legacy, "openscience-session.json"), '{"api_key":"kept"}')
+    await fs.writeFile(path.join(legacy, "auth.json"), JSON.stringify({ "openai-codex": { access: "kept" } }))
+    for (const id of ["a", "b", "c"])
+      await fs.writeFile(path.join(legacy, "storage", "session", `ses_${id}.json`), `{"id":"${id}"}`)
+
+    const results = await Promise.all([
+      resolveDataDirectory({ home, legacy }),
+      resolveDataDirectory({ home, legacy }),
+      resolveDataDirectory({ home, legacy }),
+    ])
+
+    expect(results.map((result) => result.path)).toEqual([target, target, target])
+    expect(JSON.parse(await fs.readFile(path.join(target, "auth.json"), "utf8"))["openai-codex"].access).toBe("kept")
+    expect(await fs.readFile(path.join(target, "openscience-session.json"), "utf8")).toContain("kept")
+    for (const id of ["a", "b", "c"])
+      expect(fsSync.existsSync(path.join(target, "storage", "session", `ses_${id}.json`))).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary

- import missing legacy projects, sessions, messages, parts, and other local state even when the new data root is already populated
- restore missing OpenScience account state and provider, credential, and MCP entries while preserving current values on conflicts
- merge legacy artifact records and blobs into the current artifact store
- checksum copied files, leave the legacy XDG directory untouched as a safety copy, and make the migration idempotent with a v2 marker
- make the doctor output report the migration result and active fallback path accurately

## Testing

- bun test from backend/cli
- bun test test/global/data-dir.test.ts
- bun run typecheck from the repository root
- prettier check and git diff check