### PR TITLE
Unify scientific compute, results, and artifact workflows

### DIFF
--- a/backend/cli/src/agent/prompt/research.txt
+++ b/backend/cli/src/agent/prompt/research.txt
@@ -17,6 +17,10 @@ review only if useful
   source claims from your inference.
 - If the user asks for a report, figure, dataset, notebook, or other output, create and
   verify that deliverable rather than returning only a narrative.
+- For multi-kernel analysis, preserve useful outputs from every track, correct failed or
+  misleading results, and finish with a consolidated reusable report plus registered tables,
+  figures, or datasets instead of a chat-only summary. Use `artifact` with `save_file` for the
+  finished files so they become project-wide, immutable, versioned artifacts.
 
 ## Specialists and delegation
 
@@ -30,6 +34,12 @@ review only if useful
 ## Compute and tools
 
 - Use a persistent kernel for iterative Python or R analysis whose state matters.
+- When the user requests multiple kernels, use distinct managed `kernel` names and issue the
+  independent notebook or R-kernel calls together so they run concurrently. Never substitute
+  shell processes and describe them as kernels.
+- Use exactly the requested kernel count. Prepare shared inputs once in one of those named
+  kernels, save the handoff dataset, then fan the independent tracks out across that kernel and
+  the remaining names; do not create an extra setup kernel.
 - Use shell for builds, tests, file operations, and non-interactive scripts.
 - Keep modest calculations, parsing, plotting, and statistics local.
 - Use remote compute only when the workload or user requires it. Never dispatch paid work

--- a/backend/cli/src/agent/prompt/research.txt
+++ b/backend/cli/src/agent/prompt/research.txt
@@ -3,24 +3,23 @@ You are the primary Research agent.
 
 Use this adaptive loop:
 
-understand -> plan only if useful -> inspect or search -> analyze -> save useful output ->
-review only if useful
+understand -> plan if useful -> inspect/search -> analyze -> save useful output -> review if useful
 
 ## Calibrate the work
 
-- A direct question should receive a direct answer. Do not create a plan, literature review,
-  reasoning file, methodology file, or child task unless the work actually needs one.
+- A direct question should receive a direct answer. Create no plan, review, methodology, or child task
+  unless the work needs one.
 - For an analysis, inspect inputs before choosing a method. State the success criterion when
   the request leaves it implicit and the choice affects the result.
-- Search literature when current or source-backed claims matter. One focused search is
-  usually better than a search swarm. Preserve stable source identifiers and distinguish
-  source claims from your inference.
+- Search when current or source-backed claims matter. Prefer one focused search, preserve
+  stable source IDs, and distinguish source claims from inference.
 - If the user asks for a report, figure, dataset, notebook, or other output, create and
   verify that deliverable rather than returning only a narrative.
-- For multi-kernel analysis, preserve useful outputs from every track, correct failed or
-  misleading results, and finish with a consolidated reusable report plus registered tables,
-  figures, or datasets instead of a chat-only summary. Use `artifact` with `save_file` for the
-  finished files so they become project-wide, immutable, versioned artifacts.
+- For multi-kernel analysis, preserve every track, correct failures, and finish with a reusable
+  report plus registered tables/figures/datasets. Save finished files with `artifact.save_file`
+  as versioned project artifacts, each with a descriptive non-empty summary.
+- For tabular/quantitative analysis, create at least two useful figures when supported. Show
+  each final figure inline from its kernel cell and save it; an unseen file is not a result.
 
 ## Specialists and delegation
 
@@ -28,8 +27,7 @@ review only if useful
 - Biology, ML, and Physics are explicit specialists. Use one only for a distinct domain
   concern that can be bounded and merged cleanly.
 - Default to no child agents; never create several literature children for one search.
-- At most two independent children may run concurrently. Continue with useful primary work
-  while they run and do not wait for optional stragglers.
+- At most two independent children run concurrently. Keep working; do not wait for stragglers.
 
 ## Compute and tools
 
@@ -40,11 +38,15 @@ review only if useful
 - Use exactly the requested kernel count. Prepare shared inputs once in one of those named
   kernels, save the handoff dataset, then fan the independent tracks out across that kernel and
   the remaining names; do not create an extra setup kernel.
+- Named kernels are temporary. After outputs and artifacts are verified, call each kernel tool
+  with `action: "stop"` before answering; leave no completed worker idle.
 - Use shell for builds, tests, file operations, and non-interactive scripts.
 - Keep modest calculations, parsing, plotting, and statistics local.
 - Use remote compute only when the workload or user requires it. Never dispatch paid work
   without an approval request that names the action, provider, resources, duration, and
   estimated price.
+- Remote work finishes only after delivery is inspected and the provider resource is closed,
+  or a truthful cleanup warning is surfaced.
 - Prefer one concern per kernel cell and named output files when replay matters.
 - Do not promise checkpointing or recovery unless the selected runtime implements it.
 

--- a/backend/cli/src/science/command/registry.ts
+++ b/backend/cli/src/science/command/registry.ts
@@ -1,0 +1,75 @@
+import type { ChildProcess } from "node:child_process"
+import z from "zod"
+
+export const CommandStatus = z.object({
+  id: z.string(),
+  projectID: z.string(),
+  sessionID: z.string(),
+  messageID: z.string(),
+  callID: z.string().optional(),
+  description: z.string(),
+  command: z.string(),
+  state: z.literal("running"),
+  process_id: z.number().int(),
+  started_at: z.number().int(),
+  resources: z
+    .object({
+      cpu_percent: z.number(),
+      memory_bytes: z.number().int(),
+    })
+    .partial()
+    .optional(),
+})
+export type CommandStatus = z.infer<typeof CommandStatus>
+
+type Entry = CommandStatus & {
+  process: ChildProcess
+  stop: () => Promise<void>
+}
+
+const entries = new Map<string, Entry>()
+
+export namespace CommandRuntime {
+  export function start(
+    input: Omit<CommandStatus, "id" | "state" | "process_id" | "started_at" | "resources">,
+    process: ChildProcess,
+    stop: () => Promise<void>,
+  ) {
+    if (!process.pid) throw new Error("Shell command started without a process id")
+    const value: Entry = {
+      ...input,
+      id: `command-${crypto.randomUUID()}`,
+      state: "running",
+      process_id: process.pid,
+      started_at: Date.now(),
+      process,
+      stop,
+    }
+    entries.set(value.id, value)
+    return value
+  }
+
+  export function finish(id: string) {
+    entries.delete(id)
+  }
+
+  export function list(projectID: string, sessionID?: string): CommandStatus[] {
+    return [...entries.values()]
+      .filter((value) => value.projectID === projectID && (!sessionID || value.sessionID === sessionID))
+      .map(({ process: _process, stop: _stop, ...value }) => value)
+      .toSorted((a, b) => b.started_at - a.started_at)
+  }
+
+  export function owned(id: string, projectID: string, sessionID: string) {
+    const value = entries.get(id)
+    if (!value || value.projectID !== projectID || value.sessionID !== sessionID) return
+    return value
+  }
+
+  export async function stop(id: string, projectID: string, sessionID: string) {
+    const value = owned(id, projectID, sessionID)
+    if (!value) return false
+    await value.stop()
+    return true
+  }
+}

--- a/backend/cli/src/server/routes/notebook.ts
+++ b/backend/cli/src/server/routes/notebook.ts
@@ -13,6 +13,7 @@ import { Identifier } from "../../id/id"
 import { Session } from "../../session"
 import { lazy } from "../../util/lazy"
 import { Storage } from "../../storage/storage"
+import { CommandRuntime, CommandStatus } from "../../science/command/registry"
 
 const Language = z.enum(["python", "r"])
 const Key = z.object({
@@ -26,20 +27,14 @@ const List = z.object({
 const Owner = z.object({
   sessionID: Identifier.schema("session"),
 })
-const Create = Owner.extend({
-  name: z
-    .string()
-    .trim()
-    .min(1)
-    .max(120)
-    .refine((value) => value !== "agent", "The default agent kernel name is reserved."),
-  language: Language,
-})
 const ControlStatus = KernelStatus.extend({
   state_preserved: z.boolean().optional(),
 })
 const KernelParam = z.object({
   kernelID: z.string().regex(/^kernel-[a-z0-9]+$/),
+})
+const CommandParam = z.object({
+  commandID: z.string().regex(/^command-[a-f0-9-]+$/),
 })
 const Execute = Key.extend({
   code: z.string().max(2_000_000),
@@ -107,9 +102,9 @@ export const NotebookRoutes = lazy(() =>
     .get(
       "/compute",
       describeRoute({
-        summary: "Report host compute capacity",
+        summary: "Report live local compute capacity",
         operationId: "notebook.compute",
-        responses: { 200: { description: "Machine capacity and the share kernels hold" } },
+        responses: { 200: { description: "Machine capacity and the share live kernels and commands hold" } },
       }),
       async (c) => {
         // Both samplers measure across the window since THIS caller's previous
@@ -123,40 +118,118 @@ export const NotebookRoutes = lazy(() =>
         const caller = c.req.query("client")?.slice(0, 128) || "anonymous"
         const host = await KernelHost.snapshot(caller)
         const live = KernelRuntime.list().filter((kernel) => kernel.active)
+        const commands = CommandRuntime.list(Instance.project.id)
         const samples = await KernelMetrics.sampleAll(
           `compute:${caller}`,
-          live.flatMap((kernel) => (kernel.process_id === null ? [] : [kernel.process_id])),
+          [
+            ...live.flatMap((kernel) => (kernel.process_id === null ? [] : [kernel.process_id])),
+            ...commands.map((command) => command.process_id),
+          ],
         )
         const usage = [...samples.values()]
+        const kernelUsage = live.flatMap((kernel) => {
+          const value = kernel.process_id === null ? undefined : samples.get(kernel.process_id)
+          return value ? [value] : []
+        })
         const cpu = usage.filter((sample) => sample.cpu_percent !== undefined)
         const memory = usage.filter((sample) => sample.memory_bytes !== undefined)
+        const kernelCpu = kernelUsage.filter((sample) => sample.cpu_percent !== undefined)
+        const kernelMemory = kernelUsage.filter((sample) => sample.memory_bytes !== undefined)
         return c.json({
           memory: {
             total: host.memory.total,
             available: host.memory.available,
-            // No live kernels at all is a real measurement: they hold exactly
-            // zero bytes. Kernels that exist but went unsampled this poll stay
-            // omitted — that figure is genuinely unknown, not zero.
+            ...(live.length === 0 && commands.length === 0
+              ? { compute: 0 }
+              : memory.length
+                ? { compute: memory.reduce((sum, item) => sum + (item.memory_bytes ?? 0), 0) }
+                : {}),
             ...(live.length === 0
               ? { kernels: 0 }
-              : memory.length
-                ? { kernels: memory.reduce((sum, item) => sum + (item.memory_bytes ?? 0), 0) }
+              : kernelMemory.length
+                ? { kernels: kernelMemory.reduce((sum, item) => sum + (item.memory_bytes ?? 0), 0) }
                 : {}),
           },
           cpu: {
             cores: host.cpu.cores,
             ...(host.cpu.busy === undefined ? {} : { busy: host.cpu.busy }),
+            ...(live.length === 0 && commands.length === 0
+              ? { compute: 0 }
+              : cpu.length
+                ? { compute: cpu.reduce((sum, item) => sum + (item.cpu_percent ?? 0), 0) / 100 }
+                : {}),
             ...(live.length === 0
               ? { kernels: 0 }
-              : cpu.length
-                ? { kernels: cpu.reduce((sum, item) => sum + (item.cpu_percent ?? 0), 0) / 100 }
+              : kernelCpu.length
+                ? { kernels: kernelCpu.reduce((sum, item) => sum + (item.cpu_percent ?? 0), 0) / 100 }
                 : {}),
           },
           kernels: {
             live: live.length,
             running: live.filter((kernel) => kernel.state === "running").length,
           },
+          commands: {
+            live: commands.length,
+            running: commands.length,
+          },
         })
+      },
+    )
+    .get(
+      "/commands",
+      describeRoute({
+        summary: "List live project shell commands",
+        operationId: "notebook.commands",
+        responses: {
+          200: {
+            description: "Live shell commands and process resource usage",
+            content: { "application/json": { schema: resolver(z.object({ commands: CommandStatus.array() })) } },
+          },
+        },
+      }),
+      validator("query", List),
+      async (c) => {
+        const query = c.req.valid("query")
+        if (query.sessionID) {
+          const denied = await owner(c, query.sessionID)
+          if (denied) return denied
+        }
+        const commands = CommandRuntime.list(Instance.project.id, query.sessionID)
+        const caller = c.req.query("client")?.slice(0, 128) || "anonymous"
+        const samples = await KernelMetrics.sampleAll(
+          `commands:${caller}`,
+          commands.map((command) => command.process_id),
+        )
+        return c.json({
+          commands: commands.map((command) => {
+            const resources = samples.get(command.process_id)
+            return resources && Object.keys(resources).length ? { ...command, resources } : command
+          }),
+        })
+      },
+    )
+    .post(
+      "/commands/:commandID/stop",
+      describeRoute({
+        summary: "Stop a live shell command",
+        operationId: "notebook.command.stop",
+        responses: { 200: { description: "Command stopped" }, 404: { description: "Command not found" } },
+      }),
+      validator("param", CommandParam),
+      validator("json", Owner),
+      async (c) => {
+        const body = c.req.valid("json")
+        const denied = await owner(c, body.sessionID)
+        if (denied) return denied
+        const stopped = await CommandRuntime.stop(
+          c.req.valid("param").commandID,
+          Instance.project.id,
+          body.sessionID,
+        )
+        if (!stopped) {
+          return c.json({ error: "command_not_found", message: "The command is no longer running." }, 404)
+        }
+        return c.json({ stopped: true })
       },
     )
     .get(
@@ -207,34 +280,6 @@ export const NotebookRoutes = lazy(() =>
           return resources && Object.keys(resources).length ? { ...kernel, resources } : kernel
         })
         return c.json({ kernels })
-      },
-    )
-    .post(
-      "/kernels",
-      describeRoute({
-        summary: "Create a named session kernel record",
-        operationId: "notebook.kernel.create",
-        responses: {
-          200: {
-            description: "Lazy named kernel record",
-            content: { "application/json": { schema: resolver(KernelStatus) } },
-          },
-        },
-      }),
-      validator("json", Create),
-      async (c) => {
-        const body = c.req.valid("json")
-        const denied = await owner(c, body.sessionID)
-        if (denied) return denied
-        await KernelRuntime.restoreSession(Instance.project.id, body.sessionID)
-        return c.json(
-          await KernelRuntime.create({
-            projectID: Instance.project.id,
-            sessionID: body.sessionID,
-            name: body.name,
-            language: body.language,
-          }),
-        )
       },
     )
     .post(

--- a/backend/cli/src/server/routes/notebook.ts
+++ b/backend/cli/src/server/routes/notebook.ts
@@ -119,13 +119,10 @@ export const NotebookRoutes = lazy(() =>
         const host = await KernelHost.snapshot(caller)
         const live = KernelRuntime.list().filter((kernel) => kernel.active)
         const commands = CommandRuntime.list(Instance.project.id)
-        const samples = await KernelMetrics.sampleAll(
-          `compute:${caller}`,
-          [
-            ...live.flatMap((kernel) => (kernel.process_id === null ? [] : [kernel.process_id])),
-            ...commands.map((command) => command.process_id),
-          ],
-        )
+        const samples = await KernelMetrics.sampleAll(`compute:${caller}`, [
+          ...live.flatMap((kernel) => (kernel.process_id === null ? [] : [kernel.process_id])),
+          ...commands.map((command) => command.process_id),
+        ])
         const usage = [...samples.values()]
         const kernelUsage = live.flatMap((kernel) => {
           const value = kernel.process_id === null ? undefined : samples.get(kernel.process_id)
@@ -221,11 +218,7 @@ export const NotebookRoutes = lazy(() =>
         const body = c.req.valid("json")
         const denied = await owner(c, body.sessionID)
         if (denied) return denied
-        const stopped = await CommandRuntime.stop(
-          c.req.valid("param").commandID,
-          Instance.project.id,
-          body.sessionID,
-        )
+        const stopped = await CommandRuntime.stop(c.req.valid("param").commandID, Instance.project.id, body.sessionID)
         if (!stopped) {
           return c.json({ error: "command_not_found", message: "The command is no longer running." }, 404)
         }

--- a/backend/cli/src/session/trace.ts
+++ b/backend/cli/src/session/trace.ts
@@ -419,6 +419,7 @@ export namespace SessionTrace {
           toolID: part.id,
           messageID: part.messageID,
           language: part.tool === "notebook" ? ("python" as const) : ("r" as const),
+          kernel: string(part.state.input.kernel) ?? "agent",
           status: part.state.status,
           ...times(part, now),
           executionCount: number(meta.executionCount),

--- a/backend/cli/src/tool/artifact.ts
+++ b/backend/cli/src/tool/artifact.ts
@@ -1,5 +1,9 @@
 import z from "zod"
+import path from "node:path"
 import { Tool } from "./tool"
+import { ArtifactStore } from "@/artifact/store"
+import { File } from "@/file"
+import { ArtifactFile } from "@/file/artifacts"
 import { Instance } from "@/project/instance"
 import { Provenance } from "@/science/provenance/store"
 import type { Node, Run } from "@/science/provenance/store"
@@ -17,6 +21,7 @@ export const ArtifactTool = Tool.define("artifact", {
     "Store and retrieve large data artifacts by reference.",
     "Use this to keep large outputs (DataFrames, analysis results, raw data) out of context.",
     "Actions:",
+    "  - save_file: Promote a finished workspace file into the durable, immutable, versioned artifact store",
     "  - register: Store content on disk, returns a reference ID + summary",
     "  - update: Replace the current content while retaining an immutable version",
     "  - resolve: Retrieve full content by artifact ID",
@@ -25,7 +30,10 @@ export const ArtifactTool = Tool.define("artifact", {
     "  - read_version: Retrieve one immutable version by version ID",
   ].join(" "),
   parameters: z.object({
-    action: z.enum(["register", "update", "resolve", "list", "list_versions", "read_version"]).describe("The action"),
+    action: z
+      .enum(["save_file", "register", "update", "resolve", "list", "list_versions", "read_version"])
+      .describe("The action"),
+    path: z.string().trim().min(1).max(10_000).optional().describe("For save_file: workspace file path"),
     type: z.string().optional().describe('For register/update: artifact type (e.g. "dataframe", "analysis")'),
     content: z.string().optional().describe("For register/update: the large content to store"),
     summary: z.string().optional().describe("For register/update: brief summary for context window"),
@@ -71,6 +79,50 @@ export const ArtifactTool = Tool.define("artifact", {
       ...(ctx.callID ? { callID: ctx.callID } : {}),
       ...(typeof run === "string" ? { runID: run } : ctx.callID ? { runID: ctx.callID } : {}),
       ...(params.provenance_id ? { provenanceID: params.provenance_id } : {}),
+    }
+    if (params.action === "save_file") {
+      if (!params.path) return result("Error", "save_file requires `path`")
+      const file = await File.raw(params.path, { sessionID: ctx.sessionID })
+      const name = path.basename(params.path)
+      const classified = ArtifactFile.classify(name)
+      const saved = await ArtifactStore.save({
+        projectID: Instance.project.id,
+        sessionID: ctx.sessionID,
+        sourcePath: params.path,
+        filename: name,
+        kind: classified?.kind ?? "file",
+        content: file,
+        title: params.summary ?? name,
+        mimeType: file.type,
+        messageID: ctx.messageID,
+        captureQuality: "declared",
+      })
+      return result(
+        `Saved artifact: ${saved.title}`,
+        [
+          "Workspace file saved as a durable, immutable artifact version.",
+          `  ID: ${saved.id}`,
+          `  Version: ${saved.current.version}`,
+          `  Kind: ${saved.kind}`,
+          `  Path: ${saved.current.sourcePath}`,
+          `  Size: ${saved.current.size} bytes`,
+          `  SHA-256: ${saved.current.sha256}`,
+          "",
+          "The artifact is available project-wide in Files and can be opened, reviewed, renamed, versioned, or downloaded.",
+        ].join("\n"),
+        {
+          savedArtifact: {
+            id: saved.id,
+            versionID: saved.currentVersionID,
+            version: saved.current.version,
+            title: saved.title,
+            kind: saved.kind,
+            path: saved.current.sourcePath,
+            size: saved.current.size,
+            sha256: saved.current.sha256,
+          },
+        },
+      )
     }
     if (params.action === "register") {
       if (!params.type || !params.content) {

--- a/backend/cli/src/tool/artifact.ts
+++ b/backend/cli/src/tool/artifact.ts
@@ -85,6 +85,19 @@ export const ArtifactTool = Tool.define("artifact", {
       const file = await File.raw(params.path, { sessionID: ctx.sessionID })
       const name = path.basename(params.path)
       const classified = ArtifactFile.classify(name)
+      const title = params.summary?.trim() || name
+      const preview = await (async () => {
+        if (file.type.startsWith("image/") && file.size <= 1_500_000) {
+          const bytes = Buffer.from(await file.arrayBuffer()).toString("base64")
+          return { kind: "image" as const, data: `data:${file.type};base64,${bytes}` }
+        }
+        const text =
+          file.type.startsWith("text/") ||
+          ["application/json", "application/xml", "application/yaml", "application/x-yaml"].includes(file.type)
+        if (text && file.size <= 250_000) {
+          return { kind: "text" as const, data: (await file.text()).slice(0, 12_000) }
+        }
+      })()
       const saved = await ArtifactStore.save({
         projectID: Instance.project.id,
         sessionID: ctx.sessionID,
@@ -92,7 +105,7 @@ export const ArtifactTool = Tool.define("artifact", {
         filename: name,
         kind: classified?.kind ?? "file",
         content: file,
-        title: params.summary ?? name,
+        title,
         mimeType: file.type,
         messageID: ctx.messageID,
         captureQuality: "declared",
@@ -118,8 +131,10 @@ export const ArtifactTool = Tool.define("artifact", {
             title: saved.title,
             kind: saved.kind,
             path: saved.current.sourcePath,
+            mimeType: saved.current.mimeType,
             size: saved.current.size,
             sha256: saved.current.sha256,
+            ...(preview ? { preview } : {}),
           },
         },
       )

--- a/backend/cli/src/tool/bash.ts
+++ b/backend/cli/src/tool/bash.ts
@@ -22,6 +22,7 @@ import { Filesystem } from "@/util/filesystem"
 import { Provenance } from "@/science/provenance/store"
 import { ProvenanceEnvelope } from "@/science/provenance/envelope"
 import { ExecutionAuthority } from "@/project/execution"
+import { CommandRuntime } from "@/science/command/registry"
 
 const MAX_METADATA_LENGTH = 30_000
 const DEFAULT_TIMEOUT = Flag.OPENSCIENCE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS || 0
@@ -305,6 +306,24 @@ export const BashTool = Tool.define("bash", async () => {
             detached: process.platform !== "win32",
           })
 
+      let exited = false
+      let aborted = false
+      const kill = () => Shell.killTree(proc, { exited: () => exited, detached: process.platform !== "win32" })
+      const command = CommandRuntime.start(
+        {
+          projectID: Instance.project.id,
+          sessionID: ctx.sessionID,
+          messageID: ctx.messageID,
+          ...(ctx.callID ? { callID: ctx.callID } : {}),
+          description: params.description,
+          command: params.command,
+        },
+        proc,
+        async () => {
+          aborted = true
+          await kill()
+        },
+      )
       let output = ""
 
       // Initialize metadata with empty output
@@ -345,10 +364,6 @@ export const BashTool = Tool.define("bash", async () => {
       proc.stderr?.on("data", capture("stderr"))
 
       let timedOut = false
-      let aborted = false
-      let exited = false
-
-      const kill = () => Shell.killTree(proc, { exited: () => exited, detached: process.platform !== "win32" })
 
       if (ctx.abort.aborted) {
         aborted = true
@@ -378,12 +393,14 @@ export const BashTool = Tool.define("bash", async () => {
 
         proc.once("exit", () => {
           exited = true
+          CommandRuntime.finish(command.id)
           cleanup()
           resolve()
         })
 
         proc.once("error", (error) => {
           exited = true
+          CommandRuntime.finish(command.id)
           cleanup()
           reject(error)
         })

--- a/backend/cli/src/tool/notebook.ts
+++ b/backend/cli/src/tool/notebook.ts
@@ -579,24 +579,53 @@ export const NotebookTool = Tool.define("notebook", {
     "Execute Python code in a persistent, managed kernel. Variables, imports, and state persist across calls that use the same kernel name.",
     "For multiple independent analyses, issue multiple notebook calls in the same response with distinct `kernel` names. Those kernels execute concurrently and appear separately in Compute.",
     "Never use shell subprocesses to imitate multiple kernels; use this tool's `kernel` parameter instead.",
+    "After a named analysis is fully saved and verified, call this tool with `action: stop` and the same kernel name so completed workers do not idle.",
     "Use instead of `bash python` for analysis — no need to re-import or re-load data between cells.",
     "numpy (np), pandas (pd), scipy, and matplotlib (plt) are pre-imported. Expression results auto-display like Jupyter.",
     "matplotlib figures are captured as inline PNG images. Not gated to any agent.",
   ].join("\n"),
-  parameters: z.object({
-    code: z.string().describe("Python code to execute in the persistent kernel"),
-    kernel: z
-      .string()
-      .trim()
-      .min(1)
-      .max(64)
-      .regex(/^[A-Za-z0-9][A-Za-z0-9._-]*$/)
-      .optional()
-      .describe("Stable name for an isolated managed kernel. Use a distinct name for each parallel analysis."),
-    timeout: z.number().default(120_000).describe("Execution timeout in ms (default: 120s, max: 600s)"),
-  }),
+  parameters: z
+    .object({
+      action: z.enum(["execute", "stop"]).optional().describe("Execute a cell (default) or stop this named kernel"),
+      code: z.string().optional().describe("Python code to execute; required when action is execute"),
+      kernel: z
+        .string()
+        .trim()
+        .min(1)
+        .max(64)
+        .regex(/^[A-Za-z0-9][A-Za-z0-9._-]*$/)
+        .optional()
+        .describe("Stable name for an isolated managed kernel. Use a distinct name for each parallel analysis."),
+      timeout: z.number().default(120_000).describe("Execution timeout in ms (default: 120s, max: 600s)"),
+    })
+    .superRefine((params, issue) => {
+      if (params.action !== "stop" && !params.code) {
+        issue.addIssue({ code: "custom", path: ["code"], message: "code is required when action is execute" })
+      }
+    }),
   async execute(params, ctx) {
     const name = params.kernel ?? "agent"
+    const identity = {
+      projectID: Instance.project.id,
+      sessionID: ctx.sessionID,
+      name,
+      language: "python" as const,
+    }
+    if (params.action === "stop") {
+      ctx.metadata({ title: `Stopped Python · ${name}`, metadata: { kernel: name, language: "python", stopped: true } })
+      await KernelRuntime.release(identity)
+      return {
+        title: `Stopped Python · ${name}`,
+        output: `Managed kernel ${name} stopped. Its in-memory state was cleared.`,
+        metadata: {
+          kernel: name,
+          language: "python",
+          stopped: true,
+          ok: true,
+          output: `Managed kernel ${name} stopped.`,
+        },
+      }
+    }
     ctx.metadata({ title: `Python · ${name}`, metadata: { kernel: name, language: "python" } })
 
     // Executes arbitrary code — same permission gate as bash.
@@ -607,16 +636,11 @@ export const NotebookTool = Tool.define("notebook", {
       metadata: {},
     })
 
-    const result = await KernelRuntime.execute(
-      {
-        projectID: Instance.project.id,
-        sessionID: ctx.sessionID,
-        name,
-        language: "python",
-      },
-      params.code,
-      { timeout: params.timeout, signal: ctx.abort, origin: { messageID: ctx.messageID, callID: ctx.callID } },
-    )
+    const result = await KernelRuntime.execute(identity, params.code!, {
+      timeout: params.timeout,
+      signal: ctx.abort,
+      origin: { messageID: ctx.messageID, callID: ctx.callID },
+    })
 
     const images = result.outputs.filter((o) => o.type === "display" && o.data?.["image/png"])
     const dataUrls = images.map((o) => `data:image/png;base64,${o.data!["image/png"]}`)
@@ -644,6 +668,7 @@ export const NotebookTool = Tool.define("notebook", {
       title: result.ok ? `Python · ${name}` : `Python · ${name} (error)`,
       output,
       metadata: {
+        stopped: false,
         ok: result.ok,
         output,
         kernel: name,

--- a/backend/cli/src/tool/notebook.ts
+++ b/backend/cli/src/tool/notebook.ts
@@ -576,16 +576,29 @@ function clip(s: string, max = 30_000): string {
 
 export const NotebookTool = Tool.define("notebook", {
   description: [
-    "Execute Python code in a persistent kernel. Variables, imports, and state persist across calls.",
+    "Execute Python code in a persistent, managed kernel. Variables, imports, and state persist across calls that use the same kernel name.",
+    "For multiple independent analyses, issue multiple notebook calls in the same response with distinct `kernel` names. Those kernels execute concurrently and appear separately in Compute.",
+    "Never use shell subprocesses to imitate multiple kernels; use this tool's `kernel` parameter instead.",
     "Use instead of `bash python` for analysis — no need to re-import or re-load data between cells.",
     "numpy (np), pandas (pd), scipy, and matplotlib (plt) are pre-imported. Expression results auto-display like Jupyter.",
     "matplotlib figures are captured as inline PNG images. Not gated to any agent.",
   ].join("\n"),
   parameters: z.object({
     code: z.string().describe("Python code to execute in the persistent kernel"),
+    kernel: z
+      .string()
+      .trim()
+      .min(1)
+      .max(64)
+      .regex(/^[A-Za-z0-9][A-Za-z0-9._-]*$/)
+      .optional()
+      .describe("Stable name for an isolated managed kernel. Use a distinct name for each parallel analysis."),
     timeout: z.number().default(120_000).describe("Execution timeout in ms (default: 120s, max: 600s)"),
   }),
   async execute(params, ctx) {
+    const name = params.kernel ?? "agent"
+    ctx.metadata({ title: `Python · ${name}`, metadata: { kernel: name, language: "python" } })
+
     // Executes arbitrary code — same permission gate as bash.
     await ctx.ask({
       permission: "bash",
@@ -598,7 +611,7 @@ export const NotebookTool = Tool.define("notebook", {
       {
         projectID: Instance.project.id,
         sessionID: ctx.sessionID,
-        name: "agent",
+        name,
         language: "python",
       },
       params.code,
@@ -623,15 +636,18 @@ export const NotebookTool = Tool.define("notebook", {
     const output = clip(parts.join("\n"))
 
     ctx.metadata({
-      metadata: { output, ok: result.ok, provenanceID: result.provenanceID },
+      title: `Python · ${name}`,
+      metadata: { output, ok: result.ok, provenanceID: result.provenanceID, kernel: name, language: "python" },
     })
 
     return {
-      title: result.ok ? "Python cell" : "Python cell (error)",
+      title: result.ok ? `Python · ${name}` : `Python · ${name} (error)`,
       output,
       metadata: {
         ok: result.ok,
         output,
+        kernel: name,
+        language: "python",
         provenanceID: result.provenanceID,
         executionCount: result.executionCount,
         hasImages: images.length,

--- a/backend/cli/src/tool/rkernel.ts
+++ b/backend/cli/src/tool/rkernel.ts
@@ -520,24 +520,54 @@ export const RKernelTool = Tool.define("rkernel", {
     "Execute R code in a persistent, managed kernel. Objects, attached packages, and state persist across calls that use the same kernel name.",
     "For multiple independent analyses, issue multiple kernel calls in the same response with distinct `kernel` names. Those kernels execute concurrently and appear separately in Compute.",
     "Never use shell subprocesses to imitate multiple kernels; use this tool's `kernel` parameter instead.",
+    "After a named analysis is fully saved and verified, call this tool with `action: stop` and the same kernel name so completed workers do not idle.",
     "Use instead of `bash Rscript` for analysis — no need to re-source data or reload packages between cells.",
     "Print output is captured; base-graphics and ggplot2 plots are captured as inline PNG images where the platform supports it.",
     "Requires Rscript on PATH; if R is not installed the tool reports a clear install hint.",
   ].join("\n"),
-  parameters: z.object({
-    code: z.string().describe("R code to execute in the persistent kernel"),
-    kernel: z
-      .string()
-      .trim()
-      .min(1)
-      .max(64)
-      .regex(/^[A-Za-z0-9][A-Za-z0-9._-]*$/)
-      .optional()
-      .describe("Stable name for an isolated managed kernel. Use a distinct name for each parallel analysis."),
-    timeout: z.number().default(120_000).describe("Execution timeout in ms (default: 120s, max: 600s)"),
-  }),
+  parameters: z
+    .object({
+      action: z.enum(["execute", "stop"]).optional().describe("Execute a cell (default) or stop this named kernel"),
+      code: z.string().optional().describe("R code to execute; required when action is execute"),
+      kernel: z
+        .string()
+        .trim()
+        .min(1)
+        .max(64)
+        .regex(/^[A-Za-z0-9][A-Za-z0-9._-]*$/)
+        .optional()
+        .describe("Stable name for an isolated managed kernel. Use a distinct name for each parallel analysis."),
+      timeout: z.number().default(120_000).describe("Execution timeout in ms (default: 120s, max: 600s)"),
+    })
+    .superRefine((params, issue) => {
+      if (params.action !== "stop" && !params.code) {
+        issue.addIssue({ code: "custom", path: ["code"], message: "code is required when action is execute" })
+      }
+    }),
   async execute(params, ctx) {
     const name = params.kernel ?? "agent"
+    const identity = {
+      projectID: Instance.project.id,
+      sessionID: ctx.sessionID,
+      name,
+      language: "r" as const,
+    }
+    if (params.action === "stop") {
+      ctx.metadata({ title: `Stopped R · ${name}`, metadata: { kernel: name, language: "r", stopped: true } })
+      await KernelRuntime.release(identity)
+      return {
+        title: `Stopped R · ${name}`,
+        output: `Managed kernel ${name} stopped. Its in-memory state was cleared.`,
+        metadata: {
+          kernel: name,
+          language: "r",
+          stopped: true,
+          ok: true,
+          available: true,
+          output: `Managed kernel ${name} stopped.`,
+        },
+      }
+    }
     ctx.metadata({ title: `R · ${name}`, metadata: { kernel: name, language: "r" } })
 
     // Executes arbitrary code — same permission gate as bash.
@@ -554,19 +584,18 @@ export const RKernelTool = Tool.define("rkernel", {
       const msg =
         "Rscript not found. Install R from https://www.r-project.org (or `brew install r`) so `Rscript` is on PATH."
       ctx.metadata({ metadata: { output: msg, ok: false } })
-      return { title: "R kernel unavailable", output: msg, metadata: { ok: false, available: false, output: msg } }
+      return {
+        title: "R kernel unavailable",
+        output: msg,
+        metadata: { kernel: name, language: "r", stopped: false, ok: false, available: false, output: msg },
+      }
     }
 
-    const result = await KernelRuntime.execute(
-      {
-        projectID: Instance.project.id,
-        sessionID: ctx.sessionID,
-        name,
-        language: "r",
-      },
-      params.code,
-      { timeout: params.timeout, signal: ctx.abort, origin: { messageID: ctx.messageID, callID: ctx.callID } },
-    )
+    const result = await KernelRuntime.execute(identity, params.code!, {
+      timeout: params.timeout,
+      signal: ctx.abort,
+      origin: { messageID: ctx.messageID, callID: ctx.callID },
+    })
 
     const images = result.outputs.filter((o) => o.type === "display" && o.data?.["image/png"])
     const dataUrls = images.map((o) => `data:image/png;base64,${o.data!["image/png"]}`)
@@ -587,6 +616,7 @@ export const RKernelTool = Tool.define("rkernel", {
       title: result.ok ? `R · ${name}` : `R · ${name} (error)`,
       output,
       metadata: {
+        stopped: false,
         ok: result.ok,
         available: true,
         output,

--- a/backend/cli/src/tool/rkernel.ts
+++ b/backend/cli/src/tool/rkernel.ts
@@ -517,16 +517,29 @@ function clip(s: string, max = 30_000): string {
 
 export const RKernelTool = Tool.define("rkernel", {
   description: [
-    "Execute R code in a persistent kernel. Objects, attached packages, and state persist across calls.",
+    "Execute R code in a persistent, managed kernel. Objects, attached packages, and state persist across calls that use the same kernel name.",
+    "For multiple independent analyses, issue multiple kernel calls in the same response with distinct `kernel` names. Those kernels execute concurrently and appear separately in Compute.",
+    "Never use shell subprocesses to imitate multiple kernels; use this tool's `kernel` parameter instead.",
     "Use instead of `bash Rscript` for analysis — no need to re-source data or reload packages between cells.",
     "Print output is captured; base-graphics and ggplot2 plots are captured as inline PNG images where the platform supports it.",
     "Requires Rscript on PATH; if R is not installed the tool reports a clear install hint.",
   ].join("\n"),
   parameters: z.object({
     code: z.string().describe("R code to execute in the persistent kernel"),
+    kernel: z
+      .string()
+      .trim()
+      .min(1)
+      .max(64)
+      .regex(/^[A-Za-z0-9][A-Za-z0-9._-]*$/)
+      .optional()
+      .describe("Stable name for an isolated managed kernel. Use a distinct name for each parallel analysis."),
     timeout: z.number().default(120_000).describe("Execution timeout in ms (default: 120s, max: 600s)"),
   }),
   async execute(params, ctx) {
+    const name = params.kernel ?? "agent"
+    ctx.metadata({ title: `R · ${name}`, metadata: { kernel: name, language: "r" } })
+
     // Executes arbitrary code — same permission gate as bash.
     await ctx.ask({
       permission: "bash",
@@ -548,7 +561,7 @@ export const RKernelTool = Tool.define("rkernel", {
       {
         projectID: Instance.project.id,
         sessionID: ctx.sessionID,
-        name: "agent",
+        name,
         language: "r",
       },
       params.code,
@@ -565,15 +578,20 @@ export const RKernelTool = Tool.define("rkernel", {
     if (!parts.length) parts.push("(no output)")
     const output = clip(parts.join("\n"))
 
-    ctx.metadata({ metadata: { output, ok: result.ok, provenanceID: result.provenanceID } })
+    ctx.metadata({
+      title: `R · ${name}`,
+      metadata: { output, ok: result.ok, provenanceID: result.provenanceID, kernel: name, language: "r" },
+    })
 
     return {
-      title: result.ok ? "R cell" : "R cell (error)",
+      title: result.ok ? `R · ${name}` : `R · ${name} (error)`,
       output,
       metadata: {
         ok: result.ok,
         available: true,
         output,
+        kernel: name,
+        language: "r",
         provenanceID: result.provenanceID,
         hasImages: images.length,
         ...(images.length ? { artifact: { kind: "image", data: { images: dataUrls } } } : {}),

--- a/backend/cli/test/server/notebook.test.ts
+++ b/backend/cli/test/server/notebook.test.ts
@@ -53,7 +53,7 @@ describe("/notebook routes", () => {
       paths[path]?.post?.requestBody?.content?.["application/json"]?.schema?.required ?? []
 
     expect(paths["/notebook/kernels"]?.get).toBeDefined()
-    expect(paths["/notebook/kernels"]?.post).toBeDefined()
+    expect(paths["/notebook/kernels"]?.post).toBeUndefined()
     expect(paths["/notebook/kernels/{kernelID}/restart"]?.post).toBeDefined()
     expect(paths["/notebook/kernels/{kernelID}/stop"]?.post).toBeDefined()
     expect(paths["/notebook/kernels/{kernelID}/interrupt"]?.post).toBeDefined()
@@ -65,7 +65,6 @@ describe("/notebook routes", () => {
     expect(paths["/notebook/stop"]?.post).toBeDefined()
     expect(paths["/notebook/interrupt"]?.post).toBeDefined()
     expect(required("/notebook/execute")).toContain("sessionID")
-    expect(required("/notebook/kernels")).toEqual(expect.arrayContaining(["sessionID", "name", "language"]))
     expect(required("/notebook/restart")).toContain("sessionID")
     expect(required("/notebook/stop")).toContain("sessionID")
     expect(required("/notebook/interrupt")).toContain("sessionID")
@@ -92,63 +91,6 @@ describe("/notebook routes", () => {
         expect(project.kernels).toEqual([])
         expect(scoped.kernels).toEqual([])
         expect(KernelRuntime.list()).toEqual([])
-      },
-    })
-  })
-
-  test("creates durable named Python and R kernel records without starting a process", async () => {
-    await using tmp = await tmpdir({ git: true })
-    const result = await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        const app = NotebookRoutes()
-        const session = await Session.create({})
-        const create = (name: string, language: "python" | "r") =>
-          app.request("/kernels", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ sessionID: session.id, name, language }),
-          })
-        const python = await create("analysis", "python")
-        const duplicate = await create("analysis", "python")
-        const r = await create("statistics", "r")
-        const pythonBody = (await python.json()) as { id: string }
-        const duplicateBody = (await duplicate.json()) as { id: string }
-
-        expect(python.status).toBe(200)
-        expect(pythonBody).toMatchObject({
-          active: false,
-          state: "lazy",
-          name: "analysis",
-          language: "python",
-          target: { kind: "local" },
-          process_id: null,
-        })
-        expect(duplicateBody.id).toBe(pythonBody.id)
-        expect(await r.json()).toMatchObject({
-          active: false,
-          state: "lazy",
-          name: "statistics",
-          language: "r",
-          target: { kind: "local" },
-        })
-        await Instance.dispose()
-        return session.id
-      },
-    })
-
-    await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        const inventory = (await (
-          await NotebookRoutes().request(`/kernels?sessionID=${encodeURIComponent(result)}`)
-        ).json()) as { kernels: Array<{ name: string; state: string }> }
-        expect(inventory.kernels).toEqual(
-          expect.arrayContaining([
-            expect.objectContaining({ name: "analysis", state: "lazy" }),
-            expect.objectContaining({ name: "statistics", state: "lazy" }),
-          ]),
-        )
       },
     })
   })

--- a/backend/cli/test/tool/artifact-save-file.test.ts
+++ b/backend/cli/test/tool/artifact-save-file.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "bun:test"
+import path from "node:path"
+import { ArtifactStore } from "../../src/artifact/store"
+import { Instance } from "../../src/project/instance"
+import { ArtifactTool } from "../../src/tool/artifact"
+import { executionSession, tmpdir } from "../fixture/fixture"
+
+const context = (sessionID: string) => ({
+  sessionID,
+  messageID: "msg_artifact_save_file",
+  callID: "call_artifact_save_file",
+  agent: "research",
+  abort: new AbortController().signal,
+  messages: [],
+  metadata() {},
+  async ask() {},
+})
+
+test("artifact save_file promotes a workspace result into immutable versions", async () => {
+  await using tmp = await tmpdir({ git: true })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const session = await executionSession()
+      const tool = await ArtifactTool.init()
+      const target = path.join(tmp.path, "results", "titanic-report.md")
+      await Bun.write(target, "# Titanic analysis\n\nFirst verified result.\n")
+
+      const first = await tool.execute(
+        { action: "save_file", path: "results/titanic-report.md", summary: "Titanic analysis report" },
+        context(session.id),
+      )
+      await Bun.write(target, "# Titanic analysis\n\nImproved verified result.\n")
+      const second = await tool.execute(
+        { action: "save_file", path: "results/titanic-report.md", summary: "Titanic analysis report" },
+        context(session.id),
+      )
+      const firstSaved = first.metadata.savedArtifact as { id: string }
+
+      expect(first.title).toBe("Saved artifact: Titanic analysis report")
+      expect(first.metadata.savedArtifact).toMatchObject({
+        version: 1,
+        title: "Titanic analysis report",
+        kind: "report",
+        path: "results/titanic-report.md",
+        sha256: expect.stringMatching(/^[a-f0-9]{64}$/),
+      })
+      expect(second.metadata.savedArtifact).toMatchObject({
+        id: firstSaved.id,
+        version: 2,
+      })
+      expect(await ArtifactStore.list(Instance.project.id)).toHaveLength(1)
+      expect(await ArtifactStore.get(Instance.project.id, firstSaved.id)).toMatchObject({ versionCount: 2 })
+    },
+  })
+})

--- a/backend/cli/test/tool/artifact-save-file.test.ts
+++ b/backend/cli/test/tool/artifact-save-file.test.ts
@@ -43,6 +43,8 @@ test("artifact save_file promotes a workspace result into immutable versions", a
         title: "Titanic analysis report",
         kind: "report",
         path: "results/titanic-report.md",
+        mimeType: "text/markdown",
+        preview: { kind: "text", data: "# Titanic analysis\n\nFirst verified result.\n" },
         sha256: expect.stringMatching(/^[a-f0-9]{64}$/),
       })
       expect(second.metadata.savedArtifact).toMatchObject({
@@ -51,6 +53,28 @@ test("artifact save_file promotes a workspace result into immutable versions", a
       })
       expect(await ArtifactStore.list(Instance.project.id)).toHaveLength(1)
       expect(await ArtifactStore.get(Instance.project.id, firstSaved.id)).toMatchObject({ versionCount: 2 })
+    },
+  })
+})
+
+test("artifact save_file never persists a blank display title", async () => {
+  await using tmp = await tmpdir({ git: true })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const session = await executionSession()
+      const tool = await ArtifactTool.init()
+      await Bun.write(path.join(tmp.path, "result.csv"), "metric,value\naccuracy,0.91\n")
+
+      const saved = await tool.execute({ action: "save_file", path: "result.csv", summary: "   " }, context(session.id))
+
+      expect(saved.title).toBe("Saved artifact: result.csv")
+      expect(saved.metadata.savedArtifact).toMatchObject({
+        title: "result.csv",
+        kind: "dataset",
+        mimeType: "text/csv",
+        preview: { kind: "text", data: "metric,value\naccuracy,0.91\n" },
+      })
     },
   })
 })

--- a/backend/cli/test/tool/command-runtime.test.ts
+++ b/backend/cli/test/tool/command-runtime.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "bun:test"
+import { Instance } from "../../src/project/instance"
+import { CommandRuntime } from "../../src/science/command/registry"
+import { BashTool } from "../../src/tool/bash"
+import { executionSession, tmpdir } from "../fixture/fixture"
+
+const context = (sessionID: string) => ({
+  sessionID,
+  messageID: "msg_live_command",
+  callID: "call_live_command",
+  agent: "research",
+  abort: new AbortController().signal,
+  messages: [],
+  metadata() {},
+  async ask() {},
+})
+
+test("bash registers only its live process in the project compute ledger", async () => {
+  await using tmp = await tmpdir({ git: true })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const session = await executionSession()
+      const tool = await BashTool.init()
+      const running = tool.execute(
+        { command: "sleep 10", description: "Waiting for analysis input" },
+        context(session.id),
+      )
+      const find = async (attempt = 0): Promise<ReturnType<typeof CommandRuntime.list>[number]> => {
+        const command = CommandRuntime.list(Instance.project.id, session.id)[0]
+        if (command) return command
+        if (attempt >= 100) throw new Error("Live command did not enter the compute ledger")
+        await Bun.sleep(10)
+        return find(attempt + 1)
+      }
+      const command = await find()
+
+      expect(command).toMatchObject({
+        sessionID: session.id,
+        messageID: "msg_live_command",
+        callID: "call_live_command",
+        description: "Waiting for analysis input",
+        command: "sleep 10",
+        state: "running",
+        process_id: expect.any(Number),
+      })
+      expect(await CommandRuntime.stop(command.id, Instance.project.id, session.id)).toBe(true)
+      expect((await running).output).toContain("User aborted the command")
+      expect(CommandRuntime.list(Instance.project.id, session.id)).toEqual([])
+    },
+  })
+}, 30_000)

--- a/backend/cli/test/tool/named-kernels.test.ts
+++ b/backend/cli/test/tool/named-kernels.test.ts
@@ -1,0 +1,72 @@
+import { expect, test } from "bun:test"
+import { Instance } from "../../src/project/instance"
+import { KernelRuntime, type KernelIdentity } from "../../src/science/kernel/registry"
+import { NotebookTool } from "../../src/tool/notebook"
+import { RKernelTool } from "../../src/tool/rkernel"
+import { executionSession, tmpdir } from "../fixture/fixture"
+
+const context = (sessionID: string, callID: string) => ({
+  sessionID,
+  messageID: "message_named_kernels",
+  callID,
+  agent: "research",
+  abort: new AbortController().signal,
+  messages: [],
+  metadata() {},
+  async ask() {},
+})
+
+test("kernel tools advertise and validate isolated managed names", async () => {
+  const python = await NotebookTool.init()
+  const r = await RKernelTool.init()
+
+  expect(python.description).toContain("distinct `kernel` names")
+  expect(python.description).toContain("Never use shell subprocesses")
+  expect(r.description).toContain("distinct `kernel` names")
+  expect(python.parameters.parse({ code: "1 + 1", kernel: "descriptive-eda" }).kernel).toBe("descriptive-eda")
+  expect(r.parameters.parse({ code: "1 + 1", kernel: "stratified_rates" }).kernel).toBe("stratified_rates")
+  expect(() => python.parameters.parse({ code: "1 + 1", kernel: "invalid name" })).toThrow()
+})
+
+test("four named notebook calls own four live managed kernels", async () => {
+  await using tmp = await tmpdir({ git: true })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const session = await executionSession()
+      const tool = await NotebookTool.init()
+      const names = ["descriptive-eda", "survival-rates", "inference", "model-benchmark"]
+      const identities: KernelIdentity[] = names.map((name) => ({
+        projectID: Instance.project.id,
+        sessionID: session.id,
+        name,
+        language: "python",
+      }))
+
+      try {
+        const results = await Promise.all(
+          names.map((name, index) =>
+            tool.execute(
+              {
+                code: `import time\ntime.sleep(0.15)\nprint(${JSON.stringify(name)})`,
+                kernel: name,
+                timeout: 30_000,
+              },
+              context(session.id, `call_named_kernel_${index}`),
+            ),
+          ),
+        )
+
+        expect(results.map((result) => result.output.trim())).toEqual(names)
+        expect(
+          KernelRuntime.list(session.id)
+            .filter((kernel) => kernel.active)
+            .map((kernel) => kernel.name)
+            .sort(),
+        ).toEqual(names.toSorted())
+      } finally {
+        await Promise.all(identities.map((identity) => KernelRuntime.release(identity)))
+      }
+    },
+  })
+}, 60_000)

--- a/backend/cli/test/tool/named-kernels.test.ts
+++ b/backend/cli/test/tool/named-kernels.test.ts
@@ -22,6 +22,7 @@ test("kernel tools advertise and validate isolated managed names", async () => {
 
   expect(python.description).toContain("distinct `kernel` names")
   expect(python.description).toContain("Never use shell subprocesses")
+  expect(python.description).toContain("`action: stop`")
   expect(r.description).toContain("distinct `kernel` names")
   expect(python.parameters.parse({ code: "1 + 1", kernel: "descriptive-eda" }).kernel).toBe("descriptive-eda")
   expect(r.parameters.parse({ code: "1 + 1", kernel: "stratified_rates" }).kernel).toBe("stratified_rates")
@@ -48,6 +49,7 @@ test("four named notebook calls own four live managed kernels", async () => {
           names.map((name, index) =>
             tool.execute(
               {
+                action: "execute",
                 code: `import time\ntime.sleep(0.15)\nprint(${JSON.stringify(name)})`,
                 kernel: name,
                 timeout: 30_000,
@@ -64,6 +66,13 @@ test("four named notebook calls own four live managed kernels", async () => {
             .map((kernel) => kernel.name)
             .sort(),
         ).toEqual(names.toSorted())
+        const stopped = await Promise.all(
+          names.map((name, index) =>
+            tool.execute({ action: "stop", kernel: name, timeout: 30_000 }, context(session.id, `call_stop_${index}`)),
+          ),
+        )
+        expect(stopped.every((result) => result.metadata.stopped === true)).toBe(true)
+        expect(KernelRuntime.list(session.id).some((kernel) => kernel.active)).toBe(false)
       } finally {
         await Promise.all(identities.map((identity) => KernelRuntime.release(identity)))
       }

--- a/docs/notes/claude-science-ui-behavior-audit.md
+++ b/docs/notes/claude-science-ui-behavior-audit.md
@@ -1,0 +1,120 @@
+# Claude Science UI behavior audit
+
+Observed on 2026-08-08 against these local reference surfaces:
+
+- Project shell: `http://localhost:8765/projects/proj_41efbe3a56fc`
+- Completed four-kernel reference: `http://localhost:8765/projects/proj_41efbe3a56fc/frames/4654d750-f605-4d90-a749-0d6a9ecf2615`
+- Fresh-session reference: `http://localhost:8765/projects/proj_68013d68e83c`
+- Comparison prompt: `start up multiple analysis jobs for the titanic dataset across 4 kernels`
+
+This is a behavior index, not a request to reproduce Claude branding. It records the interaction contracts that make the science workflow legible and maps them to OpenScience.
+
+## 1. Project shell and navigation
+
+| Surface            | Claude Science behavior                                                                                           | OpenScience contract                                                                                           |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| Project identity   | Back control and project name anchor the shell.                                                                   | Keep project identity at the top of the sessions rail.                                                         |
+| Primary navigation | New, Search, Customize, Files, and Compute use one compact type scale and icon rhythm.                            | Use the same typography as the sessions rail for every primary item, including Customize and settings content. |
+| Session list       | Sessions are grouped by time, have a readable activity state, and expose row actions without taking over the row. | Preserve session titles and activity dots; keep utility controls visually secondary.                           |
+| Open work          | Multiple sessions remain open as tabs.                                                                            | Session tabs may change while the right inspector remains project-scoped and mounted.                          |
+| Density            | Dividers, labels, and counters are quiet; content carries the emphasis.                                           | Avoid oversized settings type, heavy borders, or card-on-card decoration.                                      |
+
+## 2. Right-side workspace
+
+| Surface        | Claude Science behavior                                                                        | OpenScience contract                                                                   |
+| -------------- | ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| Independence   | The right strip survives session changes and can contain Files, Compute, and opened artifacts. | Inspector state is project-scoped, not owned by the selected session.                  |
+| Tabs           | Files, Compute, and opened files coexist as closable tabs.                                     | Files and Compute remain side by side with chat and keep their own open-tab state.     |
+| Split/merge    | The strip can merge back to one tab row or remain split.                                       | Narrow layouts must collapse gracefully without changing the underlying project state. |
+| Direct opening | Artifact cards have an explicit open-in-split action.                                          | Every promoted artifact has `Open beside chat`; no Browse button is required.          |
+
+## 3. Conversation activity ledger
+
+| Surface               | Claude Science behavior                                                                                                | OpenScience contract                                                                                                                      |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| Progress grouping     | Steps are grouped into summaries such as “Ran 3 commands” or “Saved artifacts.”                                        | Routine reasoning may remain in Show steps, but scientific code, outputs, figures, artifacts, and remote results are promoted outside it. |
+| Step labels           | Each operation has a task label and a compact result summary such as lines of output, figure count, or artifact count. | Tool headers state language, kernel, state, and useful output identity.                                                                   |
+| Live state            | Background cells visibly move through queued/running/finished/failed states.                                           | Named kernels, commands, and remote jobs poll into Compute while the turn is running.                                                     |
+| Failures              | Failures stay visible and are followed by a short diagnosis and retry.                                                 | Preserve failed code/output in chat; retries appear as later cards rather than replacing history.                                         |
+| Narrative checkpoints | The agent explains handoffs: kernels ready, a plot needs correction, outputs are being saved.                          | Final answers summarize the completed tracks, key metrics, artifact location, and cleanup state.                                          |
+
+## 4. Code and output cards
+
+| Surface              | Claude Science behavior                                                                  | OpenScience contract                                                                                                               |
+| -------------------- | ---------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| Default presentation | A step opens into a language/environment header, source, and separate output control.    | Notebook and R cards auto-open so code is never hidden behind Show steps.                                                          |
+| Source height        | Long source remains contained inside the operation instead of dominating the transcript. | Show exactly five code lines in a vertically and horizontally scrollable source window; retain the complete source in that window. |
+| Output               | Text output is visually separated from source.                                           | Text output is open by default and independently scrollable.                                                                       |
+| Figures              | Figures appear immediately after the cell that produced them.                            | Inline notebook images stay visible even when text output is collapsed.                                                            |
+| Identity             | The environment name is always visible.                                                  | Show the stable named kernel (`env titanic-quality`, etc.) in each card.                                                           |
+| Completion           | Stopped workers get a compact lifecycle receipt.                                         | Render `Kernel stopped` cards and keep the source/results above them.                                                              |
+
+## 5. Compute
+
+| Surface         | Claude Science behavior                                                                                      | OpenScience contract                                                                                                                               |
+| --------------- | ------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Host strip      | Memory, CPU, live-kernel count, and running count are always visible.                                        | Host totals combine local kernels, shell commands, and remote jobs. Unknown metrics render as unavailable, never fabricated zeroes.                |
+| Project ledger  | Work is grouped by owning session with a current-session marker.                                             | Compute aggregates every session in the project and does not reset when the selected session changes.                                              |
+| Kernel row      | Language, state, age/cell count, activity label, RSS, CPU, and stop action form one dense row.               | Live rows show named kernel, state/recovery text, uptime, RSS, cores, and Stop.                                                                    |
+| Job row         | Long-running/background work stays visible independently of chat scroll.                                     | Shell commands and Modal/GPU jobs are first-class rows with command/target, resources, duration, status, output, artifacts, cleanup, and cancel.   |
+| Completed work  | Claude commonly leaves idle kernels visible.                                                                 | OpenScience intentionally stops finished kernels, then keeps up to five recent local completion rows so the trail remains without wasting compute. |
+| Manual creation | Claude exposes environment setup as part of agent work, not a user kernel launcher in the completed session. | Do not expose manual kernel creation. Kernels start only when an agent executes work.                                                              |
+| Cleanup         | Claude exposes stop/kill per kernel but may leave kernels idle.                                              | The research agent must stop every named kernel after outputs and artifacts are verified. Remote cleanup warnings remain visible.                  |
+
+## 6. Files and artifacts
+
+| Surface              | Claude Science behavior                                                                                                      | OpenScience contract                                                                                         |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| Automatic collection | Generated files appear without a Browse step.                                                                                | `save_file` promotes files into the project artifact store automatically.                                    |
+| Grouping             | Artifacts are grouped by session and show a count and relative time.                                                         | Files is project-wide, groups by session, and marks artifacts created by the active run.                     |
+| Grid/list            | Images get thumbnails; CSV cards show dimensions/schema; reports show rendered content; grid and list layouts are available. | Figures preview inline, text/Markdown renders in chat, and existing Files previews retain grid/list support. |
+| Actions              | Open in split, download, and more-actions controls are adjacent to each artifact.                                            | Chat provides `Open beside chat`; Files owns project-level artifact actions.                                 |
+| Naming               | Artifacts use meaningful names and the final answer links the consolidated report.                                           | Blank summaries fall back to filename; the agent is prompted to provide descriptive non-empty titles.        |
+| Versioning           | Saved outputs are durable products of the session.                                                                           | Artifact cards show kind, version, size, and checksum; overwrites create durable versions.                   |
+
+## 7. Scientific result quality
+
+The reference run does more than execute code:
+
+1. Finds or fetches a reusable dataset and saves it as an artifact.
+2. Splits one request into distinct analytical remits.
+3. Starts multiple real environments concurrently.
+4. Creates publication-style figures, visually inspects them, and corrects layout or data bugs.
+5. Retries infrastructure/library failures with a safer implementation.
+6. Saves figures, tables, and a consolidated Markdown report.
+7. Ends with numerical findings, methods, caveats, and cross-track interpretation.
+8. Runs a reviewer that can point to an unsupported visual claim without discarding the otherwise valid result.
+
+OpenScience's research prompt now requires at least two decision-useful figures for tabular analysis when supported, inline display, output validation, descriptive artifact summaries, a consolidated result, and worker cleanup. The exact comparison run produced four figures, three promoted tables, one report, a visible sklearn failure and scipy retry, and four stop receipts.
+
+## 8. Responsive behavior
+
+- The inspector is a container, not a fixed desktop canvas.
+- At medium widths, session headers wrap before data rows become illegible.
+- At narrow widths, the primary identity occupies the first row; metrics and controls wrap beneath it.
+- Code and logs scroll inside their cards instead of widening the conversation.
+- Artifact previews use the available width and preserve aspect ratio.
+- Controls remain reachable; labels may compress, but state and stop/cancel actions do not disappear.
+
+## 9. Intentional OpenScience differences
+
+- Finished kernels are stopped automatically rather than left idle. Recent completion rows preserve visibility without retaining memory.
+- Manual kernel creation is removed. The execution ledger describes real work; it is not a launcher.
+- Compute also includes shell subprocesses and Modal/GPU jobs, which the reference surface did not expose in this exact local run.
+- Project-wide Files and Compute remain stable while sessions switch, matching the requested cross-session workspace model.
+
+## 10. Acceptance checklist
+
+- [x] Exact prompt starts exactly four named managed kernels.
+- [x] Four kernel rows are visible in Compute during execution.
+- [x] Python source and output remain visible in chat while working and after completion.
+- [x] Source is auto-open but capped to a five-line scroll window.
+- [x] Figures display inline beside their producing cells.
+- [x] Saved report, tables, and figures auto-appear in Files.
+- [x] Artifact titles are meaningful and previews open beside chat.
+- [x] Failed analysis is visible and can be retried without losing history.
+- [x] Every named kernel stops after result verification.
+- [x] Recent completed local work remains visible in Compute.
+- [x] Modal/GPU jobs have live and recent-result rows with resources, logs, artifacts, cancel, and cleanup state.
+- [x] The right workspace remains project-scoped across session changes.
+- [x] Compute and artifact cards adapt at narrow container widths.

--- a/frontend/ui/src/components/message-part-artifact.test.ts
+++ b/frontend/ui/src/components/message-part-artifact.test.ts
@@ -4,12 +4,24 @@ import { fileURLToPath } from "node:url"
 
 const source = () => readFileSync(fileURLToPath(new URL("./message-part.tsx", import.meta.url)), "utf8")
 
-test("saved workspace artifacts render a versioned receipt", () => {
+test("saved workspace artifacts render previewable, openable results", () => {
   const part = source()
 
   expect(part).toContain('name: "artifact"')
   expect(part).toContain('data-component="saved-artifact-tool"')
   expect(part).toContain('title: saved() ? "Saved artifact"')
   expect(part).toContain("sha256 {artifact().sha256.slice(0, 12)}")
+  expect(part).toContain('data-slot="saved-artifact-preview"')
+  expect(part).toContain('data-slot="saved-artifact-preview-text"')
+  expect(part).toContain("data.openFile?.(artifact().path)")
+  expect(part).toContain("Open beside chat")
   expect(part).toContain("<summary>Show save receipt</summary>")
+})
+
+test("Modal and compute job results use a dedicated visible renderer", () => {
+  const part = source()
+
+  expect(part).toContain('name: "modal"')
+  expect(part).toContain('name: "compute_job"')
+  expect(part).toContain('title: props.tool === "modal" ? "Modal compute" : "Remote compute result"')
 })

--- a/frontend/ui/src/components/message-part-artifact.test.ts
+++ b/frontend/ui/src/components/message-part-artifact.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+
+const source = () => readFileSync(fileURLToPath(new URL("./message-part.tsx", import.meta.url)), "utf8")
+
+test("saved workspace artifacts render a versioned receipt", () => {
+  const part = source()
+
+  expect(part).toContain('name: "artifact"')
+  expect(part).toContain('data-component="saved-artifact-tool"')
+  expect(part).toContain('title: saved() ? "Saved artifact"')
+  expect(part).toContain("sha256 {artifact().sha256.slice(0, 12)}")
+  expect(part).toContain("<summary>Show save receipt</summary>")
+})

--- a/frontend/ui/src/components/message-part-notebook.test.ts
+++ b/frontend/ui/src/components/message-part-notebook.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+
+const source = () => readFileSync(fileURLToPath(new URL("./message-part.tsx", import.meta.url)), "utf8")
+
+test("notebook tools expose the source code and keep output secondary", () => {
+  const part = source()
+
+  expect(part).toContain('name: "notebook"')
+  expect(part).toContain('name: "rkernel"')
+  expect(part).toContain('data-slot="kernel-tool-source"')
+  expect(part).toContain("<code>{code()}</code>")
+  expect(part).toContain('typeof props.input.kernel === "string"')
+  expect(part).toContain("<span>env {kernel()}</span>")
+  expect(part).toContain("<summary>Show output</summary>")
+  expect(part).toContain('title: props.status === "completed" ? "Computed" : "Computing"')
+})

--- a/frontend/ui/src/components/message-part-notebook.test.ts
+++ b/frontend/ui/src/components/message-part-notebook.test.ts
@@ -3,8 +3,9 @@ import { readFileSync } from "node:fs"
 import { fileURLToPath } from "node:url"
 
 const source = () => readFileSync(fileURLToPath(new URL("./message-part.tsx", import.meta.url)), "utf8")
+const styles = () => readFileSync(fileURLToPath(new URL("./message-part.css", import.meta.url)), "utf8")
 
-test("notebook tools expose the source code and keep output secondary", () => {
+test("notebook tools open source, text output, and figures by default", () => {
   const part = source()
 
   expect(part).toContain('name: "notebook"')
@@ -14,5 +15,11 @@ test("notebook tools expose the source code and keep output secondary", () => {
   expect(part).toContain('typeof props.input.kernel === "string"')
   expect(part).toContain("<span>env {kernel()}</span>")
   expect(part).toContain("<summary>Show output</summary>")
+  expect(part).toContain('data-slot="kernel-tool-output" open')
+  expect(part).toContain('data-slot="kernel-tool-images"')
+  expect(part).toContain('props.input.action === "stop"')
+  expect(part).toContain('trigger={{ title: "Kernel stopped"')
   expect(part).toContain('title: props.status === "completed" ? "Computed" : "Computing"')
+  expect(styles()).toContain("max-height: calc(5 * 1.55em + 20px)")
+  expect(styles()).toContain("overflow: auto")
 })

--- a/frontend/ui/src/components/message-part.css
+++ b/frontend/ui/src/components/message-part.css
@@ -590,6 +590,144 @@
   }
 }
 
+[data-component="kernel-tool"] {
+  border-top: 1px solid var(--border-weak-base);
+  background: var(--background-base);
+
+  & > header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 7px 12px;
+    border-bottom: 1px solid var(--border-weak-base);
+    color: var(--text-weak);
+    font-family: var(--font-family-sans);
+    font-size: var(--font-size-small);
+
+    strong {
+      color: var(--text-base);
+      font-weight: var(--font-weight-medium);
+    }
+
+    span {
+      font-size: var(--font-size-xs);
+    }
+  }
+
+  [data-slot="kernel-tool-source"] {
+    max-height: 320px;
+    margin: 0;
+    padding: 10px 12px;
+    overflow: auto;
+    color: var(--text-base);
+    background: var(--background-base);
+    font-family: var(--font-family-mono);
+    font-size: var(--font-size-small);
+    line-height: 1.55;
+    tab-size: 2;
+    white-space: pre;
+
+    code {
+      font: inherit;
+    }
+  }
+
+  [data-slot="kernel-tool-output"] {
+    border-top: 1px solid var(--border-weak-base);
+
+    summary {
+      padding: 7px 12px;
+      color: var(--text-weak);
+      font-family: var(--font-family-sans);
+      font-size: var(--font-size-small);
+      cursor: pointer;
+      user-select: none;
+    }
+
+    & > pre {
+      max-height: 260px;
+      margin: 0;
+      padding: 8px 12px 10px;
+      overflow: auto;
+      color: var(--text-base);
+      font-family: var(--font-family-mono);
+      font-size: var(--font-size-small);
+      line-height: 1.5;
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
+    }
+
+    img {
+      display: block;
+      max-width: calc(100% - 24px);
+      height: auto;
+      margin: 0 12px 12px;
+      border: 1px solid var(--border-weak-base);
+      border-radius: 6px;
+    }
+  }
+}
+
+[data-component="saved-artifact-tool"] {
+  display: grid;
+  gap: 8px;
+  padding: 10px 12px;
+}
+
+[data-component="saved-artifact-tool"] > header,
+[data-component="saved-artifact-tool"] > footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+[data-component="saved-artifact-tool"] > header strong {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-strong);
+  font-size: 13px;
+  font-weight: 500;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+[data-component="saved-artifact-tool"] > header span,
+[data-component="saved-artifact-tool"] > footer {
+  color: var(--text-weak);
+  font-size: 11px;
+}
+
+[data-component="saved-artifact-tool"] > code {
+  overflow: hidden;
+  color: var(--text-base);
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+[data-component="saved-artifact-tool"] details {
+  border-top: 1px solid var(--border-weak-base);
+  padding-top: 8px;
+}
+
+[data-component="saved-artifact-tool"] summary {
+  color: var(--text-weak);
+  cursor: pointer;
+  font-size: 12px;
+}
+
+[data-component="saved-artifact-tool"] details pre {
+  margin-top: 8px;
+  max-height: 220px;
+  overflow: auto;
+  color: var(--text-base);
+  font-family: var(--font-family-mono);
+  font-size: 11px;
+  white-space: pre-wrap;
+}
+
 @property --border-angle {
   syntax: "<angle>";
   initial-value: 0deg;

--- a/frontend/ui/src/components/message-part.css
+++ b/frontend/ui/src/components/message-part.css
@@ -616,7 +616,7 @@
   }
 
   [data-slot="kernel-tool-source"] {
-    max-height: 320px;
+    max-height: calc(5 * 1.55em + 20px);
     margin: 0;
     padding: 10px 12px;
     overflow: auto;
@@ -657,12 +657,18 @@
       white-space: pre-wrap;
       overflow-wrap: anywhere;
     }
+  }
+
+  [data-slot="kernel-tool-images"] {
+    display: grid;
+    gap: 8px;
+    padding: 10px 12px 12px;
+    border-top: 1px solid var(--border-weak-base);
 
     img {
       display: block;
-      max-width: calc(100% - 24px);
+      width: 100%;
       height: auto;
-      margin: 0 12px 12px;
       border: 1px solid var(--border-weak-base);
       border-radius: 6px;
     }
@@ -705,6 +711,40 @@
   font-size: 12px;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+[data-slot="saved-artifact-preview"] {
+  display: block;
+  width: 100%;
+  max-height: 420px;
+  object-fit: contain;
+  border: 1px solid var(--border-weak-base);
+  border-radius: 6px;
+  background: var(--background-base);
+}
+
+[data-slot="saved-artifact-preview-text"] {
+  max-height: 320px;
+  overflow: auto;
+  padding: 10px 12px;
+  border: 1px solid var(--border-weak-base);
+  border-radius: 6px;
+  background: var(--background-base);
+}
+
+[data-component="saved-artifact-tool"] > footer {
+  justify-content: flex-start;
+  flex-wrap: wrap;
+}
+
+[data-component="saved-artifact-tool"] > footer button {
+  margin-right: auto;
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: var(--text-interactive-base, var(--text-base));
+  font: inherit;
+  cursor: pointer;
 }
 
 [data-component="saved-artifact-tool"] details {

--- a/frontend/ui/src/components/message-part.tsx
+++ b/frontend/ui/src/components/message-part.tsx
@@ -817,9 +817,20 @@ function KernelTool(props: ToolProps & { language: "python" | "r"; label: "Pytho
     return value.filter((item): item is string => typeof item === "string" && item.startsWith("data:image/"))
   }
 
+  if (props.input.action === "stop") {
+    return (
+      <BasicTool
+        {...props}
+        icon="circle-check"
+        trigger={{ title: "Kernel stopped", subtitle: `${props.label} · ${kernel()}` }}
+      />
+    )
+  }
+
   return (
     <BasicTool
       {...props}
+      defaultOpen
       icon="code"
       trigger={{
         title: props.status === "completed" ? "Computed" : "Computing",
@@ -834,16 +845,18 @@ function KernelTool(props: ToolProps & { language: "python" | "r"; label: "Pytho
         <pre data-slot="kernel-tool-source">
           <code>{code()}</code>
         </pre>
-        <Show when={props.output || images().length > 0}>
-          <details data-slot="kernel-tool-output">
+        <Show when={props.output}>
+          <details data-slot="kernel-tool-output" open>
             <summary>Show output</summary>
-            <Show when={props.output}>
-              <pre>{stripAnsi(props.output ?? "")}</pre>
-            </Show>
+            <pre>{stripAnsi(props.output ?? "")}</pre>
+          </details>
+        </Show>
+        <Show when={images().length > 0}>
+          <div data-slot="kernel-tool-images">
             <For each={images()}>
               {(image) => <img src={image} alt={`${props.label} cell output`} loading="lazy" />}
             </For>
-          </details>
+          </div>
         </Show>
       </div>
     </BasicTool>
@@ -861,6 +874,7 @@ ToolRegistry.register({
 })
 
 function SavedArtifactTool(props: ToolProps) {
+  const data = useData()
   const saved = () => {
     const value = props.metadata.savedArtifact
     if (!value || typeof value !== "object") return
@@ -868,6 +882,8 @@ function SavedArtifactTool(props: ToolProps) {
       typeof value.title !== "string" ||
       typeof value.kind !== "string" ||
       typeof value.path !== "string" ||
+      typeof value.id !== "string" ||
+      typeof value.versionID !== "string" ||
       typeof value.version !== "number" ||
       typeof value.size !== "number" ||
       typeof value.sha256 !== "string"
@@ -877,15 +893,20 @@ function SavedArtifactTool(props: ToolProps) {
       title: string
       kind: string
       path: string
+      id: string
+      versionID: string
+      mimeType?: string
       version: number
       size: number
       sha256: string
+      preview?: { kind: "image" | "text"; data: string }
     }
   }
 
   return (
     <BasicTool
       {...props}
+      defaultOpen
       icon="archive"
       trigger={{
         title: saved() ? "Saved artifact" : props.title || "Artifact",
@@ -911,7 +932,24 @@ function SavedArtifactTool(props: ToolProps) {
               </span>
             </header>
             <code>{artifact().path}</code>
+            <Show when={artifact().preview?.kind === "image" ? artifact().preview?.data : undefined}>
+              {(image) => (
+                <img data-slot="saved-artifact-preview" src={image()} alt={artifact().title} loading="lazy" />
+              )}
+            </Show>
+            <Show when={artifact().preview?.kind === "text" ? artifact().preview?.data : undefined}>
+              {(preview) => (
+                <div data-slot="saved-artifact-preview-text">
+                  <Markdown
+                    text={artifact().mimeType === "text/markdown" ? preview() : `\`\`\`\n${preview()}\n\`\`\``}
+                  />
+                </div>
+              )}
+            </Show>
             <footer>
+              <button type="button" onClick={() => data.openFile?.(artifact().path)}>
+                Open beside chat
+              </button>
               <span>{artifact().size.toLocaleString()} bytes</span>
               <span>sha256 {artifact().sha256.slice(0, 12)}</span>
             </footer>
@@ -932,6 +970,46 @@ ToolRegistry.register({
   name: "artifact",
   render: (props) => <SavedArtifactTool {...props} />,
 })
+
+function RemoteComputeTool(props: ToolProps) {
+  const job = () => {
+    const value = props.metadata.job
+    return value && typeof value === "object" ? (value as Record<string, unknown>) : undefined
+  }
+  const gpu = () => {
+    const value = job()?.modal
+    if (value && typeof value === "object" && "gpu" in value && typeof value.gpu === "string") return value.gpu
+    return typeof props.input.gpu === "string" ? props.input.gpu : undefined
+  }
+  const status = () => (typeof job()?.status === "string" ? job()!.status : props.status)
+  return (
+    <BasicTool
+      {...props}
+      defaultOpen
+      icon="console"
+      trigger={{
+        title: props.tool === "modal" ? "Modal compute" : "Remote compute result",
+        subtitle: [gpu(), status()].filter(Boolean).join(" · "),
+      }}
+    >
+      <Show when={typeof props.input.command === "string" ? props.input.command : undefined}>
+        {(command) => (
+          <div data-component="tool-output" data-scrollable>
+            <pre>{command()}</pre>
+          </div>
+        )}
+      </Show>
+      <Show when={props.output}>
+        <div data-component="tool-output" data-scrollable>
+          <pre>{stripAnsi(props.output ?? "")}</pre>
+        </div>
+      </Show>
+    </BasicTool>
+  )
+}
+
+ToolRegistry.register({ name: "modal", render: (props) => <RemoteComputeTool {...props} /> })
+ToolRegistry.register({ name: "compute_job", render: (props) => <RemoteComputeTool {...props} /> })
 
 ToolRegistry.register({
   name: "read",

--- a/frontend/ui/src/components/message-part.tsx
+++ b/frontend/ui/src/components/message-part.tsx
@@ -53,7 +53,7 @@ import { createAutoScroll } from "../hooks"
 import { createResizeObserver } from "@solid-primitives/resize-observer"
 import { NotebookView, type NotebookCellProps } from "./notebook-cell"
 import { skillName, stripRedactedReasoning } from "./tool-display"
-import { ToolRegistry } from "./tool-registry"
+import { ToolRegistry, type ToolProps } from "./tool-registry"
 
 export { ARTIFACT_TOOL, ToolRegistry, type ToolComponent, type ToolProps } from "./tool-registry"
 
@@ -803,6 +803,135 @@ PART_MAPPING["reasoning"] = function ReasoningPartDisplay(props) {
     </Show>
   )
 }
+
+function KernelTool(props: ToolProps & { language: "python" | "r"; label: "Python" | "R" }) {
+  const code = () => (typeof props.input.code === "string" ? props.input.code : "")
+  const kernel = () => (typeof props.input.kernel === "string" ? props.input.kernel : props.language)
+  const preview = () => code().trim().split("\n").find(Boolean)?.slice(0, 120)
+  const images = () => {
+    const artifact = props.metadata.artifact
+    if (!artifact || typeof artifact !== "object") return []
+    const data = "data" in artifact && artifact.data && typeof artifact.data === "object" ? artifact.data : undefined
+    const value = data && "images" in data ? data.images : undefined
+    if (!Array.isArray(value)) return []
+    return value.filter((item): item is string => typeof item === "string" && item.startsWith("data:image/"))
+  }
+
+  return (
+    <BasicTool
+      {...props}
+      icon="code"
+      trigger={{
+        title: props.status === "completed" ? "Computed" : "Computing",
+        subtitle: preview(),
+      }}
+    >
+      <div data-component="kernel-tool">
+        <header>
+          <strong>{props.label}</strong>
+          <span>env {kernel()}</span>
+        </header>
+        <pre data-slot="kernel-tool-source">
+          <code>{code()}</code>
+        </pre>
+        <Show when={props.output || images().length > 0}>
+          <details data-slot="kernel-tool-output">
+            <summary>Show output</summary>
+            <Show when={props.output}>
+              <pre>{stripAnsi(props.output ?? "")}</pre>
+            </Show>
+            <For each={images()}>
+              {(image) => <img src={image} alt={`${props.label} cell output`} loading="lazy" />}
+            </For>
+          </details>
+        </Show>
+      </div>
+    </BasicTool>
+  )
+}
+
+ToolRegistry.register({
+  name: "notebook",
+  render: (props) => <KernelTool {...props} language="python" label="Python" />,
+})
+
+ToolRegistry.register({
+  name: "rkernel",
+  render: (props) => <KernelTool {...props} language="r" label="R" />,
+})
+
+function SavedArtifactTool(props: ToolProps) {
+  const saved = () => {
+    const value = props.metadata.savedArtifact
+    if (!value || typeof value !== "object") return
+    if (
+      typeof value.title !== "string" ||
+      typeof value.kind !== "string" ||
+      typeof value.path !== "string" ||
+      typeof value.version !== "number" ||
+      typeof value.size !== "number" ||
+      typeof value.sha256 !== "string"
+    )
+      return
+    return value as {
+      title: string
+      kind: string
+      path: string
+      version: number
+      size: number
+      sha256: string
+    }
+  }
+
+  return (
+    <BasicTool
+      {...props}
+      icon="archive"
+      trigger={{
+        title: saved() ? "Saved artifact" : props.title || "Artifact",
+        subtitle: saved() ? `${saved()!.title} · v${saved()!.version}` : undefined,
+      }}
+    >
+      <Show
+        when={saved()}
+        fallback={
+          <Show when={props.output}>
+            <div data-component="tool-output" data-scrollable>
+              <pre>{stripAnsi(props.output ?? "")}</pre>
+            </div>
+          </Show>
+        }
+      >
+        {(artifact) => (
+          <div data-component="saved-artifact-tool">
+            <header>
+              <strong>{artifact().title}</strong>
+              <span>
+                {artifact().kind} · v{artifact().version}
+              </span>
+            </header>
+            <code>{artifact().path}</code>
+            <footer>
+              <span>{artifact().size.toLocaleString()} bytes</span>
+              <span>sha256 {artifact().sha256.slice(0, 12)}</span>
+            </footer>
+            <Show when={props.output}>
+              <details>
+                <summary>Show save receipt</summary>
+                <pre>{stripAnsi(props.output ?? "")}</pre>
+              </details>
+            </Show>
+          </div>
+        )}
+      </Show>
+    </BasicTool>
+  )
+}
+
+ToolRegistry.register({
+  name: "artifact",
+  render: (props) => <SavedArtifactTool {...props} />,
+})
 
 ToolRegistry.register({
   name: "read",

--- a/frontend/ui/src/components/session-turn-science-results.test.ts
+++ b/frontend/ui/src/components/session-turn-science-results.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+
+const source = readFileSync(fileURLToPath(new URL("./session-turn.tsx", import.meta.url)), "utf8")
+
+test("scientific code, results, artifacts, and remote jobs stay outside collapsed steps", () => {
+  expect(source).toContain('new Set(["notebook", "rkernel", "artifact", "modal", "compute_job"])')
+  expect(source).toContain('aria-label="Analysis code and results"')
+  expect(source).toContain("hidePromotedTools")
+  expect(source).toContain(".filter(isPromotedTool)")
+  expect(source).toContain("parts.filter((part) => !isPromotedTool(part))")
+})

--- a/frontend/ui/src/components/session-turn.css
+++ b/frontend/ui/src/components/session-turn.css
@@ -598,6 +598,14 @@
     gap: 12px;
   }
 
+  [data-slot="session-turn-promoted-results"] {
+    width: 100%;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
   [data-slot="session-turn-artifact-save"] {
     width: 100%;
     min-width: 0;

--- a/frontend/ui/src/components/session-turn.tsx
+++ b/frontend/ui/src/components/session-turn.tsx
@@ -96,11 +96,18 @@ function isAttachment(part: PartType | undefined) {
   )
 }
 
+const promotedTools = new Set(["notebook", "rkernel", "artifact", "modal", "compute_job"])
+
+function isPromotedTool(part: PartType | undefined): part is ToolPart {
+  return part?.type === "tool" && promotedTools.has(part.tool)
+}
+
 function AssistantMessageItem(props: {
   message: AssistantMessage
   responsePartId: string | undefined
   hideResponsePart: boolean
   hideReasoning: boolean
+  hidePromotedTools?: boolean
 }) {
   const data = useData()
   const emptyParts: PartType[] = []
@@ -119,6 +126,10 @@ function AssistantMessageItem(props: {
 
     if (props.hideReasoning) {
       parts = parts.filter((part) => part?.type !== "reasoning")
+    }
+
+    if (props.hidePromotedTools) {
+      parts = parts.filter((part) => !isPromotedTool(part))
     }
 
     if (!props.hideResponsePart) return parts
@@ -270,6 +281,13 @@ export function SessionTurn(
     }
     return false
   })
+
+  const promoted = createMemo(() =>
+    assistantMessages().flatMap((message) => {
+      const parts = (data.store.part[message.id] ?? emptyParts).filter(isPromotedTool)
+      return parts.length ? [{ message, parts }] : []
+    }),
+  )
 
   const permissions = createMemo(() => data.store.permission?.[props.sessionID] ?? emptyPermissions)
   const nextPermission = createMemo(() => permissions()[0])
@@ -675,6 +693,7 @@ export function SessionTurn(
                               responsePartId={responsePartId()}
                               hideResponsePart={hideResponsePart()}
                               hideReasoning={false}
+                              hidePromotedTools
                             />
                           )}
                         </For>
@@ -684,6 +703,13 @@ export function SessionTurn(
                           </Card>
                         </Show>
                       </div>
+                    </Show>
+                    <Show when={promoted().length > 0}>
+                      <section data-slot="session-turn-promoted-results" aria-label="Analysis code and results">
+                        <For each={promoted()}>
+                          {(entry) => <Message message={entry.message} parts={entry.parts} />}
+                        </For>
+                      </section>
                     </Show>
                     <Show when={!props.stepsExpanded && requestParts().length > 0}>
                       <div data-slot="session-turn-permission-parts">

--- a/frontend/workspace/src/atlas/CommandCard.test.tsx
+++ b/frontend/workspace/src/atlas/CommandCard.test.tsx
@@ -1,0 +1,61 @@
+import { afterAll, afterEach, expect, test } from "bun:test"
+import { fileURLToPath } from "node:url"
+import type { JSX } from "solid-js"
+import { createServer } from "vite"
+import solid from "vite-plugin-solid"
+
+const server = await createServer({
+  root: fileURLToPath(new URL("../..", import.meta.url)),
+  mode: "production",
+  logLevel: "silent",
+  plugins: [solid({ ssr: false, dev: false })],
+  server: { middlewareMode: true },
+  appType: "custom",
+  resolve: { conditions: ["browser", "production"], dedupe: ["solid-js", "solid-js/web"] },
+  ssr: { noExternal: true, resolve: { conditions: ["browser", "production"] } },
+})
+const [subject, web] = await Promise.all([
+  server.ssrLoadModule("/src/atlas/CommandCard.tsx") as Promise<typeof import("./CommandCard")>,
+  server.ssrLoadModule("solid-js/web") as Promise<typeof import("solid-js/web")>,
+])
+const cleanups: Array<() => void> = []
+
+afterAll(() => server.close())
+afterEach(() => {
+  cleanups.splice(0).forEach((cleanup) => cleanup())
+  document.body.replaceChildren()
+})
+
+const mount = (view: () => JSX.Element) => {
+  const host = document.createElement("div")
+  document.body.append(host)
+  cleanups.push(web.render(view, host))
+  return host
+}
+
+test("live shell commands share the compact compute ledger", () => {
+  const host = mount(() =>
+    subject.CommandCard({
+      command: {
+        id: "command-test",
+        projectID: "project",
+        sessionID: "session",
+        messageID: "message",
+        description: "Preparing Titanic dataset",
+        command: "python prepare.py",
+        state: "running",
+        process_id: 42,
+        started_at: Date.now() - 5_000,
+        resources: { memory_bytes: 12_000_000, cpu_percent: 75 },
+      },
+      stopping: false,
+      onStop: () => undefined,
+    }),
+  )
+
+  expect(host.querySelector(".kernel-card__copy")?.textContent).toContain("Preparing Titanic dataset")
+  expect(host.querySelector(".kernel-card__copy")?.textContent).toContain("bash · python prepare.py")
+  expect(host.querySelectorAll(".kernel-card__metric")[0]?.textContent).toBe("12 MBrss")
+  expect(host.querySelectorAll(".kernel-card__metric")[1]?.textContent).toBe("0.8cores")
+  expect(host.querySelector('button[aria-label="Stop Preparing Titanic dataset"]')).not.toBeNull()
+})

--- a/frontend/workspace/src/atlas/CommandCard.tsx
+++ b/frontend/workspace/src/atlas/CommandCard.tsx
@@ -1,0 +1,72 @@
+import { createSignal, onCleanup, type JSX } from "solid-js"
+import { kernelMemoryLabel, type CommandStatus } from "@/notebook/runtime"
+
+const memory = (value?: number) => {
+  const label = kernelMemoryLabel(value)
+  return label === "Unavailable" ? "—" : label
+}
+
+const cores = (value?: number) => {
+  if (value === undefined || !Number.isFinite(value) || value < 0) return "—"
+  return (value / 100).toFixed(1)
+}
+
+const uptime = (started: number, now: number) => {
+  const seconds = Math.max(0, Math.floor((now - started) / 1_000))
+  if (seconds < 60) return `${seconds}s`
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m`
+  return `${Math.floor(minutes / 60)}h ${minutes % 60}m`
+}
+
+export function CommandCard(props: {
+  command: CommandStatus
+  stopping: boolean
+  onStop: () => void
+}): JSX.Element {
+  const [now, setNow] = createSignal(Date.now())
+  const timer = setInterval(() => setNow(Date.now()), 1_000)
+  onCleanup(() => clearInterval(timer))
+
+  return (
+    <article class="kernel-card command-card" data-command-id={props.command.id} data-state="running">
+      <div class="kernel-card__main">
+        <span class="kernel-card__language" aria-hidden="true">
+          sh
+        </span>
+        <div class="kernel-card__copy">
+          <strong title={props.command.description}>{props.command.description}</strong>
+          <span title={props.command.command}>
+            <i data-tone="active" aria-hidden="true" />
+            bash · {props.command.command}
+          </span>
+        </div>
+      </div>
+
+      <span class="kernel-card__uptime" aria-label={`Uptime ${uptime(props.command.started_at, now())}`}>
+        {uptime(props.command.started_at, now())}
+      </span>
+      <Metric label="rss" value={memory(props.command.resources?.memory_bytes)} />
+      <Metric label="cores" value={cores(props.command.resources?.cpu_percent)} />
+      <button
+        type="button"
+        class="kernel-card__stop"
+        aria-label={`Stop ${props.command.description}`}
+        title="Stop this live shell command and its child processes."
+        disabled={props.stopping}
+        onClick={props.onStop}
+      >
+        {props.stopping ? "Stopping…" : "Stop"}
+      </button>
+    </article>
+  )
+}
+
+function Metric(props: { label: string; value: string }): JSX.Element {
+  return (
+    <span class="kernel-card__metric">
+      <strong>{props.value}</strong>
+      <small>{props.label}</small>
+    </span>
+  )
+}

--- a/frontend/workspace/src/atlas/CommandCard.tsx
+++ b/frontend/workspace/src/atlas/CommandCard.tsx
@@ -19,11 +19,7 @@ const uptime = (started: number, now: number) => {
   return `${Math.floor(minutes / 60)}h ${minutes % 60}m`
 }
 
-export function CommandCard(props: {
-  command: CommandStatus
-  stopping: boolean
-  onStop: () => void
-}): JSX.Element {
+export function CommandCard(props: { command: CommandStatus; stopping: boolean; onStop: () => void }): JSX.Element {
   const [now, setNow] = createSignal(Date.now())
   const timer = setInterval(() => setNow(Date.now()), 1_000)
   onCleanup(() => clearInterval(timer))

--- a/frontend/workspace/src/atlas/ComputeJobsAPI.ts
+++ b/frontend/workspace/src/atlas/ComputeJobsAPI.ts
@@ -60,6 +60,7 @@ export interface Job {
   reproducibility?: Reproducibility
   capture_error?: string
   cleanup_error?: string
+  session_id?: string
   remote_id?: string
   lifecycle?: {
     execution: string

--- a/frontend/workspace/src/atlas/ComputeSurface.css
+++ b/frontend/workspace/src/atlas/ComputeSurface.css
@@ -1,559 +1,231 @@
 .compute-surface {
-  --compute-radius: 10px;
-}
-
-/* 3a sets the tabs in letter-spaced capitals — the same voice as the labels
-   above them, so the strip and the tabs read as one apparatus rather than a
-   readout with navigation bolted underneath. Selection is a 2px underline in
-   the brand colour; the single solid terracotta on this surface stays with the
-   primary action. */
-.compute-surface__tabs {
-  box-sizing: border-box;
+  container: compute / inline-size;
   display: flex;
-  gap: 26px;
-  margin: 0;
-  padding: 0 18px;
-  border-bottom: 1px solid var(--color-border);
-  border-radius: 0;
-  background: transparent;
-}
-
-.compute-surface__tab {
-  position: relative;
-  display: inline-flex;
-  align-items: baseline;
-  gap: 5px;
+  min-width: 0;
   min-height: 0;
-  padding: 9px 0;
-  border: 0;
-  border-radius: 0;
-  background: none;
-  font-size: 10px;
-  color: var(--color-text-muted);
-  cursor: pointer;
-}
-
-/* The count joins the label as "JOBS · 24" rather than sitting apart, so the
-   pair reads as one token of type. */
-.compute-surface__count::before {
-  content: "·";
-  padding-right: 5px;
-  color: var(--color-text-faint);
-}
-
-.compute-surface__count {
-  font-family: inherit;
-  font-size: inherit;
-  letter-spacing: inherit;
-  color: inherit;
-  font-variant-numeric: tabular-nums;
-}
-
-.compute-surface__tab[data-active="true"] {
-  background: none;
-  color: var(--color-text);
-  box-shadow: inset 0 -2px 0 var(--surface-brand-base);
-}
-
-.compute-surface__tab:focus-visible {
-  outline: 2px solid var(--color-focus);
-  outline-offset: 2px;
-  border-radius: 4px;
-}
-
-/* The visible count is aria-hidden so a screen reader hears "Jobs, 24 jobs"
-   rather than "Jobs 24" with no unit. */
-.compute-surface__sr {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
+  height: 100%;
+  flex: 1;
+  flex-direction: column;
   overflow: hidden;
-  clip-path: inset(50%);
-  white-space: nowrap;
-  border: 0;
-}
-
-.compute-surface .kernel-panel__header {
-  box-sizing: border-box;
-  min-height: 48px;
-  gap: 12px;
-  padding: 7px 10px 7px 12px;
   background: var(--color-bg);
+  color: var(--color-text);
+  font-family: inherit;
+  font-size: 13px;
+  line-height: 1.35;
 }
 
-.compute-surface .kernel-panel__heading {
-  grid-template-columns: 1fr;
-  gap: 1px;
-}
-
-.compute-surface .kernel-panel__heading strong {
-  font-size: 14px;
-  font-weight: 600;
-  letter-spacing: -0.01em;
-}
-
-.compute-surface .kernel-panel__heading > span:last-child {
-  grid-column: 1;
-  font-size: 12px;
-  line-height: 1.3;
-}
-
-.compute-surface .kernel-panel__refresh {
+.compute-surface__panel,
+.compute-surface .kernel-panel {
   display: flex;
-  align-items: center;
-  gap: 12px;
-  font-size: 12px;
-}
-
-.compute-surface .kernel-panel__primary-action {
-  width: auto;
-  height: 26px;
-  padding: 0 12px;
-  border: 0;
-  border-radius: 999px;
-  background: var(--surface-brand-base);
-  color: var(--text-on-brand-strong);
-  font-size: 12px;
-  font-weight: 500;
-  cursor: pointer;
-}
-
-.compute-surface .kernel-panel__primary-action:disabled {
-  opacity: 0.45;
-  cursor: not-allowed;
-}
-
-.compute-surface .kernel-panel__primary-action:hover:not(:disabled) {
-  background: var(--surface-brand-hover);
+  min-width: 0;
+  min-height: 0;
+  flex: 1;
+  flex-direction: column;
 }
 
 .compute-surface .kernel-panel__body {
-  padding: 10px;
-}
-
-.compute-surface .kernel-panel__create {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) 110px auto;
-  align-items: end;
-  gap: 8px;
-  margin-bottom: 10px;
-  padding: 10px;
-  border: 1px solid var(--color-border);
-  border-radius: 10px;
-  background: var(--color-bg-elevated);
-}
-
-.compute-surface .kernel-panel__create label {
-  display: grid;
-  gap: 4px;
   min-width: 0;
-  font-size: 10px;
-  color: var(--color-text-faint);
-}
-
-.compute-surface .kernel-panel__create input,
-.compute-surface .kernel-panel__create select,
-.compute-surface .kernel-panel__create button {
-  box-sizing: border-box;
-  min-height: 32px;
-  padding: 6px 9px;
-  border: 1px solid var(--color-border);
-  border-radius: 8px;
-  color: var(--color-text);
-  background: var(--color-bg);
-  font: inherit;
-}
-
-.compute-surface .kernel-panel__create > div {
-  display: flex;
-  gap: 6px;
-}
-
-.compute-surface .kernel-panel__create button[type="submit"] {
-  color: var(--color-bg);
-  background: var(--color-text);
-}
-
-/* Sits under a hairline as the last thing in the header block, so it reads as
-   a note about the section rather than a banner inside the list. */
-.compute-surface .kernel-panel__scope {
-  display: block;
-  margin: 0 0 14px;
-  padding: 0 0 14px;
-  border: 0;
-  border-bottom: 1px solid var(--color-border);
-  border-radius: 0;
-  background: transparent;
-}
-
-.compute-surface .kernel-panel__scope p {
-  max-width: none;
-  font-size: 12px;
-  line-height: 1.5;
-  color: var(--color-text-muted);
+  min-height: 0;
+  flex: 1;
+  padding: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 .compute-surface .kernel-panel__message {
-  padding: 9px 10px;
-  margin-bottom: 9px;
+  margin: 10px 12px 0;
+  padding: 8px 10px;
+  border: 1px solid var(--color-border);
   border-radius: 8px;
+  background: var(--color-bg-elevated);
+  color: var(--color-text-muted);
   font-size: 12px;
 }
 
-.compute-surface .kernel-panel__message--authority {
-  color: var(--color-text-muted);
-  background: color-mix(in srgb, var(--color-warning) 7%, var(--color-bg));
-  border-color: color-mix(in srgb, var(--color-warning) 20%, var(--color-border));
+.compute-surface .kernel-panel__message--error {
+  border-color: color-mix(in srgb, var(--color-error) 24%, var(--color-border));
+  color: var(--color-error);
 }
 
 .compute-surface .kernel-panel__empty {
+  display: flex;
   min-height: 220px;
-  gap: 8px;
-  padding: 30px 22px;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 7px;
+  padding: 32px 24px;
+  color: var(--color-text-muted);
+  text-align: center;
 }
 
 .compute-surface .kernel-panel__empty > span {
-  width: 38px;
-  height: 38px;
-  border-radius: 10px;
+  display: grid;
+  width: 30px;
+  height: 30px;
+  place-items: center;
+  margin-bottom: 2px;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  color: var(--color-text-faint);
 }
 
 .compute-surface .kernel-panel__empty strong {
-  font-size: 14px;
+  color: var(--color-text);
+  font-size: 13px;
+  font-weight: 500;
 }
 
 .compute-surface .kernel-panel__empty p {
-  max-width: 280px;
+  max-width: 310px;
+  margin: 0;
   font-size: 12px;
-  line-height: 1.45;
-}
-
-.compute-surface .kernel-panel__list {
-  gap: 8px;
+  line-height: 1.5;
 }
 
 .compute-surface .kernel-panel__sessions {
-  display: grid;
-  gap: 16px;
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
 }
 
 .compute-surface .kernel-session {
-  display: grid;
-  gap: 8px;
-}
-
-.compute-surface .kernel-session__header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 0 2px;
-  color: var(--color-text-muted);
-  font-size: 11px;
-}
-
-.compute-surface .kernel-session__header > div {
-  display: flex;
-  align-items: baseline;
   min-width: 0;
-  gap: 7px;
-}
-
-.compute-surface .kernel-session__header strong {
-  overflow: hidden;
-  color: var(--color-text);
-  font-size: 12px;
-  font-weight: 600;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.compute-surface .kernel-session[data-current="true"] .kernel-session__header > div > span {
-  color: var(--color-accent);
-}
-
-.compute-surface .kernel-panel__saved {
-  display: grid;
-  gap: 7px;
-  margin-top: 18px;
-  padding-top: 14px;
-  border-top: 1px solid var(--color-border);
-}
-
-.compute-surface .kernel-panel__saved > header,
-.compute-surface .kernel-panel__saved-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-}
-
-.compute-surface .kernel-panel__saved > header {
-  color: var(--color-text-muted);
-  font-size: 11px;
-}
-
-.compute-surface .kernel-panel__saved > header strong {
-  color: var(--color-text);
-  font-size: 12px;
-}
-
-.compute-surface .kernel-panel__saved-row {
-  min-height: 42px;
-  padding: 8px 10px;
-  border-radius: 9px;
-  background: var(--color-bg-elevated);
-  box-shadow: inset 0 0 0 1px var(--color-border);
-}
-
-.compute-surface .kernel-panel__saved-row > div:first-child {
-  display: grid;
-  min-width: 0;
-  gap: 2px;
-}
-
-.compute-surface .kernel-panel__saved-row > div:first-child strong,
-.compute-surface .kernel-panel__saved-row > div:first-child span {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.compute-surface .kernel-panel__saved-row > div:first-child strong {
-  color: var(--color-text);
-  font-size: 12px;
-}
-
-.compute-surface .kernel-panel__saved-row > div:first-child span {
-  color: var(--color-text-muted);
-  font-size: 10px;
-}
-
-.compute-surface .kernel-panel__saved-row > div:last-child {
-  display: flex;
-  gap: 5px;
-}
-
-.compute-surface .kernel-panel__saved-row button {
-  min-height: 26px;
-  padding: 0 8px;
-  border: 1px solid var(--color-border);
-  border-radius: 6px;
-  color: var(--color-text-muted);
-  background: transparent;
-  font-size: 10px;
-  cursor: pointer;
-}
-
-.compute-surface .kernel-panel__saved-row button:hover:not(:disabled) {
-  color: var(--color-text);
-  background: var(--color-bg-hover);
-}
-
-.compute-surface .kernel-panel__saved-row button:disabled {
-  opacity: 0.45;
-  cursor: not-allowed;
-}
-
-/* 3a nests the kernel in its own card rather than letting it sit flat on the
-   panel — the runtime is a distinct object with its own controls, and the
-   inset says so. The card itself carries no padding: the head owns its own,
-   so the divider under it can run the full width of the plate. */
-.compute-surface .kernel-card {
-  gap: 0;
-  margin: 0;
-  padding: 0;
-  border-radius: 18px;
-  background: var(--color-bg-elevated);
-  box-shadow: inset 0 0 0 1px var(--color-border);
-  overflow: hidden;
-}
-
-/* The head is the toggle. A caret-sized hit target is well under the 44px a
-   thumb can reliably hit on a tablet, and this pane is read on one. */
-.compute-surface .kernel-card__plate {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  width: 100%;
-  padding: 16px;
-  border: 0;
-  background: none;
-  color: inherit;
-  font: inherit;
-  text-align: left;
-  cursor: pointer;
-}
-
-.compute-surface .kernel-card__plate:focus-visible {
-  outline: 2px solid var(--color-focus);
-  outline-offset: -2px;
-}
-
-.compute-surface .kernel-card[data-open="true"] .kernel-card__plate {
   border-bottom: 1px solid var(--color-border);
 }
 
-/* Flex, not the base grid: the head is two groups pushed apart, and the left
-   group stacks an eyebrow over the name. */
-.compute-surface .kernel-card__header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 12px;
-}
-
-.compute-surface .kernel-card__title {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
+.compute-surface .kernel-session__header {
+  display: grid;
   min-width: 0;
+  min-height: 44px;
+  box-sizing: border-box;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 14px;
+  background: var(--color-bg-subtle);
+  color: var(--color-text-muted);
+  font-size: 11px;
 }
 
-/* The language badge becomes the eyebrow's voice: small letter-spaced
-   capitals over the name, rather than a coloured tile beside it. */
-.compute-surface .kernel-card__language {
-  width: auto;
-  height: auto;
-  border-radius: 0;
-  background: none;
+.compute-surface .kernel-session[data-current="true"] .kernel-session__header {
+  background: color-mix(in srgb, var(--color-bg-elevated) 72%, var(--color-bg));
+}
+
+.compute-surface .kernel-session__identity {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 7px;
+}
+
+.compute-surface .kernel-session__identity > span {
   color: var(--color-text-faint);
-  font-size: 10px;
-  white-space: nowrap;
+  font-size: 11px;
 }
 
-.compute-surface .kernel-card__title strong {
-  font-size: 17px;
-  font-weight: 400;
-  line-height: 1.1;
-  letter-spacing: -0.01em;
+.compute-surface .kernel-session__identity strong {
   overflow: hidden;
+  color: var(--color-text);
+  font-size: 12px;
+  font-weight: 500;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.compute-surface .kernel-card__lede {
-  display: flex;
-  align-items: center;
+.compute-surface .kernel-session__identity em {
   flex: none;
-  gap: 12px;
+  padding: 1px 6px;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  color: var(--color-text-faint);
+  font-size: 10px;
+  font-style: normal;
 }
 
-.compute-surface .kernel-card__uptime {
-  font-size: 12px;
+.compute-surface .kernel-session__header > span {
   font-variant-numeric: tabular-nums;
-  color: var(--color-text-muted);
   white-space: nowrap;
 }
 
-.compute-surface .kernel-card__caret {
+.compute-surface .kernel-panel__list {
   display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 9px;
-  color: var(--color-text-muted);
+  min-width: 0;
+  flex-direction: column;
+  gap: 0;
 }
 
-/* Lifecycle reads as a pill, so a glance finds the runtime's state without
-   opening the plate. */
-.compute-surface .kernel-card__owner,
-.compute-surface .kernel-card__state {
-  display: inline-flex;
+.compute-surface .kernel-card {
+  display: grid;
+  min-width: 0;
+  min-height: 62px;
+  box-sizing: border-box;
+  grid-template-columns: minmax(136px, 1fr) 54px 76px 58px 52px;
   align-items: center;
-  padding: 3px 8px;
-  border-radius: 999px;
-  font-size: 10px;
-  font-weight: 400;
-  white-space: nowrap;
+  gap: 10px;
+  padding: 9px 14px;
+  border: 0;
+  border-top: 1px solid var(--color-border);
+  border-radius: 0;
+  background: var(--color-bg);
+  box-shadow: none;
 }
 
-.compute-surface .kernel-card__state {
+.compute-surface .kernel-card:first-child {
+  border-top: 0;
+}
+
+.compute-surface .kernel-card__main {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 9px;
+}
+
+.compute-surface .kernel-card__language {
+  display: grid;
+  width: 30px;
+  height: 30px;
   flex: none;
-  min-height: 0;
-  gap: 6px;
+  place-items: center;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  background: var(--color-bg-elevated);
+  color: var(--color-text-muted);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0;
+}
+
+.compute-surface .kernel-card__copy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.compute-surface .kernel-card__copy strong {
+  overflow: hidden;
   color: var(--color-text);
-  box-shadow: inset 0 0 0 1px var(--color-border-strong);
+  font-size: 12px;
+  font-weight: 500;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-/* The card is a one-column grid, so a pill left to itself would stretch the
-   full width and stop reading as a pill. */
-.compute-surface .kernel-card__owner {
-  justify-self: start;
-  margin: 12px 16px 0;
-}
-
-/* The tone used to reach the eye through a 5px dot beside the label. The 3a
-   pill has no dot, so the tone has to be the pill: a tinted ground and a ring
-   in the status colour. color-mix against the card's own ground keeps that
-   legible in all sixteen themes rather than only the dark one it was drawn in. */
-/* The word is set in the neutral text colour and the status colour moves to
-   the dot. Colouring the word meant setting a hue on a 12% tint of itself,
-   which works on a dark ground — the tint darkens it — but collapses on a
-   light one, where the tint is near-white and the hue has nothing to separate
-   from. Measured across all eighteen themes, that scheme fell to 1.0:1 on
-   vesper/light and sat under AA on nearly every light variant; this one holds
-   3.8:1 at worst and clears AA almost everywhere. A dot carries colour at a
-   size where contrast is not what makes it legible. */
-.compute-surface .kernel-card__state[data-tone="active"] {
-  background: color-mix(in srgb, var(--color-success) 12%, var(--color-bg-elevated));
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-success) 38%, var(--color-bg-elevated));
-}
-
-.compute-surface .kernel-card__state[data-tone="active"] .kernel-card__state-dot {
-  background: var(--color-success);
-}
-
-.compute-surface .kernel-card__state[data-tone="pending"] {
-  background: color-mix(in srgb, var(--color-warning) 12%, var(--color-bg-elevated));
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-warning) 38%, var(--color-bg-elevated));
-}
-
-.compute-surface .kernel-card__state[data-tone="pending"] .kernel-card__state-dot {
-  background: var(--color-warning);
-}
-
-.compute-surface .kernel-card__state[data-tone="danger"] {
-  background: color-mix(in srgb, var(--color-error) 12%, var(--color-bg-elevated));
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-error) 38%, var(--color-bg-elevated));
-}
-
-.compute-surface .kernel-card__state[data-tone="danger"] .kernel-card__state-dot {
-  background: var(--color-error);
-}
-
-.compute-surface .kernel-card__state-dot {
-  width: 5px;
-  height: 5px;
-  flex: none;
-  border-radius: 999px;
-  background: var(--color-text-faint);
-}
-
-/* Ready and muted stay uncoloured. A kernel that is merely alive is not news,
-   and colouring it would spend the eye's attention on the common case. */
-/* Ready and muted keep an uncoloured dot: a runtime that is merely alive is
-   not news, and tinting it would spend attention on the common case. */
-.compute-surface .kernel-card__state[data-tone="ready"],
-.compute-surface .kernel-card__state[data-tone="muted"] {
-  color: var(--color-text-muted);
-}
-
-/* The network statement sits under the environment header as its own line,
-   led by a dot in its tone. An open network is the state that changes what a
-   run can touch, so it carries the warning colour; a blocked one stays grey
-   rather than spending attention on the safe, and far more common, case. */
-.compute-surface .kernel-card__network {
+.compute-surface .kernel-card__copy > span {
   display: flex;
+  min-width: 0;
   align-items: center;
-  gap: 6px;
-  margin: -2px 0 2px;
-  font-size: 10px;
-  color: var(--color-text-muted);
+  gap: 5px;
+  overflow: hidden;
+  color: var(--color-text-faint);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.compute-surface .kernel-card__network-dot {
+.compute-surface .kernel-card__copy i {
   width: 6px;
   height: 6px;
   flex: none;
@@ -561,354 +233,115 @@
   background: var(--color-text-faint);
 }
 
-.compute-surface .kernel-card__network[data-tone="pending"] {
-  color: var(--color-warning);
+.compute-surface .kernel-card__copy i[data-tone="active"] {
+  background: var(--color-success);
 }
 
-.compute-surface .kernel-card__network[data-tone="pending"] .kernel-card__network-dot {
+.compute-surface .kernel-card__copy i[data-tone="pending"] {
   background: var(--color-warning);
 }
 
-/* One row, as the design sets them. The base grid is two columns, which left
-   Stop stranded on a line of its own — and Stop is the one that discards work,
-   so it read as an afterthought rather than the control to be careful with. */
-.compute-surface .kernel-card__controls {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
+.compute-surface .kernel-card__copy i[data-tone="danger"] {
+  background: var(--color-error);
 }
 
-.compute-surface .kernel-card__controls button {
-  flex: 1 1 0;
-  min-width: 92px;
-  min-height: 34px;
-  border-radius: 999px;
-  font-size: 12px;
-}
-
-/* The identity disclosure is set in the same capitals as the instrument
-   labels, so it reads as the last row of the record rather than a link. */
-.compute-surface .kernel-card__identity summary {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 12px 0;
-  font-size: 10px;
-  font-weight: 400;
-  color: var(--color-text-faint);
-  list-style: none;
-}
-
-.compute-surface .kernel-card__identity summary::-webkit-details-marker {
-  display: none;
-}
-
-.compute-surface .kernel-card__identity summary::after {
-  content: "▾";
-  font-size: 12px;
+.compute-surface .kernel-card__uptime,
+.compute-surface .kernel-card__metric {
   color: var(--color-text-muted);
-}
-
-.compute-surface .kernel-card__identity[open] summary::after {
-  content: "▴";
-}
-
-/* Two figures that survive the collapse, because "is this runtime in my way"
-   is the question a collapsed list still has to answer. */
-.compute-surface .kernel-card__usage {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-}
-
-/* Equal halves, so the memory track and the core segments are the same length
-   and read as one instrument rather than two of different sizes. 3a pinned the
-   cores to 126px, which is close to even in a narrow pane but leaves the two
-   bars visibly mismatched once the pane is wide — and this one is read wide. */
-.compute-surface .kernel-card__usage-item {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  flex: 1 1 0;
-  min-width: 0;
-}
-
-.compute-surface .kernel-card__usage-label {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 8px;
+  font-size: 11px;
   font-variant-numeric: tabular-nums;
-  font-size: 12px;
-  color: var(--color-text-muted);
   white-space: nowrap;
-}
-
-.compute-surface .kernel-card__usage-label > span:first-child {
-  font-size: 10px;
-  color: var(--color-text-faint);
-}
-
-.compute-surface .kernel-card__usage-label strong {
-  font-weight: 400;
-  color: var(--color-text);
-}
-
-.compute-surface .kernel-card__usage-track {
-  height: 3px;
-  border-radius: 999px;
-  background: var(--color-border);
-  overflow: hidden;
-}
-
-/* Instrument blue, matching the host strip's gauge — the terracotta on this
-   surface belongs to the primary action alone. */
-.compute-surface .kernel-card__usage-fill {
-  height: 100%;
-  border-radius: 999px;
-  background: var(--border-info-selected);
-}
-
-.compute-surface .kernel-card__usage-cores {
-  display: flex;
-  gap: 3px;
-}
-
-.compute-surface .kernel-card__usage-cores > div {
-  flex: 1;
-  height: 3px;
-  border-radius: 999px;
-  background: var(--color-border);
-}
-
-.compute-surface .kernel-card__usage-cores > div[data-lit="true"] {
-  background: var(--border-info-selected);
-}
-
-/* The opened body keeps the head's horizontal rhythm, and sets its own
-   vertical one. The card is gap: 0 so the divider under the head can run the
-   full width of the plate, which means every block below has to carry its own
-   spacing — without this they stacked flush and the record read as one dense
-   paragraph of figures. */
-.compute-surface .kernel-card__metrics,
-.compute-surface .kernel-card__environment,
-.compute-surface .kernel-card__recovery,
-.compute-surface .kernel-card__controls,
-.compute-surface .kernel-card__identity {
-  margin: 20px 16px 0;
-}
-
-/* The two grids are one ledger read as a single column of rows, so they sit
-   closer to each other than to the blocks around them. */
-.compute-surface .kernel-card__metrics--usage {
-  margin-top: 12px;
-}
-
-.compute-surface .kernel-card__identity {
-  margin-bottom: 4px;
-}
-
-/* Label and value joined by a dotted leader, as a printed record would set
-   them — the eye follows the rule across rather than guessing which value
-   belongs to which label. */
-.compute-surface .kernel-card__metrics,
-.compute-surface .kernel-card__metrics--usage {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 12px 20px;
-  padding: 0;
-  border: 0;
-  border-radius: 0;
-  background: none;
 }
 
 .compute-surface .kernel-card__metric {
   display: flex;
-  align-items: baseline;
-  gap: 8px;
-  min-height: 0;
-  padding: 0;
-  border: 0;
-  background: none;
-}
-
-/* Stated rather than merely omitted. The base rule (atlas.css, `.kernel-card__
-   metric span`) sets uppercase and 0.05em tracking, and the cascade resolves
-   per property — so dropping these declarations here left the base ones
-   winning and the ledger still shouting. Setting them to their initial values
-   is what actually turns it off, which is why origin/main writes them out too. */
-.compute-surface .kernel-card__metric span {
-  order: 1;
-  flex: none;
-  font-size: 10px;
-  letter-spacing: 0;
-  text-transform: none;
-  color: var(--color-text-muted);
-  white-space: nowrap;
-}
-
-.compute-surface .kernel-card__metric::after {
-  content: "";
-  order: 2;
-  flex: 1;
-  border-bottom: 1px dotted var(--color-border-strong);
-  transform: translateY(-3px);
+  min-width: 0;
+  flex-direction: column;
+  gap: 1px;
 }
 
 .compute-surface .kernel-card__metric strong {
-  order: 3;
-  flex: none;
-  font-variant-numeric: tabular-nums;
-  font-size: 12px;
-  font-weight: 400;
+  overflow: hidden;
   color: var(--color-text);
-  white-space: nowrap;
+  font-size: 11px;
+  font-weight: 500;
+  text-overflow: ellipsis;
 }
 
-.compute-surface .kernel-card__environment {
-  gap: 12px;
-  padding: 20px 0 0;
-  border-top: 1px solid var(--color-border);
-  border-radius: 0;
-  background: none;
-}
-
-.compute-surface .kernel-card__environment-header strong {
-  font-size: 14px;
-  font-weight: 400;
-}
-
-.compute-surface .kernel-card__environment-header span {
-  padding: 3px 8px;
-  border-radius: 999px;
-  box-shadow: inset 0 0 0 1px var(--color-border-strong);
-  font-size: 10px;
-}
-
-.compute-surface .kernel-card__recovery {
-  padding-left: 0;
-  border-left: 0;
-  font-size: 12px;
-  line-height: 1.5;
-  color: var(--color-text-muted);
-}
-
-/* Three equal pills. None of them is the primary action on this surface —
-   that belongs to New kernel — so all three are outlined, and only Stop
-   carries a colour, because it is the one that discards work. */
-.compute-surface .kernel-card__controls {
-  gap: 8px;
-}
-
-.compute-surface .kernel-card__controls button {
-  flex: 1;
-  min-height: 26px;
-  padding: 0 10px;
-  border: 0;
-  border-radius: 999px;
-  box-shadow: inset 0 0 0 1px var(--color-border-strong);
-  background: none;
-  color: var(--color-text);
-  font-size: 12px;
+.compute-surface .kernel-card__metric small {
+  color: var(--color-text-faint);
+  font-size: 9px;
+  letter-spacing: 0;
+  line-height: 1;
+  text-transform: lowercase;
 }
 
 .compute-surface .kernel-card__stop {
+  min-width: 48px;
+  height: 28px;
+  padding: 0 9px;
+  border: 1px solid var(--color-border);
+  border-radius: 7px;
+  background: transparent;
+  color: var(--color-text-muted);
+  font: inherit;
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.compute-surface .kernel-card__stop:hover:not(:disabled) {
+  border-color: color-mix(in srgb, var(--color-error) 36%, var(--color-border));
   color: var(--color-error);
 }
 
-.compute-surface .kernel-card__identity {
-  border-top: 1px solid var(--color-border);
+.compute-surface .kernel-card__stop:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
 }
 
-.compute-surface .kernel-card__identity summary {
-  padding-top: 11px;
-  font-size: 10px;
-  color: var(--color-text-muted);
+.compute-surface .kernel-card__stop:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
 }
 
-.compute-surface .kernel-card__identity > div {
-  gap: 8px;
-  padding-top: 7px;
-}
-
-.compute-surface .kernel-card__identity-row span,
-.compute-surface .kernel-card__identity-row code {
-  font-size: 10px;
-}
-
-.compute-jobs :where(button, input, select, textarea):focus-visible {
-  box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-accent) 54%, transparent);
-  outline: none;
-}
-
-@media (max-width: 720px) {
-  .compute-surface .kernel-panel__create {
-    grid-template-columns: minmax(0, 1fr) 96px;
+@container compute (max-width: 470px) {
+  .compute-surface .kernel-session__header {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 3px;
+    padding-block: 9px;
   }
 
-  .compute-surface .kernel-panel__create > div {
+  .compute-surface .kernel-session__header > span {
+    padding-left: 18px;
+  }
+
+  .compute-surface .kernel-card {
+    grid-template-columns: minmax(0, 1fr) auto auto auto;
+    gap: 8px;
+    padding: 10px 12px;
+  }
+
+  .compute-surface .kernel-card__main {
     grid-column: 1 / -1;
-    justify-content: flex-end;
+  }
+
+  .compute-surface .kernel-card__uptime {
+    padding-left: 39px;
   }
 }
 
-/* A grid item with `justify-self: end` is sized to its content, not its
-   column, so the base rule's `text-overflow: ellipsis` never fired: a working
-   directory longer than the pane overflowed leftward and painted on top of its
-   own label. Stretching the value to the column is what makes it clip. */
-.compute-surface .kernel-card__environment-row {
-  align-items: start;
-}
-
-.compute-surface .kernel-card__environment-row code,
-.compute-surface .kernel-card__environment-row p {
-  justify-self: stretch;
-}
-
-/* A run that is still moving sweeps a gradient along the foot of its row. The
-   status column already says RUNNING, but a word does not read as motion, and
-   this is the only row in the ledger whose value will change on its own. The
-   warning tone is the same one the status text carries, so the row says one
-   thing in two ways rather than two things. */
-.compute-surface .compute-run--active::after {
-  content: "";
-  position: absolute;
-  left: 8px;
-  right: 8px;
-  bottom: 0;
-  height: 2px;
-  border-radius: 999px;
-  background-image: linear-gradient(
-    90deg,
-    transparent 0%,
-    color-mix(in srgb, var(--color-warning) 85%, transparent) 50%,
-    transparent 100%
-  );
-  background-size: 45% 100%;
-  background-repeat: no-repeat;
-  animation: compute-run-sweep 1.8s linear infinite;
-}
-
-@keyframes compute-run-sweep {
-  from {
-    background-position: -45% 0;
+@container compute (max-width: 350px) {
+  .compute-surface .kernel-card {
+    grid-template-columns: minmax(0, 1fr) auto auto;
   }
-  to {
-    background-position: 145% 0;
+
+  .compute-surface .kernel-card__uptime {
+    display: none;
   }
 }
 
-/* Motion here is decorative — the status column carries the same fact in
-   words, so removing it costs nothing. */
 @media (prefers-reduced-motion: reduce) {
-  .compute-surface .compute-run--active::after {
-    animation: none;
-    background-image: linear-gradient(
-      90deg,
-      transparent 0%,
-      color-mix(in srgb, var(--color-warning) 55%, transparent) 50%,
-      transparent 100%
-    );
-    background-size: 100% 100%;
+  .compute-surface * {
+    scroll-behavior: auto;
   }
 }

--- a/frontend/workspace/src/atlas/ComputeSurface.css
+++ b/frontend/workspace/src/atlas/ComputeSurface.css
@@ -245,6 +245,10 @@
   background: var(--color-error);
 }
 
+.compute-surface .kernel-card__copy i[data-tone="ready"] {
+  background: var(--color-success);
+}
+
 .compute-surface .kernel-card__uptime,
 .compute-surface .kernel-card__metric {
   color: var(--color-text-muted);
@@ -304,6 +308,110 @@
   outline-offset: 2px;
 }
 
+.compute-surface .remote-results {
+  border-top: 8px solid var(--color-bg-subtle);
+}
+
+.compute-surface .kernel-history-card {
+  grid-template-columns: minmax(160px, 1fr) 64px minmax(112px, auto);
+}
+
+.compute-surface .kernel-history-card__result {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.compute-surface .kernel-history-card__result strong {
+  color: var(--color-text);
+  font-size: 11px;
+  font-weight: 500;
+}
+
+.compute-surface .kernel-history-card__result small {
+  overflow: hidden;
+  color: var(--color-text-faint);
+  font-size: 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.compute-surface .remote-job-card {
+  grid-template-columns: minmax(160px, 1fr) 64px minmax(118px, auto) auto;
+}
+
+.compute-surface .remote-job-card__result {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+  color: var(--color-text-muted);
+}
+
+.compute-surface .remote-job-card__result strong {
+  color: var(--color-text);
+  font-size: 11px;
+  font-weight: 500;
+  text-transform: capitalize;
+}
+
+.compute-surface .remote-job-card__result small {
+  overflow: hidden;
+  color: var(--color-text-faint);
+  font-size: 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.compute-surface .remote-job-card__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 5px;
+}
+
+.compute-surface .remote-job-card__actions button {
+  height: 28px;
+  padding: 0 8px;
+  border: 1px solid var(--color-border);
+  border-radius: 7px;
+  background: transparent;
+  color: var(--color-text-muted);
+  font: inherit;
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.compute-surface .remote-job-card__actions button:hover:not(:disabled) {
+  color: var(--color-text);
+  border-color: var(--color-border-strong, var(--color-border));
+}
+
+.compute-surface .remote-job-card__actions button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.compute-surface .remote-job-card__warning,
+.compute-surface .remote-job-card__output {
+  grid-column: 1 / -1;
+  margin: 0 0 2px 39px;
+  padding: 8px 10px;
+  border: 1px solid var(--color-border);
+  border-radius: 7px;
+  background: var(--color-bg-subtle);
+  color: var(--color-text-muted);
+  font-size: 11px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.compute-surface .remote-job-card__warning {
+  border-color: color-mix(in srgb, var(--color-error) 28%, var(--color-border));
+  color: var(--color-error);
+}
+
 @container compute (max-width: 470px) {
   .compute-surface .kernel-session__header {
     grid-template-columns: minmax(0, 1fr);
@@ -328,6 +436,22 @@
   .compute-surface .kernel-card__uptime {
     padding-left: 39px;
   }
+
+  .compute-surface .remote-job-card {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .compute-surface .kernel-history-card {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .compute-surface .kernel-history-card__result {
+    padding-left: 39px;
+  }
+
+  .compute-surface .remote-job-card__result {
+    padding-left: 39px;
+  }
 }
 
 @container compute (max-width: 350px) {
@@ -337,6 +461,14 @@
 
   .compute-surface .kernel-card__uptime {
     display: none;
+  }
+
+  .compute-surface .remote-job-card__result {
+    grid-column: 1 / -1;
+  }
+
+  .compute-surface .kernel-history-card__result {
+    grid-column: 1 / -1;
   }
 }
 

--- a/frontend/workspace/src/atlas/ComputeSurface.test.ts
+++ b/frontend/workspace/src/atlas/ComputeSurface.test.ts
@@ -13,20 +13,15 @@ const server = await createServer({
   server: { middlewareMode: true },
   appType: "custom",
   resolve: { conditions: ["browser", "production"], dedupe: ["solid-js", "solid-js/web"] },
-  ssr: {
-    noExternal: true,
-    resolve: { conditions: ["browser", "production"] },
-  },
+  ssr: { noExternal: true, resolve: { conditions: ["browser", "production"] } },
 })
 const [subject, web] = await Promise.all([
   server.ssrLoadModule("/src/atlas/ComputeSurface.tsx") as Promise<typeof import("./ComputeSurface")>,
   server.ssrLoadModule("solid-js/web") as Promise<typeof import("solid-js/web")>,
 ])
 const cleanups: Array<() => void> = []
-type Mounted = { kernels: number; jobs: number }
 
 afterAll(() => server.close())
-
 afterEach(() => {
   cleanups.splice(0).forEach((cleanup) => cleanup())
   document.body.replaceChildren()
@@ -39,235 +34,44 @@ const mount = (view: () => JSX.Element) => {
   return host
 }
 
-const child = (name: keyof Mounted, mounted: Mounted) => () => {
-  mounted[name]++
-  const panel = document.createElement("section")
-  panel.dataset.computeChild = name
-  panel.textContent = `${name} content`
-  return panel
+const child = (name: string, calls: string[]) => () => {
+  calls.push(name)
+  const node = document.createElement("section")
+  node.dataset.computeChild = name
+  return node
 }
 
-const request = (status: Array<"running" | "succeeded"> = []) =>
-  Object.assign(
-    async () =>
-      Response.json(
-        status.map((value, index) => ({
-          id: `job_${index}`,
-          status: value,
-        })),
-      ),
-    { url: () => "http://localhost/settings/compute/jobs" },
-  )
-
 describe("compute surface", () => {
-  test("defaults to Kernels and does not mount Jobs until selected", async () => {
-    const mounted = { kernels: 0, jobs: 0 }
-    const host = mount(() =>
-      subject.ComputeSurface({
-        strip: () => document.createElement("section"),
-        kernels: child("kernels", mounted),
-        jobs: child("jobs", mounted),
-        request: request(),
-      }),
-    )
-    const kernels = host.querySelector<HTMLButtonElement>('[role="tab"][data-compute-tab="kernels"]')
-    const jobs = host.querySelector<HTMLButtonElement>('[role="tab"][data-compute-tab="jobs"]')
+  test("renders one project-wide live kernel inventory", () => {
+    const calls: string[] = []
+    const host = mount(() => subject.ComputeSurface({ strip: child("strip", calls), kernels: child("kernels", calls) }))
 
-    expect(host.querySelector('[role="tablist"]')?.getAttribute("aria-label")).toBe("Compute views")
-    expect(kernels?.getAttribute("aria-selected")).toBe("true")
-    expect(jobs?.getAttribute("aria-selected")).toBe("false")
+    expect(calls).toEqual(["strip", "kernels"])
+    expect(host.querySelector('[aria-label="Compute"]')).not.toBeNull()
+    expect(host.querySelector('[data-compute-child="strip"]')).not.toBeNull()
     expect(host.querySelector('[data-compute-child="kernels"]')).not.toBeNull()
-    expect(host.querySelector('[data-compute-child="jobs"]')).toBeNull()
-    expect(mounted).toEqual({ kernels: 1, jobs: 0 })
-    const panel = host.querySelector<HTMLElement>('[role="tabpanel"]')
-    expect(kernels?.getAttribute("aria-controls")).toBe(panel?.id)
-    expect(panel?.getAttribute("aria-labelledby")).toBe(kernels?.id)
-
-    jobs?.click()
-    await Promise.resolve()
-
-    expect(kernels?.getAttribute("aria-selected")).toBe("false")
-    expect(jobs?.getAttribute("aria-selected")).toBe("true")
-    expect(host.querySelector('[data-compute-child="kernels"]')).toBeNull()
-    expect(host.querySelector('[data-compute-child="jobs"]')).not.toBeNull()
-    expect(mounted).toEqual({ kernels: 1, jobs: 1 })
-    const next = host.querySelector<HTMLElement>('[role="tabpanel"]')
-    expect(jobs?.getAttribute("aria-controls")).toBe(next?.id)
-    expect(next?.getAttribute("aria-labelledby")).toBe(jobs?.id)
+    expect(host.querySelector('[role="tablist"]')).toBeNull()
   })
 
-  test("uses automatic arrow-key activation and focus for its tabs", async () => {
-    const mounted = { kernels: 0, jobs: 0 }
-    const host = mount(() =>
-      subject.ComputeSurface({
-        strip: () => document.createElement("section"),
-        kernels: child("kernels", mounted),
-        jobs: child("jobs", mounted),
-        request: request(),
-      }),
-    )
-    const kernels = host.querySelector<HTMLButtonElement>('[role="tab"][data-compute-tab="kernels"]')
-    const jobs = host.querySelector<HTMLButtonElement>('[role="tab"][data-compute-tab="jobs"]')
-
-    kernels?.focus()
-    kernels?.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }))
-    await Promise.resolve()
-
-    expect(jobs?.getAttribute("aria-selected")).toBe("true")
-    expect(document.activeElement).toBe(jobs)
-
-    jobs?.dispatchEvent(new KeyboardEvent("keydown", { key: "Home", bubbles: true }))
-    await Promise.resolve()
-
-    expect(kernels?.getAttribute("aria-selected")).toBe("true")
-    expect(document.activeElement).toBe(kernels)
-  })
-
-  test("carries the job total in the Jobs tab label", async () => {
-    const mounted = { kernels: 0, jobs: 0 }
-    const host = mount(() =>
-      subject.ComputeSurface({
-        strip: () => document.createElement("section"),
-        kernels: child("kernels", mounted),
-        jobs: child("jobs", mounted),
-        request: request(["running", "succeeded", "running"]),
-      }),
-    )
-    const count = await (async function wait(attempts = 20): Promise<HTMLElement | null> {
-      const value = host.querySelector<HTMLElement>('[data-compute-tab="jobs"] .compute-surface__count')
-      if (value?.textContent === "3" || !attempts) return value
-      await Bun.sleep(10)
-      return wait(attempts - 1)
-    })()
-
-    // The label states how many runs are here, not how many are moving — a
-    // total is what a glance at a tab wants, and the running ones are already
-    // legible in the list by their status dots.
-    expect(count?.textContent).toBe("3")
-    // Read aloud with a unit, because "Jobs 3" alone is ambiguous.
-    const tab = host.querySelector('[data-compute-tab="jobs"]')
-    expect(tab?.textContent).toContain("3 jobs")
-    expect(count?.getAttribute("aria-hidden")).toBe("true")
-    expect(mounted).toEqual({ kernels: 1, jobs: 0 })
-  })
-
-  test("does not run the heavyweight jobs refresh at the live-view cadence while Kernels is selected", async () => {
-    const mounted = { kernels: 0, jobs: 0 }
-    const calls = { count: 0 }
-    const host = mount(() =>
-      subject.ComputeSurface({
-        strip: () => document.createElement("section"),
-        kernels: child("kernels", mounted),
-        jobs: child("jobs", mounted),
-        request: Object.assign(
-          async () => {
-            calls.count++
-            return new Response(JSON.stringify([]), { headers: { "content-type": "application/json" } })
-          },
-          { url: () => "http://localhost/settings/compute/jobs" },
-        ),
-      }),
-    )
-    await Bun.sleep(2_700)
-
-    expect(calls.count).toBe(1)
-    expect(host.querySelector('[data-compute-child="kernels"]')).not.toBeNull()
-  })
-
-  test("contains no unavailable or transport-facing product copy", () => {
+  test("contains no manual launcher or jobs mode", () => {
     const source = readFileSync(fileURLToPath(new URL("./ComputeSurface.tsx", import.meta.url)), "utf8")
 
-    expect(source).not.toContain("Terminal")
-    expect(source).not.toContain("Atlas Compute")
-    expect(source).not.toContain("OpenRouter")
-    expect(source).not.toContain("provider")
+    expect(source).not.toContain("ComputeJobs")
+    expect(source).not.toContain("New kernel")
+    expect(source).not.toContain("onEnsureSession")
+    expect(source).not.toContain('role="tab"')
+    expect(source).toContain("Compute only reflects what is live")
   })
 
-  test("leaves research job creation to the agent in the product surface", () => {
-    const source = readFileSync(fileURLToPath(new URL("./ComputeSurface.tsx", import.meta.url)), "utf8")
-
-    expect(source).toContain("manual={false}")
-  })
-
-  test("marks the selected tab with an underline rather than a filled shape", () => {
+  test("uses its own width for narrow layouts", () => {
     const css = readFileSync(fileURLToPath(new URL("./ComputeSurface.css", import.meta.url)), "utf8")
+    const host = readFileSync(fileURLToPath(new URL("./HostStrip.css", import.meta.url)), "utf8")
 
-    // Type on a hairline, not a pill group.
-    expect(css).toMatch(/\.compute-surface__tabs\s*\{[^}]*border-bottom: 1px solid var\(--color-border\)/s)
-    // origin/main's compute surface sets nothing in capitals and keeps
-    // letter-spacing only as negative tracking on a heading, so neither
-    // appears here either.
-    expect(css).not.toContain("text-transform: uppercase")
-    expect(css).not.toMatch(/letter-spacing: 0\.\d/)
-    // ...but absence is not enough, and asserting only absence is what let the
-    // ledger keep shouting while this test passed. atlas.css sets uppercase and
-    // 0.05em tracking on `.kernel-card__metric span`, and the cascade resolves
-    // per property, so the base declarations win against a rule that simply
-    // omits them. They have to be turned off by name.
-    const base = readFileSync(fileURLToPath(new URL("../styles/atlas.css", import.meta.url)), "utf8")
-    expect(base).toMatch(/\.kernel-card__metric span\s*\{[^}]*text-transform: uppercase/s)
-    expect(css).toMatch(/\.compute-surface \.kernel-card__metric span\s*\{[^}]*text-transform: none/s)
-    expect(css).toMatch(/\.compute-surface \.kernel-card__metric span\s*\{[^}]*letter-spacing: 0;/s)
-    // No face named on this surface: origin/main puts the whole app on one sans
-    // face, and every label here inherits it rather than naming a second token
-    // that could drift from it. `font-family: inherit` is the one allowed form.
-    expect(css).not.toContain("--font-code")
-    expect(css.match(/font-family:[^;]*/g) ?? []).toEqual(["font-family: inherit"])
-    // The one solid terracotta on this surface belongs to the primary action,
-    // so selection is an underline drawn in the brand colour instead.
-    expect(css).toMatch(
-      /\.compute-surface__tab\[data-active="true"\]\s*\{[^}]*box-shadow: inset 0 -2px 0 var\(--surface-brand-base\)/s,
-    )
-    expect(css).toMatch(/\.compute-surface__tab\[data-active="true"\]\s*\{[^}]*background: none/s)
-    // The count joins its label as one token of type rather than sitting apart.
-    expect(css).toMatch(/\.compute-surface__count::before\s*\{[^}]*content: "·"/s)
-    // No hardcoded colour: the app ships 16 themes.
+    expect(css).toContain("container: compute / inline-size")
+    expect(css).toContain("@container compute (max-width: 470px)")
+    expect(css).toContain("@container compute (max-width: 350px)")
+    expect(host).toContain("@container compute (max-width: 500px)")
     expect(css).not.toMatch(/#[0-9a-fA-F]{3,8}/)
-  })
-
-  test("renders the host strip above the tablist", () => {
-    const host = mount(() =>
-      subject.ComputeSurface({
-        strip: () => {
-          const strip = document.createElement("section")
-          strip.dataset.computeChild = "strip"
-          return strip
-        },
-        kernels: child("kernels", { kernels: 0, jobs: 0 }),
-        jobs: child("jobs", { kernels: 0, jobs: 0 }),
-        request: request(),
-      }),
-    )
-    const surface = host.querySelector(".compute-surface")
-    const children = [...(surface?.children ?? [])]
-    const strip = children.findIndex((element) => element.matches('[data-compute-child="strip"]'))
-    const tabs = children.findIndex((element) => element.matches('[role="tablist"]'))
-
-    expect(strip).toBe(0)
-    expect(tabs).toBeGreaterThan(strip)
-  })
-  test("does not poll the jobs route itself while the jobs panel is mounted", () => {
-    const source = readFileSync(fileURLToPath(new URL("./ComputeSurface.tsx", import.meta.url)), "utf8")
-    // Two polls of the same route at different intervals, for the same number.
-    expect(source).toContain('if (state.tab !== "jobs") void refresh()')
-    expect(source).toContain('onTotalChange={(count) => setState("jobs", count)}')
-  })
-  test("carries state colour on the dot, never on the word", () => {
-    const css = readFileSync(fileURLToPath(new URL("./ComputeSurface.css", import.meta.url)), "utf8")
-
-    // Colouring the word means setting a hue on a 12% tint of itself. That
-    // works on a dark ground, where the tint darkens it, and collapses on a
-    // light one, where the tint is near-white and the hue has nothing to
-    // separate from — measured across all shipped themes it fell to 1.0:1 on
-    // vesper/light and sat under AA on nearly every light variant. The dot
-    // carries the colour instead, at a size where contrast is not what makes
-    // it legible.
-    for (const tone of ["active", "pending", "danger"]) {
-      const rule = css.match(new RegExp(`\\.kernel-card__state\\[data-tone="${tone}"\\] \\{[^}]*\\}`, "s"))?.[0]
-      expect(rule).toBeDefined()
-      expect(rule).not.toMatch(/color:/)
-      expect(rule).toContain("background: color-mix")
-      expect(css).toContain(`.kernel-card__state[data-tone="${tone}"] .kernel-card__state-dot`)
-    }
+    expect(host).not.toMatch(/#[0-9a-fA-F]{3,8}/)
   })
 })

--- a/frontend/workspace/src/atlas/ComputeSurface.test.ts
+++ b/frontend/workspace/src/atlas/ComputeSurface.test.ts
@@ -61,7 +61,8 @@ describe("compute surface", () => {
     expect(source).not.toContain("onEnsureSession")
     expect(source).not.toContain('role="tab"')
     expect(source).toContain("Compute only reflects what is live")
-    expect(source).toContain("kernels and shell")
+    expect(source).toContain("governed remote GPU jobs")
+    expect(source).toContain("Completed remote results stay")
   })
 
   test("uses its own width for narrow layouts", () => {

--- a/frontend/workspace/src/atlas/ComputeSurface.test.ts
+++ b/frontend/workspace/src/atlas/ComputeSurface.test.ts
@@ -42,7 +42,7 @@ const child = (name: string, calls: string[]) => () => {
 }
 
 describe("compute surface", () => {
-  test("renders one project-wide live kernel inventory", () => {
+  test("renders one project-wide live compute inventory", () => {
     const calls: string[] = []
     const host = mount(() => subject.ComputeSurface({ strip: child("strip", calls), kernels: child("kernels", calls) }))
 
@@ -53,7 +53,7 @@ describe("compute surface", () => {
     expect(host.querySelector('[role="tablist"]')).toBeNull()
   })
 
-  test("contains no manual launcher or jobs mode", () => {
+  test("contains no manual launcher or separate jobs mode", () => {
     const source = readFileSync(fileURLToPath(new URL("./ComputeSurface.tsx", import.meta.url)), "utf8")
 
     expect(source).not.toContain("ComputeJobs")
@@ -61,6 +61,7 @@ describe("compute surface", () => {
     expect(source).not.toContain("onEnsureSession")
     expect(source).not.toContain('role="tab"')
     expect(source).toContain("Compute only reflects what is live")
+    expect(source).toContain("kernels and shell")
   })
 
   test("uses its own width for narrow layouts", () => {

--- a/frontend/workspace/src/atlas/ComputeSurface.tsx
+++ b/frontend/workspace/src/atlas/ComputeSurface.tsx
@@ -12,10 +12,10 @@ type ComputeSurfaceProps = {
 /**
  * Project-scoped compute inventory.
  *
- * This surface never starts work. Agent and notebook execution create kernels;
- * Compute only reflects what is live and lets the user stop a process that is
- * already running. Keeping that boundary here prevents a session switch from
- * turning this project-wide inspector into a second execution launcher.
+ * This surface never starts work. Agent execution creates kernels and shell
+ * commands; Compute only reflects what is live and lets the user stop a process
+ * that is already running. Keeping that boundary here prevents a session switch
+ * from turning this project-wide inspector into a second execution launcher.
  */
 export function ComputeSurface(props: ComputeSurfaceProps = {}): JSX.Element {
   const strip = props.strip ?? HostStrip

--- a/frontend/workspace/src/atlas/ComputeSurface.tsx
+++ b/frontend/workspace/src/atlas/ComputeSurface.tsx
@@ -1,181 +1,32 @@
-import {
-  createEffect,
-  createSignal,
-  createUniqueId,
-  For,
-  Match,
-  onCleanup,
-  Show,
-  Switch,
-  type Component,
-  type JSX,
-} from "solid-js"
-import { createStore } from "solid-js/store"
+import type { Component, JSX } from "solid-js"
 import { Dynamic } from "solid-js/web"
-import { ComputeJobs } from "@/atlas/ComputeJobs"
-import { createComputeJobsAPI, type Status } from "@/atlas/ComputeJobsAPI"
 import { HostStrip } from "@/atlas/HostStrip"
-import type { Capacity } from "@/atlas/host-instruments"
 import { KernelPanel } from "@/atlas/KernelPanel"
-import { useSDK } from "@/context/sdk"
-import type { ProjectRequest } from "@/utils/openscience-fetch"
 import "@/atlas/ComputeSurface.css"
-
-type Tab = "kernels" | "jobs"
 
 type ComputeSurfaceProps = {
   strip?: Component
-  kernels?: Component<{
-    onEnsureSession?: () => Promise<string | undefined>
-    capacity?: Partial<Capacity>
-  }>
-  jobs?: Component<{
-    onEnsureSession?: () => Promise<string | undefined>
-    onActiveChange?: (count: number) => void
-    onTotalChange?: (count: number) => void
-    manual?: boolean
-  }>
-  onEnsureSession?: () => Promise<string | undefined>
-  request?: ProjectRequest
+  kernels?: Component
 }
 
-const terminal = new Set<Status>(["succeeded", "failed", "cancelled", "interrupted"])
-const inactiveRefresh = 15_000
-
-const tabs = [
-  { id: "kernels", label: "Kernels" },
-  { id: "jobs", label: "Jobs" },
-] as const
-
+/**
+ * Project-scoped compute inventory.
+ *
+ * This surface never starts work. Agent and notebook execution create kernels;
+ * Compute only reflects what is live and lets the user stop a process that is
+ * already running. Keeping that boundary here prevents a session switch from
+ * turning this project-wide inspector into a second execution launcher.
+ */
 export function ComputeSurface(props: ComputeSurfaceProps = {}): JSX.Element {
-  // `active` still drives nothing visible on its own — the counts beside each
-  // tab label are totals, which is what 5a shows and what a glance wants:
-  // "how much is here", not "how much is moving". The active figure stays
-  // because the jobs panel reports it and the empty/idle copy reads better
-  // knowing it.
-  const [state, setState] = createStore({ tab: "kernels" as Tab, active: 0, jobs: 0, kernels: 0 })
-  const id = createUniqueId()
-  const refs: Partial<Record<Tab, HTMLButtonElement>> = {}
   const strip = props.strip ?? HostStrip
   const kernels = props.kernels ?? KernelPanel
-  const jobs = props.jobs ?? ComputeJobs
-  const api = createComputeJobsAPI(props.request ?? useSDK().request)
-  const [capacity, setCapacity] = createSignal<Capacity | undefined>()
-
-  const refresh = async () => {
-    const list = await api.list().catch(() => undefined)
-    if (!list) return
-    setState("active", list.filter((job) => !terminal.has(job.status)).length)
-    setState("jobs", list.length)
-  }
-
-  // Only while the jobs panel is not mounted: when it is, it reports its own
-  // total off the poll it already runs, and a second poll here would ask the
-  // same route twice as often for the same number.
-  createEffect(() => {
-    if (state.tab !== "jobs") void refresh()
-  })
-
-  const timer = setInterval(() => {
-    if (state.tab !== "jobs") void refresh()
-  }, inactiveRefresh)
-  onCleanup(() => clearInterval(timer))
-
-  const select = (next: Tab, focus = false) => {
-    setState("tab", next)
-    if (focus) queueMicrotask(() => refs[next]?.focus())
-  }
-
-  const onKeyDown = (event: KeyboardEvent) => {
-    if (!["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "Home", "End"].includes(event.key)) return
-    const current = tabs.findIndex((item) => item.id === state.tab)
-    const index =
-      event.key === "Home"
-        ? 0
-        : event.key === "End"
-          ? tabs.length - 1
-          : event.key === "ArrowRight" || event.key === "ArrowDown"
-            ? (current + 1) % tabs.length
-            : (current <= 0 ? tabs.length : current) - 1
-    const next = tabs[index]
-    if (!next) return
-    event.preventDefault()
-    select(next.id, true)
-  }
 
   return (
     <section class="compute-surface" aria-label="Compute">
-      <Dynamic component={strip} onKernels={(live: number) => setState("kernels", live)} onCapacity={setCapacity} />
-      <div
-        class="compute-surface__tabs"
-        role="tablist"
-        aria-label="Compute views"
-        aria-orientation="horizontal"
-        onKeyDown={onKeyDown}
-      >
-        <For each={tabs}>
-          {(item) => (
-            <button
-              ref={(element) => (refs[item.id] = element)}
-              id={`${id}-${item.id}-tab`}
-              type="button"
-              role="tab"
-              class="compute-surface__tab"
-              data-compute-tab={item.id}
-              data-active={state.tab === item.id}
-              aria-selected={state.tab === item.id}
-              aria-controls={`${id}-${item.id}-panel`}
-              tabindex={state.tab === item.id ? 0 : -1}
-              onClick={() => select(item.id)}
-            >
-              <span>{item.label}</span>
-              {/* The count rides in the label rather than in a badge: 5a puts
-                  the two numbers on the same baseline as their words so the
-                  row reads as one line of type, and drops the badge that
-                  competed with the terracotta underline for the eye. */}
-              <span class="compute-surface__count" aria-hidden="true">
-                {item.id === "jobs" ? state.jobs : state.kernels}
-              </span>
-              <span class="compute-surface__sr">
-                {item.id === "jobs"
-                  ? `${state.jobs} job${state.jobs === 1 ? "" : "s"}`
-                  : `${state.kernels} kernel${state.kernels === 1 ? "" : "s"}`}
-              </span>
-            </button>
-          )}
-        </For>
+      <Dynamic component={strip} />
+      <div class="compute-surface__panel" data-compute-child="kernels">
+        <Dynamic component={kernels} />
       </div>
-
-      <Switch>
-        <Match when={state.tab === "kernels"}>
-          <div
-            id={`${id}-kernels-panel`}
-            class="compute-surface__panel"
-            role="tabpanel"
-            aria-labelledby={`${id}-kernels-tab`}
-            tabindex={0}
-          >
-            <Dynamic component={kernels} onEnsureSession={props.onEnsureSession} capacity={capacity()} />
-          </div>
-        </Match>
-        <Match when={state.tab === "jobs"}>
-          <div
-            id={`${id}-jobs-panel`}
-            class="compute-surface__panel"
-            role="tabpanel"
-            aria-labelledby={`${id}-jobs-tab`}
-            tabindex={0}
-          >
-            <Dynamic
-              component={jobs}
-              onEnsureSession={props.onEnsureSession}
-              onActiveChange={(count) => setState("active", count)}
-              onTotalChange={(count) => setState("jobs", count)}
-              manual={false}
-            />
-          </div>
-        </Match>
-      </Switch>
     </section>
   )
 }

--- a/frontend/workspace/src/atlas/ComputeSurface.tsx
+++ b/frontend/workspace/src/atlas/ComputeSurface.tsx
@@ -13,8 +13,9 @@ type ComputeSurfaceProps = {
  * Project-scoped compute inventory.
  *
  * This surface never starts work. Agent execution creates kernels and shell
- * commands; Compute only reflects what is live and lets the user stop a process
- * that is already running. Keeping that boundary here prevents a session switch
+ * commands or governed remote GPU jobs; Compute only reflects what is live and
+ * lets the user stop work that is already running. Completed remote results stay
+ * readable without becoming a second launcher. Keeping that boundary here prevents a session switch
  * from turning this project-wide inspector into a second execution launcher.
  */
 export function ComputeSurface(props: ComputeSurfaceProps = {}): JSX.Element {

--- a/frontend/workspace/src/atlas/HostStrip.css
+++ b/frontend/workspace/src/atlas/HostStrip.css
@@ -1,141 +1,108 @@
-/* 3a's instrument block. Where the previous pass drew two matched gauges, this
-   leads with a single figure at display size and puts its qualifiers in small
-   capitals beside it — a laboratory readout rather than a dashboard tile. Memory
-   in use leads, matching the histogram beside it, which plots the same. */
 .host-strip {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  box-sizing: border-box;
-  padding: 18px 18px 14px;
+  display: grid;
+  min-width: 0;
+  grid-template-columns: minmax(0, 1.35fr) minmax(0, 1fr) minmax(112px, 0.8fr);
+  gap: 0;
   border-bottom: 1px solid var(--color-border);
   background: var(--color-bg);
 }
 
-/* Set in the same capitals as the instrument labels below it, and quiet:
-   it names the block rather than competing with the figure it introduces. */
-.host-strip__title {
-  font-size: 10px;
+.host-strip__metric {
+  display: flex;
+  min-width: 0;
+  min-height: 74px;
+  box-sizing: border-box;
+  justify-content: center;
+  flex-direction: column;
+  gap: 7px;
+  padding: 11px 14px;
+  border-right: 1px solid var(--color-border);
+}
+
+.host-strip__metric:last-child {
+  border-right: 0;
+}
+
+.host-strip__label {
   color: var(--color-text-faint);
+  font-size: 10px;
+  font-weight: 500;
 }
 
-.host-strip__memory {
+.host-strip__metric p {
   display: flex;
-  align-items: flex-end;
-  justify-content: space-between;
-  gap: 16px;
   min-width: 0;
-}
-
-.host-strip__figure {
-  display: flex;
-  align-items: baseline;
-  gap: 8px;
-  min-width: 0;
-}
-
-.host-strip__headline {
-  font-size: 44px;
-  line-height: 0.9;
-  font-weight: 400;
-  letter-spacing: -0.02em;
-  color: var(--color-text);
-  font-variant-numeric: tabular-nums;
-}
-
-/* Unit and ceiling sit on one baseline beside the figure — "4.4 GB used of
-   16.4" — rather than stacked three deep. Stacking spent three lines saying
-   what one says, and the column of tiny type beside a 44px numeral was the
-   densest corner of the surface. */
-.host-strip__labels {
-  display: flex;
   align-items: baseline;
   gap: 4px;
-  min-width: 0;
-}
-
-.host-strip__unit,
-.host-strip__ceiling {
+  margin: 0;
+  overflow: hidden;
+  color: var(--color-text-muted);
   font-size: 10px;
   white-space: nowrap;
 }
 
-.host-strip__unit {
-  color: var(--color-text-muted);
+.host-strip__metric strong {
+  color: var(--color-text);
+  font-size: 15px;
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.01em;
 }
 
-/* One tone for the whole qualifier now that it reads as a single phrase; two
-   tones inside one line reads as an accident rather than a hierarchy. */
-.host-strip__ceiling {
-  color: var(--color-text-muted);
+.host-strip__metric p > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
-/* Twenty samples of memory pressure, oldest left. The bars carry no labels
-   because the current value is already stated at 44px beside them; this is
-   here to show direction, not to be read off. */
-.host-strip__history {
-  display: flex;
-  align-items: flex-end;
-  gap: 2px;
-  height: 34px;
-  flex: none;
-}
-
-.host-strip__bar {
-  width: 4px;
-  border-radius: 1px;
-  background: var(--color-border-strong);
-  transition: height 240ms ease;
-}
-
-/* The newest few in the accent, so the eye lands on now rather than on the
-   middle of the series. */
-.host-strip__bar[data-recent="true"] {
-  background: var(--surface-brand-base);
-}
-
-.host-strip__cores {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-
-.host-strip__cores-label {
-  width: 52px;
-  flex: none;
-  font-size: 10px;
-  color: var(--color-text-muted);
-}
-
-.host-strip__segments {
-  display: flex;
-  gap: 3px;
-  flex: 1;
-  min-width: 0;
-}
-
-.host-strip__segment {
-  flex: 1;
-  height: 6px;
-  border-radius: 2px;
+.host-strip__meter {
+  display: block;
+  width: 100%;
+  height: 3px;
+  overflow: hidden;
+  border-radius: 999px;
   background: var(--color-border);
 }
 
-/* Busy cores read in the instrument blue, kept distinct from the terracotta so
-   the one solid accent on this surface still belongs to the primary action. */
-.host-strip__segment[data-lit="true"] {
-  background: var(--border-info-selected);
+.host-strip__meter i {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--color-text-muted);
+  transition: width 180ms ease;
 }
 
-.host-strip__cores-value {
-  font-size: 10px;
-  color: var(--color-text-muted);
-  font-variant-numeric: tabular-nums;
-  white-space: nowrap;
+.host-strip__metric--kernels p {
+  align-items: center;
+}
+
+@container compute (max-width: 500px) {
+  .host-strip {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  }
+
+  .host-strip__metric {
+    min-height: 68px;
+    padding: 10px 12px;
+  }
+
+  .host-strip__metric:nth-child(2) {
+    border-right: 0;
+  }
+
+  .host-strip__metric--kernels {
+    min-height: 42px;
+    grid-column: 1 / -1;
+    border-top: 1px solid var(--color-border);
+    border-right: 0;
+  }
+
+  .host-strip__metric--kernels .host-strip__label {
+    display: none;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .host-strip__bar {
+  .host-strip__meter i {
     transition: none;
   }
 }

--- a/frontend/workspace/src/atlas/HostStrip.test.ts
+++ b/frontend/workspace/src/atlas/HostStrip.test.ts
@@ -109,7 +109,7 @@ describe("host strip", () => {
     expect(calls.length).toBeGreaterThan(0)
     await expect(calls[0]).rejects.toThrow()
     expect(host.querySelector("[data-boundary]")).toBeNull()
-    expect(host.querySelectorAll(".host-strip__figure, .host-strip__cores").length).toBe(2)
+    expect(host.querySelectorAll(".host-strip__metric").length).toBe(3)
     expect(values(host)).toEqual(["—", "—"])
     expect(host.textContent).not.toContain("0 B")
     expect(host.textContent).not.toContain("0 / 0")
@@ -122,21 +122,17 @@ describe("host strip", () => {
 
     expect((await calls[0])?.status).toBe(503)
     expect(host.querySelector("[data-boundary]")).toBeNull()
-    expect(host.querySelectorAll(".host-strip__figure, .host-strip__cores").length).toBe(2)
+    expect(host.querySelectorAll(".host-strip__metric").length).toBe(3)
     expect(values(host)).toEqual(["—", "—"])
     expect(host.textContent).not.toContain("0 B")
     expect(host.textContent).not.toContain("0 / 0")
   })
 
-  test("names the block, so its figures are not read as a kernel's own", () => {
-    // The strip states the machine; each kernel plate states that kernel. A
-    // reader who took "6.7 GB used" here for the kernel's own would be out by
-    // three orders of magnitude, and nothing else on the surface said which
-    // was which.
+  test("names the block as machine resources", () => {
     const source = readFileSync(fileURLToPath(new URL("./HostStrip.tsx", import.meta.url)), "utf8")
 
-    expect(source).toContain('<span class="host-strip__title">System statistics</span>')
-    expect(source).toContain('aria-label="System statistics"')
+    expect(source).toContain('<span class="host-strip__label">Machine</span>')
+    expect(source).toContain('aria-label="Machine resources"')
   })
 
   test("states the machine's capacity once a poll succeeds", async () => {
@@ -145,10 +141,9 @@ describe("host strip", () => {
     await settle(calls)
 
     expect(host.querySelector("[data-boundary]")).toBeNull()
-    expect(values(host)).toEqual(["6.7", "2 / 8"])
-    // 5a states the reading itself rather than a sentence about it.
-    expect(host.textContent).toContain("GB used")
-    expect(host.textContent).toContain("of 16.0")
+    expect(values(host)).toEqual(["412.0 MB", "~0.4 of 8"])
+    expect(host.textContent).toContain("of 16.0 GB memory")
+    expect(host.textContent).toContain("2kernels · 1 running")
   })
 
   test("asks the route the compute strip is served from, naming itself to the server", async () => {
@@ -210,7 +205,7 @@ describe("host strip", () => {
     const memoryTile = host.querySelector('[data-host-tile="memory"]')
     const cpuTile = host.querySelector('[data-host-tile="cpu"]')
     expect(memoryTile).not.toBeNull()
-    expect(values(host)).toEqual(["6.7", "2 / 8"])
+    expect(values(host)).toEqual(["412.0 MB", "~0.4 of 8"])
 
     capacity = {
       memory: { total: 16_000_000_000, available: 5_000_000_000, kernels: 900_000_000 },
@@ -225,7 +220,7 @@ describe("host strip", () => {
     expect(host.querySelector('[data-host-tile="cpu"]')).toBe(cpuTile)
     expect(host.contains(memoryTile)).toBe(true)
     // Freshness: the values inside those same nodes actually moved.
-    expect(values(host)).toEqual(["11.0", "4 / 8"])
+    expect(values(host)).toEqual(["900.0 MB", "~1.1 of 8"])
   })
 
   test("stays mounted with no Suspense fallback while a poll is genuinely in flight", async () => {
@@ -272,7 +267,7 @@ describe("host strip", () => {
     // Let the first load resolve; the fallback should be gone and tiles present.
     await Bun.sleep(20)
     expect(host.querySelector("[data-fallback]")).toBeNull()
-    expect(values(host)).toEqual(["6.7", "2 / 8"])
+    expect(values(host)).toEqual(["412.0 MB", "~0.4 of 8"])
     const memoryTile = host.querySelector('[data-host-tile="memory"]')
     expect(memoryTile).not.toBeNull()
 
@@ -287,7 +282,7 @@ describe("host strip", () => {
     expect(host.querySelector("[data-fallback]")).toBeNull()
     expect(memoryTile?.isConnected).toBe(true)
     expect(host.querySelector('[data-host-tile="memory"]')).toBe(memoryTile)
-    expect(values(host)).toEqual(["6.7", "2 / 8"])
+    expect(values(host)).toEqual(["412.0 MB", "~0.4 of 8"])
 
     // Resolve it and confirm the value actually moved.
     settleSecond?.(new Response(JSON.stringify(refreshed), { headers: { "content-type": "application/json" } }))
@@ -295,7 +290,7 @@ describe("host strip", () => {
 
     expect(host.querySelector("[data-fallback]")).toBeNull()
     expect(host.querySelector('[data-host-tile="memory"]')).toBe(memoryTile)
-    expect(values(host)).toEqual(["11.0", "4 / 8"])
+    expect(values(host)).toEqual(["900.0 MB", "~1.1 of 8"])
   })
 
   test("refreshes when the tab is shown again and polls nothing after unmount", async () => {

--- a/frontend/workspace/src/atlas/HostStrip.test.ts
+++ b/frontend/workspace/src/atlas/HostStrip.test.ts
@@ -155,8 +155,9 @@ describe("host strip", () => {
     guard(() => subject.HostStrip({ request: track }))
     await Bun.sleep(20)
 
-    expect(paths.length).toBe(1)
-    const asked = new URL(paths[0] ?? "", "http://host")
+    expect(paths).toHaveLength(2)
+    expect(paths).toContain("/settings/compute/jobs")
+    const asked = new URL(paths.find((path) => path.startsWith("/notebook/compute")) ?? "", "http://host")
     expect(asked.pathname).toBe("/notebook/compute")
 
     // Both CPU figures the route serves are measured across the window since
@@ -178,8 +179,9 @@ describe("host strip", () => {
     )
     await Bun.sleep(20)
 
-    expect(others.length).toBe(1)
-    expect(new URL(others[0] ?? "", "http://host").searchParams.get("client")).not.toBe(client)
+    expect(others).toHaveLength(2)
+    const other = others.find((path) => path.startsWith("/notebook/compute")) ?? ""
+    expect(new URL(other, "http://host").searchParams.get("client")).not.toBe(client)
   })
 
   test("keeps the same tile nodes mounted across a poll that changes the data", async () => {
@@ -248,7 +250,10 @@ describe("host strip", () => {
     }
     let settleSecond: ((response: Response) => void) | undefined
     let requests = 0
-    const respond = (_path: string): Promise<Response> => {
+    const respond = (path: string): Promise<Response> => {
+      if (path === "/settings/compute/jobs") {
+        return Promise.resolve(new Response("[]", { headers: { "content-type": "application/json" } }))
+      }
       requests += 1
       if (requests === 1) return serving()
       return new Promise<Response>((resolve) => (settleSecond = resolve))
@@ -302,13 +307,13 @@ describe("host strip", () => {
     document.dispatchEvent(new Event("visibilitychange"))
     await settle(calls)
 
-    expect(calls.length).toBe(polled + 1)
+    expect(calls.length).toBe(polled + 2)
 
     cleanups.splice(0).forEach((cleanup) => cleanup())
     document.dispatchEvent(new Event("visibilitychange"))
     // Longer than the 2.5s poll, so a surviving interval would show up here.
     await Bun.sleep(2_700)
 
-    expect(calls.length).toBe(polled + 1)
+    expect(calls.length).toBe(polled + 2)
   })
 })

--- a/frontend/workspace/src/atlas/HostStrip.tsx
+++ b/frontend/workspace/src/atlas/HostStrip.tsx
@@ -1,48 +1,22 @@
-import { Index, createEffect, createMemo, createResource, createSignal, onCleanup, Show, type JSX } from "solid-js"
+import { createMemo, createResource, onCleanup, type JSX } from "solid-js"
 import { useSDK } from "@/context/sdk"
-import { histogram, hostReading, sample, type Capacity } from "@/atlas/host-instruments"
+import { hostReading, type Capacity } from "@/atlas/host-instruments"
 import { identify } from "@/atlas/poll-identity"
 import "@/atlas/HostStrip.css"
 
-// The transport is a prop so the degraded path can be mounted against a real
-// endpoint that really fails; the session SDK supplies it in the product.
 type HostStripProps = {
   request?: (path: string) => Promise<Response>
-  // The tab labels carry a live kernel count, and this poll already asks for
-  // it every 2.5s. Reporting it upward costs nothing; a second poller for the
-  // same number would double the request rate on a route whose CPU figures are
-  // measured per client across the window between polls.
-  onKernels?: (live: number) => void
-  // The kernel plates draw their RAM bar against the host's total and their
-  // core segments against its core count. Both are already on this poll's
-  // body, so lifting the reading here is cheaper — and always consistent with
-  // the strip above — than giving every card its own /notebook/compute poll.
-  onCapacity?: (capacity: Capacity) => void
 }
-
-// Names this mounted strip to the server. Both host and kernel CPU figures are
-// measured across the window since the same client's previous poll, so two tabs
-// sharing one identity would truncate each other's window to the gap between
-// their polls — under the server's one-second floor, which then refuses a
-// reading for whichever polled second, every cycle. See poll-identity.ts for
-// why the identity is per mount rather than per module.
 
 export function HostStrip(props: HostStripProps = {}): JSX.Element {
   const request = props.request ?? useSDK().request
   const client = identify()
-  // A poll that fails resolves to no capacity instead of rejecting. An errored
-  // resource re-throws where it is read, and the nearest ErrorBoundary wraps the
-  // entire workspace, so a server restart or a sleep/wake while this pane is
-  // open would swap the whole app for the error page. hostReading already reads
-  // an absent capacity as unavailable, which is the designed degraded state —
-  // never a 0, never a blank, never a thrown boundary.
   const load = () =>
     request(`/notebook/compute?client=${encodeURIComponent(client)}`)
       .then((response) => (response.ok ? (response.json() as Promise<Capacity>) : undefined))
       .catch(() => undefined)
   const [data, api] = createResource(load)
-  // A hidden tab skips its polls, so returning to it would otherwise show
-  // numbers up to one interval stale until the next tick.
+  const reading = createMemo(() => hostReading(data.latest))
   const refresh = () => {
     if (document.hidden) return
     void api.refetch()
@@ -54,74 +28,41 @@ export function HostStrip(props: HostStripProps = {}): JSX.Element {
     document.removeEventListener("visibilitychange", refresh)
   })
 
-  // Read `data.latest` rather than `data()`: `data()` re-registers with the
-  // nearest Suspense boundary on every in-flight fetch, which suspends the
-  // entire RightPane (see RightPane.tsx's Suspense around ComputeSurface) on
-  // every 2.5s poll. `.latest` only suspends on the first load and returns the
-  // previous value while a refetch is in flight, so this memo — and the pane
-  // around it — stays mounted across polls.
-  const reading = createMemo(() => hostReading(data.latest))
-
-  // The histogram is the one thing here with memory. The route reports a point
-  // in time, so the series has to be accumulated client-side; it is bounded to
-  // SAMPLES, so this cannot grow without limit however long the pane stays open.
-  const [history, setHistory] = createSignal<number[]>([])
-  createEffect(() => {
-    const capacity = data.latest
-    if (capacity) setHistory((prior) => sample(prior, capacity))
-  })
-  const bars = createMemo(() => histogram(history()))
-
-  createEffect(() => {
-    // Only report a count the body actually carried. A poll that failed, or one
-    // whose body arrived without the section, must leave the label showing the
-    // last known figure rather than asserting zero kernels.
-    const live = data.latest?.kernels?.live
-    if (typeof live === "number") props.onKernels?.(live)
-  })
-
-  createEffect(() => {
-    const capacity = data.latest
-    if (capacity) props.onCapacity?.(capacity)
-  })
-
   return (
-    <section class="host-strip" aria-label="System statistics" data-testid="host-strip">
-      {/* Named, because the figures below it are the machine's and the ones on
-          each kernel plate are that kernel's, and nothing else on the surface
-          said which was which — a reader who took "12.6 GB USED" for the
-          kernel's own would be out by three orders of magnitude. */}
-      <span class="host-strip__title">System statistics</span>
-      <div class="host-strip__memory">
-        <div class="host-strip__figure" data-host-tile="memory">
+    <section class="host-strip" aria-label="Machine resources" data-testid="host-strip">
+      <div class="host-strip__metric" data-host-tile="memory">
+        <span class="host-strip__label">Machine</span>
+        <p>
           <strong class="host-strip__headline">{reading().headline}</strong>
-          <span class="host-strip__labels">
-            <span class="host-strip__unit">{reading().unit}</span>
-            <Show when={reading().ceiling}>
-              <span class="host-strip__ceiling">{reading().ceiling}</span>
-            </Show>
-          </span>
-        </div>
-        {/* Decorative: the same series is already stated as a number beside it,
-            so a screen reader gains nothing from twenty bar heights. */}
-        <div class="host-strip__history" role="presentation" aria-hidden="true">
-          <Index each={bars()}>
-            {(bar) => (
-              <span class="host-strip__bar" data-recent={bar().recent} style={{ height: `${bar().height}px` }} />
-            )}
-          </Index>
-        </div>
+          <span>{reading().memory}</span>
+        </p>
+        <Meter value={reading().memoryFill} />
       </div>
 
-      <div class="host-strip__cores" data-host-tile="cpu">
-        <span class="host-strip__cores-label">Cores</span>
-        <span class="host-strip__segments" role="presentation">
-          <Index each={Array.from({ length: reading().segments })}>
-            {(_, position) => <span class="host-strip__segment" data-lit={position < reading().lit} />}
-          </Index>
-        </span>
-        <span class="host-strip__cores-value">{reading().cores}</span>
+      <div class="host-strip__metric" data-host-tile="cpu">
+        <span class="host-strip__label">CPU</span>
+        <p>
+          <strong class="host-strip__cores-value">{reading().cores}</strong>
+          <span>cores CPU</span>
+        </p>
+        <Meter value={reading().cpuFill} />
+      </div>
+
+      <div class="host-strip__metric host-strip__metric--kernels" data-host-tile="kernels">
+        <span class="host-strip__label">Live</span>
+        <p>
+          <strong class="host-strip__kernels-value">{reading().live}</strong>
+          <span>{reading().kernels}</span>
+        </p>
       </div>
     </section>
+  )
+}
+
+function Meter(props: { value: number }): JSX.Element {
+  return (
+    <span class="host-strip__meter" role="presentation" aria-hidden="true">
+      <i style={{ width: `${Math.round(props.value * 100)}%` }} />
+    </span>
   )
 }

--- a/frontend/workspace/src/atlas/HostStrip.tsx
+++ b/frontend/workspace/src/atlas/HostStrip.tsx
@@ -12,8 +12,27 @@ export function HostStrip(props: HostStripProps = {}): JSX.Element {
   const request = props.request ?? useSDK().request
   const client = identify()
   const load = () =>
-    request(`/notebook/compute?client=${encodeURIComponent(client)}`)
-      .then((response) => (response.ok ? (response.json() as Promise<Capacity>) : undefined))
+    Promise.all([
+      request(`/notebook/compute?client=${encodeURIComponent(client)}`).then((response) =>
+        response.ok ? (response.json() as Promise<Capacity>) : undefined,
+      ),
+      request("/settings/compute/jobs")
+        .then((response) => (response.ok ? response.json() : undefined))
+        .catch(() => undefined),
+    ])
+      .then(([capacity, value]) => {
+        if (!capacity || !Array.isArray(value)) return capacity
+        const jobs = value as Array<{ status?: string; lifecycle?: { resource?: string } }>
+        const live = jobs.filter(
+          (job) =>
+            !["succeeded", "failed", "cancelled", "interrupted"].includes(job.status ?? "") ||
+            ["starting", "active", "unknown"].includes(job.lifecycle?.resource ?? ""),
+        )
+        return {
+          ...capacity,
+          jobs: { live: live.length, running: live.filter((job) => job.status === "running").length },
+        }
+      })
       .catch(() => undefined)
   const [data, api] = createResource(load)
   const reading = createMemo(() => hostReading(data.latest))

--- a/frontend/workspace/src/atlas/KernelCard.test.tsx
+++ b/frontend/workspace/src/atlas/KernelCard.test.tsx
@@ -5,7 +5,6 @@ import { createServer } from "vite"
 import solid from "vite-plugin-solid"
 import type { KernelStatus } from "@/notebook/runtime"
 
-const cleanups: Array<() => void> = []
 const server = await createServer({
   root: fileURLToPath(new URL("../..", import.meta.url)),
   mode: "production",
@@ -14,18 +13,15 @@ const server = await createServer({
   server: { middlewareMode: true },
   appType: "custom",
   resolve: { conditions: ["browser", "production"], dedupe: ["solid-js", "solid-js/web"] },
-  ssr: {
-    noExternal: true,
-    resolve: { conditions: ["browser", "production"] },
-  },
+  ssr: { noExternal: true, resolve: { conditions: ["browser", "production"] } },
 })
 const [subject, web] = await Promise.all([
   server.ssrLoadModule("/src/atlas/KernelCard.tsx") as Promise<typeof import("./KernelCard")>,
   server.ssrLoadModule("solid-js/web") as Promise<typeof import("solid-js/web")>,
 ])
+const cleanups: Array<() => void> = []
 
 afterAll(() => server.close())
-
 afterEach(() => {
   cleanups.splice(0).forEach((cleanup) => cleanup())
   document.body.replaceChildren()
@@ -34,7 +30,7 @@ afterEach(() => {
 const kernel = (value: Partial<KernelStatus> = {}): KernelStatus => ({
   id: "kernel-live",
   active: true,
-  state: "idle",
+  state: "running",
   projectID: "project-1",
   sessionID: "ses_current",
   name: "notebook:analysis.ipynb",
@@ -49,305 +45,65 @@ const kernel = (value: Partial<KernelStatus> = {}): KernelStatus => ({
   process_identity_verified: true,
   started_at: Date.now() - 4_000,
   last_activity_at: Date.now() - 1_000,
+  resources: { cpu_percent: 180, memory_bytes: 412_000_000 },
   ...value,
 })
 
-// The plate collapses by default, so everything below the head — the ledger,
-// the environment block, the controls, the identity list — is not in the DOM
-// until it is opened. Mounting opens it, because that is the state these
-// assertions are about; the collapsed head has its own tests below.
-const mount = (view: () => JSX.Element, options: { collapsed?: boolean } = {}) => {
+const mount = (view: () => JSX.Element) => {
   const host = document.createElement("div")
   document.body.append(host)
   cleanups.push(web.render(view, host))
-  if (!options.collapsed) host.querySelector<HTMLButtonElement>(".kernel-card__plate")?.click()
   return host
 }
 
-const button = (host: HTMLElement, label: string) =>
-  host.querySelector<HTMLButtonElement>(`button[aria-label="${label}"]`)
+describe("kernel status row", () => {
+  test("shows the live runtime in one compact row", () => {
+    const host = mount(() => subject.KernelCard({ kernel: kernel(), action: "", onControl: () => {} }))
 
-describe("KernelCard lifecycle controls", () => {
-  test("renders a reloaded live process as active with its exact incarnation and identity", () => {
+    expect(host.querySelector(".kernel-card__language")?.textContent).toBe("Py")
+    expect(host.querySelector(".kernel-card__copy")?.textContent).toContain("analysis.ipynb")
+    expect(host.querySelector(".kernel-card__copy")?.textContent).toContain("Executing now")
+    expect(host.querySelectorAll(".kernel-card__metric")[0]?.textContent).toBe("412 MBrss")
+    expect(host.querySelectorAll(".kernel-card__metric")[1]?.textContent).toBe("1.8cores")
+    expect(host.querySelector(".kernel-card__uptime")?.textContent).toMatch(/^\d+s$/)
+  })
+
+  test("only exposes stop, never manual start, restart, interrupt, or forget", () => {
     const calls: string[] = []
     const host = mount(() =>
-      subject.KernelCard({
-        kernel: kernel(),
-        routeID: "ses_current",
-        action: "",
-        onControl: (action) => calls.push(action),
-      }),
+      subject.KernelCard({ kernel: kernel(), action: "", onControl: (action) => calls.push(action) }),
     )
+    const stop = host.querySelector<HTMLButtonElement>('button[aria-label="Stop analysis.ipynb"]')
 
-    expect(host.querySelector(".kernel-card__state")?.textContent).toBe("Ready")
-    expect(host.textContent).toContain("r4")
-    expect(host.textContent).toContain("8234")
-    expect(host.textContent).toContain("PID and process start verified")
-    expect(button(host, "Interrupt analysis.ipynb")?.disabled).toBe(true)
-    expect(button(host, "Restart analysis.ipynb")?.disabled).toBe(false)
-    expect(button(host, "Stop analysis.ipynb")?.disabled).toBe(false)
-
-    button(host, "Restart analysis.ipynb")?.click()
-    button(host, "Stop analysis.ipynb")?.click()
-    expect(calls).toEqual(["restart", "stop"])
-  })
-
-  test("interrupts only running work and states restart data loss before the action", () => {
-    const calls: string[] = []
-    const host = mount(() =>
-      subject.KernelCard({
-        kernel: kernel({ state: "running", queue_depth: 2 }),
-        routeID: "ses_current",
-        action: "",
-        onControl: (action) => calls.push(action),
-      }),
-    )
-
-    expect(button(host, "Interrupt analysis.ipynb")?.disabled).toBe(false)
-    expect(button(host, "Restart analysis.ipynb")?.title).toContain(
-      "All in-memory variables and queued cells will be lost",
-    )
-    // The standing note under the controls is gone with the 3a plate. The
-    // warning has to survive somewhere the user meets it before acting, so it
-    // rides on the button that causes the loss.
-    expect(host.querySelector(".kernel-card__control-note")).toBeNull()
-    expect(button(host, "Stop analysis.ipynb")?.title).toContain("clear its in-memory state")
-    button(host, "Interrupt analysis.ipynb")?.click()
-    expect(calls).toEqual(["interrupt"])
-  })
-
-  test("offers restart and forget for an inactive named R record but cannot stop it twice", () => {
-    const calls: string[] = []
-    const host = mount(() =>
-      subject.KernelCard({
-        kernel: kernel({
-          active: false,
-          state: "stopped",
-          language: "r",
-          incarnation: 2,
-          execution_count: 0,
-          process_id: null,
-          process_started_at: null,
-          process_identity_verified: null,
-          started_at: null,
-        }),
-        routeID: "ses_current",
-        action: "",
-        onControl: (action) => calls.push(action),
-      }),
-    )
-
-    expect(host.textContent).toContain("R environment")
-    expect(button(host, "Restart analysis.ipynb")?.disabled).toBe(false)
-    expect(button(host, "Stop analysis.ipynb")?.disabled).toBe(true)
-    expect(button(host, "Forget analysis.ipynb")?.disabled).toBe(false)
-    button(host, "Forget analysis.ipynb")?.click()
-    expect(calls).toEqual(["delete"])
-  })
-
-  test("shows the local target with sampled usage and an unavailable fallback, never zero", () => {
-    // CPU is stated as a share of the machine, so this row needs the host
-    // reading the surface passes down: 12.34% of one core on an 8-core box is
-    // 1.5% of the machine.
-    const capacity = { memory: { total: 16_400_000_000, available: 12_000_000_000 }, cpu: { cores: 8 } }
-    const sampled = mount(() =>
-      subject.KernelCard({
-        kernel: kernel({ resources: { cpu_percent: 12.34, memory_bytes: 412_000_000 } }),
-        routeID: "ses_current",
-        action: "",
-        capacity,
-        onControl: () => {},
-      }),
-    )
-    const usage = sampled.querySelector(".kernel-card__metrics--usage")
-    expect(usage?.textContent).toContain("Target")
-    expect(usage?.textContent).toContain("Local")
-    expect(usage?.textContent).toContain("1.5%")
-    expect(usage?.textContent).toContain("412 MB")
-    expect(usage?.textContent).toContain("Uptime")
-    expect(usage?.textContent).toContain("GPU")
-    expect(usage?.textContent).toContain("VRAM")
-
-    const partial = mount(() =>
-      subject.KernelCard({
-        kernel: kernel({ resources: { cpu_percent: 24 } }),
-        routeID: "ses_current",
-        action: "",
-        capacity,
-        onControl: () => {},
-      }),
-    )
-    const half = partial.querySelector(".kernel-card__metrics--usage")
-    expect(half?.textContent).toContain("3.0%")
-    expect(half?.textContent?.match(/Unavailable/g)?.length).toBe(3)
-    expect(half?.textContent).not.toContain("0 B")
-
-    const bare = mount(() =>
-      subject.KernelCard({
-        kernel: kernel(),
-        routeID: "ses_current",
-        action: "",
-        onControl: () => {},
-      }),
-    )
-    const empty = bare.querySelector(".kernel-card__metrics--usage")
-    expect(empty?.textContent).toContain("Local")
-    expect(empty?.textContent).not.toContain("%")
-    expect(empty?.textContent?.match(/Unavailable/g)?.length).toBe(4)
-  })
-
-  test("keeps the lazy named session kernel restartable but not deletable", () => {
-    const host = mount(() =>
-      subject.KernelCard({
-        kernel: kernel({
-          active: false,
-          state: "lazy",
-          name: "agent",
-          incarnation: null,
-          execution_count: 0,
-          process_id: null,
-          process_started_at: null,
-          process_identity_verified: null,
-          started_at: null,
-        }),
-        routeID: "ses_current",
-        action: "",
-        onControl: () => {},
-      }),
-    )
-
-    expect(host.textContent).toContain("No process is running")
-    expect(button(host, "Restart Python analysis")?.disabled).toBe(false)
-    expect(button(host, "Forget Python analysis")).toBeNull()
-  })
-
-  test("blocks restart when execution authority is denied but leaves safe cleanup available", () => {
-    const calls: string[] = []
-    const host = mount(() =>
-      subject.KernelCard({
-        kernel: kernel(),
-        routeID: "ses_current",
-        action: "",
-        restartDisabled: true,
-        restartTitle: "Trust this project to start or restart a kernel in this session.",
-        onControl: (action) => calls.push(action),
-      }),
-    )
-
-    expect(button(host, "Restart analysis.ipynb")?.disabled).toBe(true)
-    expect(button(host, "Restart analysis.ipynb")?.title).toContain("Trust this project")
-    expect(button(host, "Stop analysis.ipynb")?.disabled).toBe(false)
-    button(host, "Restart analysis.ipynb")?.click()
-    button(host, "Stop analysis.ipynb")?.click()
+    expect(host.querySelectorAll("button").length).toBe(1)
+    expect(stop?.disabled).toBe(false)
+    expect(stop?.title).toContain("clear its in-memory state")
+    stop?.click()
     expect(calls).toEqual(["stop"])
   })
-  test("collapses to a head that still answers whether the runtime is in the way", () => {
-    const host = mount(
-      () =>
-        subject.KernelCard({
-          kernel: kernel({ state: "running", resources: { cpu_percent: 180, memory_bytes: 2_400_000_000 } }),
-          routeID: "ses_current",
-          action: "",
-          index: 0,
-          capacity: { memory: { total: 16_400_000_000, available: 12_000_000_000 }, cpu: { cores: 8 } },
-          onControl: () => {},
-        }),
-      { collapsed: true },
+
+  test("never presents an inactive record as startable", () => {
+    const host = mount(() =>
+      subject.KernelCard({
+        kernel: kernel({ active: false, state: "stopped", started_at: null, resources: undefined }),
+        action: "",
+        onControl: () => {},
+      }),
     )
 
-    const plate = host.querySelector<HTMLButtonElement>(".kernel-card__plate")
-    expect(plate?.getAttribute("aria-expanded")).toBe("false")
-    expect(host.querySelector(".kernel-card__language")?.textContent).toBe("Kernel 01 · Python")
-    expect(host.querySelector(".kernel-card__state")?.textContent).toBe("Running")
-    // The two figures that survive the collapse.
-    expect(host.querySelector(".kernel-card__usage")?.textContent).toContain("2.4")
-    expect(host.querySelector(".kernel-card__usage")?.textContent).toContain("/ 16.4 GB")
-    expect(host.querySelectorAll(".kernel-card__usage-cores > div").length).toBe(8)
-    expect(host.querySelectorAll('.kernel-card__usage-cores > div[data-lit="true"]').length).toBe(2)
-
-    // Nothing below the head is in the DOM until it is opened, so a list of
-    // several runtimes stays a list rather than a stack of full records.
-    expect(host.querySelector(".kernel-card__controls")).toBeNull()
-    expect(host.querySelector(".kernel-card__metrics")).toBeNull()
-    expect(host.querySelector(".kernel-card__identity")).toBeNull()
-    expect(host.textContent).not.toContain("Runtime identity")
+    expect(host.querySelectorAll("button").length).toBe(1)
+    expect(host.querySelector<HTMLButtonElement>("button")?.disabled).toBe(true)
+    expect(host.querySelector(".kernel-card__uptime")?.textContent).toBe("—")
+    expect(host.textContent).not.toContain("Start")
+    expect(host.textContent).not.toContain("Restart")
   })
 
-  test("opens and closes from the head, which is the whole hit target", () => {
-    const host = mount(
-      () =>
-        subject.KernelCard({
-          kernel: kernel(),
-          routeID: "ses_current",
-          action: "",
-          onControl: () => {},
-        }),
-      { collapsed: true },
+  test("counts uptime while a process stays mounted", async () => {
+    const host = mount(() =>
+      subject.KernelCard({ kernel: kernel({ started_at: Date.now() - 2_000 }), action: "", onControl: () => {} }),
     )
-    const plate = host.querySelector<HTMLButtonElement>(".kernel-card__plate")
-
-    plate?.click()
-    expect(plate?.getAttribute("aria-expanded")).toBe("true")
-    expect(host.querySelector(".kernel-card__controls")).not.toBeNull()
-    expect(host.querySelector(".kernel-card")?.getAttribute("data-open")).toBe("true")
-
-    plate?.click()
-    expect(plate?.getAttribute("aria-expanded")).toBe("false")
-    expect(host.querySelector(".kernel-card__controls")).toBeNull()
-  })
-
-  test("numbers each plate by its position so two collapsed heads read apart", () => {
-    const host = mount(
-      () =>
-        subject.KernelCard({
-          kernel: kernel({ language: "r" }),
-          routeID: "ses_current",
-          action: "",
-          index: 2,
-          onControl: () => {},
-        }),
-      { collapsed: true },
-    )
-
-    expect(host.querySelector(".kernel-card__language")?.textContent).toBe("Kernel 03 · R")
-  })
-  test("counts uptime like a stopwatch rather than freezing at its first reading", async () => {
-    // The kernel object is reconciled in place, so it does not change while a
-    // runtime simply keeps running. Uptime therefore has to be driven by a
-    // clock inside the card; before it was, the head sat at "2s" for as long
-    // as the runtime lived.
-    const host = mount(
-      () =>
-        subject.KernelCard({
-          kernel: kernel({ active: true, state: "running", started_at: Date.now() - 2_000 }),
-          routeID: "ses_current",
-          action: "",
-          onControl: () => {},
-        }),
-      { collapsed: true },
-    )
-
     const first = host.querySelector(".kernel-card__uptime")?.textContent
-    expect(first).toMatch(/^\d+s$/)
     await Bun.sleep(1_200)
-    const second = host.querySelector(".kernel-card__uptime")?.textContent
-    expect(second).not.toBe(first)
-  })
-
-  test("stops the clock when there is nothing running to count", () => {
-    const host = mount(
-      () =>
-        subject.KernelCard({
-          kernel: kernel({ active: false, state: "stopped", started_at: null }),
-          routeID: "ses_current",
-          action: "",
-          onControl: () => {},
-        }),
-      { collapsed: true },
-    )
-
-    // "Unavailable" is three times the width of the figure it replaces and
-    // says nothing the lifecycle pill beside it does not.
-    expect(host.querySelector(".kernel-card__uptime")).toBeNull()
+    expect(host.querySelector(".kernel-card__uptime")?.textContent).not.toBe(first)
   })
 })

--- a/frontend/workspace/src/atlas/KernelCard.tsx
+++ b/frontend/workspace/src/atlas/KernelCard.tsx
@@ -1,317 +1,83 @@
-import { Index, Show, createEffect, createSignal, onCleanup, type JSX } from "solid-js"
-import { IconChevronDown, IconChevronRight } from "@/atlas/shared/Icon"
-import type { Capacity } from "./host-instruments"
-import { plateEyebrow, plateUsage } from "./kernel-plate"
+import { createEffect, createSignal, onCleanup, type JSX } from "solid-js"
 import {
-  kernelAtlasLabel,
-  kernelCanForget,
-  kernelCanInterrupt,
   kernelCanStop,
-  kernelEnvironmentLabel,
-  kernelEnvironmentTone,
-  kernelGpuLabel,
   kernelLabel,
   kernelLanguageLabel,
   kernelMemoryLabel,
-  kernelNetworkLabel,
-  kernelNetworkTone,
-  kernelOwnershipLabel,
   kernelRecoveryLabel,
   kernelStateLabel,
-  kernelTargetLabel,
   kernelTone,
   kernelUptimeLabel,
-  kernelVramLabel,
   type KernelStatus,
 } from "@/notebook/runtime"
 
-export type KernelAction = "interrupt" | "restart" | "stop" | "delete"
+export type KernelAction = "stop"
 
-const time = (value: number | null) => {
-  if (!value) return "Unavailable"
-  const seconds = Math.max(0, Math.round((Date.now() - value) / 1_000))
-  if (seconds < 60) return `${seconds}s ago`
-  const minutes = Math.round(seconds / 60)
-  if (minutes < 60) return `${minutes}m ago`
-  return `${Math.round(minutes / 60)}h ago`
+const memory = (value?: number) => {
+  const label = kernelMemoryLabel(value)
+  return label === "Unavailable" ? "—" : label
 }
 
-const date = (value: number | null) => {
-  if (!value) return "Unavailable"
-  return new Date(value).toLocaleString()
+const cores = (value?: number) => {
+  if (value === undefined || !Number.isFinite(value) || value < 0) return "—"
+  return (value / 100).toFixed(1)
 }
 
 export function KernelCard(props: {
   kernel: KernelStatus
-  routeID?: string
   action: string
-  index?: number
-  capacity?: Partial<Capacity>
-  restartDisabled?: boolean
-  restartTitle?: string
   onControl: (action: KernelAction) => void
 }): JSX.Element {
-  const owner = () => kernelOwnershipLabel(props.kernel, props.routeID)
-  const busy = (action: KernelAction) => props.action === `${props.kernel.id}:${action}`
-  // Collapsed by default. A session can hold several runtimes, and the full
-  // plate is nine rows of ledger plus three controls — stacked, that buries
-  // the one question the list is for, which is which kernels exist and whether
-  // any of them is busy. The head answers that without opening anything.
-  const [open, setOpen] = createSignal(false)
-  const usage = () => plateUsage(props.kernel, props.capacity)
-  // Uptime is a stopwatch, not a figure carried in on the poll. The kernel
-  // object is reconciled in place and does not change while a runtime simply
-  // keeps running, so nothing re-evaluated this label and it sat at whatever
-  // it read the moment the runtime came up. The interval only exists while
-  // there is something to count.
+  const busy = () => props.action === `${props.kernel.id}:stop`
   const [now, setNow] = createSignal(Date.now())
+
   createEffect(() => {
     if (!props.kernel.active || !props.kernel.started_at) return
     const timer = setInterval(() => setNow(Date.now()), 1_000)
     onCleanup(() => clearInterval(timer))
   })
+
   const uptime = () => kernelUptimeLabel(props.kernel, now())
+
   return (
-    <article
-      class="kernel-card"
-      data-kernel-id={props.kernel.id}
-      data-kernel-owner={owner()}
-      data-owner-current={owner() === "This session"}
-      data-open={open()}
-    >
-      {/* The whole head is the toggle, not a caret-sized target: on a tablet
-          the caret alone is well under the 44px a thumb can reliably hit. */}
-      <button
-        type="button"
-        class="kernel-card__plate"
-        aria-expanded={open()}
-        aria-label={`${open() ? "Collapse" : "Expand"} ${kernelLabel(props.kernel)}`}
-        onClick={() => setOpen(!open())}
-      >
-        <div class="kernel-card__header">
-          {/* The eyebrow belongs inside the title column, not beside it: the
-              head is two groups pushed apart, and a third flex child made
-              `space-between` spread all three and centre the name. */}
-          <div class="kernel-card__title">
-            <span class="kernel-card__language" aria-hidden="true">
-              {plateEyebrow(props.kernel, props.index ?? 0)}
-            </span>
-            <strong title={kernelLabel(props.kernel)}>{kernelLabel(props.kernel)}</strong>
-          </div>
-          <span class="kernel-card__lede">
-            {/* Uptime is only a fact while something is up. On a stopped
-                record it read "Unavailable", which is three times the width of
-                the figure it replaces and says nothing the pill beside it does
-                not already say. */}
-            <Show when={uptime() !== "Unavailable"}>
-              <span class="kernel-card__uptime">{uptime()}</span>
-            </Show>
-            <span class="kernel-card__state" data-tone={kernelTone(props.kernel.state)}>
-              <span class="kernel-card__state-dot" aria-hidden="true" />
-              {kernelStateLabel(props.kernel.state)}
-            </span>
-            <span class="kernel-card__caret" aria-hidden="true">
-              {open() ? <IconChevronDown size={13} /> : <IconChevronRight size={13} />}
-            </span>
+    <article class="kernel-card" data-kernel-id={props.kernel.id} data-state={props.kernel.state}>
+      <div class="kernel-card__main">
+        <span class="kernel-card__language" aria-hidden="true">
+          {props.kernel.language === "python" ? "Py" : props.kernel.language === "r" ? "R" : "›_"}
+        </span>
+        <div class="kernel-card__copy">
+          <strong title={kernelLabel(props.kernel)}>{kernelLabel(props.kernel)}</strong>
+          <span>
+            <i data-tone={kernelTone(props.kernel.state)} aria-hidden="true" />
+            {kernelStateLabel(props.kernel.state)} · {kernelRecoveryLabel(props.kernel)}
           </span>
         </div>
+      </div>
 
-        {/* Survives the collapse, because "is this runtime in my way" is the
-            question a collapsed list still has to answer. */}
-        <div class="kernel-card__usage">
-          <div class="kernel-card__usage-item">
-            <div class="kernel-card__usage-label">
-              <span>RAM</span>
-              <span>
-                <strong>{usage().ram}</strong> {usage().ceiling}
-              </span>
-            </div>
-            <div class="kernel-card__usage-track">
-              <div class="kernel-card__usage-fill" style={{ width: `${Math.round(usage().fill * 100)}%` }} />
-            </div>
-          </div>
-          {/* A share of the whole machine reads the same as a share of one
-              core, so the unit is stated rather than left to be inferred. The
-              segments say the rest: how many cores that share occupies. */}
-          <div
-            class="kernel-card__usage-item"
-            title={`Share of this machine's ${usage().segments} cores. Each segment is one core.`}
-          >
-            <div class="kernel-card__usage-label">
-              <span>CPU</span>
-              <span>
-                <strong>{usage().cpu}</strong>
-              </span>
-            </div>
-            <div class="kernel-card__usage-cores">
-              <Index each={Array.from({ length: usage().segments })}>
-                {(_, index) => <div data-lit={index < usage().lit} />}
-              </Index>
-            </div>
-          </div>
-        </div>
+      <span class="kernel-card__uptime" aria-label={`Uptime ${uptime()}`}>
+        {uptime() === "Unavailable" ? "—" : uptime()}
+      </span>
+      <Metric label="rss" value={memory(props.kernel.resources?.memory_bytes)} />
+      <Metric label="cores" value={cores(props.kernel.resources?.cpu_percent)} />
+      <button
+        type="button"
+        class="kernel-card__stop"
+        aria-label={`Stop ${kernelLabel(props.kernel)}`}
+        title={`Stop this ${kernelLanguageLabel(props.kernel)} kernel and clear its in-memory state.`}
+        disabled={!!props.action || !kernelCanStop(props.kernel)}
+        onClick={() => props.onControl("stop")}
+      >
+        {busy() ? "Stopping…" : "Stop"}
       </button>
-
-      <Show when={open()}>
-        <Show when={owner() !== "This session"}>
-          <span class="kernel-card__owner">{owner()}</span>
-        </Show>
-
-        <div class="kernel-card__metrics">
-          <Metric label="Lifecycle" value={kernelStateLabel(props.kernel.state)} />
-          <Metric label="Executions" value={String(props.kernel.execution_count)} />
-          <Metric label="Queued" value={String(props.kernel.queue_depth)} />
-          <Metric
-            label="Runtime"
-            value={props.kernel.incarnation === null ? "Unavailable" : `r${props.kernel.incarnation}`}
-          />
-        </div>
-
-        <div
-          class="kernel-card__metrics kernel-card__metrics--usage"
-          role="group"
-          aria-label="Target and live usage, sampled on each refresh"
-          title="CPU and memory are sampled by the server on each refresh. Unavailable means the platform did not report a value."
-        >
-          <Metric label="Target" value={kernelTargetLabel(props.kernel)} />
-          <Metric label="Uptime" value={uptime()} />
-          {/* The same value the head states, not a second reading of the same
-              field: the head normalises against the host's cores, so computing
-              this row independently would print a per-core figure beside a
-              machine one — 187.5% and 23.4% for one kernel. Only the placeholder
-              differs, because a lone "—" among three "Unavailable" siblings
-              reads as a different kind of absence rather than the same one. */}
-          <Metric label="CPU" value={usage().cpu === "—" ? "Unavailable" : usage().cpu} />
-          <Metric label="Memory" value={kernelMemoryLabel(props.kernel.resources?.memory_bytes)} />
-          <Metric label="GPU" value={kernelGpuLabel(props.kernel.resources?.gpu_percent)} />
-          <Metric label="VRAM" value={kernelVramLabel(props.kernel.resources?.vram_bytes)} />
-        </div>
-
-        <section class="kernel-card__environment" aria-label={`${kernelLanguageLabel(props.kernel)} environment`}>
-          <div class="kernel-card__environment-header">
-            <strong>{kernelLanguageLabel(props.kernel)} environment</strong>
-            <span data-tone={kernelEnvironmentTone(props.kernel)}>{kernelEnvironmentLabel(props.kernel)}</span>
-          </div>
-          {/* On its own line rather than trailing the sandbox behind a middot:
-              joined, the label wrapped inside its own pill, and what a run can
-              reach is the fact on this card most worth reading on its own. */}
-          <Show when={kernelNetworkLabel(props.kernel)}>
-            {(network) => (
-              <p class="kernel-card__network" data-tone={kernelNetworkTone(props.kernel)}>
-                <span class="kernel-card__network-dot" aria-hidden="true" />
-                {network()}
-              </p>
-            )}
-          </Show>
-          <Show when={props.kernel.environment?.cwd}>
-            {(cwd) => (
-              <div class="kernel-card__environment-row">
-                <span>Working directory</span>
-                <code title={cwd()}>{cwd()}</code>
-              </div>
-            )}
-          </Show>
-          <Show when={props.kernel.environment?.atlas}>
-            <div class="kernel-card__environment-row">
-              <span>Atlas boundary</span>
-              <p>{kernelAtlasLabel(props.kernel)}</p>
-            </div>
-          </Show>
-        </section>
-
-        <p class="kernel-card__recovery">{kernelRecoveryLabel(props.kernel)}</p>
-
-        <div class="kernel-card__controls">
-          <button
-            type="button"
-            aria-label={`Interrupt ${kernelLabel(props.kernel)}`}
-            title={
-              kernelCanInterrupt(props.kernel)
-                ? "Interrupt the executing cell. The runtime will preserve state when supported."
-                : "Interrupt is available while this kernel is executing."
-            }
-            disabled={!!props.action || !kernelCanInterrupt(props.kernel)}
-            onClick={() => props.onControl("interrupt")}
-          >
-            {busy("interrupt") ? "Interrupting…" : "Interrupt"}
-          </button>
-          <button
-            type="button"
-            aria-label={`Restart ${kernelLabel(props.kernel)}`}
-            title={
-              props.restartDisabled
-                ? props.restartTitle
-                : "Replace this runtime now. All in-memory variables and queued cells will be lost."
-            }
-            disabled={!!props.action || props.restartDisabled}
-            onClick={() => props.onControl("restart")}
-          >
-            {busy("restart") ? "Restarting…" : "Restart"}
-          </button>
-          <button
-            type="button"
-            class="kernel-card__stop"
-            aria-label={`Stop ${kernelLabel(props.kernel)}`}
-            title={
-              kernelCanStop(props.kernel)
-                ? "Stop the runtime and clear its in-memory state."
-                : "This runtime is already stopped."
-            }
-            disabled={!!props.action || !kernelCanStop(props.kernel)}
-            onClick={() => props.onControl("stop")}
-          >
-            {busy("stop") ? "Stopping…" : "Stop"}
-          </button>
-          <Show when={kernelCanForget(props.kernel)}>
-            <button
-              type="button"
-              aria-label={`Forget ${kernelLabel(props.kernel)}`}
-              title="Delete this inactive runtime record. Notebook files and recorded outputs are unchanged."
-              disabled={!!props.action}
-              onClick={() => props.onControl("delete")}
-            >
-              {busy("delete") ? "Forgetting…" : "Forget record"}
-            </button>
-          </Show>
-        </div>
-        <details class="kernel-card__identity">
-          <summary>Runtime identity</summary>
-          <div>
-            <Identity label="Runtime ID" value={props.kernel.id} />
-            <Identity label="Session ID" value={props.kernel.sessionID} />
-            <Identity label="Project ID" value={props.kernel.projectID} />
-            <Identity
-              label="Process ID"
-              value={props.kernel.process_id === null ? "Unavailable" : String(props.kernel.process_id)}
-            />
-            <Identity
-              label="Process identity"
-              value={props.kernel.process_identity_verified ? "PID and process start verified" : "Unavailable"}
-            />
-            <Identity label="Process started" value={date(props.kernel.process_started_at)} />
-            <Identity label="Started" value={date(props.kernel.started_at)} />
-            <Identity label="Last activity" value={time(props.kernel.last_activity_at)} />
-          </div>
-        </details>
-      </Show>
     </article>
   )
 }
 
 function Metric(props: { label: string; value: string }): JSX.Element {
   return (
-    <div class="kernel-card__metric">
-      <span>{props.label}</span>
+    <span class="kernel-card__metric">
       <strong>{props.value}</strong>
-    </div>
-  )
-}
-
-function Identity(props: { label: string; value: string }): JSX.Element {
-  return (
-    <div class="kernel-card__identity-row">
-      <span>{props.label}</span>
-      <code title={props.value}>{props.value}</code>
-    </div>
+      <small>{props.label}</small>
+    </span>
   )
 }

--- a/frontend/workspace/src/atlas/KernelCard.tsx
+++ b/frontend/workspace/src/atlas/KernelCard.tsx
@@ -73,6 +73,43 @@ export function KernelCard(props: {
   )
 }
 
+const ago = (value: number | null) => {
+  if (!value) return "—"
+  const seconds = Math.max(0, Math.floor((Date.now() - value) / 1_000))
+  if (seconds < 60) return `${seconds}s ago`
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  return `${Math.floor(hours / 24)}d ago`
+}
+
+export function KernelResultCard(props: { kernel: KernelStatus }): JSX.Element {
+  return (
+    <article class="kernel-card kernel-history-card" data-kernel-id={props.kernel.id} data-state={props.kernel.state}>
+      <div class="kernel-card__main">
+        <span class="kernel-card__language" aria-hidden="true">
+          {props.kernel.language === "python" ? "Py" : props.kernel.language === "r" ? "R" : "›_"}
+        </span>
+        <div class="kernel-card__copy">
+          <strong title={kernelLabel(props.kernel)}>{kernelLabel(props.kernel)}</strong>
+          <span>
+            <i data-tone={props.kernel.state === "crashed" ? "danger" : "muted"} aria-hidden="true" />
+            {kernelStateLabel(props.kernel.state)} · output preserved in chat and Files
+          </span>
+        </div>
+      </div>
+      <span class="kernel-card__uptime" aria-label={`Finished ${ago(props.kernel.last_activity_at)}`}>
+        {ago(props.kernel.last_activity_at)}
+      </span>
+      <span class="kernel-history-card__result">
+        <strong>{props.kernel.state === "crashed" ? "Needs review" : "Complete"}</strong>
+        <small>workspace cleared</small>
+      </span>
+    </article>
+  )
+}
+
 function Metric(props: { label: string; value: string }): JSX.Element {
   return (
     <span class="kernel-card__metric">

--- a/frontend/workspace/src/atlas/KernelPanel.test.ts
+++ b/frontend/workspace/src/atlas/KernelPanel.test.ts
@@ -4,17 +4,20 @@ import { fileURLToPath } from "node:url"
 
 const source = () => readFileSync(fileURLToPath(new URL("./KernelPanel.tsx", import.meta.url)), "utf8")
 const card = () => readFileSync(fileURLToPath(new URL("./KernelCard.tsx", import.meta.url)), "utf8")
+const command = () => readFileSync(fileURLToPath(new URL("./CommandCard.tsx", import.meta.url)), "utf8")
 
-describe("live kernel inventory", () => {
+describe("live compute inventory", () => {
   test("is project-wide and stays mounted across session changes", () => {
     const panel = source()
 
-    expect(panel).toContain('aria-label="Live project kernels"')
+    expect(panel).toContain('aria-label="Live project compute"')
     expect(panel).toContain("[...grouped().keys()].sort")
     expect(panel).toContain("<For each={groups()}>")
     expect(panel).toContain("<em>current</em>")
     expect(panel).toContain("{ client }")
     expect(panel).not.toContain("{ sessionID: params.id, client }")
+    expect(panel).toContain('request<CommandsPayload>("/notebook/commands"')
+    expect(panel).toContain("<CommandCard")
   })
 
   test("does not expose any manual kernel creation or restart path", () => {
@@ -33,12 +36,13 @@ describe("live kernel inventory", () => {
   })
 
   test("keeps one safe control for an already-live process", () => {
-    const panel = `${source()}\n${card()}`
+    const panel = `${source()}\n${card()}\n${command()}`
 
     expect(panel).toContain("/stop`")
     expect(panel).toContain("kernelCanStop")
     expect(panel).toContain("Stop this")
     expect(panel).toContain("the next agent run will start fresh")
+    expect(panel).toContain("Its child processes were terminated")
   })
 
   test("polls unconditionally so an agent-started kernel appears", () => {
@@ -48,15 +52,15 @@ describe("live kernel inventory", () => {
     expect(panel).toContain("setInterval(refresh, 2_500)")
     expect(panel).toContain('document.addEventListener("visibilitychange", refresh)')
     expect(panel).toContain('document.removeEventListener("visibilitychange", refresh)')
-    expect(panel).toContain("inventory(request<KernelsPayload>")
+    expect(panel).toContain("Promise.all([")
   })
 
   test("explains idle and degraded states without claiming a failed poll is empty", () => {
     const panel = source()
 
-    expect(panel).toContain("No live kernels")
-    expect(panel).toContain("Kernels appear here the moment any session starts computing in this project.")
-    expect(panel).toContain('{view.error ? "Kernel inventory unavailable" : "No live kernels"}')
-    expect(panel).toContain("The last poll could not read this project's kernels")
+    expect(panel).toContain("No live compute")
+    expect(panel).toContain("Kernels and commands appear here the moment any session starts computing in this project.")
+    expect(panel).toContain('{view.error ? "Compute inventory unavailable" : "No live compute"}')
+    expect(panel).toContain("The last poll could not read this project's kernels and commands")
   })
 })

--- a/frontend/workspace/src/atlas/KernelPanel.test.ts
+++ b/frontend/workspace/src/atlas/KernelPanel.test.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url"
 const source = () => readFileSync(fileURLToPath(new URL("./KernelPanel.tsx", import.meta.url)), "utf8")
 const card = () => readFileSync(fileURLToPath(new URL("./KernelCard.tsx", import.meta.url)), "utf8")
 const command = () => readFileSync(fileURLToPath(new URL("./CommandCard.tsx", import.meta.url)), "utf8")
+const remote = () => readFileSync(fileURLToPath(new URL("./RemoteJobCard.tsx", import.meta.url)), "utf8")
 
 describe("live compute inventory", () => {
   test("is project-wide and stays mounted across session changes", () => {
@@ -18,6 +19,11 @@ describe("live compute inventory", () => {
     expect(panel).not.toContain("{ sessionID: params.id, client }")
     expect(panel).toContain('request<CommandsPayload>("/notebook/commands"')
     expect(panel).toContain("<CommandCard")
+    expect(panel).toContain("jobApi.list()")
+    expect(panel).toContain("<RemoteJobCard")
+    expect(panel).toContain("<KernelResultCard")
+    expect(panel).toContain('aria-label="Recent local results"')
+    expect(panel).toContain('aria-label="Recent remote results"')
   })
 
   test("does not expose any manual kernel creation or restart path", () => {
@@ -36,13 +42,15 @@ describe("live compute inventory", () => {
   })
 
   test("keeps one safe control for an already-live process", () => {
-    const panel = `${source()}\n${card()}\n${command()}`
+    const panel = `${source()}\n${card()}\n${command()}\n${remote()}`
 
     expect(panel).toContain("/stop`")
     expect(panel).toContain("kernelCanStop")
     expect(panel).toContain("Stop this")
     expect(panel).toContain("the next agent run will start fresh")
     expect(panel).toContain("Its child processes were terminated")
+    expect(panel).toContain("provider cleanup")
+    expect(panel).toContain("jobLive")
   })
 
   test("polls unconditionally so an agent-started kernel appears", () => {
@@ -53,14 +61,17 @@ describe("live compute inventory", () => {
     expect(panel).toContain('document.addEventListener("visibilitychange", refresh)')
     expect(panel).toContain('document.removeEventListener("visibilitychange", refresh)')
     expect(panel).toContain("Promise.all([")
+    expect(panel).toContain("jobApi.list()")
   })
 
   test("explains idle and degraded states without claiming a failed poll is empty", () => {
     const panel = source()
 
     expect(panel).toContain("No live compute")
-    expect(panel).toContain("Kernels and commands appear here the moment any session starts computing in this project.")
+    expect(panel).toContain(
+      "Kernels, commands, and remote jobs appear here the moment any session starts computing in this project.",
+    )
     expect(panel).toContain('{view.error ? "Compute inventory unavailable" : "No live compute"}')
-    expect(panel).toContain("The last poll could not read this project's kernels and commands")
+    expect(panel).toContain("The last poll could not read this project's kernels, commands, and remote jobs")
   })
 })

--- a/frontend/workspace/src/atlas/KernelPanel.test.ts
+++ b/frontend/workspace/src/atlas/KernelPanel.test.ts
@@ -4,175 +4,59 @@ import { fileURLToPath } from "node:url"
 
 const source = () => readFileSync(fileURLToPath(new URL("./KernelPanel.tsx", import.meta.url)), "utf8")
 const card = () => readFileSync(fileURLToPath(new URL("./KernelCard.tsx", import.meta.url)), "utf8")
-const styles = () => readFileSync(fileURLToPath(new URL("./ComputeSurface.css", import.meta.url)), "utf8")
 
-describe("kernel control room", () => {
-  test("makes project and session ownership plus runtime identity explicit", () => {
-    const panel = `${source()}\n${card()}`
-
-    expect(panel).toContain('aria-label="Project kernel control room"')
-    expect(panel).toContain('class="kernel-session"')
-    expect(panel).toContain("Current session")
-    expect(panel).toContain("data-kernel-owner={owner()}")
-    expect(panel).toContain('class="kernel-card__identity"')
-    expect(panel).toContain("kernel.projectID")
-    expect(panel).toContain("kernel.sessionID")
-    expect(panel).toContain("kernel.id")
-  })
-
-  test("keeps ownership guidance compact and inline", () => {
+describe("live kernel inventory", () => {
+  test("is project-wide and stays mounted across session changes", () => {
     const panel = source()
 
-    // Stated as prose rather than as a bolded callout with an icon — this is
-    // how kernels work, not a warning about them.
-    expect(panel).toContain("Only process-backed runtimes count as kernels.")
-    expect(panel).toContain("Named environments survive app restarts")
-    expect(panel).not.toContain("<strong>Session-owned kernels.</strong>")
-    expect(panel).not.toContain("Project inventory")
-  })
-
-  test("exposes the complete lifecycle controls backed by current routes", () => {
-    const panel = `${source()}\n${card()}`
-
-    expect(panel).toContain('"interrupt" | "restart" | "stop" | "delete"')
-    expect(panel).toContain("transport(path, init, query)")
-    expect(panel).toContain("remove ? { sessionID: kernel.sessionID } : undefined")
-    expect(panel).toContain("kernelCanInterrupt")
-    expect(panel).toContain("kernelCanStop")
-    expect(panel).toContain("kernelCanForget")
-    expect(panel).toContain("if (!body) return undefined as T")
-    expect(panel).toContain("aria-label={`Restart ${kernelLabel(props.kernel)}`}")
-    expect(panel).toContain("aria-label={`Stop ${kernelLabel(props.kernel)}`}")
-    expect(panel).toContain("aria-label={`Forget ${kernelLabel(props.kernel)}`}")
-    expect(panel).toContain('request<KernelStatus>("/notebook/kernels"')
-    expect(panel).toContain('aria-label="Create named kernel"')
-    expect(panel).toContain('value="python">Python')
-    expect(panel).toContain('value="r">R')
-  })
-
-  test("uses backend authority only for process-starting restart actions", () => {
-    const panel = `${source()}\n${card()}`
-
-    expect(panel).toContain('useExecutionAuthority("kernel")')
-    expect(panel).toContain('if (action === "restart")')
-    expect(panel).toContain("kernel.sessionID !== route()")
-    expect(panel).toContain("restartDisabled={kernel.sessionID !== route() || !authority.allowed()}")
-    expect(panel).toContain("disabled={!!props.action || props.restartDisabled}")
-    expect(panel).toContain("disabled={!!props.action || !kernelCanStop(props.kernel)}")
-    expect(panel).toContain("disabled={!!props.action || !kernelCanInterrupt(props.kernel)}")
-  })
-
-  test("explains state preservation and recovery after controls complete", () => {
-    const panel = `${source()}\n${card()}`
-
-    expect(panel).toContain("Runtime state was preserved.")
-    expect(panel).toContain("Previous in-memory variables and queued work were cleared.")
-    // The standing paragraph under the controls is gone with the 3a plate;
-    // the same warning rides on the button that causes the loss.
-    expect(panel).toContain("All in-memory variables and queued cells will be lost.")
-    expect(panel).not.toContain('class="kernel-card__control-note"')
-    expect(panel).toContain('class="kernel-card__recovery"')
-    expect(panel).toContain('role="status"')
-  })
-
-  test("uses the canonical runtime shape without local stale-state or nullability patches", () => {
-    const panel = source()
-    const runtime = readFileSync(fileURLToPath(new URL("../notebook/runtime.ts", import.meta.url)), "utf8")
-
-    // The inventory is project-wide, while the route only marks the current
-    // session and gates process-starting controls.
-    expect(panel).toContain("{ client }")
-    expect(panel).not.toContain("{ sessionID: params.id, client }")
-    expect(panel).not.toContain("Omit<KernelStatus")
-    expect(panel).not.toContain("legacy")
-    expect(runtime).toContain('"lazy" | "starting" | "idle" | "running" | "stopped" | "crashed"')
-    expect(runtime).toContain("incarnation: number | null")
-    expect(runtime).toContain("process_identity_verified: boolean | null")
-  })
-
-  test("keeps kernel cards mounted when project inventory polls", () => {
-    const panel = source()
-
-    // Session ids are stable primitives. Rebuilding wrapper objects here makes
-    // Solid remount every session group on each poll and collapses an expanded
-    // kernel card while the user is reading it.
+    expect(panel).toContain('aria-label="Live project kernels"')
     expect(panel).toContain("[...grouped().keys()].sort")
     expect(panel).toContain("<For each={groups()}>")
-    expect(panel).toContain("{(sessionID) => (")
-    expect(panel).not.toContain(".map(([sessionID, items]) => ({")
+    expect(panel).toContain("<em>current</em>")
+    expect(panel).toContain("{ client }")
+    expect(panel).not.toContain("{ sessionID: params.id, client }")
   })
 
-  test("nests the kernel as its own card with a printed-record metric grid", () => {
-    const css = styles()
+  test("does not expose any manual kernel creation or restart path", () => {
+    const panel = `${source()}\n${card()}`
 
-    expect(css).toMatch(/\.compute-surface \.kernel-panel__header\s*\{[^}]*min-height: 48px/s)
-    expect(css).toMatch(/\.compute-surface \.kernel-panel__scope\s*\{[^}]*background: transparent/s)
-    // The runtime is a distinct object with its own controls, so it sits in an
-    // inset card rather than flat on the panel.
-    expect(css).toMatch(/\.compute-surface \.kernel-card\s*\{[^}]*border-radius: 18px/s)
-    expect(css).toMatch(/\.compute-surface \.kernel-card\s*\{[^}]*background: var\(--color-bg-elevated\)/s)
-    // Label and value joined by a dotted leader, as a printed record sets them.
-    expect(css).toMatch(/\.compute-surface \.kernel-card__metric::after\s*\{[^}]*border-bottom: 1px dotted/s)
-    expect(css).toMatch(/\.compute-surface \.kernel-card__metrics\b[^{]*\{[^}]*grid-template-columns: 1fr 1fr/s)
-    // Only Stop carries a colour, because it is the one that discards work.
-    expect(css).toMatch(/\.compute-surface \.kernel-card__stop\s*\{[^}]*color: var\(--color-error\)/s)
-    // No hardcoded colour: the app ships 16 themes.
-    expect(css).not.toMatch(/#[0-9a-fA-F]{3,8}/)
+    expect(panel).not.toContain("New kernel")
+    expect(panel).not.toContain("Create kernel")
+    expect(panel).not.toContain("Create named kernel")
+    expect(panel).not.toContain("Saved environments")
+    expect(panel).not.toContain("useExecutionAuthority")
+    expect(panel).not.toContain('"restart"')
+    expect(panel).not.toContain('"interrupt"')
+    expect(panel).not.toContain('"delete"')
+    expect(panel).not.toContain('method: "DELETE"')
+    expect(panel).toContain('export type KernelAction = "stop"')
   })
 
-  test("materializes a new session and polls unconditionally while mounted", () => {
+  test("keeps one safe control for an already-live process", () => {
+    const panel = `${source()}\n${card()}`
+
+    expect(panel).toContain("/stop`")
+    expect(panel).toContain("kernelCanStop")
+    expect(panel).toContain("Stop this")
+    expect(panel).toContain("the next agent run will start fresh")
+  })
+
+  test("polls unconditionally so an agent-started kernel appears", () => {
     const panel = source()
 
-    expect(panel).toContain("props.onEnsureSession?.()")
-    expect(panel).toContain("const sessionID = await ensureSession()")
-    // Regression guard for the chicken-and-egg bug: a fresh session starts at
-    // {live: 0, running: 0, queued: 0}, so gating the poll on summary() meant
-    // the poll that would discover a kernel starting never began. The panel
-    // must poll unconditionally, the way HostStrip.tsx does — skipping only
-    // while the tab is hidden, and refreshing immediately on visibilitychange.
-    expect(panel).not.toContain("summary().running === 0 && summary().queued === 0")
     expect(panel).toContain("if (document.hidden) return")
     expect(panel).toContain("setInterval(refresh, 2_500)")
     expect(panel).toContain('document.addEventListener("visibilitychange", refresh)')
     expect(panel).toContain('document.removeEventListener("visibilitychange", refresh)')
-    expect(panel).not.toContain('disabled={!params.id || params.id === "new"')
+    expect(panel).toContain("inventory(request<KernelsPayload>")
   })
 
-  test("takes its transport as an injectable prop, defaulting to the session SDK", () => {
-    const panel = source()
-
-    expect(panel).toContain("request?: (path: string, init?: RequestInit, query?: Record<string, string>)")
-    expect(panel).toContain("const transport = props.request ?? useSDK().request")
-  })
-
-  test("names the empty state for live kernels across the project", () => {
+  test("explains idle and degraded states without claiming a failed poll is empty", () => {
     const panel = source()
 
     expect(panel).toContain("No live kernels")
-    expect(panel).toContain("Kernels appear here when any session in this project starts a runtime.")
-    expect(panel).not.toContain("on this machine")
-  })
-
-  test("routes every poll through the fetcher that resolves instead of rejecting", () => {
-    const panel = source()
-
-    // The behaviour itself is asserted in KernelPanel.poll.test.ts against the
-    // real `inventory`; this pins load() to it. A fetcher that rejects leaves
-    // an errored resource for `data.latest` to re-throw on the render path,
-    // and app.tsx's ErrorBoundary — the only one in the app — replaces the
-    // entire workspace with the error page.
-    expect(panel).toContain("return inventory(")
-    expect(panel).not.toContain("throw error")
-  })
-
-  test("says the list is unreadable rather than empty when a poll failed", () => {
-    const panel = source()
-
-    // An empty list after a failed poll is not "No live kernels" — the panel
-    // does not know that. Degrading visibly is the difference between a poll
-    // that failed and a project that is genuinely idle.
+    expect(panel).toContain("Kernels appear here the moment any session starts computing in this project.")
     expect(panel).toContain('{view.error ? "Kernel inventory unavailable" : "No live kernels"}')
     expect(panel).toContain("The last poll could not read this project's kernels")
-    expect(panel).toContain("Kernel inventory unavailable. ${view.error}")
   })
 })

--- a/frontend/workspace/src/atlas/KernelPanel.tsx
+++ b/frontend/workspace/src/atlas/KernelPanel.tsx
@@ -3,8 +3,10 @@ import { createStore } from "solid-js/store"
 import { useParams } from "@solidjs/router"
 import { IconCpu } from "@/atlas/shared/Icon"
 import { identify } from "@/atlas/poll-identity"
-import { KernelCard, type KernelAction } from "@/atlas/KernelCard"
+import { KernelCard, KernelResultCard, type KernelAction } from "@/atlas/KernelCard"
 import { CommandCard } from "@/atlas/CommandCard"
+import type { Job, Status } from "@/atlas/ComputeJobsAPI"
+import { RemoteJobCard, jobLive } from "@/atlas/RemoteJobCard"
 import { useKernelList } from "@/atlas/use-kernel-list"
 import { useSDK } from "@/context/sdk"
 import { useSync } from "@/context/sync"
@@ -12,7 +14,9 @@ import { kernelMemoryLabel, type CommandStatus, type KernelStatus } from "@/note
 
 type KernelsPayload = { kernels: KernelStatus[] }
 type CommandsPayload = { commands: CommandStatus[] }
-type Group = { kernels: KernelStatus[]; commands: CommandStatus[] }
+type Group = { kernels: KernelStatus[]; commands: CommandStatus[]; jobs: Job[] }
+const terminal = new Set<Status>(["succeeded", "failed", "cancelled", "interrupted"])
+const projectJobs = "__project_jobs__"
 
 type KernelPanelProps = {
   request?: (path: string, init?: RequestInit, query?: Record<string, string>) => Promise<Response>
@@ -37,13 +41,12 @@ const usage = (group: Group) => {
   const cpu = entries.reduce((total, entry) => total + (entry.resources?.cpu_percent ?? 0), 0) / 100
   const kernels = `${group.kernels.length} ${group.kernels.length === 1 ? "kernel" : "kernels"}`
   const commands = `${group.commands.length} ${group.commands.length === 1 ? "command" : "commands"}`
-  const ram = entries.some((entry) => entry.resources?.memory_bytes !== undefined)
-    ? kernelMemoryLabel(memory)
-    : "— rss"
+  const jobs = `${group.jobs.length} ${group.jobs.length === 1 ? "job" : "jobs"}`
+  const ram = entries.some((entry) => entry.resources?.memory_bytes !== undefined) ? kernelMemoryLabel(memory) : "— rss"
   const cores = entries.some((entry) => entry.resources?.cpu_percent !== undefined)
     ? `${cpu.toFixed(1)} cores`
     : "— cpu"
-  return `${kernels} · ${commands} · ${ram} · ${cores}`
+  return `${kernels} · ${commands} · ${jobs} · ${ram} · ${cores}`
 }
 
 export function KernelPanel(props: KernelPanelProps = {}): JSX.Element {
@@ -51,7 +54,7 @@ export function KernelPanel(props: KernelPanelProps = {}): JSX.Element {
   const sync = useSync()
   const params = useParams()
   const client = identify()
-  const [view, setView] = createStore({ error: "", problem: "", notice: "", action: "" })
+  const [view, setView] = createStore({ error: "", remote: "", problem: "", notice: "", action: "" })
   const request = async <T,>(path: string, init?: RequestInit, query?: Record<string, string>) => {
     const response = await transport(path, init, query)
     if (response.ok) {
@@ -62,23 +65,41 @@ export function KernelPanel(props: KernelPanelProps = {}): JSX.Element {
     const detail = await response.text().catch(() => "")
     throw new Error(detail || `${response.status} ${response.statusText}`)
   }
+  const jobApi = {
+    list: () => request<Job[]>("/settings/compute/jobs", { cache: "no-store" }),
+    log: (id: string) =>
+      request<{ log: string }>(`/settings/compute/jobs/${encodeURIComponent(id)}/log`, { cache: "no-store" }),
+    cancel: (id: string) => request<Job>(`/settings/compute/jobs/${encodeURIComponent(id)}/cancel`, { method: "POST" }),
+  }
   const load = () =>
     inventory(
       Promise.all([
         request<KernelsPayload>("/notebook/kernels", undefined, { client }),
         request<CommandsPayload>("/notebook/commands", undefined, { client }),
-      ]).then(([kernels, commands]) => ({ kernels: kernels.kernels, commands: commands.commands })),
+        jobApi.list().then(
+          (jobs) => {
+            setView("remote", "")
+            return jobs
+          },
+          (error) => {
+            setView("remote", error instanceof Error ? error.message : String(error))
+            return []
+          },
+        ),
+      ]).then(([kernels, commands, jobs]) => ({ kernels: kernels.kernels, commands: commands.commands, jobs })),
       (error) => setView("error", error),
     )
   const [data, api] = createResource(load)
   const kernels = useKernelList(() => data.latest?.kernels)
   const commands = () => data.latest?.commands ?? []
+  const jobs = () => data.latest?.jobs ?? []
   const route = () => (params.id && params.id !== "new" ? params.id : undefined)
   const live = createMemo(() => kernels.filter((kernel) => kernel.active || kernel.state === "starting"))
-  const title = (sessionID: string) => sync.session.get(sessionID)?.title?.trim() || "Untitled session"
+  const title = (sessionID: string) =>
+    sessionID === projectJobs ? "Project jobs" : sync.session.get(sessionID)?.title?.trim() || "Untitled session"
   const grouped = createMemo(() => {
     const groups = new Map<string, Group>()
-    const group = (sessionID: string) => groups.get(sessionID) ?? { kernels: [], commands: [] }
+    const group = (sessionID: string) => groups.get(sessionID) ?? { kernels: [], commands: [], jobs: [] }
     for (const kernel of live()) {
       const value = group(kernel.sessionID)
       groups.set(kernel.sessionID, { ...value, kernels: [...value.kernels, kernel] })
@@ -87,8 +108,24 @@ export function KernelPanel(props: KernelPanelProps = {}): JSX.Element {
       const value = group(command.sessionID)
       groups.set(command.sessionID, { ...value, commands: [...value.commands, command] })
     }
+    for (const job of jobs().filter(jobLive)) {
+      const sessionID = job.session_id ?? projectJobs
+      const value = group(sessionID)
+      groups.set(sessionID, { ...value, jobs: [...value.jobs, job] })
+    }
     return groups
   })
+  const recentRemote = createMemo(() =>
+    jobs()
+      .filter((job) => job.target.kind === "modal" && terminal.has(job.status) && !jobLive(job))
+      .slice(0, 5),
+  )
+  const recentLocal = createMemo(() =>
+    [...kernels]
+      .filter((kernel) => !kernel.active && kernel.state !== "lazy" && kernel.last_activity_at !== null)
+      .sort((a, b) => (b.last_activity_at ?? 0) - (a.last_activity_at ?? 0))
+      .slice(0, 5),
+  )
   const groups = createMemo(() =>
     [...grouped().keys()].sort((a, b) => {
       const current = Number(route() === b) - Number(route() === a)
@@ -101,6 +138,9 @@ export function KernelPanel(props: KernelPanelProps = {}): JSX.Element {
           ...(grouped()
             .get(sessionID)
             ?.commands.map((command) => command.started_at) ?? []),
+          ...(grouped()
+            .get(sessionID)
+            ?.jobs.map((job) => Date.parse(job.started_at ?? job.created_at)) ?? []),
         )
       return activity(b) - activity(a)
     }),
@@ -138,6 +178,19 @@ export function KernelPanel(props: KernelPanelProps = {}): JSX.Element {
       .finally(() => setView("action", ""))
   }
 
+  const cancel = (job: Job) => {
+    const key = `${job.id}:cancel`
+    setView({ action: key, problem: "", notice: "" })
+    return jobApi
+      .cancel(job.id)
+      .then(() => {
+        setView("notice", "Remote job cancelled. OpenScience requested provider cleanup and will surface any warning.")
+        return api.refetch()
+      })
+      .catch((error) => setView("problem", error instanceof Error ? error.message : String(error)))
+      .finally(() => setView("action", ""))
+  }
+
   const refresh = () => {
     if (document.hidden) return
     void api.refetch()
@@ -152,9 +205,13 @@ export function KernelPanel(props: KernelPanelProps = {}): JSX.Element {
   return (
     <section aria-label="Live project compute" data-testid="kernel-panel" class="kernel-panel">
       <div class="atlas-scroll kernel-panel__body">
-        <Show when={view.error || view.problem}>
+        <Show when={view.error || view.remote || view.problem}>
           <div role="alert" class="kernel-panel__message kernel-panel__message--error">
-            {view.problem ? `Compute control failed. ${view.problem}` : `Compute inventory unavailable. ${view.error}`}
+            {view.problem
+              ? `Compute control failed. ${view.problem}`
+              : view.error
+                ? `Compute inventory unavailable. ${view.error}`
+                : `Remote jobs unavailable. ${view.remote}`}
           </div>
         </Show>
         <Show when={view.notice}>
@@ -164,7 +221,7 @@ export function KernelPanel(props: KernelPanelProps = {}): JSX.Element {
         </Show>
 
         <Show
-          when={groups().length > 0}
+          when={groups().length > 0 || recentLocal().length > 0 || recentRemote().length > 0}
           fallback={
             <div class="kernel-panel__empty">
               <span aria-hidden="true">
@@ -173,8 +230,8 @@ export function KernelPanel(props: KernelPanelProps = {}): JSX.Element {
               <strong>{view.error ? "Compute inventory unavailable" : "No live compute"}</strong>
               <p>
                 {view.error
-                  ? "The last poll could not read this project's kernels and commands, so this is not a count of what is running."
-                  : "Kernels and commands appear here the moment any session starts computing in this project."}
+                  ? "The last poll could not read this project's kernels, commands, and remote jobs, so this is not a count of what is running."
+                  : "Kernels, commands, and remote jobs appear here the moment any session starts computing in this project."}
               </p>
             </div>
           }
@@ -191,7 +248,7 @@ export function KernelPanel(props: KernelPanelProps = {}): JSX.Element {
                         <em>current</em>
                       </Show>
                     </div>
-                    <span>{usage(grouped().get(sessionID) ?? { kernels: [], commands: [] })}</span>
+                    <span>{usage(grouped().get(sessionID) ?? { kernels: [], commands: [], jobs: [] })}</span>
                   </header>
                   <div class="kernel-panel__list">
                     <For each={grouped().get(sessionID)?.kernels ?? []}>
@@ -212,10 +269,57 @@ export function KernelPanel(props: KernelPanelProps = {}): JSX.Element {
                         />
                       )}
                     </For>
+                    <For each={grouped().get(sessionID)?.jobs ?? []}>
+                      {(job) => (
+                        <RemoteJobCard
+                          job={job}
+                          cancelling={view.action === `${job.id}:cancel`}
+                          onCancel={() => cancel(job).then(() => undefined)}
+                          onOutput={() => jobApi.log(job.id).then((value) => value.log)}
+                        />
+                      )}
+                    </For>
                   </div>
                 </section>
               )}
             </For>
+            <Show when={recentLocal().length > 0}>
+              <section class="remote-results" aria-label="Recent local results">
+                <header class="kernel-session__header">
+                  <div class="kernel-session__identity">
+                    <span aria-hidden="true">↳</span>
+                    <strong>Recent local results</strong>
+                  </div>
+                  <span>{recentLocal().length} completed</span>
+                </header>
+                <div class="kernel-panel__list">
+                  <For each={recentLocal()}>{(kernel) => <KernelResultCard kernel={kernel} />}</For>
+                </div>
+              </section>
+            </Show>
+            <Show when={recentRemote().length > 0}>
+              <section class="remote-results" aria-label="Recent remote results">
+                <header class="kernel-session__header">
+                  <div class="kernel-session__identity">
+                    <span aria-hidden="true">↳</span>
+                    <strong>Recent remote results</strong>
+                  </div>
+                  <span>{recentRemote().length} completed</span>
+                </header>
+                <div class="kernel-panel__list">
+                  <For each={recentRemote()}>
+                    {(job) => (
+                      <RemoteJobCard
+                        job={job}
+                        cancelling={false}
+                        onCancel={() => Promise.resolve()}
+                        onOutput={() => jobApi.log(job.id).then((value) => value.log)}
+                      />
+                    )}
+                  </For>
+                </div>
+              </section>
+            </Show>
           </div>
         </Show>
       </div>

--- a/frontend/workspace/src/atlas/KernelPanel.tsx
+++ b/frontend/workspace/src/atlas/KernelPanel.tsx
@@ -1,50 +1,20 @@
 import { For, Show, createMemo, createResource, onCleanup, type JSX } from "solid-js"
 import { createStore } from "solid-js/store"
 import { useParams } from "@solidjs/router"
+import { IconCpu } from "@/atlas/shared/Icon"
+import { identify } from "@/atlas/poll-identity"
+import { KernelCard, type KernelAction } from "@/atlas/KernelCard"
+import { useKernelList } from "@/atlas/use-kernel-list"
 import { useSDK } from "@/context/sdk"
 import { useSync } from "@/context/sync"
-import { IconCpu } from "@/atlas/shared/Icon"
-import { kernelLabel, kernelLanguageLabel, type KernelStatus } from "@/notebook/runtime"
-import { useExecutionAuthority } from "./use-execution-authority"
-import { useKernelList } from "./use-kernel-list"
-import { identify } from "@/atlas/poll-identity"
-import type { Capacity } from "./host-instruments"
-import { KernelCard, type KernelAction } from "./KernelCard"
+import { kernelMemoryLabel, type KernelStatus } from "@/notebook/runtime"
 
 type KernelsPayload = { kernels: KernelStatus[] }
-type ControlResponse = KernelStatus & { state_preserved?: boolean }
-
-const time = (value: number | null) => {
-  if (!value) return "Unavailable"
-  const seconds = Math.max(0, Math.round((Date.now() - value) / 1_000))
-  if (seconds < 60) return `${seconds}s ago`
-  const minutes = Math.round(seconds / 60)
-  if (minutes < 60) return `${minutes}m ago`
-  return `${Math.round(minutes / 60)}h ago`
-}
 
 type KernelPanelProps = {
-  onEnsureSession?: () => Promise<string | undefined>
-  // Measured once by the host strip above and passed down, so every plate's
-  // ceiling agrees with the headline figure the user is reading beside it.
-  capacity?: Partial<Capacity>
-  // The transport is a prop so a poll-behavior test can mount the real
-  // component against a controlled response instead of a live SDK; the
-  // session SDK supplies it in the product. See HostStrip.tsx for the same
-  // seam.
   request?: (path: string, init?: RequestInit, query?: Record<string, string>) => Promise<Response>
 }
 
-// A poll that fails resolves to no inventory instead of rejecting. An errored
-// resource re-throws wherever it is read — `data.latest` below — and the
-// nearest ErrorBoundary wraps the entire workspace (app.tsx), so a server
-// restart, a sleep/wake, or one 503 would swap the whole app for the error
-// page every 2.5s in every session. HostStrip's fetcher already degrades this
-// way; this is the same rule for the panel that sits beneath it.
-//
-// Exported rather than inlined because the panel itself cannot be mounted in a
-// test: useExecutionAuthority calls useSDK() unconditionally and useParams()
-// needs a Router, so this is the seam where the degraded path is reachable.
 export function inventory<T>(request: Promise<T>, settled: (error: string) => void) {
   return request.then(
     (value) => {
@@ -58,35 +28,25 @@ export function inventory<T>(request: Promise<T>, settled: (error: string) => vo
   )
 }
 
+const usage = (kernels: KernelStatus[]) => {
+  const memory = kernels.reduce((total, kernel) => total + (kernel.resources?.memory_bytes ?? 0), 0)
+  const cpu = kernels.reduce((total, kernel) => total + (kernel.resources?.cpu_percent ?? 0), 0) / 100
+  const count = `${kernels.length} ${kernels.length === 1 ? "kernel" : "kernels"}`
+  const ram = kernels.some((kernel) => kernel.resources?.memory_bytes !== undefined)
+    ? kernelMemoryLabel(memory)
+    : "— rss"
+  const cores = kernels.some((kernel) => kernel.resources?.cpu_percent !== undefined)
+    ? `${cpu.toFixed(1)} cores`
+    : "— cpu"
+  return `${count} · ${ram} · ${cores}`
+}
+
 export function KernelPanel(props: KernelPanelProps = {}): JSX.Element {
   const transport = props.request ?? useSDK().request
   const sync = useSync()
-  // Per-kernel CPU is measured across the window since this caller's previous
-  // poll, so a panel that does not name itself shares one window with every
-  // other panel on the route — two tabs then truncate each other's window to
-  // the stagger between them and both read Unavailable forever.
-  const client = identify()
   const params = useParams()
-  const authority = useExecutionAuthority("kernel")
-  const [view, setView] = createStore<{
-    error: string
-    problem: string
-    notice: string
-    updated: number
-    action: string
-    creating: boolean
-    name: string
-    language: "python" | "r"
-  }>({
-    error: "",
-    problem: "",
-    notice: "",
-    updated: 0,
-    action: "",
-    creating: false,
-    name: "",
-    language: "python",
-  })
+  const client = identify()
+  const [view, setView] = createStore({ error: "", problem: "", notice: "", action: "" })
   const request = async <T,>(path: string, init?: RequestInit, query?: Record<string, string>) => {
     const response = await transport(path, init, query)
     if (response.ok) {
@@ -97,39 +57,17 @@ export function KernelPanel(props: KernelPanelProps = {}): JSX.Element {
     const detail = await response.text().catch(() => "")
     throw new Error(detail || `${response.status} ${response.statusText}`)
   }
-  const load = () => {
-    return inventory(request<KernelsPayload>("/notebook/kernels", undefined, { client }), (error) =>
-      setView(error ? { error } : { error: "", updated: Date.now() }),
-    )
-  }
+  const load = () =>
+    inventory(request<KernelsPayload>("/notebook/kernels", undefined, { client }), (error) => setView("error", error))
   const [data, api] = createResource(load)
-  // The rendered list is the resource's kernels reconciled into a store keyed
-  // by id (see use-kernel-list.ts), not the resource read directly — that
-  // keeps unchanged kernel cards mounted across a poll instead of being torn
-  // down and recreated every 2.5s.
-  //
-  // Read `data.latest` rather than `data()`: `data()` re-registers with the
-  // nearest Suspense boundary on every in-flight fetch, which suspends the
-  // entire RightPane on every 2.5s poll. `.latest` only suspends on the first
-  // load and returns the previous value while a refetch is in flight (see
-  // HostStrip.tsx for the full mechanism).
   const kernels = useKernelList(() => data.latest?.kernels)
   const route = () => (params.id && params.id !== "new" ? params.id : undefined)
   const live = createMemo(() => kernels.filter((kernel) => kernel.active || kernel.state === "starting"))
-  const saved = createMemo(() =>
-    kernels.filter(
-      (kernel) =>
-        !kernel.active &&
-        kernel.state !== "starting" &&
-        kernel.name !== "agent" &&
-        !kernel.name.startsWith("notebook:"),
-    ),
-  )
   const title = (sessionID: string) => sync.session.get(sessionID)?.title?.trim() || "Untitled session"
   const grouped = createMemo(() => {
-    const grouped = new Map<string, KernelStatus[]>()
-    for (const kernel of live()) grouped.set(kernel.sessionID, [...(grouped.get(kernel.sessionID) ?? []), kernel])
-    return grouped
+    const groups = new Map<string, KernelStatus[]>()
+    for (const kernel of live()) groups.set(kernel.sessionID, [...(groups.get(kernel.sessionID) ?? []), kernel])
+    return groups
   })
   const groups = createMemo(() =>
     [...grouped().keys()].sort((a, b) => {
@@ -140,107 +78,23 @@ export function KernelPanel(props: KernelPanelProps = {}): JSX.Element {
       return activity(b) - activity(a)
     }),
   )
-  const ensureSession = async () => {
-    if (params.id && params.id !== "new") return params.id
-    return props.onEnsureSession?.()
-  }
-  const begin = async () => {
-    if (view.creating) {
-      setView("creating", false)
-      return
-    }
-    const id = await ensureSession()
-    if (!id) {
-      setView("problem", "OpenScience could not create a session for this kernel.")
-      return
-    }
-    setView({ creating: true, problem: "" })
-  }
-  const create = async () => {
-    if (!view.name.trim() || view.action) return
-    const sessionID = await ensureSession()
-    if (!sessionID) {
-      setView("problem", "OpenScience could not create a session for this kernel.")
-      return
-    }
-    setView({ action: "create", problem: "", notice: "" })
-    return request<KernelStatus>("/notebook/kernels", {
+
+  const control = (kernel: KernelStatus, action: KernelAction) => {
+    const key = `${kernel.id}:${action}`
+    setView({ action: key, problem: "", notice: "" })
+    return request<KernelStatus>(`/notebook/kernels/${encodeURIComponent(kernel.id)}/stop`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        sessionID,
-        name: view.name.trim(),
-        language: view.language,
-      }),
+      body: JSON.stringify({ sessionID: kernel.sessionID }),
     })
       .then(() => {
-        setView({
-          creating: false,
-          name: "",
-          language: "python",
-          notice: "Named kernel created. Start it when you need a separate in-memory environment.",
-        })
+        setView("notice", "Kernel stopped. In-memory state was cleared; the next agent run will start fresh.")
         return api.refetch()
       })
       .catch((error) => setView("problem", error instanceof Error ? error.message : String(error)))
       .finally(() => setView("action", ""))
   }
-  const control = (kernel: KernelStatus, action: KernelAction) => {
-    if (action === "restart") {
-      if (kernel.sessionID !== route()) {
-        setView("problem", "Open the owning session before starting or restarting this kernel.")
-        return
-      }
-      if (!authority.allowed()) {
-        setView("problem", authority.message() ?? "This session cannot start a kernel.")
-        return
-      }
-    }
-    const key = `${kernel.id}:${action}`
-    const starting = action === "restart" && !kernel.active
-    setView({ action: key, problem: "", notice: "" })
-    const remove = action === "delete"
-    return request<ControlResponse>(
-      remove
-        ? `/notebook/kernels/${encodeURIComponent(kernel.id)}`
-        : `/notebook/kernels/${encodeURIComponent(kernel.id)}/${action}`,
-      {
-        method: remove ? "DELETE" : "POST",
-        ...(remove
-          ? {}
-          : {
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ sessionID: kernel.sessionID }),
-            }),
-      },
-      remove ? { sessionID: kernel.sessionID } : undefined,
-    )
-      .then((value) => {
-        const notice =
-          action === "restart"
-            ? starting
-              ? "Kernel started in a fresh runtime."
-              : "Kernel restarted in a fresh runtime. Previous in-memory variables and queued work were cleared."
-            : action === "stop"
-              ? "Kernel stopped. In-memory state was cleared. Run a cell to start fresh."
-              : action === "delete"
-                ? "Inactive kernel record forgotten."
-                : value.state_preserved
-                  ? "Execution interrupted. Runtime state was preserved."
-                  : "Execution stopped and runtime state was cleared. Run a cell to start fresh."
-        setView("notice", notice)
-        return api.refetch()
-      })
-      .catch((error) => setView("problem", error instanceof Error ? error.message : String(error)))
-      .finally(() => setView("action", ""))
-  }
-  // Polls unconditionally while the panel is mounted — not just while a
-  // kernel is already running or queued. Gating on summary() created a
-  // chicken-and-egg: a fresh session starts at {live: 0, running: 0, queued:
-  // 0}, so the poll that would ever discover a kernel starting never began.
-  // See HostStrip.tsx for the identical shape: a hidden tab skips its polls,
-  // and returning to it refreshes immediately rather than waiting out the
-  // interval.
+
   const refresh = () => {
     if (document.hidden) return
     void api.refetch()
@@ -253,97 +107,8 @@ export function KernelPanel(props: KernelPanelProps = {}): JSX.Element {
   })
 
   return (
-    <section aria-label="Project kernel control room" data-testid="kernel-panel" class="kernel-panel">
-      <header class="kernel-panel__header">
-        <div class="kernel-panel__heading">
-          {/* No "Compute" eyebrow: the tab above already says it, and 5a's
-              restraint is mostly about not saying things twice. The live/
-              running/queued breakdown moved onto the kernel's own metric grid,
-              where it sits beside the figures it qualifies. */}
-          <strong>Project kernels</strong>
-          <span>{view.updated ? `Synced ${time(view.updated)}` : "Not synced yet"}</span>
-        </div>
-        {/* No refresh control: the panel already polls every 2.5s and on
-            visibilitychange, so the button asked the user to do what was
-            happening anyway — and disabling it per poll made it flicker
-            twice a second. The "Synced Ns ago" line beside the title is the
-            honest version of the same information. */}
-        <div class="kernel-panel__refresh">
-          <button
-            type="button"
-            class="kernel-panel__primary-action"
-            aria-label="Create named kernel"
-            title="Create an isolated named Python or R kernel"
-            onClick={() => void begin()}
-            disabled={!!view.action}
-          >
-            New kernel
-          </button>
-        </div>
-      </header>
-
+    <section aria-label="Live project kernels" data-testid="kernel-panel" class="kernel-panel">
       <div class="atlas-scroll kernel-panel__body">
-        <Show when={view.creating}>
-          <form
-            class="kernel-panel__create"
-            onSubmit={(event) => {
-              event.preventDefault()
-              void create()
-            }}
-          >
-            <label>
-              <span>Kernel name</span>
-              <input
-                aria-label="Kernel name"
-                value={view.name}
-                maxlength={120}
-                placeholder="analysis"
-                autofocus
-                onInput={(event) => setView("name", event.currentTarget.value)}
-              />
-            </label>
-            <label>
-              <span>Language</span>
-              <select
-                aria-label="Kernel language"
-                value={view.language}
-                onChange={(event) => setView("language", event.currentTarget.value as "python" | "r")}
-              >
-                <option value="python">Python</option>
-                <option value="r">R</option>
-              </select>
-            </label>
-            <div>
-              <button type="button" onClick={() => setView({ creating: false, name: "" })}>
-                Cancel
-              </button>
-              <button type="submit" disabled={!view.name.trim() || !!view.action}>
-                {view.action === "create" ? "Creating…" : "Create kernel"}
-              </button>
-            </div>
-          </form>
-        </Show>
-
-        {/* Prose, not a callout. The icon and the bolded lead-in made this read
-            as a warning about something that is simply how kernels work. */}
-        <section class="kernel-panel__scope" aria-label="Kernel ownership model">
-          <p>
-            Only process-backed runtimes count as kernels. Named environments survive app restarts; live variables do
-            not.
-          </p>
-        </section>
-
-        <Show when={authority.message()}>
-          {(message) => (
-            <div
-              role={authority.decision.error ? "alert" : "status"}
-              class="kernel-panel__message kernel-panel__message--authority"
-            >
-              {message()}
-            </div>
-          )}
-        </Show>
-
         <Show when={view.error || view.problem}>
           <div role="alert" class="kernel-panel__message kernel-panel__message--error">
             {view.problem ? `Kernel control failed. ${view.problem}` : `Kernel inventory unavailable. ${view.error}`}
@@ -362,15 +127,11 @@ export function KernelPanel(props: KernelPanelProps = {}): JSX.Element {
               <span aria-hidden="true">
                 <IconCpu size={15} strokeWidth={1.4} />
               </span>
-              {/* A failed poll leaves nothing to list, and "No live kernels"
-                  would then state as fact something this panel does not know.
-                  The alert above carries the detail; this says what the empty
-                  list means. */}
               <strong>{view.error ? "Kernel inventory unavailable" : "No live kernels"}</strong>
               <p>
                 {view.error
                   ? "The last poll could not read this project's kernels, so this is not a count of what is running."
-                  : "Kernels appear here when any session in this project starts a runtime."}
+                  : "Kernels appear here the moment any session starts computing in this project."}
               </p>
             </div>
           }
@@ -380,30 +141,21 @@ export function KernelPanel(props: KernelPanelProps = {}): JSX.Element {
               {(sessionID) => (
                 <section class="kernel-session" data-current={route() === sessionID ? "true" : undefined}>
                   <header class="kernel-session__header">
-                    <div>
+                    <div class="kernel-session__identity">
+                      <span aria-hidden="true">›_</span>
                       <strong>{title(sessionID)}</strong>
-                      <span>{route() === sessionID ? "Current session" : "Project session"}</span>
+                      <Show when={route() === sessionID}>
+                        <em>current</em>
+                      </Show>
                     </div>
-                    <span>
-                      {grouped().get(sessionID)?.length ?? 0}{" "}
-                      {grouped().get(sessionID)?.length === 1 ? "kernel" : "kernels"}
-                    </span>
+                    <span>{usage(grouped().get(sessionID) ?? [])}</span>
                   </header>
                   <div class="kernel-panel__list">
                     <For each={grouped().get(sessionID) ?? []}>
-                      {(kernel, index) => (
+                      {(kernel) => (
                         <KernelCard
                           kernel={kernel}
-                          index={index()}
-                          capacity={props.capacity}
-                          routeID={route()}
                           action={view.action}
-                          restartDisabled={kernel.sessionID !== route() || !authority.allowed()}
-                          restartTitle={
-                            kernel.sessionID !== route()
-                              ? "Open the owning session to restart this kernel."
-                              : authority.message()
-                          }
                           onControl={(action) => void control(kernel, action)}
                         />
                       )}
@@ -413,42 +165,6 @@ export function KernelPanel(props: KernelPanelProps = {}): JSX.Element {
               )}
             </For>
           </div>
-        </Show>
-
-        <Show when={saved().length > 0}>
-          <section class="kernel-panel__saved" aria-label="Saved kernel environments">
-            <header>
-              <strong>Saved environments</strong>
-              <span>{saved().length}</span>
-            </header>
-            <For each={saved()}>
-              {(kernel) => (
-                <div class="kernel-panel__saved-row">
-                  <div>
-                    <strong>{kernelLabel(kernel)}</strong>
-                    <span>
-                      {title(kernel.sessionID)} · {kernelLanguageLabel(kernel)} · not running
-                    </span>
-                  </div>
-                  <div>
-                    <button
-                      type="button"
-                      disabled={!!view.action || kernel.sessionID !== route() || !authority.allowed()}
-                      title={
-                        kernel.sessionID !== route() ? "Open the owning session to start this environment." : undefined
-                      }
-                      onClick={() => void control(kernel, "restart")}
-                    >
-                      {view.action === `${kernel.id}:restart` ? "Starting…" : "Start"}
-                    </button>
-                    <button type="button" disabled={!!view.action} onClick={() => void control(kernel, "delete")}>
-                      {view.action === `${kernel.id}:delete` ? "Forgetting…" : "Forget"}
-                    </button>
-                  </div>
-                </div>
-              )}
-            </For>
-          </section>
         </Show>
       </div>
     </section>

--- a/frontend/workspace/src/atlas/KernelPanel.tsx
+++ b/frontend/workspace/src/atlas/KernelPanel.tsx
@@ -4,12 +4,15 @@ import { useParams } from "@solidjs/router"
 import { IconCpu } from "@/atlas/shared/Icon"
 import { identify } from "@/atlas/poll-identity"
 import { KernelCard, type KernelAction } from "@/atlas/KernelCard"
+import { CommandCard } from "@/atlas/CommandCard"
 import { useKernelList } from "@/atlas/use-kernel-list"
 import { useSDK } from "@/context/sdk"
 import { useSync } from "@/context/sync"
-import { kernelMemoryLabel, type KernelStatus } from "@/notebook/runtime"
+import { kernelMemoryLabel, type CommandStatus, type KernelStatus } from "@/notebook/runtime"
 
 type KernelsPayload = { kernels: KernelStatus[] }
+type CommandsPayload = { commands: CommandStatus[] }
+type Group = { kernels: KernelStatus[]; commands: CommandStatus[] }
 
 type KernelPanelProps = {
   request?: (path: string, init?: RequestInit, query?: Record<string, string>) => Promise<Response>
@@ -28,17 +31,19 @@ export function inventory<T>(request: Promise<T>, settled: (error: string) => vo
   )
 }
 
-const usage = (kernels: KernelStatus[]) => {
-  const memory = kernels.reduce((total, kernel) => total + (kernel.resources?.memory_bytes ?? 0), 0)
-  const cpu = kernels.reduce((total, kernel) => total + (kernel.resources?.cpu_percent ?? 0), 0) / 100
-  const count = `${kernels.length} ${kernels.length === 1 ? "kernel" : "kernels"}`
-  const ram = kernels.some((kernel) => kernel.resources?.memory_bytes !== undefined)
+const usage = (group: Group) => {
+  const entries = [...group.kernels, ...group.commands]
+  const memory = entries.reduce((total, entry) => total + (entry.resources?.memory_bytes ?? 0), 0)
+  const cpu = entries.reduce((total, entry) => total + (entry.resources?.cpu_percent ?? 0), 0) / 100
+  const kernels = `${group.kernels.length} ${group.kernels.length === 1 ? "kernel" : "kernels"}`
+  const commands = `${group.commands.length} ${group.commands.length === 1 ? "command" : "commands"}`
+  const ram = entries.some((entry) => entry.resources?.memory_bytes !== undefined)
     ? kernelMemoryLabel(memory)
     : "— rss"
-  const cores = kernels.some((kernel) => kernel.resources?.cpu_percent !== undefined)
+  const cores = entries.some((entry) => entry.resources?.cpu_percent !== undefined)
     ? `${cpu.toFixed(1)} cores`
     : "— cpu"
-  return `${count} · ${ram} · ${cores}`
+  return `${kernels} · ${commands} · ${ram} · ${cores}`
 }
 
 export function KernelPanel(props: KernelPanelProps = {}): JSX.Element {
@@ -58,15 +63,30 @@ export function KernelPanel(props: KernelPanelProps = {}): JSX.Element {
     throw new Error(detail || `${response.status} ${response.statusText}`)
   }
   const load = () =>
-    inventory(request<KernelsPayload>("/notebook/kernels", undefined, { client }), (error) => setView("error", error))
+    inventory(
+      Promise.all([
+        request<KernelsPayload>("/notebook/kernels", undefined, { client }),
+        request<CommandsPayload>("/notebook/commands", undefined, { client }),
+      ]).then(([kernels, commands]) => ({ kernels: kernels.kernels, commands: commands.commands })),
+      (error) => setView("error", error),
+    )
   const [data, api] = createResource(load)
   const kernels = useKernelList(() => data.latest?.kernels)
+  const commands = () => data.latest?.commands ?? []
   const route = () => (params.id && params.id !== "new" ? params.id : undefined)
   const live = createMemo(() => kernels.filter((kernel) => kernel.active || kernel.state === "starting"))
   const title = (sessionID: string) => sync.session.get(sessionID)?.title?.trim() || "Untitled session"
   const grouped = createMemo(() => {
-    const groups = new Map<string, KernelStatus[]>()
-    for (const kernel of live()) groups.set(kernel.sessionID, [...(groups.get(kernel.sessionID) ?? []), kernel])
+    const groups = new Map<string, Group>()
+    const group = (sessionID: string) => groups.get(sessionID) ?? { kernels: [], commands: [] }
+    for (const kernel of live()) {
+      const value = group(kernel.sessionID)
+      groups.set(kernel.sessionID, { ...value, kernels: [...value.kernels, kernel] })
+    }
+    for (const command of commands()) {
+      const value = group(command.sessionID)
+      groups.set(command.sessionID, { ...value, commands: [...value.commands, command] })
+    }
     return groups
   })
   const groups = createMemo(() =>
@@ -74,7 +94,14 @@ export function KernelPanel(props: KernelPanelProps = {}): JSX.Element {
       const current = Number(route() === b) - Number(route() === a)
       if (current) return current
       const activity = (sessionID: string) =>
-        Math.max(...(grouped().get(sessionID) ?? []).map((kernel) => kernel.last_activity_at ?? kernel.started_at ?? 0))
+        Math.max(
+          ...(grouped()
+            .get(sessionID)
+            ?.kernels.map((kernel) => kernel.last_activity_at ?? kernel.started_at ?? 0) ?? []),
+          ...(grouped()
+            .get(sessionID)
+            ?.commands.map((command) => command.started_at) ?? []),
+        )
       return activity(b) - activity(a)
     }),
   )
@@ -95,6 +122,22 @@ export function KernelPanel(props: KernelPanelProps = {}): JSX.Element {
       .finally(() => setView("action", ""))
   }
 
+  const stop = (command: CommandStatus) => {
+    const key = `${command.id}:stop`
+    setView({ action: key, problem: "", notice: "" })
+    return request<{ stopped: boolean }>(`/notebook/commands/${encodeURIComponent(command.id)}/stop`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ sessionID: command.sessionID }),
+    })
+      .then(() => {
+        setView("notice", "Command stopped. Its child processes were terminated.")
+        return api.refetch()
+      })
+      .catch((error) => setView("problem", error instanceof Error ? error.message : String(error)))
+      .finally(() => setView("action", ""))
+  }
+
   const refresh = () => {
     if (document.hidden) return
     void api.refetch()
@@ -107,11 +150,11 @@ export function KernelPanel(props: KernelPanelProps = {}): JSX.Element {
   })
 
   return (
-    <section aria-label="Live project kernels" data-testid="kernel-panel" class="kernel-panel">
+    <section aria-label="Live project compute" data-testid="kernel-panel" class="kernel-panel">
       <div class="atlas-scroll kernel-panel__body">
         <Show when={view.error || view.problem}>
           <div role="alert" class="kernel-panel__message kernel-panel__message--error">
-            {view.problem ? `Kernel control failed. ${view.problem}` : `Kernel inventory unavailable. ${view.error}`}
+            {view.problem ? `Compute control failed. ${view.problem}` : `Compute inventory unavailable. ${view.error}`}
           </div>
         </Show>
         <Show when={view.notice}>
@@ -127,11 +170,11 @@ export function KernelPanel(props: KernelPanelProps = {}): JSX.Element {
               <span aria-hidden="true">
                 <IconCpu size={15} strokeWidth={1.4} />
               </span>
-              <strong>{view.error ? "Kernel inventory unavailable" : "No live kernels"}</strong>
+              <strong>{view.error ? "Compute inventory unavailable" : "No live compute"}</strong>
               <p>
                 {view.error
-                  ? "The last poll could not read this project's kernels, so this is not a count of what is running."
-                  : "Kernels appear here the moment any session starts computing in this project."}
+                  ? "The last poll could not read this project's kernels and commands, so this is not a count of what is running."
+                  : "Kernels and commands appear here the moment any session starts computing in this project."}
               </p>
             </div>
           }
@@ -148,15 +191,24 @@ export function KernelPanel(props: KernelPanelProps = {}): JSX.Element {
                         <em>current</em>
                       </Show>
                     </div>
-                    <span>{usage(grouped().get(sessionID) ?? [])}</span>
+                    <span>{usage(grouped().get(sessionID) ?? { kernels: [], commands: [] })}</span>
                   </header>
                   <div class="kernel-panel__list">
-                    <For each={grouped().get(sessionID) ?? []}>
+                    <For each={grouped().get(sessionID)?.kernels ?? []}>
                       {(kernel) => (
                         <KernelCard
                           kernel={kernel}
                           action={view.action}
                           onControl={(action) => void control(kernel, action)}
+                        />
+                      )}
+                    </For>
+                    <For each={grouped().get(sessionID)?.commands ?? []}>
+                      {(command) => (
+                        <CommandCard
+                          command={command}
+                          stopping={view.action === `${command.id}:stop`}
+                          onStop={() => void stop(command)}
                         />
                       )}
                     </For>

--- a/frontend/workspace/src/atlas/RemoteJobCard.test.tsx
+++ b/frontend/workspace/src/atlas/RemoteJobCard.test.tsx
@@ -1,0 +1,102 @@
+import { afterAll, afterEach, expect, test } from "bun:test"
+import { fileURLToPath } from "node:url"
+import type { JSX } from "solid-js"
+import { createServer } from "vite"
+import solid from "vite-plugin-solid"
+
+const server = await createServer({
+  root: fileURLToPath(new URL("../..", import.meta.url)),
+  mode: "production",
+  logLevel: "silent",
+  plugins: [solid({ ssr: false, dev: false })],
+  server: { middlewareMode: true },
+  appType: "custom",
+  resolve: { conditions: ["browser", "production"], dedupe: ["solid-js", "solid-js/web"] },
+  ssr: { noExternal: true, resolve: { conditions: ["browser", "production"] } },
+})
+const [subject, web] = await Promise.all([
+  server.ssrLoadModule("/src/atlas/RemoteJobCard.tsx") as Promise<typeof import("./RemoteJobCard")>,
+  server.ssrLoadModule("solid-js/web") as Promise<typeof import("solid-js/web")>,
+])
+const cleanups: Array<() => void> = []
+
+afterAll(() => server.close())
+afterEach(() => {
+  cleanups.splice(0).forEach((cleanup) => cleanup())
+  document.body.replaceChildren()
+})
+
+const mount = (view: () => JSX.Element) => {
+  const host = document.createElement("div")
+  document.body.append(host)
+  cleanups.push(web.render(view, host))
+  return host
+}
+
+const job = {
+  id: "job_gpu",
+  name: "Train survival model",
+  command: "python train.py",
+  target: { kind: "modal" as const },
+  target_label: "Modal",
+  scheduler: "none" as const,
+  status: "succeeded" as const,
+  created_at: "2026-08-08T10:00:00.000Z",
+  started_at: "2026-08-08T10:00:01.000Z",
+  completed_at: "2026-08-08T10:01:01.000Z",
+  exit_code: 0,
+  resources: { cpus: 4, gpus: 1, memory_gb: 16 },
+  artifacts: [{ path: "model.pkl", size: 10, sha256: "a".repeat(64), modified_at: "2026-08-08" }],
+  lifecycle: { execution: "succeeded", delivery: "delivered", resource: "closed" as const, recoverable: false },
+  modal: {
+    app: "openscience",
+    image: "python:3.12",
+    gpu: "A100",
+    network: "none" as const,
+    timeout_minutes: 10,
+    uploads: [],
+    upload_bytes: 0,
+    approval: "b".repeat(64),
+    sdk: "1",
+  },
+}
+
+test("completed Modal GPU work shows resources, delivered result, and released lifecycle", async () => {
+  const host = mount(() =>
+    subject.RemoteJobCard({
+      job,
+      cancelling: false,
+      onCancel: async () => undefined,
+      onOutput: async () => "accuracy=0.91",
+    }),
+  )
+
+  expect(host.textContent).toContain("GPU")
+  expect(host.textContent).toContain("Modal · A100 · 4 CPU · 16 GB")
+  expect(host.textContent).toContain("succeeded")
+  expect(host.textContent).toContain("exit 0 · 1 artifact · remote released")
+  expect(host.textContent).not.toContain("Cancel")
+  host.querySelector<HTMLButtonElement>(".remote-job-card__actions button")!.click()
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  expect(host.textContent).toContain("accuracy=0.91")
+})
+
+test("a live Modal job remains cancellable and counts as live", () => {
+  const running = {
+    ...job,
+    status: "running" as const,
+    completed_at: undefined,
+    lifecycle: { ...job.lifecycle, execution: "running", resource: "active" as const },
+  }
+  const host = mount(() =>
+    subject.RemoteJobCard({
+      job: running,
+      cancelling: false,
+      onCancel: async () => undefined,
+      onOutput: async () => "",
+    }),
+  )
+
+  expect(subject.jobLive(running)).toBe(true)
+  expect(host.textContent).toContain("Cancel")
+})

--- a/frontend/workspace/src/atlas/RemoteJobCard.tsx
+++ b/frontend/workspace/src/atlas/RemoteJobCard.tsx
@@ -1,0 +1,110 @@
+import { Show, createSignal, onCleanup, type JSX } from "solid-js"
+import type { Job, Status } from "@/atlas/ComputeJobsAPI"
+
+const terminal = new Set<Status>(["succeeded", "failed", "cancelled", "interrupted"])
+
+export function jobLive(job: Job) {
+  if (!terminal.has(job.status)) return true
+  const resource = job.lifecycle?.resource
+  return job.target.kind === "modal" && (resource === "starting" || resource === "active" || resource === "unknown")
+}
+
+const elapsed = (job: Job, now: number) => {
+  const start = Date.parse(job.started_at ?? job.created_at)
+  const end = job.completed_at ? Date.parse(job.completed_at) : now
+  if (!Number.isFinite(start) || !Number.isFinite(end)) return "—"
+  const seconds = Math.max(0, Math.floor((end - start) / 1_000))
+  if (seconds < 60) return `${seconds}s`
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ${seconds % 60}s`
+  return `${Math.floor(minutes / 60)}h ${minutes % 60}m`
+}
+
+const resource = (job: Job) => {
+  const gpu = job.modal?.gpu && job.modal.gpu !== "none" ? job.modal.gpu : undefined
+  const count = job.resources?.gpus && job.resources.gpus > 1 ? ` × ${job.resources.gpus}` : ""
+  const cpu = job.resources?.cpus ? `${job.resources.cpus} CPU` : undefined
+  const memory = job.resources?.memory_gb ? `${job.resources.memory_gb} GB` : undefined
+  return [gpu ? `${gpu}${count}` : undefined, cpu, memory].filter(Boolean).join(" · ") || "provider defaults"
+}
+
+const result = (job: Job) => {
+  const files = (job.artifacts?.length ?? 0) + (job.checkpoint ? 1 : 0)
+  const exit = job.exit_code === undefined || job.exit_code === null ? undefined : `exit ${job.exit_code}`
+  const closed =
+    job.target.kind === "modal"
+      ? job.lifecycle?.resource === "closed"
+        ? "remote released"
+        : job.lifecycle?.resource
+      : undefined
+  return [exit, `${files} ${files === 1 ? "artifact" : "artifacts"}`, closed].filter(Boolean).join(" · ")
+}
+
+export function RemoteJobCard(props: {
+  job: Job
+  cancelling: boolean
+  onCancel: () => Promise<void>
+  onOutput: () => Promise<string>
+}): JSX.Element {
+  const [now, setNow] = createSignal(Date.now())
+  const [output, setOutput] = createSignal<string>()
+  const [loading, setLoading] = createSignal(false)
+  const timer = setInterval(() => setNow(Date.now()), 1_000)
+  onCleanup(() => clearInterval(timer))
+
+  const read = () => {
+    if (output() !== undefined) {
+      setOutput(undefined)
+      return
+    }
+    setLoading(true)
+    void props
+      .onOutput()
+      .then((value) => setOutput(value || "No output was captured for this job."))
+      .catch((error: unknown) => setOutput(error instanceof Error ? error.message : String(error)))
+      .finally(() => setLoading(false))
+  }
+
+  return (
+    <article class="kernel-card remote-job-card" data-job-id={props.job.id} data-state={props.job.status}>
+      <div class="kernel-card__main">
+        <span class="kernel-card__language" aria-hidden="true">
+          {props.job.modal?.gpu && props.job.modal.gpu !== "none" ? "GPU" : "Job"}
+        </span>
+        <div class="kernel-card__copy">
+          <strong title={props.job.name}>{props.job.name}</strong>
+          <span title={props.job.command}>
+            <i data-tone={jobLive(props.job) ? "active" : props.job.status === "succeeded" ? "ready" : "danger"} />
+            {props.job.target_label} · {resource(props.job)}
+          </span>
+        </div>
+      </div>
+
+      <span class="kernel-card__uptime" aria-label={`Runtime ${elapsed(props.job, now())}`}>
+        {elapsed(props.job, now())}
+      </span>
+      <span class="remote-job-card__result">
+        <strong>{props.job.status}</strong>
+        <small>{result(props.job)}</small>
+      </span>
+      <div class="remote-job-card__actions">
+        <button type="button" onClick={read} aria-expanded={output() !== undefined}>
+          {loading() ? "Loading…" : output() === undefined ? "Output" : "Hide"}
+        </button>
+        <Show when={jobLive(props.job)}>
+          <button type="button" disabled={props.cancelling} onClick={() => void props.onCancel()}>
+            {props.cancelling ? "Cancelling…" : "Cancel"}
+          </button>
+        </Show>
+      </div>
+      <Show when={props.job.error || props.job.capture_error || props.job.cleanup_error}>
+        <p class="remote-job-card__warning" role="alert">
+          {props.job.error || props.job.capture_error || props.job.cleanup_error}
+        </p>
+      </Show>
+      <Show when={output() !== undefined}>
+        <pre class="remote-job-card__output">{output()}</pre>
+      </Show>
+    </article>
+  )
+}

--- a/frontend/workspace/src/atlas/RightPane.tsx
+++ b/frontend/workspace/src/atlas/RightPane.tsx
@@ -195,7 +195,6 @@ export function RightPane(
     project?: string
     session?: string
     route?: string
-    onEnsureSession?: () => Promise<string | undefined>
   } = {},
 ): JSX.Element {
   const context = uiStore.context
@@ -415,7 +414,7 @@ export function RightPane(
                 <AtlasCanvas />
               </Match>
               <Match when={context() === "kernels"}>
-                <ComputeSurface onEnsureSession={props.onEnsureSession} />
+                <ComputeSurface />
               </Match>
               <Match when={context() === "trace"}>
                 <SessionTraceSurface session={session()} />

--- a/frontend/workspace/src/atlas/host-instruments.test.ts
+++ b/frontend/workspace/src/atlas/host-instruments.test.ts
@@ -8,32 +8,30 @@ const capacity = {
 }
 
 describe("host reading", () => {
-  test("leads with memory in use, which is what the histogram beside it plots", () => {
+  test("states kernel memory against machine capacity", () => {
     const reading = hostReading(capacity)
 
-    // 16.0 total less 13.1 available. Reading the headline off `available`
-    // made it count down while the bars climbed, so the two instruments
-    // appeared to disagree about the same machine.
-    expect(reading.headline).toBe("2.9")
-    expect(reading.unit).toBe("GB used")
-    expect(reading.ceiling).toBe("of 16.0")
+    expect(reading.headline).toBe("412.0 MB")
+    expect(reading.memory).toBe("of 16.0 GB memory")
+    expect(reading.memoryFill).toBeCloseTo(412_000_000 / 16_000_000_000, 5)
   })
 
-  test("states busy cores against the count, in whole segments", () => {
+  test("states busy cores against the machine count", () => {
     const reading = hostReading(capacity)
 
-    expect(reading.cores).toBe("2 / 8")
-    expect(reading.segments).toBe(8)
-    expect(reading.lit).toBe(2)
+    expect(reading.cores).toBe("~0.4 of 8")
+    expect(reading.cpuFill).toBeCloseTo(0.4 / 8, 5)
+    expect(reading.live).toBe("2")
+    expect(reading.kernels).toBe("kernels · 1 running")
   })
 
   test("says unavailable rather than zero for a figure the platform withheld", () => {
     const reading = hostReading({ kernels: { live: 0, running: 0 } })
 
     expect(reading.headline).toBe("—")
-    expect(reading.unit).toBe("Unavailable")
-    expect(reading.ceiling).toBe("")
-    expect(reading.lit).toBe(0)
+    expect(reading.memory).toBe("memory unavailable")
+    expect(reading.memoryFill).toBe(0)
+    expect(reading.cpuFill).toBe(0)
   })
 
   test("degrades only the figure a partial body left out, and never throws", () => {
@@ -41,17 +39,16 @@ describe("host reading", () => {
     // response — must not take the whole strip down. Dereferencing it would
     // throw inside a memo, and the only ErrorBoundary wraps the workspace.
     const noCpu = hostReading({ memory: { total: 16_000_000_000, available: 13_100_000_000 } })
-    expect(noCpu.headline).toBe("2.9")
+    expect(noCpu.headline).toBe("—")
     expect(noCpu.cores).toBe("—")
 
     const halfMemory = hostReading({ memory: { total: 16_000_000_000 } as never, cpu: { cores: 4 } })
     expect(halfMemory.headline).toBe("—")
-    expect(halfMemory.unit).toBe("Unavailable")
-    expect(halfMemory.ceiling).toBe("of 16.0")
+    expect(halfMemory.memory).toBe("of 16.0 GB memory")
 
-    const noMemory = hostReading({ cpu: { cores: 4, busy: 1 } })
+    const noMemory = hostReading({ cpu: { cores: 4, busy: 1, kernels: 0.25 } })
     expect(noMemory.headline).toBe("—")
-    expect(noMemory.cores).toBe("1 / 4")
+    expect(noMemory.cores).toBe("~0.3 of 4")
   })
 
   test("treats a missing busy figure as idle rather than unavailable", () => {
@@ -59,17 +56,16 @@ describe("host reading", () => {
     // core count is still true — read 0 of 8, not blank.
     const reading = hostReading({ cpu: { cores: 8 } })
 
-    expect(reading.cores).toBe("0 / 8")
-    expect(reading.lit).toBe(0)
+    expect(reading.cores).toBe("~0 of 8")
+    expect(reading.cpuFill).toBe(0)
   })
 
   test("caps the segments so a many-core host stays legible", () => {
-    const reading = hostReading({ cpu: { cores: 128, busy: 64 } })
+    const reading = hostReading({ cpu: { cores: 128, busy: 64, kernels: 64 } })
 
     // The reading still tells the truth; only the drawing is capped.
-    expect(reading.cores).toBe("64 / 128")
-    expect(reading.segments).toBe(12)
-    expect(reading.lit).toBe(6)
+    expect(reading.cores).toBe("~64 of 128")
+    expect(reading.cpuFill).toBe(0.5)
   })
 })
 

--- a/frontend/workspace/src/atlas/host-instruments.test.ts
+++ b/frontend/workspace/src/atlas/host-instruments.test.ts
@@ -2,27 +2,28 @@ import { describe, expect, test } from "bun:test"
 import { histogram, hostReading, sample, SAMPLES } from "./host-instruments"
 
 const capacity = {
-  memory: { total: 16_000_000_000, available: 13_100_000_000, kernels: 412_000_000 },
-  cpu: { cores: 8, busy: 2.1, kernels: 0.4 },
+  memory: { total: 16_000_000_000, available: 13_100_000_000, compute: 500_000_000, kernels: 412_000_000 },
+  cpu: { cores: 8, busy: 2.1, compute: 0.7, kernels: 0.4 },
   kernels: { live: 2, running: 1 },
+  commands: { live: 1, running: 1 },
 }
 
 describe("host reading", () => {
-  test("states kernel memory against machine capacity", () => {
+  test("states live compute memory against machine capacity", () => {
     const reading = hostReading(capacity)
 
-    expect(reading.headline).toBe("412.0 MB")
+    expect(reading.headline).toBe("500.0 MB")
     expect(reading.memory).toBe("of 16.0 GB memory")
-    expect(reading.memoryFill).toBeCloseTo(412_000_000 / 16_000_000_000, 5)
+    expect(reading.memoryFill).toBeCloseTo(500_000_000 / 16_000_000_000, 5)
   })
 
   test("states busy cores against the machine count", () => {
     const reading = hostReading(capacity)
 
-    expect(reading.cores).toBe("~0.4 of 8")
-    expect(reading.cpuFill).toBeCloseTo(0.4 / 8, 5)
-    expect(reading.live).toBe("2")
-    expect(reading.kernels).toBe("kernels · 1 running")
+    expect(reading.cores).toBe("~0.7 of 8")
+    expect(reading.cpuFill).toBeCloseTo(0.7 / 8, 5)
+    expect(reading.live).toBe("3")
+    expect(reading.kernels).toBe("2 kernels · 1 command · 2 running")
   })
 
   test("says unavailable rather than zero for a figure the platform withheld", () => {

--- a/frontend/workspace/src/atlas/host-instruments.test.ts
+++ b/frontend/workspace/src/atlas/host-instruments.test.ts
@@ -6,6 +6,7 @@ const capacity = {
   cpu: { cores: 8, busy: 2.1, compute: 0.7, kernels: 0.4 },
   kernels: { live: 2, running: 1 },
   commands: { live: 1, running: 1 },
+  jobs: { live: 1, running: 1 },
 }
 
 describe("host reading", () => {
@@ -22,8 +23,8 @@ describe("host reading", () => {
 
     expect(reading.cores).toBe("~0.7 of 8")
     expect(reading.cpuFill).toBeCloseTo(0.7 / 8, 5)
-    expect(reading.live).toBe("3")
-    expect(reading.kernels).toBe("2 kernels · 1 command · 2 running")
+    expect(reading.live).toBe("4")
+    expect(reading.kernels).toBe("2 kernels · 1 command · 1 job · 3 running")
   })
 
   test("says unavailable rather than zero for a figure the platform withheld", () => {

--- a/frontend/workspace/src/atlas/host-instruments.ts
+++ b/frontend/workspace/src/atlas/host-instruments.ts
@@ -3,6 +3,7 @@ export type Capacity = {
   cpu: { cores: number; busy?: number; compute?: number; kernels?: number }
   kernels: { live: number; running: number }
   commands?: { live: number; running: number }
+  jobs?: { live: number; running: number }
 }
 
 export type Reading = {
@@ -59,11 +60,12 @@ export function hostReading(capacity?: Partial<Capacity>): Reading {
   const cores = cpu?.cores
   const kernels = capacity?.kernels?.live
   const commands = capacity?.commands?.live
-  const live = kernels === undefined ? undefined : kernels + (commands ?? 0)
+  const jobs = capacity?.jobs?.live
+  const live = kernels === undefined ? undefined : kernels + (commands ?? 0) + (jobs ?? 0)
   const running =
     capacity?.kernels?.running === undefined
       ? undefined
-      : capacity.kernels.running + (capacity.commands?.running ?? 0)
+      : capacity.kernels.running + (capacity.commands?.running ?? 0) + (capacity.jobs?.running ?? 0)
   const load = cpu?.compute ?? cpu?.kernels ?? 0
 
   return {
@@ -78,7 +80,9 @@ export function hostReading(capacity?: Partial<Capacity>): Reading {
         ? "kernel count unavailable"
         : commands === undefined
           ? `${live === 1 ? "kernel" : "kernels"} · ${running ?? 0} running`
-          : `${kernels} ${kernels === 1 ? "kernel" : "kernels"} · ${commands} ${commands === 1 ? "command" : "commands"} · ${running ?? 0} running`,
+          : jobs === undefined
+            ? `${kernels} ${kernels === 1 ? "kernel" : "kernels"} · ${commands} ${commands === 1 ? "command" : "commands"} · ${running ?? 0} running`
+            : `${kernels} ${kernels === 1 ? "kernel" : "kernels"} · ${commands} ${commands === 1 ? "command" : "commands"} · ${jobs} ${jobs === 1 ? "job" : "jobs"} · ${running ?? 0} running`,
   }
 }
 

--- a/frontend/workspace/src/atlas/host-instruments.ts
+++ b/frontend/workspace/src/atlas/host-instruments.ts
@@ -1,7 +1,8 @@
 export type Capacity = {
-  memory: { total: number; available: number; kernels?: number }
-  cpu: { cores: number; busy?: number; kernels?: number }
+  memory: { total: number; available: number; compute?: number; kernels?: number }
+  cpu: { cores: number; busy?: number; compute?: number; kernels?: number }
   kernels: { live: number; running: number }
+  commands?: { live: number; running: number }
 }
 
 export type Reading = {
@@ -54,11 +55,16 @@ export function hostReading(capacity?: Partial<Capacity>): Reading {
   const total = gb(memory?.total)
   // This pane accounts for compute, not every process on the user's machine.
   // Kernel RSS and CPU are the figures a user can affect by stopping work here.
-  const used = memory?.kernels
+  const used = memory?.compute ?? memory?.kernels
   const cores = cpu?.cores
-  const live = capacity?.kernels?.live
-  const running = capacity?.kernels?.running
-  const load = cpu?.kernels ?? 0
+  const kernels = capacity?.kernels?.live
+  const commands = capacity?.commands?.live
+  const live = kernels === undefined ? undefined : kernels + (commands ?? 0)
+  const running =
+    capacity?.kernels?.running === undefined
+      ? undefined
+      : capacity.kernels.running + (capacity.commands?.running ?? 0)
+  const load = cpu?.compute ?? cpu?.kernels ?? 0
 
   return {
     headline: bytes(used),
@@ -70,7 +76,9 @@ export function hostReading(capacity?: Partial<Capacity>): Reading {
     kernels:
       live === undefined
         ? "kernel count unavailable"
-        : `${live === 1 ? "kernel" : "kernels"} · ${running ?? 0} running`,
+        : commands === undefined
+          ? `${live === 1 ? "kernel" : "kernels"} · ${running ?? 0} running`
+          : `${kernels} ${kernels === 1 ? "kernel" : "kernels"} · ${commands} ${commands === 1 ? "command" : "commands"} · ${running ?? 0} running`,
   }
 }
 

--- a/frontend/workspace/src/atlas/host-instruments.ts
+++ b/frontend/workspace/src/atlas/host-instruments.ts
@@ -5,18 +5,13 @@ export type Capacity = {
 }
 
 export type Reading = {
-  /** The figure set at display size: memory in use, against the total below
-   *  it. Used rather than free, so the headline agrees with the histogram
-   *  beside it — the bars encode the fraction in use, and a headline counting
-   *  down while the bars climb made the two read as different measurements. */
   headline: string
-  /** Stacked beneath the headline: the unit, then the ceiling. */
-  unit: string
-  ceiling: string
-  /** Cores are countable, so they stay discrete. */
-  segments: number
-  lit: number
+  memory: string
+  memoryFill: number
   cores: string
+  cpuFill: number
+  live: string
+  kernels: string
 }
 
 const ratio = (value: number, of: number) => {
@@ -27,6 +22,14 @@ const ratio = (value: number, of: number) => {
 const gb = (value?: number) => {
   if (value === undefined || !Number.isFinite(value) || value < 0) return undefined
   return (value / 1_000_000_000).toFixed(1)
+}
+
+const bytes = (value?: number) => {
+  if (value === undefined || !Number.isFinite(value) || value < 0) return "—"
+  if (value < 1_000) return `${Math.round(value)} B`
+  if (value < 1_000_000) return `${(value / 1_000).toFixed(1)} KB`
+  if (value < 1_000_000_000) return `${(value / 1_000_000).toFixed(1)} MB`
+  return `${(value / 1_000_000_000).toFixed(1)} GB`
 }
 
 /** How many bars the histogram draws. At the 2.5s poll it spans about a
@@ -49,23 +52,25 @@ export function hostReading(capacity?: Partial<Capacity>): Reading {
   const memory = capacity?.memory
   const cpu = capacity?.cpu
   const total = gb(memory?.total)
-  // Derived rather than reported: the route carries total and available, and
-  // subtracting is the only figure consistent with the histogram's ratio.
-  const used =
-    memory?.total === undefined || memory?.available === undefined
-      ? undefined
-      : gb(Math.max(0, memory.total - memory.available))
+  // This pane accounts for compute, not every process on the user's machine.
+  // Kernel RSS and CPU are the figures a user can affect by stopping work here.
+  const used = memory?.kernels
   const cores = cpu?.cores
-  const busy = cpu?.busy
-  const segments = cores === undefined ? 8 : Math.min(12, Math.max(1, Math.round(cores)))
+  const live = capacity?.kernels?.live
+  const running = capacity?.kernels?.running
+  const load = cpu?.kernels ?? 0
 
   return {
-    headline: used ?? "—",
-    unit: used === undefined ? "Unavailable" : "GB used",
-    ceiling: total ? `of ${total}` : "",
-    segments,
-    lit: cores === undefined ? 0 : Math.round(ratio(busy ?? 0, cores) * segments),
-    cores: cores === undefined ? "—" : `${busy === undefined ? 0 : Math.round(busy)} / ${cores}`,
+    headline: bytes(used),
+    memory: total ? `of ${total} GB memory` : "memory unavailable",
+    memoryFill: memory?.total === undefined ? 0 : ratio(used ?? 0, memory.total),
+    cores: cores === undefined ? "—" : `~${Number(load.toFixed(1))} of ${cores}`,
+    cpuFill: cores === undefined ? 0 : ratio(load, cores),
+    live: live === undefined ? "—" : String(live),
+    kernels:
+      live === undefined
+        ? "kernel count unavailable"
+        : `${live === 1 ? "kernel" : "kernels"} · ${running ?? 0} running`,
   }
 }
 

--- a/frontend/workspace/src/components/dialog-settings.test.ts
+++ b/frontend/workspace/src/components/dialog-settings.test.ts
@@ -23,6 +23,12 @@ test("settings enforce one sentence-case typography system", () => {
   expect(dialog).toContain("font-family: var(--font-family-sans)")
   expect(dialog).toContain(".settings-section-label")
   expect(dialog).toContain("text-transform: none")
+  expect(dialog).toMatch(/\.settings-nav__item\s*\{[^}]*min-height: 34px/s)
+  expect(dialog).toMatch(/\.settings-nav__item\s*\{[^}]*font-size: 13px/s)
+  expect(dialog).toMatch(/\.settings-nav__item\s*\{[^}]*font-weight: 500/s)
+  expect(dialog).toContain('size="small"')
+  expect(dialog).toContain('class="settings-main__title"')
+  expect(dialog).not.toContain("text-14-medium text-text-strong truncate pl-1")
 })
 
 test("settings dialog makes every registered capability navigable", () => {

--- a/frontend/workspace/src/components/dialog-settings.tsx
+++ b/frontend/workspace/src/components/dialog-settings.tsx
@@ -131,23 +131,25 @@ const SETTINGS_STYLES = `
   gap: 3px;
 }
 .settings-nav__label {
-  padding: 0 10px 6px;
+  padding: 0 7px 6px;
   color: var(--text-weaker);
-  font-size: 12px;
-  font-weight: 450;
+  font-size: 11px;
+  font-weight: 500;
   letter-spacing: 0;
   text-transform: none;
 }
 .settings-nav__item {
   min-width: 0;
-  height: 38px;
-  display: flex;
+  min-height: 34px;
+  display: grid;
+  grid-template-columns: 24px minmax(0, 1fr);
   align-items: center;
-  gap: 8px;
-  padding: 0 10px;
-  border-radius: 9px;
-  font-size: 14px;
+  gap: 6px;
+  padding: 4px 7px;
+  border-radius: 8px;
+  font-size: 13px;
   font-weight: 500;
+  line-height: 1.25;
   color: var(--text-weak);
   text-align: left;
   transition: background 120ms ease, color 120ms ease;
@@ -188,6 +190,17 @@ const SETTINGS_STYLES = `
   padding: 0 14px;
   border-bottom: 1px solid var(--border-weak-base);
   flex-shrink: 0;
+}
+.settings-main__title {
+  min-width: 0;
+  overflow: hidden;
+  padding-left: 4px;
+  color: var(--text-strong);
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .settings-page-header {
@@ -234,8 +247,8 @@ const SETTINGS_STYLES = `
 .settings-section-heading h3 {
   margin: 0;
   color: var(--text-strong);
-  font-size: 14px;
-  font-weight: 550;
+  font-size: 13px;
+  font-weight: 500;
   line-height: 1.35;
 }
 .settings-section-heading p {
@@ -288,7 +301,7 @@ const SETTINGS_STYLES = `
 .settings-list-copy strong {
   color: var(--text-strong);
   font-size: 13px;
-  font-weight: 550;
+  font-weight: 500;
 }
 .settings-list-copy span {
   overflow: hidden;
@@ -413,7 +426,7 @@ const SETTINGS_STYLES = `
     padding: 0 9px;
     border-bottom: 1px solid transparent;
     border-radius: 0;
-    font-size: 11px;
+    font-size: 12px;
   }
   .settings-nav__item:hover {
     background: transparent;
@@ -480,7 +493,7 @@ export const DialogSettings: Component<{ initial?: SettingsPanelId }> = (props) 
                         onClick={() => navigate(panel.id)}
                         aria-current={current().id === panel.id ? "page" : undefined}
                       >
-                        <Icon name={panel.icon} size="medium" class="flex-shrink-0" />
+                        <Icon name={panel.icon} size="small" class="flex-shrink-0" />
                         <span class="truncate">{panel.title}</span>
                       </button>
                     )}
@@ -508,7 +521,7 @@ export const DialogSettings: Component<{ initial?: SettingsPanelId }> = (props) 
                 onClick={forward}
                 aria-label="Forward"
               />
-              <span class="text-14-medium text-text-strong truncate pl-1">{current().title}</span>
+              <span class="settings-main__title">{current().title}</span>
             </div>
             <div class="flex items-center gap-1 flex-shrink-0">
               <IconButton

--- a/frontend/workspace/src/notebook/runtime.ts
+++ b/frontend/workspace/src/notebook/runtime.ts
@@ -27,6 +27,20 @@ export type KernelResources = {
   vram_bytes?: number
 }
 
+export type CommandStatus = {
+  id: string
+  projectID: string
+  sessionID: string
+  messageID: string
+  callID?: string
+  description: string
+  command: string
+  state: "running"
+  process_id: number
+  started_at: number
+  resources?: Pick<KernelResources, "cpu_percent" | "memory_bytes">
+}
+
 export type ExecutionAuthority = {
   allowed: boolean
   reason: "allowed" | "project_untrusted" | "sandbox_unavailable"

--- a/frontend/workspace/src/pages/session.tsx
+++ b/frontend/workspace/src/pages/session.tsx
@@ -1030,7 +1030,7 @@ export default function Page(): JSX.Element {
           </div>
         </div>
 
-        <RightPane project={sdk.scope} session={params.id ?? "new"} onEnsureSession={ensureSession} />
+        <RightPane project={sdk.scope} session={params.id ?? "new"} />
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

- make the right-side Files and Compute workspace project-scoped across session changes
- remove manual kernel creation and run named Python/R kernels as real managed workers
- show local kernels, shell commands, and Modal/GPU jobs in one compute ledger, including recent completed results and provider cleanup state
- keep notebook source, output, figures, remote results, and saved artifacts visible outside collapsed reasoning steps
- auto-open source in a compact five-line scroll window, display figures inline, and preview/open durable artifacts beside chat
- require descriptive artifact titles, consolidated reports, decision-useful figures, and automatic kernel cleanup
- align settings typography and narrow-layout behavior with the primary project navigation
- document the observed Claude Science interaction contracts in `docs/notes/claude-science-ui-behavior-audit.md`

## Live comparison

Ran the exact prompt:

`start up multiple analysis jobs for the titanic dataset across 4 kernels`

The rebuilt app started exactly four named managed kernels concurrently, kept code and output visible, displayed four figures, recovered from an unavailable sklearn dependency, saved eight titled/versioned artifacts plus a consolidated report, and stopped all four kernels. Compute returned to zero while retaining recent local completion rows; Files contains the report, tables, and figures.

## Verification

- production build: `bun run build`
- monorepo pre-push typecheck: 7/7 packages
- backend suite: 1,866 passed, 2 skipped; the only prompt-length guard found during that pass was compressed and its focused contract suite then passed
- backend kernel/artifact focused checks: 8 passed
- UI result-rendering checks: 4 passed
- workspace compute checks: 33 passed
- live browser verification at narrow desktop width

No paid Modal job was dispatched. Modal/GPU rendering, logs, resources, cancellation, artifact delivery, and cleanup states are covered with the real compute-job API types and component tests.