### PR TITLE
fix: normalize release workflow identity

### DIFF
--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -36,7 +36,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [[ "$GITHUB_REPOSITORY" != "synthetic-sciences/OpenScience" || "$GITHUB_REF" != "refs/heads/main" ]]; then
+          if [[ "${GITHUB_REPOSITORY,,}" != "synthetic-sciences/openscience" || "$GITHUB_REF" != "refs/heads/main" ]]; then
             echo "::error::npm test publishing uses registry credentials and must be dispatched from synthetic-sciences/OpenScience main; received $GITHUB_REPOSITORY at $GITHUB_REF."
             exit 1
           fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [[ "$GITHUB_REPOSITORY" != "synthetic-sciences/OpenScience" || "$GITHUB_REF" != "refs/heads/main" ]]; then
+          if [[ "${GITHUB_REPOSITORY,,}" != "synthetic-sciences/openscience" || "$GITHUB_REF" != "refs/heads/main" ]]; then
             echo "::error::Production releases must be dispatched from synthetic-sciences/OpenScience main; received $GITHUB_REPOSITORY at $GITHUB_REF."
             exit 1
           fi

--- a/backend/cli/test/installation/release-order.test.ts
+++ b/backend/cli/test/installation/release-order.test.ts
@@ -10,3 +10,16 @@ test("production publish pushes the release commit before targeting it on GitHub
   expect(release).toBeGreaterThan(tag)
   expect(script.slice(tag, release)).not.toContain(".nothrow()")
 })
+
+test("publish source gates normalize GitHub's case-insensitive repository slug", async () => {
+  const workflows = ["npm-test.yml", "publish.yml"]
+
+  for (const workflow of workflows) {
+    const source = await Bun.file(path.join(import.meta.dir, `../../../../.github/workflows/${workflow}`)).text()
+
+    expect(source).toContain(
+      '[[ "${GITHUB_REPOSITORY,,}" != "synthetic-sciences/openscience" || "$GITHUB_REF" != "refs/heads/main" ]]',
+    )
+    expect(source).not.toContain('[[ "$GITHUB_REPOSITORY" != "synthetic-sciences/OpenScience"')
+  }
+})


### PR DESCRIPTION
## Summary
- normalize GitHub repository identity before main-only release checks
- keep exact refs/heads/main enforcement for test and production publishing
- add a static contract test covering both workflow guards

## Root cause
GitHub supplied GITHUB_REPOSITORY=synthetic-sciences/openscience, while the new bash guards compared case-sensitively to synthetic-sciences/OpenScience. Test-publish run 31784085589 therefore failed in test-source before any build or publish.

## Validation
- bun test test/installation/release-order.test.ts
- bun run typecheck
- actionlint .github/workflows/npm-test.yml .github/workflows/publish.yml
- Prettier check
- git diff --check