### PR TITLE
feat(app): improve project terminal workflow

### DIFF
--- a/backend/cli/src/pty/environment.ts
+++ b/backend/cli/src/pty/environment.ts
@@ -1,3 +1,5 @@
+import { hostname } from "node:os"
+
 const inherited = new Set([
   "SHELL_SESSION_DIR",
   "SHELL_SESSION_FILE",
@@ -7,14 +9,27 @@ const inherited = new Set([
   "TERM_SESSION_ID",
 ])
 
-export function terminalEnv(source: NodeJS.ProcessEnv, projectID: string, sessionID: string): Record<string, string> {
+export function terminalEnv(
+  source: NodeJS.ProcessEnv,
+  projectID: string,
+  sessionID: string,
+  command: string,
+  machine = hostname(),
+): Record<string, string> {
   const env = Object.fromEntries(
     Object.entries(source).filter(
       (entry): entry is [string, string] => typeof entry[1] === "string" && !inherited.has(entry[0]),
     ),
   )
+  const host = machine.split(".")[0]?.replace(/[^a-zA-Z0-9_-]/g, "") || "localhost"
+  const prompt: Record<string, string> = command.endsWith("zsh")
+    ? { PROMPT: `%n@${host} %1~ %# ` }
+    : command.endsWith("sh")
+      ? { PS1: `\\u@${host} \\W \\$ ` }
+      : {}
   return {
     ...env,
+    ...prompt,
     TERM: "xterm-256color",
     HISTFILE: "/dev/null",
     SHELL_SESSIONS_DISABLE: "1",

--- a/backend/cli/src/pty/index.ts
+++ b/backend/cli/src/pty/index.ts
@@ -108,7 +108,7 @@ export namespace Pty {
     const args = terminalArgs(command)
     const cwd = authority.workspace
     const source = await OpenScience.subprocessEnv(process.env)
-    const env = terminalEnv(source, Instance.project.id, input.sessionID)
+    const env = terminalEnv(source, Instance.project.id, input.sessionID, command)
     const sandbox = Sandbox.wrapArgv({
       file: command,
       args,

--- a/backend/cli/test/pty-environment.test.ts
+++ b/backend/cli/test/pty-environment.test.ts
@@ -14,6 +14,8 @@ test("project terminals do not inherit the parent macOS terminal session", () =>
     },
     "project_1",
     "ses_1",
+    "/bin/zsh",
+    "workstation.local",
   )
 
   expect(env.PATH).toBe("/usr/bin:/bin")
@@ -22,11 +24,23 @@ test("project terminals do not inherit the parent macOS terminal session", () =>
   expect(env.SHELL_SESSIONS_DISABLE).toBe("1")
   expect(env.OPENSCIENCE_PROJECT_ID).toBe("project_1")
   expect(env.OPENSCIENCE_SESSION_ID).toBe("ses_1")
+  expect(env.PROMPT).toBe("%n@workstation %1~ %# ")
+  expect(env.PS1).toBeUndefined()
   expect(env.TERM_SESSION_ID).toBeUndefined()
   expect(env.TERM_PROGRAM).toBeUndefined()
   expect(env.SHELL_SESSION_DIR).toBeUndefined()
   expect(env.SHELL_SESSION_FILE).toBeUndefined()
   expect(env.SHELL_SESSION_HISTORY).toBeUndefined()
+})
+
+test("project terminals show the current workspace folder in common shell prompts", () => {
+  expect(terminalEnv({}, "project_1", "ses_1", "/bin/zsh", "Aayams-MacBook-Pro-3.local").PROMPT).toBe(
+    "%n@Aayams-MacBook-Pro-3 %1~ %# ",
+  )
+  expect(terminalEnv({}, "project_1", "ses_1", "/bin/bash", "Aayams-MacBook-Pro-3.local").PS1).toBe(
+    "\\u@Aayams-MacBook-Pro-3 \\W \\$ ",
+  )
+  expect(terminalEnv({}, "project_1", "ses_1", "nu", "workstation.local").PROMPT).toBeUndefined()
 })
 
 test("zsh keeps user startup files but skips the global history override", () => {

--- a/frontend/workspace/src/atlas/TerminalSurface.tsx
+++ b/frontend/workspace/src/atlas/TerminalSurface.tsx
@@ -1,48 +1,89 @@
-import { createEffect, createMemo, createSignal, For, Show, type JSX } from "solid-js"
-import { Terminal } from "@/components/terminal"
+import { createEffect, createMemo, For, on, Show, type JSX } from "solid-js"
+import { createStore } from "solid-js/store"
+import { preloadTerminal, Terminal, type TerminalController, type TerminalSearchResult } from "@/components/terminal"
 import { useSDK } from "@/context/sdk"
 import { useTerminal } from "@/context/terminal"
-import { IconPlus, IconTerminal, IconX } from "@/atlas/shared/Icon"
+import { IconChevronLeft, IconChevronRight, IconPlus, IconSearch, IconX } from "@/atlas/shared/Icon"
 import { terminalEndpointAvailable } from "@/atlas/terminal-endpoint"
 import { useExecutionAuthority } from "@/atlas/use-execution-authority"
 
+const EMPTY_RESULT: TerminalSearchResult = { current: 0, total: 0 }
+
 export function TerminalSurface(): JSX.Element {
+  preloadTerminal()
   const sdk = useSDK()
   const terminal = useTerminal()
   const authority = useExecutionAuthority("terminal")
-  const [starting, setStarting] = createSignal(false)
-  const [connecting, setConnecting] = createSignal(false)
-  const [error, setError] = createSignal("")
+  const [state, setState] = createStore({
+    starting: false,
+    connecting: false,
+    error: "",
+    searching: false,
+    query: "",
+    result: EMPTY_RESULT,
+  })
   const available = createMemo(() => terminalEndpointAvailable(sdk.url))
   const active = createMemo(() => terminal.all().find((item) => item.id === terminal.active()))
+  const controls = new Map<string, TerminalController>()
+  const search = { input: undefined as HTMLInputElement | undefined }
+
+  const control = () => {
+    const id = active()?.id
+    if (!id) return
+    return controls.get(id)
+  }
+
+  const openSearch = () => {
+    if (!control()) return
+    setState("searching", true)
+    queueMicrotask(() => search.input?.focus())
+  }
+
+  const closeSearch = () => {
+    setState({ searching: false, query: "", result: EMPTY_RESULT })
+    control()?.clearSelection()
+    control()?.focus()
+  }
+
+  const find = (direction: "next" | "previous" = "next") => {
+    const next = control()?.search(state.query, direction) ?? EMPTY_RESULT
+    setState("result", next)
+  }
 
   createEffect(() => {
     if (!terminal.ready() || terminal.active() || !terminal.all().length) return
     terminal.open(terminal.all()[0].id)
   })
 
+  createEffect(
+    on(
+      () => active()?.id,
+      () => setState("result", EMPTY_RESULT),
+    ),
+  )
+
   const launch = () => {
-    if (!available() || starting()) return
+    if (!available() || state.starting) return
     if (!authority.allowed()) {
-      setError(authority.message() ?? "This session cannot start a terminal.")
+      setState("error", authority.message() ?? "This session cannot start a terminal.")
       return
     }
-    setStarting(true)
-    setConnecting(true)
-    setError("")
+    setState({ starting: true, connecting: true, error: "" })
     void terminal
       .new()
-      .then(() => setError(""))
+      .then(() => setState("error", ""))
       .catch((cause: unknown) => {
-        setConnecting(false)
-        setError(cause instanceof Error ? cause.message : "OpenScience could not start the terminal.")
+        setState({
+          connecting: false,
+          error: cause instanceof Error ? cause.message : "OpenScience could not start the terminal.",
+        })
       })
-      .finally(() => setStarting(false))
+      .finally(() => setState("starting", false))
   }
 
   const autostart = { requested: false }
   createEffect(() => {
-    if (autostart.requested || !available() || !terminal.ready() || terminal.all().length || starting()) return
+    if (autostart.requested || !available() || !terminal.ready() || terminal.all().length || state.starting) return
     if (!authority.allowed()) return
     autostart.requested = true
     launch()
@@ -50,25 +91,7 @@ export function TerminalSurface(): JSX.Element {
 
   return (
     <section class="terminal-surface" aria-label="Session terminal">
-      <div class="terminal-surface__toolbar">
-        <div class="terminal-surface__identity">
-          <IconTerminal size={13} strokeWidth={1.5} />
-          <span>Session shell</span>
-        </div>
-        <button
-          type="button"
-          class="terminal-surface__new"
-          onClick={launch}
-          disabled={!available() || starting() || !authority.allowed()}
-          title={authority.message()}
-          aria-label={starting() ? "Starting terminal" : "New terminal"}
-        >
-          <IconPlus size={12} strokeWidth={1.7} />
-          <span>{starting() ? "Starting…" : "New"}</span>
-        </button>
-      </div>
-
-      <Show when={error()}>
+      <Show when={state.error}>
         {(message) => (
           <div class="terminal-surface__error" role="alert">
             {message()}
@@ -112,48 +135,108 @@ export function TerminalSurface(): JSX.Element {
                   &gt;_
                 </span>
                 <strong>Run commands in this session</strong>
-                <p>The shell opens on demand inside this session’s approved workspace.</p>
+                <p>Start a persistent shell, then open more tabs whenever you need parallel work.</p>
                 <button
                   type="button"
                   onClick={launch}
-                  disabled={starting() || !authority.allowed()}
+                  disabled={state.starting || !authority.allowed()}
                   title={authority.message()}
                   data-modal-initial-focus
                 >
-                  {starting() ? "Starting…" : "Start terminal"}
+                  {state.starting ? "Starting…" : "Start terminal"}
                 </button>
               </div>
             }
           >
-            <nav class="terminal-surface__tabs" role="tablist" aria-label="Open terminals">
-              <For each={terminal.all()}>
-                {(pty) => (
-                  <div class="terminal-surface__tab-shell" data-active={active()?.id === pty.id ? "true" : undefined}>
-                    <button
-                      type="button"
-                      class="terminal-surface__tab"
-                      role="tab"
-                      aria-selected={active()?.id === pty.id}
-                      aria-controls={`terminal-wrapper-${pty.id}`}
-                      onClick={() => terminal.open(pty.id)}
-                    >
-                      {pty.title}
-                    </button>
-                    <button
-                      type="button"
-                      class="terminal-surface__close"
-                      aria-label={`Close ${pty.title}`}
-                      onClick={() => void terminal.close(pty.id)}
-                    >
-                      <IconX size={10} strokeWidth={1.7} />
-                    </button>
-                  </div>
-                )}
-              </For>
-            </nav>
+            <div class="terminal-surface__tabs-row">
+              <nav class="terminal-surface__tabs" role="tablist" aria-label="Open terminals">
+                <For each={terminal.all()}>
+                  {(pty) => (
+                    <div class="terminal-surface__tab-shell" data-active={active()?.id === pty.id ? "true" : undefined}>
+                      <button
+                        type="button"
+                        class="terminal-surface__tab"
+                        role="tab"
+                        aria-selected={active()?.id === pty.id}
+                        aria-controls={`terminal-wrapper-${pty.id}`}
+                        onClick={() => terminal.open(pty.id)}
+                      >
+                        {pty.title}
+                      </button>
+                      <button
+                        type="button"
+                        class="terminal-surface__close"
+                        aria-label={`Close ${pty.title}`}
+                        onClick={() => void terminal.close(pty.id)}
+                      >
+                        <IconX size={10} strokeWidth={1.7} />
+                      </button>
+                    </div>
+                  )}
+                </For>
+              </nav>
+              <button
+                type="button"
+                class="terminal-surface__new"
+                onClick={launch}
+                disabled={!available() || state.starting || !authority.allowed()}
+                title={authority.message() ?? "New terminal"}
+                aria-label={state.starting ? "Starting terminal" : "New terminal"}
+              >
+                <IconPlus size={12} strokeWidth={1.7} />
+                <span>{state.starting ? "Starting…" : "New"}</span>
+              </button>
+            </div>
+
+            <Show when={state.searching}>
+              <form
+                class="terminal-surface__search"
+                role="search"
+                onSubmit={(event) => {
+                  event.preventDefault()
+                  find("next")
+                }}
+              >
+                <IconSearch size={12} strokeWidth={1.5} />
+                <input
+                  ref={(node) => (search.input = node)}
+                  type="search"
+                  value={state.query}
+                  placeholder="Find in output"
+                  aria-label="Find in terminal output"
+                  autocomplete="off"
+                  onInput={(event) => {
+                    setState("query", event.currentTarget.value)
+                    find()
+                  }}
+                  onKeyDown={(event) => {
+                    if (event.key !== "Escape") return
+                    event.preventDefault()
+                    closeSearch()
+                  }}
+                />
+                <span class="terminal-surface__search-count" aria-live="polite">
+                  {state.query ? `${state.result.current}/${state.result.total}` : ""}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => find("previous")}
+                  aria-label="Previous match"
+                  title="Previous match"
+                >
+                  <IconChevronLeft size={12} strokeWidth={1.5} />
+                </button>
+                <button type="button" onClick={() => find("next")} aria-label="Next match" title="Next match">
+                  <IconChevronRight size={12} strokeWidth={1.5} />
+                </button>
+                <button type="button" onClick={closeSearch} aria-label="Close search" title="Close search (Esc)">
+                  <IconX size={11} strokeWidth={1.6} />
+                </button>
+              </form>
+            </Show>
 
             <div class="terminal-surface__viewport">
-              <Show when={connecting()}>
+              <Show when={state.connecting}>
                 <div class="terminal-surface__connecting" role="status" aria-live="polite">
                   <span class="terminal-surface__connecting-mark" aria-hidden="true">
                     &gt;_
@@ -174,14 +257,17 @@ export function TerminalSurface(): JSX.Element {
                     <Terminal
                       pty={pty}
                       active={active()?.id === pty.id}
+                      onReady={(controller) => {
+                        if (controller) controls.set(pty.id, controller)
+                        if (!controller) controls.delete(pty.id)
+                      }}
+                      onOpenSearch={openSearch}
                       onCleanup={(next) => terminal.update(next)}
                       onConnect={() => {
-                        setConnecting(false)
-                        setError("")
+                        setState({ connecting: false, error: "" })
                       }}
                       onConnectError={(cause) => {
-                        setConnecting(false)
-                        setError(cause.message)
+                        setState({ connecting: false, error: cause.message })
                       }}
                     />
                   </div>

--- a/frontend/workspace/src/components/terminal-search.test.ts
+++ b/frontend/workspace/src/components/terminal-search.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test"
+import { terminalMatches } from "./terminal-search"
+
+describe("terminal scrollback search", () => {
+  test("finds every match with case-insensitive row and column coordinates", () => {
+    expect(terminalMatches(["Build complete", "build again", "idle"], "BUILD")).toEqual([
+      { column: 0, row: 0, length: 5 },
+      { column: 0, row: 1, length: 5 },
+    ])
+  })
+
+  test("finds repeated and overlapping matches", () => {
+    expect(terminalMatches(["aaaa"], "aa")).toEqual([
+      { column: 0, row: 0, length: 2 },
+      { column: 1, row: 0, length: 2 },
+      { column: 2, row: 0, length: 2 },
+    ])
+  })
+
+  test("returns no coordinates for an empty or missing query", () => {
+    expect(terminalMatches(["output"], "")).toEqual([])
+    expect(terminalMatches(["output"], "error")).toEqual([])
+  })
+})

--- a/frontend/workspace/src/components/terminal-search.ts
+++ b/frontend/workspace/src/components/terminal-search.ts
@@ -1,0 +1,19 @@
+export type TerminalMatch = {
+  column: number
+  row: number
+  length: number
+}
+
+export function terminalMatches(lines: string[], query: string): TerminalMatch[] {
+  const needle = query.toLocaleLowerCase()
+  if (!needle) return []
+
+  return lines
+    .map((line, row) => {
+      const value = line.toLocaleLowerCase()
+      return Array.from({ length: value.length }, (_, column) => column)
+        .filter((column) => value.indexOf(needle, column) === column)
+        .map((column) => ({ column, row, length: query.length }))
+    })
+    .flat()
+}

--- a/frontend/workspace/src/components/terminal-surface.test.ts
+++ b/frontend/workspace/src/components/terminal-surface.test.ts
@@ -26,14 +26,24 @@ describe("contextual project terminal", () => {
     expect(pane).toContain("<TerminalSurface />")
     expect(action).toContain('ariaLabel="Open project terminal"')
     expect(action).toContain('props.onContext("terminal")')
+    expect(action).toContain("onWarm={preloadTerminal}")
     expect(surface).toContain('aria-label="Session terminal"')
     expect(surface).toContain("useExecutionAuthority")
     expect(surface).toContain("!authority.allowed()")
-    expect(surface).toContain("Session shell")
+    expect(surface).toContain('class="terminal-surface__tabs-row"')
+    expect(surface).toContain('class="terminal-surface__new"')
     expect(surface).toContain('role="tablist"')
     expect(surface).toContain('role="tabpanel"')
     expect(surface).toContain("active={active()?.id === pty.id}")
     expect(surface).toContain("terminal.close(pty.id)")
+    expect(surface).not.toContain('aria-label="Copy terminal selection"')
+    expect(surface).not.toContain('aria-label="Copy all output"')
+    expect(surface).not.toContain('aria-label="Find in terminal"')
+    expect(surface).not.toContain('aria-label="Scroll to first output"')
+    expect(surface).not.toContain('aria-label="Follow latest output"')
+    expect(surface).not.toContain("terminal-surface__toolbar")
+    expect(surface).not.toContain("terminal-surface__status-dot")
+    expect(surface).not.toContain("terminal-surface__tab-dot")
   })
 
   test("offers keyboard and palette commands while keeping PTY requests project scoped", async () => {
@@ -50,14 +60,18 @@ describe("contextual project terminal", () => {
     expect(context).toContain("load(sdk.scope, params.id)")
     expect(context).toContain("sdk.client.pty")
     expect(terminal).toContain("sdk.request.url(`/pty/${local.pty.id}/connect`)")
+    expect(terminal).toContain("onOpenSearch")
+    expect(terminal).toContain("export const preloadTerminal")
+    expect(terminal).toContain("void write(t.getSelection())")
+    expect(terminal).toContain("t.selectAll()")
   })
 
   test("keeps existing terminals closable while authority only gates new process creation", async () => {
     const surface = await read("../atlas/TerminalSurface.tsx")
 
     expect(surface).toContain('useExecutionAuthority("terminal")')
-    expect(surface).toContain("disabled={!available() || starting() || !authority.allowed()}")
-    expect(surface).toContain("disabled={starting() || !authority.allowed()}")
+    expect(surface).toContain("disabled={!available() || state.starting || !authority.allowed()}")
+    expect(surface).toContain("disabled={state.starting || !authority.allowed()}")
     expect(surface).toContain("terminal.close(pty.id)")
     expect(surface).not.toContain(
       "disabled={!authority.allowed()}\n                      onClick={() => void terminal.close",

--- a/frontend/workspace/src/components/terminal.tsx
+++ b/frontend/workspace/src/components/terminal.tsx
@@ -8,6 +8,7 @@ import { connectionError } from "./terminal-error"
 import { resolveThemeVariant, useTheme, withAlpha, type HexColor } from "@synsci/ui/theme"
 import { useLanguage } from "@/context/language"
 import { showToast } from "@synsci/ui/toast"
+import { terminalMatches, type TerminalMatch } from "./terminal-search"
 
 export interface TerminalProps extends ComponentProps<"div"> {
   pty: LocalPTY
@@ -16,6 +17,19 @@ export interface TerminalProps extends ComponentProps<"div"> {
   onCleanup?: (pty: LocalPTY) => void
   onConnect?: () => void
   onConnectError?: (error: Error) => void
+  onReady?: (controller?: TerminalController) => void
+  onOpenSearch?: () => void
+}
+
+export type TerminalSearchResult = {
+  current: number
+  total: number
+}
+
+export type TerminalController = {
+  focus: () => void
+  clearSelection: () => void
+  search: (query: string, direction?: "next" | "previous") => TerminalSearchResult
 }
 
 let shared: Promise<{ mod: typeof import("ghostty-web"); ghostty: Ghostty }> | undefined
@@ -29,6 +43,10 @@ const loadGhostty = () => {
       throw err
     })
   return shared
+}
+
+export const preloadTerminal = () => {
+  void loadGhostty().catch(() => {})
 }
 
 type TerminalColors = {
@@ -59,7 +77,18 @@ export const Terminal = (props: TerminalProps) => {
   const theme = useTheme()
   const language = useLanguage()
   let container!: HTMLDivElement
-  const [local, others] = splitProps(props, ["pty", "active", "class", "classList", "onConnect", "onConnectError"])
+  const [local, others] = splitProps(props, [
+    "pty",
+    "active",
+    "class",
+    "classList",
+    "onConnect",
+    "onConnectError",
+    "onSubmit",
+    "onCleanup",
+    "onReady",
+    "onOpenSearch",
+  ])
   let term: Term | undefined
   let serializeAddon: SerializeAddon
   let fitAddon: FitAddon
@@ -176,44 +205,109 @@ export const Terminal = (props: TerminalProps) => {
       }
       term = t
 
-      const copy = () => {
-        const selection = t.getSelection()
-        if (!selection) return false
-
+      const fallback = (value: string) => {
         const body = document.body
-        if (body) {
-          const textarea = document.createElement("textarea")
-          textarea.value = selection
-          textarea.setAttribute("readonly", "")
-          textarea.style.position = "fixed"
-          textarea.style.opacity = "0"
-          body.appendChild(textarea)
-          textarea.select()
-          const copied = document.execCommand("copy")
-          body.removeChild(textarea)
-          if (copied) return true
-        }
+        if (!body) return false
+        const textarea = document.createElement("textarea")
+        textarea.value = value
+        textarea.setAttribute("readonly", "")
+        textarea.style.position = "fixed"
+        textarea.style.opacity = "0"
+        body.appendChild(textarea)
+        textarea.select()
+        const copied = document.execCommand("copy")
+        body.removeChild(textarea)
+        return copied
+      }
 
+      const write = (value: string) => {
+        if (!value) return Promise.resolve(false)
+        if (fallback(value)) return Promise.resolve(true)
         const clipboard = navigator.clipboard
         if (clipboard?.writeText) {
-          clipboard.writeText(selection).catch(() => {})
-          return true
+          return clipboard.writeText(value).then(
+            () => true,
+            () => false,
+          )
         }
-
-        return false
+        return Promise.resolve(false)
       }
+
+      const state = {
+        query: "",
+        index: -1,
+        matches: [] as TerminalMatch[],
+      }
+
+      const controller: TerminalController = {
+        focus: focusTerminal,
+        clearSelection: () => t.clearSelection(),
+        search: (query, direction = "next") => {
+          const needle = query.toLocaleLowerCase()
+          if (!needle) {
+            state.query = ""
+            state.index = -1
+            state.matches = []
+            t.clearSelection()
+            return { current: 0, total: 0 }
+          }
+
+          if (state.query !== needle) {
+            state.query = needle
+            state.index = -1
+            const lines = Array.from(
+              { length: t.buffer.active.length },
+              (_, row) => t.buffer.active.getLine(row)?.translateToString(true) ?? "",
+            )
+            state.matches = terminalMatches(lines, query)
+          }
+
+          if (!state.matches.length) {
+            t.clearSelection()
+            return { current: 0, total: 0 }
+          }
+
+          const offset = direction === "previous" ? -1 : 1
+          state.index = (state.index + offset + state.matches.length) % state.matches.length
+          const match = state.matches[state.index]
+          t.select(match.column, match.row, match.length)
+          t.scrollToLine(match.row)
+          return { current: state.index + 1, total: state.matches.length }
+        },
+      }
+
+      local.onReady?.(controller)
+      cleanups.push(() => local.onReady?.())
 
       t.attachCustomKeyEventHandler((event) => {
         const key = event.key.toLowerCase()
 
         if (event.ctrlKey && event.shiftKey && !event.metaKey && key === "c") {
-          copy()
+          void write(t.getSelection())
           return true
         }
 
         if (event.metaKey && !event.ctrlKey && !event.altKey && key === "c") {
           if (!t.hasSelection()) return true
-          copy()
+          void write(t.getSelection())
+          return true
+        }
+
+        if (event.ctrlKey && !event.shiftKey && !event.metaKey && key === "insert") {
+          void write(t.getSelection())
+          return true
+        }
+
+        if (
+          (event.metaKey && !event.ctrlKey && !event.altKey && key === "f") ||
+          (event.ctrlKey && event.shiftKey && !event.metaKey && key === "f")
+        ) {
+          local.onOpenSearch?.()
+          return true
+        }
+
+        if (event.metaKey && !event.ctrlKey && !event.altKey && key === "a") {
+          t.selectAll()
           return true
         }
 
@@ -236,6 +330,14 @@ export const Terminal = (props: TerminalProps) => {
       t.open(container)
       container.addEventListener("pointerdown", handlePointerDown)
       cleanups.push(() => container.removeEventListener("pointerdown", handlePointerDown))
+      const handlePointerUp = () => {
+        queueMicrotask(() => {
+          if (!t.hasSelection()) return
+          void write(t.getSelection())
+        })
+      }
+      container.addEventListener("pointerup", handlePointerUp, true)
+      cleanups.push(() => container.removeEventListener("pointerup", handlePointerUp, true))
 
       handleTextareaFocus = () => {
         t.options.cursorBlink = true

--- a/frontend/workspace/src/pages/session-sidebar-action.tsx
+++ b/frontend/workspace/src/pages/session-sidebar-action.tsx
@@ -1,5 +1,6 @@
 import { Show, type JSX } from "solid-js"
 import { IconActivity, IconCpu, IconFile, IconFolderTree, IconLayoutGrid, IconTerminal } from "@/atlas/shared/Icon"
+import { preloadTerminal } from "@/components/terminal"
 
 export type SessionContext = "files" | "terminal" | "canvas" | "kernels" | "trace" | "artifact"
 
@@ -25,6 +26,8 @@ export function CompactContextActions(props: {
         type="button"
         role="menuitem"
         aria-pressed={props.context === "terminal" && props.contextOpen}
+        onPointerEnter={preloadTerminal}
+        onFocus={preloadTerminal}
         onClick={() => props.onContext("terminal")}
       >
         <IconTerminal size={13} strokeWidth={1.5} />
@@ -73,6 +76,7 @@ export function SidebarAction(props: {
   shortcut?: string
   active?: boolean
   disabled?: boolean
+  onWarm?: () => void
   onClick: () => void
   children: JSX.Element
 }): JSX.Element {
@@ -84,6 +88,8 @@ export function SidebarAction(props: {
       aria-pressed={props.active === undefined ? undefined : props.active}
       data-selected={props.active ? "true" : undefined}
       disabled={props.disabled}
+      onPointerEnter={() => props.onWarm?.()}
+      onFocus={() => props.onWarm?.()}
       onClick={() => props.onClick()}
     >
       <span class="session-sidebar__action-icon" aria-hidden="true">
@@ -126,6 +132,7 @@ export function SessionSidebarActions(props: {
           ariaLabel="Open project terminal"
           shortcut="⌃`"
           active={props.context === "terminal" && props.contextOpen}
+          onWarm={preloadTerminal}
           onClick={(_event?: Event) => props.onContext("terminal")}
         >
           <IconTerminal size={15} strokeWidth={1.5} />

--- a/frontend/workspace/src/styles/atlas.css
+++ b/frontend/workspace/src/styles/atlas.css
@@ -6052,32 +6052,95 @@ button.research-launchpad__status-item:hover {
   background: color-mix(in srgb, var(--color-bg) 94%, var(--color-bg-subtle));
 }
 
-.terminal-surface__toolbar {
+.terminal-surface__search button {
+  appearance: none;
+  height: 25px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  padding: 0 7px;
+  border: 0;
+  border-radius: 6px;
+  font-family: var(--font-family-sans);
+  font-size: 10px;
+  color: var(--color-text-faint);
+  background: transparent;
+  cursor: pointer;
+  transition:
+    color 120ms ease,
+    background 120ms ease;
+}
+
+.terminal-surface__search button:hover:not(:disabled) {
+  color: var(--color-text);
+  background: var(--color-bg-subtle);
+}
+
+.terminal-surface__search button:disabled {
+  opacity: 0.32;
+  cursor: default;
+}
+
+.terminal-surface__search {
   min-height: 34px;
   flex: 0 0 auto;
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 4px 8px 4px 10px;
-  border-bottom: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
-}
-
-.terminal-surface__identity {
-  min-width: 0;
-  flex: 1;
-  display: flex;
-  align-items: center;
-  gap: 7px;
+  gap: 5px;
+  padding: 4px 6px 4px 10px;
   color: var(--color-text-faint);
+  background: color-mix(in srgb, var(--color-bg-subtle) 48%, var(--color-bg));
+  border-bottom: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
+  animation: atlas-terminal-search-in 120ms ease-out;
 }
 
-.terminal-surface__identity span {
-  overflow: hidden;
+.terminal-surface__search input {
+  min-width: 40px;
+  flex: 1;
+  height: 25px;
+  padding: 0 7px;
+  border: 1px solid color-mix(in srgb, var(--color-border) 76%, transparent);
+  border-radius: 6px;
+  outline: 0;
   font-family: var(--font-family-mono);
   font-size: 10px;
-  letter-spacing: 0.01em;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  color: var(--color-text);
+  background: color-mix(in srgb, var(--color-bg) 90%, transparent);
+}
+
+.terminal-surface__search input:focus {
+  border-color: color-mix(in srgb, var(--color-accent) 48%, var(--color-border));
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-accent) 9%, transparent);
+}
+
+.terminal-surface__search input::-webkit-search-cancel-button {
+  display: none;
+}
+
+.terminal-surface__search-count {
+  min-width: 34px;
+  font-family: var(--font-family-mono);
+  font-size: 9px;
+  color: var(--color-text-faint);
+  text-align: right;
+}
+
+.terminal-surface__search button {
+  width: 24px;
+  padding: 0;
+}
+
+@keyframes atlas-terminal-search-in {
+  from {
+    opacity: 0;
+    transform: translateY(-2px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .terminal-surface__new,
@@ -6192,16 +6255,30 @@ button.research-launchpad__status-item:hover {
   font-size: 11px;
 }
 
-.terminal-surface__tabs {
+.terminal-surface__tabs-row {
   min-height: 32px;
   flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
+}
+
+.terminal-surface__tabs {
+  min-width: 0;
+  min-height: 32px;
+  flex: 1 1 auto;
   display: flex;
   align-items: center;
   gap: 3px;
   padding: 4px 6px;
   overflow-x: auto;
-  border-bottom: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
   scrollbar-width: none;
+}
+
+.terminal-surface__tabs-row > .terminal-surface__new {
+  height: 24px;
+  flex: 0 0 auto;
+  margin: 4px 6px 4px 0;
 }
 
 .terminal-surface__tabs::-webkit-scrollbar {


### PR DESCRIPTION
## Summary
- use the familiar `user@machine folder %` prompt while starting each shell in the approved project workspace
- keep terminal chrome minimal: tabs on the left and `New` at the far right
- retain native selection copy and keyboard search without permanent action buttons
- prewarm Ghostty on intent and load it in parallel with PTY creation

## Validation
- `bun run typecheck`
- `bun test` from `backend/cli`
- focused terminal and sidebar tests
- workspace production build
- live UI verification at `http://localhost:4444`