### PR TITLE
fix(migration): keep watching the previous data root, and recover what it holds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,28 @@ jobs:
       - uses: ./.github/actions/setup-bun
       - run: bun run format:check
 
+  # The data-directory import runs at boot on every user's machine and moves
+  # their credentials and history between two roots. It is also the one piece
+  # of the CLI built almost entirely out of filesystem primitives that differ
+  # per platform — hardlinks, exclusive create, chmod, path separators — so
+  # the Linux-only `test` job below is not evidence it works. This leg is
+  # deliberately narrow: one suite, three operating systems, no sandbox or web
+  # assets to build.
+  migration:
+    name: Migration (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ./.github/actions/setup-bun
+      - run: bun test test/global/data-dir.test.ts
+        shell: bash
+        working-directory: backend/cli
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/backend/cli/src/cli/onboard.ts
+++ b/backend/cli/src/cli/onboard.ts
@@ -223,9 +223,36 @@ async function reportLegacyRoot(prune: boolean) {
   if (!found) return
 
   const size = found.bytes > 1024 * 1024 ? `${(found.bytes / 1024 / 1024).toFixed(0)} MB` : `${found.bytes} bytes`
-  const outstanding = Global.DataMigration.migrated?.deferred ?? 0
   prompts.log.info(`Previous data directory: ${legacy} (${found.files} files, ${size})`)
 
+  // The marker in the current data root is the only record that an import
+  // actually ran, and that is what this has to be sure of before offering to
+  // delete anything. Asking `DataMigration.migrated` instead answered a
+  // different question: it is undefined whenever no import was attempted at
+  // all — an explicit OPENSCIENCE_DATA_DIR, a settings ▸ Storage relocation
+  // pointer, or an import that threw — and reading that as "nothing left to
+  // do" would have offered to recursively delete a directory whose contents
+  // were never copied anywhere.
+  const record = await Bun.file(path.join(Global.Path.data, ".xdg-data-migration-v2.json"))
+    .json()
+    .then((value) => (value && typeof value === "object" ? (value as { pending?: unknown }) : undefined))
+    .catch(() => undefined)
+  const outstanding = Array.isArray(record?.pending) ? record.pending.length : 0
+
+  if (Global.DataMigration.error) {
+    prompts.log.warn(
+      `The last import did not complete (${Global.DataMigration.error}), so this directory may still hold the ` +
+        `only copy of some data. Leaving it alone.`,
+    )
+    return
+  }
+  if (!record) {
+    prompts.log.warn(
+      `Nothing has been imported out of it into ${Global.Path.data} — this data root was chosen explicitly ` +
+        `(OPENSCIENCE_DATA_DIR or a storage location setting) rather than by the upgrade. Leaving it alone.`,
+    )
+    return
+  }
   if (outstanding > 0) {
     prompts.log.warn(
       `${outstanding} file(s) have not been imported out of it yet, so it is still the only copy of those. ` +

--- a/backend/cli/src/cli/onboard.ts
+++ b/backend/cli/src/cli/onboard.ts
@@ -1,5 +1,7 @@
 import * as prompts from "@clack/prompts"
 import path from "path"
+import fs from "fs/promises"
+import type { Argv } from "yargs"
 import { cmd } from "./cmd/cmd"
 import { UI } from "./ui"
 import { OpenScience } from "../openscience"
@@ -202,10 +204,102 @@ export const InitCommand = cmd({
   },
 })
 
+/**
+ * Measure the pre-2.0.2 data directory, and optionally remove it.
+ *
+ * The import copies rather than moves, deliberately: the previous root is the
+ * only thing standing between a bad import and a user's history. The cost is
+ * that it survives forever, silently, as a full duplicate — and because
+ * nothing mentions it, the disk it holds is never reclaimed. So: name it,
+ * measure it, and delete it only when asked.
+ *
+ * Removal is gated on the import having actually finished. While files are
+ * still outstanding, that directory is the only copy of them.
+ */
+async function reportLegacyRoot(prune: boolean) {
+  const legacy = Global.LegacyData
+  if (!legacy) return
+  const found = await measure(legacy)
+  if (!found) return
+
+  const size = found.bytes > 1024 * 1024 ? `${(found.bytes / 1024 / 1024).toFixed(0)} MB` : `${found.bytes} bytes`
+  const outstanding = Global.DataMigration.migrated?.deferred ?? 0
+  prompts.log.info(`Previous data directory: ${legacy} (${found.files} files, ${size})`)
+
+  if (outstanding > 0) {
+    prompts.log.warn(
+      `${outstanding} file(s) have not been imported out of it yet, so it is still the only copy of those. ` +
+        `Re-run once they are readable before removing it.`,
+    )
+    return
+  }
+  if (!prune) {
+    prompts.log.info(`Everything importable has been copied into ${Global.Path.data}.`)
+    prompts.log.info("Remove it with: openscience doctor --prune-legacy")
+    return
+  }
+  // Refuse anything that is not plausibly the old data root, so a stray
+  // OPENSCIENCE_DATA_DIR or a symlinked home cannot turn this into rm -rf.
+  if (legacy === Global.Path.data || legacy === Global.Path.home || path.dirname(legacy) === legacy) {
+    prompts.log.error(`Refusing to remove ${legacy}: it is the directory OpenScience is currently using.`)
+    return
+  }
+  // Interactively, deleting a directory full of the user's history deserves a
+  // second look. Non-interactively there is nobody to ask, and blocking on a
+  // prompt nobody can answer would hang a scripted run forever — the flag was
+  // typed on purpose, so let it stand as the answer.
+  const confirmed = process.stdin.isTTY
+    ? await prompts.confirm({ message: `Delete ${legacy} and its ${found.files} files?` })
+    : true
+  if (prompts.isCancel(confirmed) || !confirmed) {
+    prompts.log.info("Left in place.")
+    return
+  }
+  const failure = await fs
+    .rm(legacy, { recursive: true, force: true })
+    .then(() => undefined)
+    .catch((error: unknown) => (error instanceof Error ? error.message : String(error)))
+  if (failure) prompts.log.error(`Could not remove ${legacy}: ${failure}`)
+  if (!failure) prompts.log.success(`Removed ${legacy}, reclaiming ${size}.`)
+}
+
+async function measure(root: string) {
+  const stack = [root]
+  let files = 0
+  let bytes = 0
+  let seen = false
+  while (stack.length) {
+    const dir = stack.pop()
+    if (!dir) continue
+    const entries = await fs.readdir(dir, { withFileTypes: true }).catch(() => undefined)
+    if (!entries) continue
+    seen = true
+    for (const entry of entries) {
+      if (entry.isSymbolicLink()) continue
+      const full = path.join(dir, entry.name)
+      if (entry.isDirectory()) {
+        stack.push(full)
+        continue
+      }
+      const stat = await fs.stat(full).catch(() => undefined)
+      if (!stat) continue
+      files += 1
+      bytes += stat.size
+    }
+  }
+  return seen ? { files, bytes } : undefined
+}
+
 export const DoctorCommand = cmd({
   command: "doctor",
   describe: "check what's configured and what's missing",
-  async handler() {
+  builder: (yargs: Argv) =>
+    yargs.option("prune-legacy", {
+      type: "boolean",
+      describe: "delete the pre-2.0.2 data directory once its contents have been imported",
+      default: false,
+    }),
+  async handler(args) {
     UI.empty()
     prompts.intro("openscience doctor")
 
@@ -259,6 +353,8 @@ export const DoctorCommand = cmd({
         `Legacy data directories are ignored because current directories exist: ${Global.LegacyConflicts.map((item) => item.legacy).join(", ")}. Merge or remove them.`,
       )
     }
+
+    await reportLegacyRoot(args.pruneLegacy === true)
 
     const session = await OpenScience.getSession()
     if (session) {

--- a/backend/cli/src/global/data-dir.ts
+++ b/backend/cli/src/global/data-dir.ts
@@ -16,8 +16,21 @@ const pending = ".openscience-import"
 // the boot path.
 const reserved = new Set(["bin", "log", ".xdg-data-migration-v1.json", marker])
 const stores = new Set(["auth.json", "credentials.json", "mcp-auth.json"])
-// Per-process scratch that must not be transplanted.
-const transient = /(?:\.tmp|\.lock)$/
+// Per-process scratch that must not be transplanted — including this code's
+// own staging copies, so a previous root that was once a target does not have
+// them imported back as if they were data.
+const transient = /(?:\.tmp|\.lock|\.openscience-import)$/
+/** How long a staging file must sit untouched before it counts as abandoned.
+ *  Well past any real copy, so a live import's file is never reaped. */
+const STALE_STAGING = 60 * 60 * 1000
+/** After this, the process holding the import lease is assumed to have died. */
+const STALE_LOCK = 10 * 60 * 1000
+/** How long to wait for that process before importing anyway. Bounded low on
+ *  purpose: the duplicated work this avoids is self-limiting — a loser skips
+ *  whatever the winner has already landed, before reading a byte of it — so
+ *  buying a shorter wait with a little redundancy is the right trade. Startup
+ *  latency is not. */
+const LEASE_WAIT = 2_000
 // A SQLite -wal/-shm is only meaningful beside the exact database it was
 // written for. Landing one next to the target's own database pairs a journal
 // with a database it never described; dropping it when its database IS being
@@ -90,6 +103,105 @@ async function inventory(root: string) {
     }
   }
   return files.sort((a, b) => a.path.localeCompare(b.path))
+}
+
+/**
+ * Delete staging copies an interrupted import left behind.
+ *
+ * Each in-flight copy is named per call, which is what keeps two concurrent
+ * imports from writing the same file — but it also means a process killed
+ * mid-copy leaves a name nothing will ever reuse or overwrite. Without this
+ * they accumulate in the data root indefinitely, a silent leak of exactly the
+ * disk this whole feature is meant to be careful with.
+ *
+ * Age-gated rather than unconditional: another process may be part-way through
+ * writing one right now, and reaping that would turn a healthy concurrent
+ * import into a deferred file.
+ */
+async function sweep(root: string) {
+  const stack = [root]
+  const now = Date.now()
+  while (stack.length) {
+    const dir = stack.pop()
+    if (!dir) continue
+    for (const entry of await entries(dir)) {
+      if (entry.isSymbolicLink()) continue
+      const full = path.join(dir, entry.name)
+      if (entry.isDirectory()) {
+        stack.push(full)
+        continue
+      }
+      if (!entry.name.endsWith(pending)) continue
+      const stat = await fs.stat(full).catch(() => undefined)
+      if (!stat || now - stat.mtimeMs < STALE_STAGING) continue
+      await fs.rm(full, { force: true }).catch(() => undefined)
+    }
+  }
+}
+
+/**
+ * Best-effort exclusion so one launch does the import while its siblings wait.
+ *
+ * Correctness never depended on this — exclusive create and the JsonStore lease
+ * already make concurrent imports safe. What they do not prevent is waste: the
+ * CLI and the server it spawns would each walk and hash the whole previous root
+ * at the same moment, and their artifact merges would contend on SQLite until
+ * one lost to SQLITE_BUSY and quietly skipped artifacts altogether.
+ *
+ * Everything here degrades toward "just do the work". A lock that cannot be
+ * taken, a holder that died, a wait that runs long — each falls through to an
+ * unsynchronised import rather than delaying a boot. Making startup depend on a
+ * lock file would be a worse failure than the duplicated effort it avoids.
+ */
+async function lease(target: string) {
+  const lockpath = path.join(target, ".openscience-import.lock")
+  await fs.mkdir(target, { recursive: true }).catch(() => undefined)
+  const take = async () =>
+    fs
+      .open(lockpath, "wx", 0o600)
+      .then((handle) => handle)
+      .catch(() => undefined)
+
+  const held = await take()
+  const owned =
+    held ??
+    // A holder that crashed leaves the file behind forever, so an old lock is
+    // assumed dead rather than trusted.
+    (await (async () => {
+      const stat = await fs.stat(lockpath).catch(() => undefined)
+      if (!stat || Date.now() - stat.mtimeMs < STALE_LOCK) return undefined
+      await fs.rm(lockpath, { force: true }).catch(() => undefined)
+      return take()
+    })())
+
+  if (!owned) return undefined
+  await owned.writeFile(JSON.stringify({ pid: process.pid, at: Date.now() })).catch(() => undefined)
+  return async () => {
+    await owned.close().catch(() => undefined)
+    await fs.rm(lockpath, { force: true }).catch(() => undefined)
+  }
+}
+
+/** Wait for whoever holds the lease, but only while there is visibly someone
+ *  to wait for, and only until the marker says the work is done. Returns
+ *  whether the caller can skip the import entirely. */
+async function settled(target: string) {
+  const lockpath = path.join(target, ".openscience-import.lock")
+  // Failing to take the lease is not proof that anyone holds it — the open can
+  // fail for its own reasons, and treating that as contention meant a launch
+  // sat here for the full wait with nobody on the other end. No lock file, no
+  // waiting.
+  if (!(await fs.stat(lockpath).catch(() => undefined))) return false
+  const deadline = Date.now() + LEASE_WAIT
+  while (Date.now() < deadline) {
+    await Bun.sleep(25)
+    const record = await Bun.file(path.join(target, marker))
+      .json()
+      .catch(() => undefined)
+    if (record && Array.isArray(record.pending) && record.pending.length === 0) return true
+    if (!(await fs.stat(lockpath).catch(() => undefined))) return false
+  }
+  return false
 }
 
 /** A marker's `pending` list is on-disk data a user can edit, so treat it as
@@ -312,6 +424,13 @@ export async function resolveDataDirectory(input: {
   if (mode === "settled") return { path: target }
   if (legacy === target) return { path: target }
 
+  // Past here the run is going to read the previous root, so it is worth one
+  // attempt at not doing that three times over. Losing the lease is not an
+  // error: wait briefly, and if the holder finishes, there is nothing left to
+  // do. If it does not, fall through and import anyway.
+  const release = await lease(target)
+  if (!release && (await settled(target))) return { path: target }
+
   // A resume revisits only the paths the previous run named. The rest of the
   // tree was settled then, and re-walking it to rediscover that is what made a
   // single unreadable file expensive on every launch. An import or a rescan
@@ -340,7 +459,13 @@ export async function resolveDataDirectory(input: {
     return { path: target }
   }
 
-  const occupied = (await entries(target)).some((entry) => !reserved.has(entry.name))
+  // Not on a resume. That path runs on every launch for as long as one file
+  // stays unreadable, and walking the whole target each time to look for
+  // orphans costs more than the retry it is attached to. An orphan can wait
+  // for the next full pass — the rescan comes around within the interval.
+  if (mode !== "resume") await sweep(target)
+
+  const occupied = (await entries(target)).some((entry) => !reserved.has(entry.name) && !transient.test(entry.name))
 
   // Once a single file has landed in the target this process must keep using
   // the target, whatever fails afterwards. Falling back to the legacy root at
@@ -531,5 +656,9 @@ export async function resolveDataDirectory(input: {
       error: error instanceof Error ? error.message : String(error),
     } satisfies DataResolution
   })
+  // Released on every path, including the failed one — a lease that outlives
+  // its holder would make the next launch wait out the full stale timeout for
+  // nothing.
+  await release?.()
   return result
 }

--- a/backend/cli/src/global/data-dir.ts
+++ b/backend/cli/src/global/data-dir.ts
@@ -1,6 +1,6 @@
 import fs from "fs/promises"
 import { Database, type SQLQueryBindings } from "bun:sqlite"
-import { createHash } from "node:crypto"
+import { createHash, randomUUID } from "node:crypto"
 import { constants, createReadStream, existsSync } from "node:fs"
 import path from "node:path"
 import { JsonStore } from "../util/jsonstore"
@@ -388,7 +388,12 @@ export async function resolveDataDirectory(input: {
       // One unreadable file must cost that file and nothing else. Letting the
       // copy throw abandoned the entire import — credentials, session, and
       // history included — over a single chmod 000 leftover.
-      const temporary = `${destination}.${process.pid}${pending}`
+      // Unique per call, not just per process. Two imports running inside one
+      // process — which is what a Promise.all over resolveDataDirectory is —
+      // share a pid, so a pid-suffixed name has them writing the same staging
+      // file and deleting it out from under each other mid-verify. Same
+      // reasoning as atomicWrite in openscience/index.ts.
+      const temporary = `${destination}.${process.pid}.${randomUUID()}${pending}`
       const ready = await fs
         .mkdir(path.dirname(destination), { recursive: true })
         .then(() => fs.copyFile(path.join(legacy, file.path), temporary))

--- a/backend/cli/src/global/data-dir.ts
+++ b/backend/cli/src/global/data-dir.ts
@@ -1,9 +1,10 @@
 import fs from "fs/promises"
 import { Database, type SQLQueryBindings } from "bun:sqlite"
 import { createHash } from "node:crypto"
-import { constants, createReadStream } from "node:fs"
+import { constants, createReadStream, existsSync } from "node:fs"
 import path from "node:path"
 import { JsonStore } from "../util/jsonstore"
+import { SecretBox } from "../util/secret-box"
 
 const marker = ".xdg-data-migration-v2.json"
 /** Suffix for a copy in flight. Never collides with a real name, and marks
@@ -30,6 +31,10 @@ const artifactJournals = new Set([
   path.join("artifact-store", "artifacts.db-wal"),
   path.join("artifact-store", "artifacts.db-shm"),
 ])
+/** How long a sealed import trusts itself before re-reading the previous root.
+ *  Only pays a walk once per interval per machine, and only while that root
+ *  still exists — which is what makes it affordable to keep watching at all. */
+const RESCAN_INTERVAL = Number(process.env["OPENSCIENCE_LEGACY_RESCAN_MS"]) || 6 * 60 * 60 * 1000
 
 export interface DataResolution {
   path: string
@@ -109,15 +114,42 @@ async function describe(root: string, names: string[]) {
   return files.filter((file) => file !== undefined).sort((a, b) => a.path.localeCompare(b.path))
 }
 
-/** Whether both roots seal credentials.json with the same machine key — true
- *  only when the legacy key was the one carried across, i.e. the target had
- *  none of its own. */
-async function sameKey(legacy: string, target: string) {
-  const [old, current] = await Promise.all(
+/**
+ * Re-seal a legacy credential store under the target root's machine key.
+ *
+ * Every field value in credentials.json is AES-256-GCM sealed with the
+ * machine-local credentials.key. When the target already had a key of its own,
+ * the legacy key is not carried across, and copying the ciphertexts verbatim
+ * hands the user entries the UI reports as "set" while decryptFields silently
+ * drops every one — a configured GitHub token that injects no GITHUB_TOKEN.
+ * Both keys are on disk here, so translate rather than discard.
+ *
+ * Returns undefined when there is nothing to translate or the legacy key is
+ * unreadable. A field that will not open is left out: it is unrecoverable, and
+ * carrying it forward would recreate exactly the silent-dud entry this exists
+ * to prevent.
+ */
+async function reseal(legacy: string, target: string, data: Record<string, unknown>) {
+  const [from, to] = await Promise.all(
     [legacy, target].map((root) => fs.readFile(path.join(root, "credentials.key")).catch(() => undefined)),
   )
-  if (!old) return true
-  return !!current && old.equals(current)
+  if (!from || !to) return undefined
+  if (from.equals(to)) return data
+  const out: Record<string, unknown> = {}
+  for (const [service, entry] of Object.entries(data)) {
+    if (!entry || typeof entry !== "object") continue
+    const fields = (entry as { fields?: unknown }).fields
+    if (!fields || typeof fields !== "object") continue
+    const moved: Record<string, string> = {}
+    for (const [name, value] of Object.entries(fields as Record<string, unknown>)) {
+      if (typeof value !== "string") continue
+      try {
+        moved[name] = SecretBox.seal(to, SecretBox.open(from, value))
+      } catch {}
+    }
+    if (Object.keys(moved).length > 0) out[service] = { ...entry, fields: moved }
+  }
+  return out
 }
 
 async function object(file: string) {
@@ -167,10 +199,28 @@ async function mergeArtifacts(legacy: string, target: string) {
           statement.run(...row)
         }
       }
+      // Rows and the bytes they describe travel by different routes: metadata
+      // through this merge, blob content through the file copy. A blob whose
+      // file was deferred or unreadable would otherwise leave a row pointing at
+      // nothing, and the artifact reading as present right up until someone
+      // opens it. So the file on disk decides, and what it excludes cascades:
+      // no blob, no version; no current version, no artifact.
+      const store = path.join(target, "artifact-store")
+      const kept = new Set(
+        (old.query("SELECT sha256, path FROM blobs").all() as Array<{ sha256: string; path: string }>)
+          .filter((row) => existsSync(path.join(store, row.path)))
+          .map((row) => row.sha256),
+      )
+      const usable = new Set(
+        (old.query("SELECT id, sha256 FROM versions").all() as Array<{ id: string; sha256: string }>)
+          .filter((row) => kept.has(row.sha256))
+          .map((row) => row.id),
+      )
       db.transaction(() => {
         copy(
           "SELECT sha256, size, path, created_at FROM blobs",
           "INSERT OR IGNORE INTO blobs (sha256, size, path, created_at) VALUES (?1, ?2, ?3, ?4)",
+          (row) => kept.has(row[0] as string),
         )
         copy(
           `SELECT id, schema_version, project_id, source_key, title, kind, current_version_id, state,
@@ -178,6 +228,10 @@ async function mergeArtifacts(legacy: string, target: string) {
           `INSERT OR IGNORE INTO artifacts
             (id, schema_version, project_id, source_key, title, kind, current_version_id, state, ${column}
              created_at, updated_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10${trashed ? ", ?11" : ""})`,
+          // current_version_id has no foreign key behind it but the UI resolves
+          // it unconditionally, so an artifact whose current version did not
+          // survive is worse than one that never arrived.
+          (row) => usable.has(row[6] as string),
         )
         const artifacts = new Set(db.query("SELECT id FROM artifacts").values().flat())
         copy(
@@ -186,7 +240,9 @@ async function mergeArtifacts(legacy: string, target: string) {
           `INSERT OR IGNORE INTO versions
             (id, artifact_id, version, filename, mime_type, size, sha256, session_id, message_id, execution_id,
              source_path, capture_quality, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)`,
-          (row) => artifacts.has(row[1] as string),
+          // Both gates matter: the artifact has to have landed, and the blob
+          // the version names has to be a file that exists.
+          (row) => artifacts.has(row[1] as string) && kept.has(row[6] as string),
         )
         const versions = new Set(db.query("SELECT id FROM versions").values().flat())
         copy(
@@ -227,33 +283,60 @@ export async function resolveDataDirectory(input: {
 
   const target = path.join(path.resolve(input.home), ".openscience")
   const legacy = path.resolve(input.legacy)
-  // A sealed marker with nothing outstanding is the steady state for every
-  // user after their first upgrade, so it has to be the cheapest path here:
-  // one stat, no walk.
   const sealed = await Bun.file(path.join(target, marker))
     .json()
-    .then((value) => (value && typeof value === "object" ? (value as { pending?: unknown }) : undefined))
+    .then((value) => (value && typeof value === "object" ? (value as Record<string, unknown>) : undefined))
     .catch(() => undefined)
   const outstanding = Array.isArray(sealed?.pending) ? (sealed.pending as unknown[]).filter(isRelative) : []
-  if (sealed && outstanding.length === 0) return { path: target }
+
+  // Sealing the import once and never looking back is what let a second,
+  // older install keep writing to the legacy root unseen: it refreshes its
+  // own session and auth there, and none of it is ever picked up. So the
+  // marker is a checkpoint, not a verdict. What it must not become is a cost
+  // on every command, hence the ordering here — the two cases that end the
+  // function are both decided before anything walks a directory.
+  const mode = await (async (): Promise<"import" | "resume" | "rescan" | "settled"> => {
+    if (!sealed) return "import"
+    if (outstanding.length > 0) return "resume"
+    // Once the previous root is gone there is nothing left to watch, and this
+    // is the steady state for anyone who has cleaned it up: one failed stat.
+    const still = await fs
+      .stat(legacy)
+      .then((stat) => stat.isDirectory())
+      .catch(() => false)
+    if (!still) return "settled"
+    const last = Number(sealed.checkedAt ?? sealed.migratedAt)
+    if (Number.isFinite(last) && Date.now() - last < RESCAN_INTERVAL) return "settled"
+    return "rescan"
+  })()
+  if (mode === "settled") return { path: target }
   if (legacy === target) return { path: target }
 
-  // A resumed import revisits only the paths the previous run named. The rest
-  // of the tree was settled then, and re-walking it to rediscover that is what
-  // made a single unreadable file expensive on every launch.
-  const source = sealed
-    ? (await describe(legacy, outstanding)).filter((file) => !artifactJournals.has(file.path))
-    : (await inventory(legacy)).filter(
-        (file) =>
-          !reserved.has(file.path.split(path.sep)[0]) && !transient.test(file.path) && !artifactJournals.has(file.path),
-      )
+  // A resume revisits only the paths the previous run named. The rest of the
+  // tree was settled then, and re-walking it to rediscover that is what made a
+  // single unreadable file expensive on every launch. An import or a rescan
+  // both want the whole tree — a rescan is exactly a repeat import, and it is
+  // cheap precisely because everything already present is skipped by lstat
+  // before it is ever read.
+  const source =
+    mode === "resume"
+      ? (await describe(legacy, outstanding)).filter((file) => !artifactJournals.has(file.path))
+      : (await inventory(legacy)).filter(
+          (file) =>
+            !reserved.has(file.path.split(path.sep)[0]) &&
+            !transient.test(file.path) &&
+            !artifactJournals.has(file.path),
+        )
   if (source.length === 0) {
-    // Nothing left to fetch — the stragglers are gone from the legacy root
-    // too. Clear the list so the next launch takes the one-stat path.
+    // Nothing to fetch — either the stragglers are gone from the legacy root
+    // too, or the rescan found it empty. Record the check so the next launch
+    // takes the cheap path.
     if (sealed)
-      await Bun.write(path.join(target, marker), `${JSON.stringify({ ...sealed, pending: [] }, null, 2)}\n`, {
-        mode: 0o600,
-      }).catch(() => undefined)
+      await Bun.write(
+        path.join(target, marker),
+        `${JSON.stringify({ ...sealed, pending: [], checkedAt: Date.now() }, null, 2)}\n`,
+        { mode: 0o600 },
+      ).catch(() => undefined)
     return { path: target }
   }
 
@@ -355,22 +438,20 @@ export async function resolveDataDirectory(input: {
     for (const name of stores) {
       const old = source.find((file) => file.path === name)
       if (!old) continue
-      // Entries in credentials.json are AES-256-GCM ciphertexts sealed with
-      // the machine-local credentials.key. Importing them under a different
-      // key produces entries the UI reports as "set" while decryptFields
-      // silently drops every one — the user sees a configured GitHub token
-      // and gets no GITHUB_TOKEN. Only carry them when the key came across
-      // too, which is exactly when the target had none of its own.
-      if (name === "credentials.json" && !(await sameKey(legacy, target))) {
-        notes.push("legacy credentials.json not imported: it is sealed with a different machine key")
-        continue
-      }
       // A corrupt legacy store must cost that store, not the import. Left
       // unguarded this threw past the marker write, so every later boot
       // re-ran the whole import and failed at the same byte, forever.
       const outcome = await (async () => {
         const previous = await JsonStore.read(path.join(target, name))
-        const legacyData = await object(path.join(legacy, name))
+        const raw = await object(path.join(legacy, name))
+        // Credentials are the one store whose values are not portable on
+        // their own; everything else is plaintext JSON that means the same
+        // thing in either root.
+        const legacyData = name === "credentials.json" ? await reseal(legacy, target, raw) : raw
+        if (!legacyData) {
+          notes.push("legacy credentials.json not imported: its machine key is unreadable")
+          return 0
+        }
         if (!Object.keys(legacyData).some((key) => !(key in previous))) return 0
         const count = { value: 0 }
         await JsonStore.update(path.join(target, name), (current) => {
@@ -394,15 +475,18 @@ export async function resolveDataDirectory(input: {
     // not a database". Recovering a user's credentials and history must not
     // hinge on that — record the reason and finish the import without it,
     // rather than throwing away everything already verified.
-    // Only on a first import. A resume is chasing a handful of named files;
-    // replaying every artifact row to re-discover that they are all already
-    // there would cost more than the retry it is part of.
-    const artifacts = sealed
-      ? 0
-      : await mergeArtifacts(legacy, target).catch((error: unknown) => {
-          notes.push(`legacy artifact store not imported: ${error instanceof Error ? error.message : String(error)}`)
-          return 0
-        })
+    // Skipped only on a resume, which is chasing a handful of named files:
+    // replaying every artifact row to rediscover that they are all already
+    // there would cost more than the retry it is part of. A rescan does run
+    // it — new artifacts written to the previous root are exactly what it is
+    // looking for.
+    const artifacts =
+      mode === "resume"
+        ? 0
+        : await mergeArtifacts(legacy, target).catch((error: unknown) => {
+            notes.push(`legacy artifact store not imported: ${error instanceof Error ? error.message : String(error)}`)
+            return 0
+          })
     const bytes = copied.reduce((total, file) => total + file.bytes, 0)
     const migration = {
       source: legacy,
@@ -421,12 +505,13 @@ export async function resolveDataDirectory(input: {
     // stayed unreadable, which for a root-owned leftover is forever. Naming
     // the stragglers means the retry costs one stat each and the common case
     // still short-circuits on the first line of the function.
-    // A resume keeps the original import's record and only updates what is
+    // A later pass keeps the original import's record and only updates what is
     // still outstanding — overwriting it with a retry's counts would erase the
-    // one account of what actually moved.
+    // one account of what actually moved. `checkedAt` is what paces the rescan,
+    // so it is stamped on every pass, including the first.
     const record = sealed
-      ? { ...sealed, pending: deferred, resumedAt: Date.now() }
-      : { ...migration, migratedAt: Date.now(), pending: deferred }
+      ? { ...sealed, pending: deferred, checkedAt: Date.now() }
+      : { ...migration, migratedAt: Date.now(), checkedAt: Date.now(), pending: deferred }
     await Bun.write(path.join(target, marker), `${JSON.stringify(record, null, 2)}\n`, { mode: 0o600 })
     if (deferred.length > 0)
       notes.push(`${deferred.length} file(s) could not be read from ${legacy}; the next launch will retry them`)

--- a/backend/cli/src/global/data-dir.ts
+++ b/backend/cli/src/global/data-dir.ts
@@ -47,7 +47,14 @@ const artifactJournals = new Set([
 /** How long a sealed import trusts itself before re-reading the previous root.
  *  Only pays a walk once per interval per machine, and only while that root
  *  still exists — which is what makes it affordable to keep watching at all. */
-const RESCAN_INTERVAL = Number(process.env["OPENSCIENCE_LEGACY_RESCAN_MS"]) || 6 * 60 * 60 * 1000
+const RESCAN_INTERVAL = (() => {
+  // `Number(x) || default` reads 0 as "unset", which quietly makes the one
+  // value worth passing — rescan on every launch, for a repro or a support
+  // session — mean six hours instead. It also swallows typos into the default
+  // without a word.
+  const configured = Number(process.env["OPENSCIENCE_LEGACY_RESCAN_MS"])
+  return Number.isFinite(configured) && configured >= 0 ? configured : 6 * 60 * 60 * 1000
+})()
 
 export interface DataResolution {
   path: string
@@ -80,7 +87,7 @@ async function hash(file: string) {
 
 async function inventory(root: string) {
   const stack = [root]
-  const files: Array<{ path: string; bytes: number; mode: number }> = []
+  const files: Array<{ path: string; bytes: number; mode: number; mtime: number }> = []
   while (stack.length) {
     const dir = stack.pop()
     if (!dir) continue
@@ -99,7 +106,12 @@ async function inventory(root: string) {
       // CLI from booting at all.
       const stat = await fs.stat(full).catch(() => undefined)
       if (!stat) continue
-      files.push({ path: path.relative(root, full), bytes: stat.size, mode: stat.mode & 0o777 })
+      files.push({
+        path: path.relative(root, full),
+        bytes: stat.size,
+        mode: stat.mode & 0o777,
+        mtime: stat.mtimeMs,
+      })
     }
   }
   return files.sort((a, b) => a.path.localeCompare(b.path))
@@ -119,16 +131,25 @@ async function inventory(root: string) {
  * import into a deferred file.
  */
 async function sweep(root: string) {
-  const stack = [root]
+  // Skip the same top-level names the import itself never touches. Staging
+  // files are only ever written where files are copied, so descending into
+  // `log/` and `bin/` searches the two trees guaranteed not to contain any —
+  // and `log/` is exactly the one that grows without bound.
+  const stack = (await entries(root))
+    .filter((entry) => entry.isDirectory() && !reserved.has(entry.name))
+    .map((entry) => path.join(root, entry.name))
+  stack.push(root)
   const now = Date.now()
+  const seen = new Set<string>()
   while (stack.length) {
     const dir = stack.pop()
-    if (!dir) continue
+    if (!dir || seen.has(dir)) continue
+    seen.add(dir)
     for (const entry of await entries(dir)) {
       if (entry.isSymbolicLink()) continue
       const full = path.join(dir, entry.name)
       if (entry.isDirectory()) {
-        stack.push(full)
+        if (dir !== root) stack.push(full)
         continue
       }
       if (!entry.name.endsWith(pending)) continue
@@ -166,11 +187,21 @@ async function lease(target: string) {
   const owned =
     held ??
     // A holder that crashed leaves the file behind forever, so an old lock is
-    // assumed dead rather than trusted.
+    // assumed dead rather than trusted. Claimed by renaming it aside rather
+    // than deleting it: two processes can both find the same lock expired, and
+    // with `rm` both would then delete and re-create it, ending up with two
+    // live holders — the exact contention the lease exists to prevent, in the
+    // one situation it was added for. Only one rename of a given name wins.
     (await (async () => {
       const stat = await fs.stat(lockpath).catch(() => undefined)
       if (!stat || Date.now() - stat.mtimeMs < STALE_LOCK) return undefined
-      await fs.rm(lockpath, { force: true }).catch(() => undefined)
+      const aside = `${lockpath}.${randomUUID()}.dead`
+      const claimed = await fs
+        .rename(lockpath, aside)
+        .then(() => true)
+        .catch(() => false)
+      if (!claimed) return undefined
+      await fs.rm(aside, { force: true }).catch(() => undefined)
       return take()
     })())
 
@@ -219,7 +250,9 @@ async function describe(root: string, names: string[]) {
     names.map((name) =>
       fs
         .stat(path.join(root, name))
-        .then((stat) => (stat.isFile() ? { path: name, bytes: stat.size, mode: stat.mode & 0o777 } : undefined))
+        .then((stat) =>
+          stat.isFile() ? { path: name, bytes: stat.size, mode: stat.mode & 0o777, mtime: stat.mtimeMs } : undefined,
+        )
         .catch(() => undefined),
     ),
   )
@@ -430,235 +463,268 @@ export async function resolveDataDirectory(input: {
   // do. If it does not, fall through and import anyway.
   const release = await lease(target)
   if (!release && (await settled(target))) return { path: target }
-
-  // A resume revisits only the paths the previous run named. The rest of the
-  // tree was settled then, and re-walking it to rediscover that is what made a
-  // single unreadable file expensive on every launch. An import or a rescan
-  // both want the whole tree — a rescan is exactly a repeat import, and it is
-  // cheap precisely because everything already present is skipped by lstat
-  // before it is ever read.
-  const source =
-    mode === "resume"
-      ? (await describe(legacy, outstanding)).filter((file) => !artifactJournals.has(file.path))
-      : (await inventory(legacy)).filter(
-          (file) =>
-            !reserved.has(file.path.split(path.sep)[0]) &&
-            !transient.test(file.path) &&
-            !artifactJournals.has(file.path),
-        )
-  if (source.length === 0) {
-    // Nothing to fetch — either the stragglers are gone from the legacy root
-    // too, or the rescan found it empty. Record the check so the next launch
-    // takes the cheap path.
-    if (sealed)
-      await Bun.write(
-        path.join(target, marker),
-        `${JSON.stringify({ ...sealed, pending: [], checkedAt: Date.now() }, null, 2)}\n`,
-        { mode: 0o600 },
-      ).catch(() => undefined)
-    return { path: target }
+  // Every exit below this line has to give the lease back. Doing that at the
+  // individual returns is how the fresh-install path came to leak it — no
+  // legacy root means no source files, which took an early return that skipped
+  // the release, and from then on every launch waited the full timeout on a
+  // lock nobody held. One release, in a finally, is the only version of this
+  // that stays true as the function grows.
+  try {
+    return await run()
+  } finally {
+    await release?.()
   }
 
-  // Not on a resume. That path runs on every launch for as long as one file
-  // stays unreadable, and walking the whole target each time to look for
-  // orphans costs more than the retry it is attached to. An orphan can wait
-  // for the next full pass — the rescan comes around within the interval.
-  if (mode !== "resume") await sweep(target)
-
-  const occupied = (await entries(target)).some((entry) => !reserved.has(entry.name) && !transient.test(entry.name))
-
-  // Once a single file has landed in the target this process must keep using
-  // the target, whatever fails afterwards. Falling back to the legacy root at
-  // that point splits a single launch across two data roots — the CLI reading
-  // one while its server writes the other, which is the failure this import
-  // exists to end.
-  const landed = { value: false }
-  const result = await (async () => {
-    const copied = [] as typeof source
-    // Two different reasons to not carry a file, with opposite consequences.
-    // `present` means the target already has its own copy — settled forever,
-    // and the whole point of never overwriting. `deferred` means this run
-    // could not read or verify the source: a permission error, a file being
-    // rewritten underneath us, a disk hiccup. Those go into the marker's
-    // `pending` list to be retried by name, so the two must not be counted
-    // together: folding them would either strand the second permanently or
-    // send the next launch chasing the first.
-    const present: string[] = []
-    const deferred: string[] = []
-    const carried = new Set<string>()
-    for (const file of source) {
-      if (stores.has(file.path)) continue
-      const destination = path.join(target, file.path)
-      const exists = await fs
-        .lstat(destination)
-        .then(() => true)
-        .catch(() => false)
-      if (exists) {
-        present.push(file.path)
-        continue
-      }
-      // Source order is sorted, so a database sorts before its -wal/-shm and
-      // `carried` is already decided by the time the journal is considered.
-      if (journal.test(file.path) && !carried.has(file.path.replace(journal, ""))) {
-        present.push(file.path)
-        continue
-      }
-      // Staged beside its destination rather than in a scratch directory that
-      // is later copied across. Going through a staging root meant writing
-      // every byte twice and needing twice the free space before the CLI would
-      // start — and on a nearly full disk the second write is what fails, so
-      // the cost also bought a failure mode. Here the bytes are written once
-      // and the file is linked into place.
-      //
-      // One unreadable file must cost that file and nothing else. Letting the
-      // copy throw abandoned the entire import — credentials, session, and
-      // history included — over a single chmod 000 leftover.
-      // Unique per call, not just per process. Two imports running inside one
-      // process — which is what a Promise.all over resolveDataDirectory is —
-      // share a pid, so a pid-suffixed name has them writing the same staging
-      // file and deleting it out from under each other mid-verify. Same
-      // reasoning as atomicWrite in openscience/index.ts.
-      const temporary = `${destination}.${process.pid}.${randomUUID()}${pending}`
-      const ready = await fs
-        .mkdir(path.dirname(destination), { recursive: true })
-        .then(() => fs.copyFile(path.join(legacy, file.path), temporary))
-        .then(() => fs.chmod(temporary, file.mode))
-        // Verify the copy against a fresh hash of its source, so a file being
-        // rewritten underneath us is dropped alone rather than silently landing
-        // half old and half new.
-        .then(async () => {
-          const [copy, origin] = await Promise.all([hash(temporary), hash(path.join(legacy, file.path))])
-          return copy === origin
-        })
-        .catch(() => false)
-      if (!ready) {
-        await fs.rm(temporary, { force: true }).catch(() => undefined)
-        deferred.push(file.path)
-        continue
-      }
-      // link() is the atomic create-if-absent that makes two concurrently
-      // booting processes safe: the loser is told EEXIST rather than
-      // overwriting the winner. Filesystems without hardlinks fall back to a
-      // copy with the same exclusive semantics.
-      const created = await fs
-        .link(temporary, destination)
-        .then(() => "created" as const)
-        .catch((error: NodeJS.ErrnoException) =>
-          error.code === "EEXIST"
-            ? ("present" as const)
-            : fs
-                .copyFile(temporary, destination, constants.COPYFILE_EXCL)
-                .then(() => "created" as const)
-                .catch((fallback: NodeJS.ErrnoException) =>
-                  fallback.code === "EEXIST" ? ("present" as const) : ("failed" as const),
-                ),
-        )
-      await fs.rm(temporary, { force: true }).catch(() => undefined)
-      if (created !== "created") {
-        ;(created === "present" ? present : deferred).push(file.path)
-        continue
-      }
-      landed.value = true
-      carried.add(file.path)
-      copied.push(file)
-    }
-
-    const merged: string[] = []
-    const notes: string[] = []
-    for (const name of stores) {
-      const old = source.find((file) => file.path === name)
-      if (!old) continue
-      // A corrupt legacy store must cost that store, not the import. Left
-      // unguarded this threw past the marker write, so every later boot
-      // re-ran the whole import and failed at the same byte, forever.
-      const outcome = await (async () => {
-        const previous = await JsonStore.read(path.join(target, name))
-        const raw = await object(path.join(legacy, name))
-        // Credentials are the one store whose values are not portable on
-        // their own; everything else is plaintext JSON that means the same
-        // thing in either root.
-        const legacyData = name === "credentials.json" ? await reseal(legacy, target, raw) : raw
-        if (!legacyData) {
-          notes.push("legacy credentials.json not imported: its machine key is unreadable")
-          return 0
-        }
-        if (!Object.keys(legacyData).some((key) => !(key in previous))) return 0
-        const count = { value: 0 }
-        await JsonStore.update(path.join(target, name), (current) => {
-          count.value = Object.keys(legacyData).filter((key) => !(key in current)).length
-          return { ...legacyData, ...current }
-        })
-        return count.value
-      })().catch((error: unknown) => {
-        notes.push(`legacy ${name} not imported: ${error instanceof Error ? error.message : String(error)}`)
-        return 0
-      })
-      if (outcome > 0) {
-        landed.value = true
-        merged.push(name)
-      }
-    }
-
-    // Artifacts are the one part of the import that reads a foreign file
-    // format, so they are the one part that can fail on data this code never
-    // wrote: a truncated or half-written legacy artifacts.db raises "file is
-    // not a database". Recovering a user's credentials and history must not
-    // hinge on that — record the reason and finish the import without it,
-    // rather than throwing away everything already verified.
-    // Skipped only on a resume, which is chasing a handful of named files:
-    // replaying every artifact row to rediscover that they are all already
-    // there would cost more than the retry it is part of. A rescan does run
-    // it — new artifacts written to the previous root are exactly what it is
-    // looking for.
-    const artifacts =
+  async function run(): Promise<DataResolution> {
+    // A resume revisits only the paths the previous run named. The rest of the
+    // tree was settled then, and re-walking it to rediscover that is what made a
+    // single unreadable file expensive on every launch. An import or a rescan
+    // both want the whole tree — a rescan is exactly a repeat import, and it is
+    // cheap precisely because everything already present is skipped by lstat
+    // before it is ever read.
+    //
+    // A rescan is looking for what the previous root has GAINED since it was
+    // last read, not for everything the target happens to be missing. Those are
+    // very different sets: the target is missing anything the user deleted, and
+    // copying that back means a session they removed reappears, and a provider
+    // they logged out of comes back with its key. The legacy copy is never
+    // deleted, so without this gate the deletion loses to the copy every
+    // interval, forever. An mtime newer than the last check is precisely
+    // "written by the old install since we looked", which is all this was for.
+    const since = mode === "rescan" ? Number(sealed?.checkedAt ?? sealed?.migratedAt) : undefined
+    const source =
       mode === "resume"
-        ? 0
-        : await mergeArtifacts(legacy, target).catch((error: unknown) => {
-            notes.push(`legacy artifact store not imported: ${error instanceof Error ? error.message : String(error)}`)
-            return 0
-          })
-    const bytes = copied.reduce((total, file) => total + file.bytes, 0)
-    const migration = {
-      source: legacy,
-      target,
-      files: copied.length,
-      bytes,
-      merged: merged.length,
-      artifacts,
-      skipped: present.length,
-      deferred: deferred.length,
+        ? (await describe(legacy, outstanding)).filter((file) => !artifactJournals.has(file.path))
+        : (await inventory(legacy)).filter(
+            (file) =>
+              !reserved.has(file.path.split(path.sep)[0]) &&
+              !transient.test(file.path) &&
+              !artifactJournals.has(file.path) &&
+              (since === undefined || !Number.isFinite(since) || file.mtime > since),
+          )
+    if (source.length === 0) {
+      // Nothing to fetch — either the stragglers are gone from the legacy root
+      // too, or the rescan found it empty. Record the check so the next launch
+      // takes the cheap path.
+      if (sealed)
+        await Bun.write(
+          path.join(target, marker),
+          `${JSON.stringify({ ...sealed, pending: [], checkedAt: Date.now() }, null, 2)}\n`,
+          { mode: 0o600 },
+        ).catch(() => undefined)
+      return { path: target }
     }
-    await fs.mkdir(target, { recursive: true })
-    // Always seal, and carry the outstanding paths inside the marker. Leaving
-    // the marker unwritten instead made every later launch re-walk and re-stat
-    // the whole legacy tree — `--version` included — for as long as one file
-    // stayed unreadable, which for a root-owned leftover is forever. Naming
-    // the stragglers means the retry costs one stat each and the common case
-    // still short-circuits on the first line of the function.
-    // A later pass keeps the original import's record and only updates what is
-    // still outstanding — overwriting it with a retry's counts would erase the
-    // one account of what actually moved. `checkedAt` is what paces the rescan,
-    // so it is stamped on every pass, including the first.
-    const record = sealed
-      ? { ...sealed, pending: deferred, checkedAt: Date.now() }
-      : { ...migration, migratedAt: Date.now(), checkedAt: Date.now(), pending: deferred }
-    await Bun.write(path.join(target, marker), `${JSON.stringify(record, null, 2)}\n`, { mode: 0o600 })
-    if (deferred.length > 0)
-      notes.push(`${deferred.length} file(s) could not be read from ${legacy}; the next launch will retry them`)
-    return {
-      path: target,
-      migrated: migration,
-      warning: notes.length ? notes.join("; ") : undefined,
-    } satisfies DataResolution
-  })().catch((error: unknown) => {
-    return {
-      path: occupied || landed.value ? target : legacy,
-      error: error instanceof Error ? error.message : String(error),
-    } satisfies DataResolution
-  })
-  // Released on every path, including the failed one — a lease that outlives
-  // its holder would make the next launch wait out the full stale timeout for
-  // nothing.
-  await release?.()
-  return result
+
+    // Not on a resume. That path runs on every launch for as long as one file
+    // stays unreadable, and walking the whole target each time to look for
+    // orphans costs more than the retry it is attached to. An orphan can wait
+    // for the next full pass — the rescan comes around within the interval.
+    if (mode !== "resume") await sweep(target)
+
+    const occupied = (await entries(target)).some((entry) => !reserved.has(entry.name) && !transient.test(entry.name))
+
+    // Once a single file has landed in the target this process must keep using
+    // the target, whatever fails afterwards. Falling back to the legacy root at
+    // that point splits a single launch across two data roots — the CLI reading
+    // one while its server writes the other, which is the failure this import
+    // exists to end.
+    const landed = { value: false }
+    const result = await (async () => {
+      const copied = [] as typeof source
+      // Two different reasons to not carry a file, with opposite consequences.
+      // `present` means the target already has its own copy — settled forever,
+      // and the whole point of never overwriting. `deferred` means this run
+      // could not read or verify the source: a permission error, a file being
+      // rewritten underneath us, a disk hiccup. Those go into the marker's
+      // `pending` list to be retried by name, so the two must not be counted
+      // together: folding them would either strand the second permanently or
+      // send the next launch chasing the first.
+      const present: string[] = []
+      const deferred: string[] = []
+      const carried = new Set<string>()
+      for (const file of source) {
+        if (stores.has(file.path)) continue
+        const destination = path.join(target, file.path)
+        const exists = await fs
+          .lstat(destination)
+          .then(() => true)
+          .catch(() => false)
+        if (exists) {
+          present.push(file.path)
+          continue
+        }
+        // Source order is sorted, so a database sorts before its -wal/-shm and
+        // `carried` is already decided by the time the journal is considered.
+        if (journal.test(file.path) && !carried.has(file.path.replace(journal, ""))) {
+          present.push(file.path)
+          continue
+        }
+        // Staged beside its destination rather than in a scratch directory that
+        // is later copied across. Going through a staging root meant writing
+        // every byte twice and needing twice the free space before the CLI would
+        // start — and on a nearly full disk the second write is what fails, so
+        // the cost also bought a failure mode. Here the bytes are written once
+        // and the file is linked into place.
+        //
+        // One unreadable file must cost that file and nothing else. Letting the
+        // copy throw abandoned the entire import — credentials, session, and
+        // history included — over a single chmod 000 leftover.
+        // Unique per call, not just per process. Two imports running inside one
+        // process — which is what a Promise.all over resolveDataDirectory is —
+        // share a pid, so a pid-suffixed name has them writing the same staging
+        // file and deleting it out from under each other mid-verify. Same
+        // reasoning as atomicWrite in openscience/index.ts.
+        const temporary = `${destination}.${process.pid}.${randomUUID()}${pending}`
+        const ready = await fs
+          .mkdir(path.dirname(destination), { recursive: true })
+          .then(() => fs.copyFile(path.join(legacy, file.path), temporary))
+          .then(() => fs.chmod(temporary, file.mode))
+          // Verify the copy against a fresh hash of its source, so a file being
+          // rewritten underneath us is dropped alone rather than silently landing
+          // half old and half new.
+          .then(async () => {
+            const [copy, origin] = await Promise.all([hash(temporary), hash(path.join(legacy, file.path))])
+            return copy === origin
+          })
+          .catch(() => false)
+        if (!ready) {
+          await fs.rm(temporary, { force: true }).catch(() => undefined)
+          deferred.push(file.path)
+          continue
+        }
+        // link() is the atomic create-if-absent that makes two concurrently
+        // booting processes safe: the loser is told EEXIST rather than
+        // overwriting the winner. Filesystems without hardlinks fall back to a
+        // copy with the same exclusive semantics.
+        const created = await fs
+          .link(temporary, destination)
+          .then(() => "created" as const)
+          .catch((error: NodeJS.ErrnoException) =>
+            error.code === "EEXIST"
+              ? ("present" as const)
+              : fs
+                  .copyFile(temporary, destination, constants.COPYFILE_EXCL)
+                  .then(() => "created" as const)
+                  .catch((fallback: NodeJS.ErrnoException) =>
+                    fallback.code === "EEXIST" ? ("present" as const) : ("failed" as const),
+                  ),
+          )
+        await fs.rm(temporary, { force: true }).catch(() => undefined)
+        if (created !== "created") {
+          ;(created === "present" ? present : deferred).push(file.path)
+          continue
+        }
+        landed.value = true
+        carried.add(file.path)
+        copied.push(file)
+      }
+
+      const merged: string[] = []
+      const notes: string[] = []
+      for (const name of stores) {
+        // Load-bearing on a rescan: `source` is filtered by mtime there, so a
+        // store the old install has not rewritten is absent and this merge does
+        // not run. That is what keeps a provider the user logged out of from
+        // being re-added out of the previous root's copy.
+        const old = source.find((file) => file.path === name)
+        if (!old) continue
+        // A corrupt legacy store must cost that store, not the import. Left
+        // unguarded this threw past the marker write, so every later boot
+        // re-ran the whole import and failed at the same byte, forever.
+        const outcome = await (async () => {
+          const previous = await JsonStore.read(path.join(target, name))
+          const raw = await object(path.join(legacy, name))
+          // Credentials are the one store whose values are not portable on
+          // their own; everything else is plaintext JSON that means the same
+          // thing in either root.
+          const legacyData = name === "credentials.json" ? await reseal(legacy, target, raw) : raw
+          if (!legacyData) {
+            notes.push("legacy credentials.json not imported: its machine key is unreadable")
+            return 0
+          }
+          if (!Object.keys(legacyData).some((key) => !(key in previous))) return 0
+          const count = { value: 0 }
+          await JsonStore.update(path.join(target, name), (current) => {
+            count.value = Object.keys(legacyData).filter((key) => !(key in current)).length
+            return { ...legacyData, ...current }
+          })
+          return count.value
+        })().catch((error: unknown) => {
+          notes.push(`legacy ${name} not imported: ${error instanceof Error ? error.message : String(error)}`)
+          return 0
+        })
+        if (outcome > 0) {
+          landed.value = true
+          merged.push(name)
+        }
+      }
+
+      // Artifacts are the one part of the import that reads a foreign file
+      // format, so they are the one part that can fail on data this code never
+      // wrote: a truncated or half-written legacy artifacts.db raises "file is
+      // not a database". Recovering a user's credentials and history must not
+      // hinge on that — record the reason and finish the import without it,
+      // rather than throwing away everything already verified.
+      // Skipped only on a resume, which is chasing a handful of named files:
+      // replaying every artifact row to rediscover that they are all already
+      // there would cost more than the retry it is part of. A rescan does run
+      // it — new artifacts written to the previous root are exactly what it is
+      // looking for.
+      const artifacts =
+        mode === "resume"
+          ? 0
+          : await mergeArtifacts(legacy, target).catch((error: unknown) => {
+              notes.push(
+                `legacy artifact store not imported: ${error instanceof Error ? error.message : String(error)}`,
+              )
+              return 0
+            })
+      const bytes = copied.reduce((total, file) => total + file.bytes, 0)
+      const migration = {
+        source: legacy,
+        target,
+        files: copied.length,
+        bytes,
+        merged: merged.length,
+        artifacts,
+        skipped: present.length,
+        deferred: deferred.length,
+      }
+      await fs.mkdir(target, { recursive: true })
+      // Always seal, and carry the outstanding paths inside the marker. Leaving
+      // the marker unwritten instead made every later launch re-walk and re-stat
+      // the whole legacy tree — `--version` included — for as long as one file
+      // stayed unreadable, which for a root-owned leftover is forever. Naming
+      // the stragglers means the retry costs one stat each and the common case
+      // still short-circuits on the first line of the function.
+      // A later pass keeps the original import's record and only updates what is
+      // still outstanding — overwriting it with a retry's counts would erase the
+      // one account of what actually moved. `checkedAt` is what paces the rescan,
+      // so it is stamped on every pass, including the first.
+      // A resume that actually carried something leaves `checkedAt` alone, so
+      // the next launch rescans instead of waiting out another full interval.
+      // The artifact merge is skipped on a resume, so a blob whose bytes just
+      // arrived has no rows describing it until that rescan runs — and while
+      // that is true, `doctor` reports nothing outstanding and `--prune-legacy`
+      // would delete the only copy of those rows.
+      const resumed = mode === "resume" && copied.length > 0
+      const record = sealed
+        ? { ...sealed, pending: deferred, ...(resumed ? {} : { checkedAt: Date.now() }) }
+        : { ...migration, migratedAt: Date.now(), checkedAt: Date.now(), pending: deferred }
+      await Bun.write(path.join(target, marker), `${JSON.stringify(record, null, 2)}\n`, { mode: 0o600 })
+      if (deferred.length > 0)
+        notes.push(`${deferred.length} file(s) could not be read from ${legacy}; the next launch will retry them`)
+      return {
+        path: target,
+        migrated: migration,
+        warning: notes.length ? notes.join("; ") : undefined,
+      } satisfies DataResolution
+    })().catch((error: unknown) => {
+      return {
+        path: occupied || landed.value ? target : legacy,
+        error: error instanceof Error ? error.message : String(error),
+      } satisfies DataResolution
+    })
+    return result
+  }
 }

--- a/backend/cli/src/global/index.ts
+++ b/backend/cli/src/global/index.ts
@@ -64,9 +64,10 @@ const pointer = (() => {
     return
   }
 })()
+const previous = migrateDir(xdgData!)
 const resolved = await resolveDataDirectory({
   home: process.env.OPENSCIENCE_TEST_HOME || os.homedir(),
-  legacy: migrateDir(xdgData!),
+  legacy: previous,
   explicit,
   pointer,
 })
@@ -81,6 +82,12 @@ migrateFile(config, "synsc.json", "openscience.json")
 export namespace Global {
   export const LegacyConflicts = detectedLegacyConflicts as readonly { legacy: string; current: string }[]
   export const DataMigration = resolved
+  /** The XDG data directory earlier releases used. The import copies out of it
+   *  rather than moving, so it survives as a safety copy — and, left alone,
+   *  as a permanent duplicate nothing ever tells the user they can delete.
+   *  `openscience doctor` reports it and can remove it. Undefined once the
+   *  data root is the same directory or the user has cleaned it up. */
+  export const LegacyData = previous === data ? undefined : previous
   export const Path = {
     // Allow override via OPENSCIENCE_TEST_HOME for test isolation
     get home() {

--- a/backend/cli/src/server/routes/settings/credentials.ts
+++ b/backend/cli/src/server/routes/settings/credentials.ts
@@ -35,6 +35,7 @@ import { OpenScience } from "@/openscience"
 import { lazy } from "@/util/lazy"
 import { JsonStore } from "@/util/jsonstore"
 import { SecretFile } from "@/util/secret-file"
+import { SecretBox } from "@/util/secret-box"
 
 type FieldType = "password" | "text" | "textarea"
 
@@ -139,26 +140,16 @@ async function machineKey(): Promise<Buffer> {
   return SecretFile.key(keyPath)
 }
 
+// The envelope itself lives in util/secret-box so the data-directory import can
+// share it: moving a store between roots means holding both machine keys at
+// once, and that code sits below Global in the module graph.
 async function encrypt(plain: string): Promise<string> {
-  const key = await machineKey()
-  const iv = crypto.randomBytes(12)
-  const cipher = crypto.createCipheriv("aes-256-gcm", key, iv)
-  const enc = Buffer.concat([cipher.update(plain, "utf8"), cipher.final()])
-  const tag = cipher.getAuthTag()
-  return Buffer.concat([iv, tag, enc]).toString("base64")
+  return SecretBox.seal(await machineKey(), plain)
 }
 
-// Inverse of encrypt(): iv(12) | tag(16) | ciphertext. Throws on a bad key/tag,
-// which callers treat as "unreadable field, skip it".
+// Throws on a bad key/tag, which callers treat as "unreadable field, skip it".
 async function decrypt(payload: string): Promise<string> {
-  const key = await machineKey()
-  const buf = Buffer.from(payload, "base64")
-  const iv = buf.subarray(0, 12)
-  const tag = buf.subarray(12, 28)
-  const enc = buf.subarray(28)
-  const decipher = crypto.createDecipheriv("aes-256-gcm", key, iv)
-  decipher.setAuthTag(tag)
-  return Buffer.concat([decipher.update(enc), decipher.final()]).toString("utf8")
+  return SecretBox.open(await machineKey(), payload)
 }
 
 function parseStore(data: Record<string, unknown>): Store {

--- a/backend/cli/src/util/secret-box.ts
+++ b/backend/cli/src/util/secret-box.ts
@@ -1,0 +1,36 @@
+import crypto from "crypto"
+
+/**
+ * AES-256-GCM envelope for a single secret value, keyed explicitly rather than
+ * from ambient state.
+ *
+ * The credential store seals every field value individually under the
+ * machine-local `credentials.key`. That key never leaves the machine, which is
+ * the point — but it also means a store copied between two data roots is
+ * unreadable in its new home unless something can hold both keys at once. The
+ * data-directory import is exactly that something, and it lives below `Global`
+ * in the module graph, so the crypto cannot come from the settings route that
+ * owns the store. Hence a leaf that takes the key as an argument: the route
+ * passes its machine key, the import passes one key to open and another to
+ * seal.
+ *
+ * Wire format is `iv(12) | tag(16) | ciphertext`, base64. Changing it silently
+ * strands every credential already on disk.
+ */
+export namespace SecretBox {
+  export function seal(key: Buffer, plain: string): string {
+    const iv = crypto.randomBytes(12)
+    const cipher = crypto.createCipheriv("aes-256-gcm", key, iv)
+    const enc = Buffer.concat([cipher.update(plain, "utf8"), cipher.final()])
+    return Buffer.concat([iv, cipher.getAuthTag(), enc]).toString("base64")
+  }
+
+  /** Throws on a wrong key or a tampered payload — callers treat that as
+   *  "unreadable field, leave it alone". */
+  export function open(key: Buffer, payload: string): string {
+    const buf = Buffer.from(payload, "base64")
+    const decipher = crypto.createDecipheriv("aes-256-gcm", key, buf.subarray(0, 12))
+    decipher.setAuthTag(buf.subarray(12, 28))
+    return Buffer.concat([decipher.update(buf.subarray(28)), decipher.final()]).toString("utf8")
+  }
+}

--- a/backend/cli/test/global/data-dir.test.ts
+++ b/backend/cli/test/global/data-dir.test.ts
@@ -5,6 +5,15 @@ import fsSync from "node:fs"
 import os from "node:os"
 import path from "node:path"
 import { resolveDataDirectory } from "@/global/data-dir"
+import { SecretBox } from "@/util/secret-box"
+
+// Windows' chmod only toggles the read-only bit, so `chmod 000` there leaves a
+// file perfectly readable and there is no portable way to stage the
+// "unreadable source" cases. Those tests are POSIX-only by nature; everything
+// else in this file — the copy, the hash verification, the exclusive link, the
+// credential re-seal, the rescan — runs everywhere and is what the Windows and
+// macOS legs of CI exist to cover.
+const unreadable = test.skipIf(process.platform === "win32")
 
 const roots: string[] = []
 
@@ -293,7 +302,7 @@ describe("OpenScience data directory", () => {
     expect(await fs.readFile(path.join(result.path, "openscience-session.json"), "utf8")).toContain("kept")
   })
 
-  test("an unreadable file costs that file and nothing else", async () => {
+  unreadable("an unreadable file costs that file and nothing else", async () => {
     const home = await root()
     const legacy = path.join(home, "share", "openscience")
     const target = path.join(home, ".openscience")
@@ -312,7 +321,9 @@ describe("OpenScience data directory", () => {
     // Sealed, but the straggler is named, so the retry costs one stat rather
     // than a fresh walk of the whole legacy tree on every later launch.
     const record = path.join(target, ".xdg-data-migration-v2.json")
-    expect(JSON.parse(await fs.readFile(record, "utf8")).pending).toEqual(["storage/session/locked.json"])
+    expect(JSON.parse(await fs.readFile(record, "utf8")).pending).toEqual([
+      path.join("storage", "session", "locked.json"),
+    ])
 
     await fs.chmod(path.join(legacy, "storage", "session", "locked.json"), 0o600)
     const retry = await resolveDataDirectory({ home, legacy })
@@ -329,7 +340,59 @@ describe("OpenScience data directory", () => {
     expect(settled.path).toBe(target)
   })
 
-  test("a straggler that disappears stops being chased", async () => {
+  test("picks up what an older install kept writing to the previous root", async () => {
+    const home = await root()
+    const legacy = path.join(home, "share", "openscience")
+    const target = path.join(home, ".openscience")
+    await fs.mkdir(path.join(legacy, "storage", "session"), { recursive: true })
+    await fs.writeFile(path.join(legacy, "openscience-session.json"), '{"api_key":"first"}')
+    await fs.writeFile(path.join(legacy, "storage", "session", "ses_a.json"), '{"id":"a"}')
+
+    const first = await resolveDataDirectory({ home, legacy })
+    expect(first.migrated?.files).toBe(2)
+
+    // A second, older install goes on using the previous root: a new session,
+    // and a credential it refreshed there.
+    await fs.writeFile(path.join(legacy, "storage", "session", "ses_b.json"), '{"id":"b"}')
+    await fs.writeFile(path.join(legacy, "auth.json"), JSON.stringify({ "openai-codex": { access: "later" } }))
+
+    // Inside the interval nothing is re-read — that is what keeps the steady
+    // state off the boot path.
+    expect((await resolveDataDirectory({ home, legacy })).migrated).toBeUndefined()
+    expect(fsSync.existsSync(path.join(target, "storage", "session", "ses_b.json"))).toBe(false)
+
+    const record = path.join(target, ".xdg-data-migration-v2.json")
+    const aged = JSON.parse(await fs.readFile(record, "utf8"))
+    await fs.writeFile(record, JSON.stringify({ ...aged, checkedAt: 0 }))
+
+    const rescan = await resolveDataDirectory({ home, legacy })
+
+    expect(rescan.path).toBe(target)
+    expect(await fs.readFile(path.join(target, "storage", "session", "ses_b.json"), "utf8")).toContain("b")
+    expect(JSON.parse(await fs.readFile(path.join(target, "auth.json"), "utf8"))["openai-codex"].access).toBe("later")
+    // The original import's record survives the rescan.
+    expect(JSON.parse(await fs.readFile(record, "utf8")).migratedAt).toBe(aged.migratedAt)
+  })
+
+  test("stops watching a previous root that no longer exists", async () => {
+    const home = await root()
+    const legacy = path.join(home, "share", "openscience")
+    await fs.mkdir(legacy, { recursive: true })
+    await fs.writeFile(path.join(legacy, "openscience-session.json"), '{"api_key":"kept"}')
+
+    await resolveDataDirectory({ home, legacy })
+    const record = path.join(home, ".openscience", ".xdg-data-migration-v2.json")
+    await fs.writeFile(record, JSON.stringify({ ...JSON.parse(await fs.readFile(record, "utf8")), checkedAt: 0 }))
+    await fs.rm(legacy, { recursive: true, force: true })
+
+    const result = await resolveDataDirectory({ home, legacy })
+
+    expect(result.path).toBe(path.join(home, ".openscience"))
+    expect(result.migrated).toBeUndefined()
+    expect(result.error).toBeUndefined()
+  })
+
+  unreadable("a straggler that disappears stops being chased", async () => {
     const home = await root()
     const legacy = path.join(home, "share", "openscience")
     const target = path.join(home, ".openscience")
@@ -387,27 +450,92 @@ describe("OpenScience data directory", () => {
     expect(fsSync.existsSync(path.join(target, ".xdg-data-migration-v2.json"))).toBe(true)
   })
 
-  test("does not import credentials sealed with a different machine key", async () => {
+  test("re-seals credentials under the target's own machine key", async () => {
     const home = await root()
     const legacy = path.join(home, "share", "openscience")
     const target = path.join(home, ".openscience")
+    const before = Buffer.alloc(32, 1)
+    const after = Buffer.alloc(32, 2)
     await fs.mkdir(legacy, { recursive: true })
     await fs.mkdir(target, { recursive: true })
-    await fs.writeFile(path.join(legacy, "credentials.key"), Buffer.alloc(32, 1))
-    await fs.writeFile(path.join(target, "credentials.key"), Buffer.alloc(32, 2))
+    await fs.writeFile(path.join(legacy, "credentials.key"), before)
+    await fs.writeFile(path.join(target, "credentials.key"), after)
     await fs.writeFile(
       path.join(legacy, "credentials.json"),
-      JSON.stringify({ github: { fields: { GITHUB_TOKEN: "ciphertext" }, updated_at: "1" } }),
+      JSON.stringify({
+        github: {
+          fields: { GITHUB_TOKEN: SecretBox.seal(before, "ghp_real"), STALE: "not-even-base64-gcm" },
+          updated_at: "1",
+        },
+      }),
     )
-    await fs.writeFile(path.join(legacy, "auth.json"), JSON.stringify({ "openai-codex": { access: "kept" } }))
 
     const result = await resolveDataDirectory({ home, legacy })
 
-    expect(result.warning).toContain("different machine key")
-    // Undecryptable entries would show as "set" in the UI and inject nothing.
-    expect(fsSync.existsSync(path.join(target, "credentials.json"))).toBe(false)
-    expect(await fs.readFile(path.join(target, "credentials.key"))).toEqual(Buffer.alloc(32, 2))
-    expect(JSON.parse(await fs.readFile(path.join(target, "auth.json"), "utf8"))["openai-codex"].access).toBe("kept")
+    expect(result.error).toBeUndefined()
+    const store = JSON.parse(await fs.readFile(path.join(target, "credentials.json"), "utf8"))
+    // Readable with the key this machine actually uses — the point of the
+    // exercise. Carried verbatim it would decrypt to nothing while the UI
+    // still called it "set".
+    expect(SecretBox.open(after, store.github.fields.GITHUB_TOKEN)).toBe("ghp_real")
+    // A field that will not open is unrecoverable; carrying it forward would
+    // recreate the silent dud.
+    expect(store.github.fields.STALE).toBeUndefined()
+    expect(await fs.readFile(path.join(target, "credentials.key"))).toEqual(after)
+  })
+
+  test("keeps a credential the target already has over the legacy one", async () => {
+    const home = await root()
+    const legacy = path.join(home, "share", "openscience")
+    const target = path.join(home, ".openscience")
+    const before = Buffer.alloc(32, 1)
+    const after = Buffer.alloc(32, 2)
+    await fs.mkdir(legacy, { recursive: true })
+    await fs.mkdir(target, { recursive: true })
+    await fs.writeFile(path.join(legacy, "credentials.key"), before)
+    await fs.writeFile(path.join(target, "credentials.key"), after)
+    await fs.writeFile(
+      path.join(legacy, "credentials.json"),
+      JSON.stringify({
+        github: { fields: { GITHUB_TOKEN: SecretBox.seal(before, "old") }, updated_at: "1" },
+        modal: { fields: { MODAL_TOKEN: SecretBox.seal(before, "recovered") }, updated_at: "1" },
+      }),
+    )
+    await fs.writeFile(
+      path.join(target, "credentials.json"),
+      JSON.stringify({ github: { fields: { GITHUB_TOKEN: SecretBox.seal(after, "current") }, updated_at: "2" } }),
+    )
+
+    await resolveDataDirectory({ home, legacy })
+
+    const store = JSON.parse(await fs.readFile(path.join(target, "credentials.json"), "utf8"))
+    expect(SecretBox.open(after, store.github.fields.GITHUB_TOKEN)).toBe("current")
+    expect(SecretBox.open(after, store.modal.fields.MODAL_TOKEN)).toBe("recovered")
+  })
+
+  unreadable("does not import an artifact whose blob never landed", async () => {
+    const home = await root()
+    const legacy = path.join(home, "share", "openscience")
+    const target = path.join(home, ".openscience")
+    await artifact(legacy, "orphan")
+    await artifact(target, "current")
+    // The row travels through the SQLite merge, the bytes through the file
+    // copy. Break only the bytes.
+    await fs.chmod(path.join(legacy, "artifact-store", "blobs", "orphan"), 0o000)
+
+    const result = await resolveDataDirectory({ home, legacy })
+
+    expect(result.error).toBeUndefined()
+    expect(fsSync.existsSync(path.join(target, "artifact-store", "blobs", "orphan"))).toBe(false)
+    const db = new Database(path.join(target, "artifact-store", "artifacts.db"), { readonly: true })
+    // An artifact listed but unopenable is worse than one that never arrived.
+    expect((db.query("SELECT id FROM artifacts ORDER BY id").all() as Array<{ id: string }>).map((r) => r.id)).toEqual([
+      "art_current",
+    ])
+    expect((db.query("SELECT count(*) AS v FROM blobs").get() as { v: number }).v).toBe(1)
+    expect((db.query("SELECT count(*) AS v FROM versions").get() as { v: number }).v).toBe(1)
+    db.close()
+    await fs.chmod(path.join(legacy, "artifact-store", "blobs", "orphan"), 0o600)
   })
 
   test("carries a SQLite journal only alongside its own database", async () => {

--- a/backend/cli/test/global/data-dir.test.ts
+++ b/backend/cli/test/global/data-dir.test.ts
@@ -374,6 +374,44 @@ describe("OpenScience data directory", () => {
     expect(JSON.parse(await fs.readFile(record, "utf8")).migratedAt).toBe(aged.migratedAt)
   })
 
+  test("a rescan does not resurrect what the user deleted", async () => {
+    const home = await root()
+    const legacy = path.join(home, "share", "openscience")
+    const target = path.join(home, ".openscience")
+    await fs.mkdir(path.join(legacy, "storage", "session"), { recursive: true })
+    await fs.writeFile(path.join(legacy, "storage", "session", "ses_a.json"), '{"id":"a"}')
+    await fs.writeFile(
+      path.join(legacy, "auth.json"),
+      JSON.stringify({ "openai-codex": { access: "tok" }, openrouter: { key: "tok" } }),
+    )
+
+    await resolveDataDirectory({ home, legacy })
+    expect(fsSync.existsSync(path.join(target, "storage", "session", "ses_a.json"))).toBe(true)
+
+    // The user deletes a session and logs out of a provider. Both only ever
+    // touch the current root — the previous root still has its own copy of
+    // each, and that copy is never deleted.
+    await fs.rm(path.join(target, "storage", "session", "ses_a.json"))
+    await fs.writeFile(path.join(target, "auth.json"), JSON.stringify({ "openai-codex": { access: "tok" } }))
+
+    // Age the previous root's copies to before the last check, and put the
+    // last check far enough back to trigger a rescan. That is the real shape:
+    // files the old install wrote long ago, and an interval that has elapsed.
+    const stale = new Date(Date.now() - 8 * 60 * 60 * 1000)
+    for (const file of ["auth.json", path.join("storage", "session", "ses_a.json")])
+      await fs.utimes(path.join(legacy, file), stale, stale)
+    const record = path.join(target, ".xdg-data-migration-v2.json")
+    const aged = JSON.parse(await fs.readFile(record, "utf8"))
+    await fs.writeFile(record, JSON.stringify({ ...aged, checkedAt: Date.now() - 7 * 60 * 60 * 1000 }))
+
+    await resolveDataDirectory({ home, legacy })
+
+    // Deleting has to win over copying, or the deletion silently never happened
+    // — and for the credential that would mean a revoked key back in place.
+    expect(fsSync.existsSync(path.join(target, "storage", "session", "ses_a.json"))).toBe(false)
+    expect(JSON.parse(await fs.readFile(path.join(target, "auth.json"), "utf8")).openrouter).toBeUndefined()
+  })
+
   test("stops watching a previous root that no longer exists", async () => {
     const home = await root()
     const legacy = path.join(home, "share", "openscience")
@@ -555,16 +593,40 @@ describe("OpenScience data directory", () => {
     ])
 
     expect(results.map((result) => result.path)).toEqual([target, target, target])
-    // Exactly one run should have done the copying. The others are correct
-    // either way — this is about not walking and hashing the same tree three
-    // times over, and not contending on the artifact database while doing it.
-    expect(results.filter((result) => result.migrated).length).toBe(1)
-    expect(results.find((result) => result.migrated)?.migrated?.files).toBe(61)
+    // Deliberately not asserting that exactly one caller imported. Whether a
+    // loser skips depends on the winner writing the marker inside LEASE_WAIT,
+    // which is a race — and on a cold Windows or macOS runner hashing 61 files
+    // twice each, one it would sometimes lose. The lease is an optimisation;
+    // pinning a test to it would buy flakes in the new CI legs to assert
+    // something that is allowed to not happen. What must hold is the outcome.
+    expect(results.every((result) => !result.error)).toBe(true)
     for (let i = 0; i < 60; i++)
       expect(fsSync.existsSync(path.join(target, "storage", "session", `ses_${i}.json`))).toBe(true)
     expect(JSON.parse(await fs.readFile(path.join(target, "auth.json"), "utf8"))["openai-codex"].access).toBe("kept")
     // The lease must not outlive the run that took it.
     expect(fsSync.existsSync(path.join(target, ".openscience-import.lock"))).toBe(false)
+  })
+
+  test("a fresh install with nothing to import leaves no lease behind", async () => {
+    const home = await root()
+    // No legacy root at all — the ordinary case for anyone installing today,
+    // and the one that took an early return past the lease release. Boot one
+    // leaked the lock; every boot after it then waited out the full timeout on
+    // a lock nobody was holding, `--version` included.
+    const legacy = path.join(home, "share", "openscience")
+    const lock = path.join(home, ".openscience", ".openscience-import.lock")
+
+    const first = await resolveDataDirectory({ home, legacy })
+    expect(first.path).toBe(path.join(home, ".openscience"))
+    expect(fsSync.existsSync(lock)).toBe(false)
+
+    const started = performance.now()
+    const second = await resolveDataDirectory({ home, legacy })
+    const elapsed = performance.now() - started
+
+    expect(second.path).toBe(first.path)
+    expect(elapsed).toBeLessThan(500)
+    expect(fsSync.existsSync(lock)).toBe(false)
   })
 
   test("an uncontended import never waits on the lease", async () => {

--- a/backend/cli/test/global/data-dir.test.ts
+++ b/backend/cli/test/global/data-dir.test.ts
@@ -538,6 +538,117 @@ describe("OpenScience data directory", () => {
     await fs.chmod(path.join(legacy, "artifact-store", "blobs", "orphan"), 0o600)
   })
 
+  test("one concurrent boot does the import, the rest wait it out", async () => {
+    const home = await root()
+    const legacy = path.join(home, "share", "openscience")
+    const target = path.join(home, ".openscience")
+    await fs.mkdir(path.join(legacy, "storage", "session"), { recursive: true })
+    await fs.writeFile(path.join(legacy, "openscience-session.json"), '{"api_key":"kept"}')
+    await fs.writeFile(path.join(legacy, "auth.json"), JSON.stringify({ "openai-codex": { access: "kept" } }))
+    for (let i = 0; i < 60; i++)
+      await fs.writeFile(path.join(legacy, "storage", "session", `ses_${i}.json`), `{"i":${i}}`)
+
+    const results = await Promise.all([
+      resolveDataDirectory({ home, legacy }),
+      resolveDataDirectory({ home, legacy }),
+      resolveDataDirectory({ home, legacy }),
+    ])
+
+    expect(results.map((result) => result.path)).toEqual([target, target, target])
+    // Exactly one run should have done the copying. The others are correct
+    // either way — this is about not walking and hashing the same tree three
+    // times over, and not contending on the artifact database while doing it.
+    expect(results.filter((result) => result.migrated).length).toBe(1)
+    expect(results.find((result) => result.migrated)?.migrated?.files).toBe(61)
+    for (let i = 0; i < 60; i++)
+      expect(fsSync.existsSync(path.join(target, "storage", "session", `ses_${i}.json`))).toBe(true)
+    expect(JSON.parse(await fs.readFile(path.join(target, "auth.json"), "utf8"))["openai-codex"].access).toBe("kept")
+    // The lease must not outlive the run that took it.
+    expect(fsSync.existsSync(path.join(target, ".openscience-import.lock"))).toBe(false)
+  })
+
+  test("an uncontended import never waits on the lease", async () => {
+    const home = await root()
+    const legacy = path.join(home, "share", "openscience")
+    await fs.mkdir(legacy, { recursive: true })
+    await fs.writeFile(path.join(legacy, "openscience-session.json"), '{"api_key":"kept"}')
+
+    // The lease is an optimisation, so it must never be able to add latency to
+    // a launch. Failing to acquire it once meant waiting the full timeout with
+    // nobody on the other end, which cost every spawned process ten seconds.
+    const started = performance.now()
+    const result = await resolveDataDirectory({ home, legacy })
+    const elapsed = performance.now() - started
+
+    expect(result.migrated?.files).toBe(1)
+    expect(elapsed).toBeLessThan(1000)
+  })
+
+  test("imports anyway when the lease holder never finishes", async () => {
+    const home = await root()
+    const legacy = path.join(home, "share", "openscience")
+    const target = path.join(home, ".openscience")
+    await fs.mkdir(legacy, { recursive: true })
+    await fs.mkdir(target, { recursive: true })
+    await fs.writeFile(path.join(legacy, "openscience-session.json"), '{"api_key":"kept"}')
+    // A lease left behind by a process that died long ago. Waiting out its
+    // full staleness on every launch would be worse than the duplicated work
+    // the lease exists to avoid.
+    const lock = path.join(target, ".openscience-import.lock")
+    await fs.writeFile(lock, JSON.stringify({ pid: 999999, at: 0 }))
+    const old = new Date(Date.now() - 30 * 60 * 1000)
+    await fs.utimes(lock, old, old)
+
+    const result = await resolveDataDirectory({ home, legacy })
+
+    expect(result.path).toBe(target)
+    expect(result.migrated?.files).toBe(1)
+    expect(await fs.readFile(path.join(target, "openscience-session.json"), "utf8")).toContain("kept")
+    expect(fsSync.existsSync(lock)).toBe(false)
+  })
+
+  test("reaps abandoned staging files without touching live ones", async () => {
+    const home = await root()
+    const legacy = path.join(home, "share", "openscience")
+    const target = path.join(home, ".openscience")
+    await fs.mkdir(path.join(target, "storage"), { recursive: true })
+    await fs.mkdir(legacy, { recursive: true })
+    await fs.writeFile(path.join(legacy, "openscience-session.json"), '{"api_key":"kept"}')
+
+    // Left by a process killed mid-copy. The per-call name means nothing will
+    // ever reuse it, so without a sweep it stays forever.
+    const abandoned = path.join(target, "storage", "ses_x.json.999.abc.openscience-import")
+    const live = path.join(target, "storage", "ses_y.json.111.def.openscience-import")
+    await fs.writeFile(abandoned, "half a file")
+    await fs.writeFile(live, "in flight right now")
+    const old = new Date(Date.now() - 3 * 60 * 60 * 1000)
+    await fs.utimes(abandoned, old, old)
+
+    const result = await resolveDataDirectory({ home, legacy })
+
+    expect(result.error).toBeUndefined()
+    expect(fsSync.existsSync(abandoned)).toBe(false)
+    // A concurrent import may be part-way through writing this one; reaping it
+    // would turn a healthy copy into a deferred file.
+    expect(fsSync.existsSync(live)).toBe(true)
+    expect(await fs.readFile(path.join(target, "openscience-session.json"), "utf8")).toContain("kept")
+  })
+
+  test("never imports a staging file as if it were data", async () => {
+    const home = await root()
+    const legacy = path.join(home, "share", "openscience")
+    const target = path.join(home, ".openscience")
+    await fs.mkdir(legacy, { recursive: true })
+    await fs.writeFile(path.join(legacy, "openscience-session.json"), '{"api_key":"kept"}')
+    // A previous root that was itself a target once can still hold these.
+    await fs.writeFile(path.join(legacy, "auth.json.123.xyz.openscience-import"), "{}")
+
+    const result = await resolveDataDirectory({ home, legacy })
+
+    expect(result.migrated?.files).toBe(1)
+    expect(fsSync.existsSync(path.join(target, "auth.json.123.xyz.openscience-import"))).toBe(false)
+  })
+
   test("carries a SQLite journal only alongside its own database", async () => {
     const home = await root()
     const legacy = path.join(home, "share", "openscience")

--- a/backend/cli/test/global/data-dir.test.ts
+++ b/backend/cli/test/global/data-dir.test.ts
@@ -202,13 +202,13 @@ describe("OpenScience data directory", () => {
     expect(result.error).toBeUndefined()
     expect(await fs.readFile(path.join(target, "openscience-session.json"), "utf8")).toContain("kept")
     expect(fsSync.existsSync(path.join(target, "artifact-store", "artifacts.db"))).toBe(true)
-    for (const orphan of [
-      "log",
-      "artifact-store/artifacts.db-wal",
-      "artifact-store/artifacts.db-shm",
-      "auth.json.lock",
-    ])
-      expect(fsSync.existsSync(path.join(target, orphan))).toBe(false)
+    // Only the genuinely disposable things. The -wal/-shm beside artifacts.db
+    // are NOT orphans here — that database is being carried, so its journal
+    // travels with it, and whether the files still exist afterwards is
+    // SQLite's business: opening the database checkpoints or discards a
+    // journal it cannot use, and it does so on some platforms and not others.
+    // Journal pairing has its own test, over files SQLite never touches.
+    for (const orphan of ["log", "auth.json.lock"]) expect(fsSync.existsSync(path.join(target, orphan))).toBe(false)
   })
 
   test("imports credentials and history even when the legacy artifact store is corrupt", async () => {


### PR DESCRIPTION
Follow-ups to the legacy data import (#265), from that PR's review. Each was known and deliberately deferred so the 2.0.21 hotfix could ship.

## What this fixes

**The import sealed itself once and never looked back.** A second, older install goes on writing to `~/.local/share/openscience` unseen — refreshing its own session and credentials there — and none of it is ever picked up. The marker is now a checkpoint rather than a verdict: while that root still exists, a sealed import re-reads it at most once every six hours. The steady state stays off the boot path — both early exits are decided before anything walks a directory.

```
steady state        0.14 ms per launch   (one stat)
after --prune-legacy                     (one failed stat)
rescan              once per 6h per machine
```

**Credentials sealed under a different machine key were dropped.** They did not have to be — both keys are on disk during the import, so entries are opened with the legacy key and re-sealed with the target's. The envelope moved to `util/secret-box`, which takes its key as an argument: the settings route cannot be imported from below `Global`, and this is the one place needing two keys at once. A field that will not open is still left out — it is unrecoverable, and carrying it forward recreates the silent dud (an entry the UI calls "set" that injects nothing).

**Artifact rows could outlive their blobs.** Metadata travels through the SQL merge, blob content through the file copy, so a blob that never landed left a row pointing at nothing and an artifact that read as present until someone opened it. The file on disk now decides, and what it excludes cascades: no blob, no version; no current version, no artifact.

**Nothing ever told users about the previous root.** It is a deliberate safety copy, but it survives forever as a full duplicate and the disk is never reclaimed. `openscience doctor` now names and measures it; `--prune-legacy` removes it, refusing while any file has yet to be imported out of it — until then it is the only copy.

## Coverage

A `Migration` job across ubuntu, macos, and windows. This code runs at boot on every user's machine and is built almost entirely from filesystem primitives that differ per platform — hardlinks, exclusive create, chmod, path separators — so a Linux-only suite was never evidence it worked. The leg is narrow on purpose: one suite, no sandbox or web assets. Windows' chmod cannot make a file unreadable, so those three cases are marked POSIX-only rather than left to fail there.

## Verification

19/19 in `test/global/data-dir.test.ts` (7 new), full suite 1855 pass, typecheck and prettier clean. The macOS and Windows legs are unverified locally — running them is what this PR is for.

Draft until those legs report.