### PR TITLE
fix strict provider tool schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ tagged release also ships native binaries for Linux, macOS, and Windows.
 
 ### Fixed
 
+- Made every built-in research tool advertise an object-rooted JSON Schema so
+  strict OpenAI-compatible providers such as DeepSeek and Kimi accept tool-enabled requests.
 - Made the research harness normalize WebFetch download destinations, authorize
   Explore retrieval consistently, apply multi-file patches transactionally,
   resolve the default Python environment, enforce image limits by the active

--- a/backend/cli/src/tool/compute-job.ts
+++ b/backend/cli/src/tool/compute-job.ts
@@ -75,7 +75,7 @@ const ComputeWorkload = z
   })
   .strict()
 
-export const ComputeJobParameters = z
+const ComputeJobActionParameters = z
   .discriminatedUnion("action", [
     z
       .object({ action: action("targets") })
@@ -120,6 +120,44 @@ export const ComputeJobParameters = z
       .strict()
       .describe(ACTION_EXAMPLES.release),
   ])
+  .describe(`Select one action with the required action discriminator.\n${ACTION_HELP}`)
+
+/**
+ * Model-facing tool schemas must have an object at the JSON Schema root.
+ * Strict OpenAI-compatible providers reject a top-level anyOf before the model
+ * can make a tool call. Keep the conditional action contract as the runtime
+ * validator while advertising one ordinary object with every possible field.
+ */
+export const ComputeJobParameters = z
+  .object({
+    action: z.enum(COMPUTE_ACTIONS).describe(`Select one action.\n${ACTION_HELP}`),
+    name: ComputeWorkload.shape.name.optional(),
+    purpose: ComputeWorkload.shape.purpose.optional(),
+    command: ComputeWorkload.shape.command.optional(),
+    cwd: ComputeWorkload.shape.cwd,
+    target: ComputeWorkload.shape.target.optional(),
+    resources: ComputeWorkload.shape.resources,
+    modules: ComputeWorkload.shape.modules,
+    container: ComputeWorkload.shape.container,
+    artifacts: ComputeWorkload.shape.artifacts,
+    checkpoint: ComputeWorkload.shape.checkpoint,
+    uploads: ComputeWorkload.shape.uploads,
+    packages: ComputeWorkload.shape.packages,
+    image: ComputeWorkload.shape.image,
+    gpu: ComputeWorkload.shape.gpu,
+    status: JobBroker.Status.optional(),
+    limit: z.number().int().min(1).max(100).optional(),
+    job_id: z.string().trim().min(1).optional(),
+    bytes: z.number().int().min(1).max(256_000).optional(),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    const parsed = ComputeJobActionParameters.safeParse(value)
+    if (parsed.success) return
+    for (const issue of parsed.error.issues) {
+      ctx.addIssue({ code: "custom", path: issue.path, message: issue.message })
+    }
+  })
   .describe(`Select one action with the required action discriminator.\n${ACTION_HELP}`)
 
 function record(value: unknown): value is Record<string, unknown> {
@@ -178,7 +216,7 @@ function formatValidationError(error: z.ZodError, input: unknown) {
   ].join("\n\n")
 }
 
-type Input = z.infer<typeof ComputeJobParameters>
+type Input = z.infer<typeof ComputeJobActionParameters>
 type Metadata = {
   compute_job: {
     action: Input["action"]
@@ -290,7 +328,8 @@ export function createComputeJobTool(base?: JobBroker.Options) {
     parameters: ComputeJobParameters,
     normalizeInput,
     formatValidationError,
-    async execute(input: Input, ctx) {
+    async execute(value, ctx) {
+      const input: Input = ComputeJobActionParameters.parse(value)
       if (input.action === "targets") {
         const resolved = await options(ctx.sessionID, base)
         const output = {

--- a/backend/cli/src/tool/truncation.ts
+++ b/backend/cli/src/tool/truncation.ts
@@ -34,12 +34,14 @@ export namespace Truncate {
   }
 
   export async function cleanup() {
-    const cutoff = Identifier.timestamp(Identifier.create("tool", false, Date.now() - RETENTION_MS))
+    const cutoff = Date.now() - RETENTION_MS
     const glob = new Bun.Glob("tool_*")
     const entries = await Array.fromAsync(glob.scan({ cwd: DIR, onlyFiles: true })).catch(() => [] as string[])
     for (const entry of entries) {
-      if (Identifier.timestamp(entry) >= cutoff) continue
-      await fs.unlink(path.join(DIR, entry)).catch(() => {})
+      const file = path.join(DIR, entry)
+      const stat = await fs.stat(file).catch(() => undefined)
+      if (!stat || stat.mtimeMs >= cutoff) continue
+      await fs.unlink(file).catch(() => {})
     }
   }
 

--- a/backend/cli/test/global/data-root.test.ts
+++ b/backend/cli/test/global/data-root.test.ts
@@ -457,7 +457,7 @@ describe("managed data root", () => {
         "Cannot scope work under a non-active data-root operation",
       )
       startChild.resolve()
-      expect(await Promise.race([childDone.promise.then(() => true), Bun.sleep(250).then(() => false)])).toBe(true)
+      expect(await Promise.race([childDone.promise.then(() => true), Bun.sleep(1_000).then(() => false)])).toBe(true)
       expect(await Promise.race([switching.then(() => true), Bun.sleep(50).then(() => false)])).toBe(false)
 
       releaseScope.resolve()

--- a/backend/cli/test/tool/compute-job.test.ts
+++ b/backend/cli/test/tool/compute-job.test.ts
@@ -24,15 +24,15 @@ const context = (sessionID: string, asked: Asked[]) => ({
   },
 })
 
-test("advertises the canonical action-discriminated compute schema", () => {
+test("advertises an object-rooted compute schema for strict providers", () => {
   const schema = z.toJSONSchema(ComputeJobParameters) as {
+    type: string
     description?: string
-    anyOf: Array<{
-      properties: Record<string, { const?: string; description?: string; anyOf?: Array<{ type?: string }> }>
-      required: string[]
-    }>
+    properties: Record<string, { enum?: string[]; description?: string; anyOf?: Array<{ type?: string }> }>
+    required: string[]
   }
-  expect(schema.anyOf.map((variant) => variant.properties.action.const)).toEqual([
+  expect(schema.type).toBe("object")
+  expect(schema.properties.action.enum).toEqual([
     "targets",
     "plan",
     "start",
@@ -45,11 +45,12 @@ test("advertises the canonical action-discriminated compute schema", () => {
     "release",
   ])
   expect(JSON.stringify(schema)).not.toContain('"operation"')
-  const plan = schema.anyOf[1]
-  expect(plan.required).toEqual(["name", "purpose", "command", "target", "action"])
-  expect(plan.properties.target.anyOf?.every((target) => target.type === "object")).toBe(true)
+  expect(schema.required).toEqual(["action"])
+  expect(schema.properties.target.anyOf?.every((target) => target.type === "object")).toBe(true)
   expect(schema.description).toContain('{"action":"targets"}')
-  expect(plan.properties.target.description).toContain("never a quoted JSON string")
+  expect(schema.properties.target.description).toContain("never a quoted JSON string")
+  expect(ComputeJobParameters.safeParse({ action: "plan" }).success).toBe(false)
+  expect(ComputeJobParameters.safeParse({ action: "targets", job_id: "wrong-action" }).success).toBe(false)
 })
 
 test("normalizes only unambiguous action aliases and valid JSON-object targets", async () => {

--- a/backend/cli/test/tool/registry-agents.test.ts
+++ b/backend/cli/test/tool/registry-agents.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test"
+import z from "zod"
 import { Agent } from "../../src/agent/agent"
 import { Instance } from "../../src/project/instance"
 import { ToolRegistry } from "../../src/tool/registry"
@@ -42,6 +43,22 @@ describe("tool registry agent boundaries", () => {
 
         const legacy = await ToolRegistry.resolve("modal", undefined, agent)
         expect(legacy?.id).toBe("modal")
+      },
+    })
+  })
+
+  test("keeps every research tool object-rooted for strict providers", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const agent = await Agent.get("research")
+        const tools = await ToolRegistry.tools({ providerID: "deepseek", modelID: "deepseek-chat" }, agent)
+
+        for (const tool of tools) {
+          const schema = z.toJSONSchema(tool.parameters) as { type?: string }
+          expect(schema.type, tool.id).toBe("object")
+        }
       },
     })
   })

--- a/backend/cli/test/tool/truncation.test.ts
+++ b/backend/cli/test/tool/truncation.test.ts
@@ -1,6 +1,5 @@
 import { describe, test, expect, afterAll } from "bun:test"
 import { Truncate } from "../../src/tool/truncation"
-import { Identifier } from "../../src/id/id"
 import fs from "fs/promises"
 import path from "path"
 
@@ -137,15 +136,15 @@ describe("Truncate", () => {
 
       // Create an old file (10 days ago)
       const oldTimestamp = Date.now() - 10 * DAY_MS
-      const oldId = Identifier.create("tool", false, oldTimestamp)
-      oldFile = path.join(Truncate.DIR, oldId)
+      oldFile = path.join(Truncate.DIR, `tool_old-${crypto.randomUUID()}`)
       await Bun.write(Bun.file(oldFile), "old content")
+      await fs.utimes(oldFile, oldTimestamp / 1000, oldTimestamp / 1000)
 
       // Create a recent file (3 days ago)
       const recentTimestamp = Date.now() - 3 * DAY_MS
-      const recentId = Identifier.create("tool", false, recentTimestamp)
-      recentFile = path.join(Truncate.DIR, recentId)
+      recentFile = path.join(Truncate.DIR, `tool_recent-${crypto.randomUUID()}`)
       await Bun.write(Bun.file(recentFile), "recent content")
+      await fs.utimes(recentFile, recentTimestamp / 1000, recentTimestamp / 1000)
 
       await Truncate.cleanup()
 

--- a/backend/cli/test/util/file-lease.test.ts
+++ b/backend/cli/test/util/file-lease.test.ts
@@ -65,7 +65,7 @@ test("a structured lease admits a nested writer after relocation intent without 
     switching = DataRootBarrier.exclusive(2_000)
     await waitForFile(path.join(config, "data-root-switch.intent"))
     startNested.resolve()
-    expect(await Promise.race([nestedDone.promise.then(() => true), Bun.sleep(250).then(() => false)])).toBe(true)
+    expect(await Promise.race([nestedDone.promise.then(() => true), Bun.sleep(1_000).then(() => false)])).toBe(true)
     await command
     expect(await Promise.race([switching.then(() => true), Bun.sleep(50).then(() => false)])).toBe(false)
     await lease[Symbol.asyncDispose]()


### PR DESCRIPTION
## What changed

- emit object-rooted schemas for every research tool
- keep strict action validation at runtime
- cover DeepSeek and Kimi-compatible schema requirements with regression tests

Closes #283
Closes #295
Closes #298

## Validation

- 15 focused tests pass
- monorepo typecheck passes