### PR TITLE
test(workspace): align access mode e2e

### DIFF
--- a/frontend/workspace/e2e/session.spec.ts
+++ b/frontend/workspace/e2e/session.spec.ts
@@ -65,7 +65,7 @@ test("research effort persists without changing the model", async ({ page, openS
   const ultra = page.getByRole("radio", { name: "Ultra", exact: true })
   await ultra.click()
   await expect(ultra).toHaveAttribute("aria-checked", "true")
-  await expect(research).toHaveAttribute("aria-label", "Research tools, Ultra effort")
+  await expect(research).toHaveAttribute("aria-label", "Research tools, Ultra effort, Full access")
 
   await research.click()
   await research.click()

--- a/frontend/workspace/e2e/workspace-consistency.spec.ts
+++ b/frontend/workspace/e2e/workspace-consistency.spec.ts
@@ -21,7 +21,7 @@ test("keeps Files and Customize labels visually consistent", async ({ page, goto
     ["Compute", "Add host"],
     ["Network", "Add domain"],
     ["Permissions"],
-    ["Sandbox", "Run self-test"],
+    ["Sandbox"],
     ["Credentials"],
     ["Storage"],
     ["General", "System"],


### PR DESCRIPTION
Updates the packaged E2E contract for the new Research tools access-mode label and removes an unrelated dynamic sandbox control from the typography smoke.\n\nVerification: 7/7 affected Playwright tests, workspace typecheck, Prettier, and diff check.