### PR TITLE
fix x86 baseline binary selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ tagged release also ships native binaries for Linux, macOS, and Windows.
 
 - Made every built-in research tool advertise an object-rooted JSON Schema so
   strict OpenAI-compatible providers such as DeepSeek and Kimi accept tool-enabled requests.
+- Selected the x86-64 baseline binary automatically on Linux and macOS hosts
+  that do not support AVX2, with an actionable SIGILL diagnostic.
 - Made the research harness normalize WebFetch download destinations, authorize
   Explore retrieval consistently, apply multi-file patches transactionally,
   resolve the default Python environment, enforce image limits by the active

--- a/backend/cli/bin/openscience
+++ b/backend/cli/bin/openscience
@@ -35,6 +35,28 @@ function detectMusl(platform = os.platform()) {
   }
 }
 
+function cpuSupportsAvx2(platform = os.platform(), arch = os.arch(), linuxInfo) {
+  if (arch !== "x64") return undefined
+  if (platform === "linux") {
+    const info = (() => {
+      if (linuxInfo !== undefined) return linuxInfo
+      try {
+        return fs.readFileSync("/proc/cpuinfo", "utf8")
+      } catch {
+        return undefined
+      }
+    })()
+    if (!info) return undefined
+    const flags = /^(?:flags|features)\s*:\s*(.+)$/im.exec(info)?.[1]
+    if (!flags) return undefined
+    return flags.toLowerCase().split(/\s+/).includes("avx2")
+  }
+  if (platform !== "darwin") return undefined
+  const result = childProcess.spawnSync("sysctl", ["-n", "machdep.cpu.leaf7_features"], { encoding: "utf8" })
+  if (result.status !== 0) return undefined
+  return result.stdout.toLowerCase().split(/\s+/).includes("avx2")
+}
+
 function expectedPlatformPackages(platform, arch, musl) {
   const suffix = musl ? "-musl" : ""
   const name = `openscience-${platform}-${arch}${suffix}`
@@ -104,7 +126,8 @@ function run(target) {
     console.error(
       `openscience was terminated by ${result.signal}. The prebuilt native binary may be ` +
         `incompatible with this host (platform ${os.platform()}, arch ${os.arch()}). ` +
-        `Some ARM64 hosts (e.g. 64KB page-size kernels) cannot run the prebuilt binary. ` +
+        `Some ARM64 hosts (e.g. 64KB page-size kernels) and x86-64 hosts without AVX2 ` +
+        `cannot run the optimized prebuilt binary. ` +
         `Try reinstalling, set OPENSCIENCE_BIN_PATH to a compatible binary, or report at ` +
         `https://github.com/synthetic-sciences/openscience/issues`,
     )
@@ -128,17 +151,20 @@ function isBinary(p) {
 }
 
 // Rank matching platform packages instead of trusting readdir order (which
-// is filesystem-dependent): right libc first, exact name before suffixed
-// variants like -baseline, wrong libc only as a last resort.
-function variantRank(prefix, entry, preferMusl) {
+// is filesystem-dependent): right libc first, then the CPU-compatible build,
+// with wrong-libc packages only as a last resort.
+function variantRank(prefix, entry, preferMusl, preferBaseline = false) {
   const entryMusl = entry.includes("-musl")
   if (entryMusl !== preferMusl) return 0
-  return entry === prefix || entry === prefix + "-musl" ? 2 : 1
+  const entryBaseline = entry.includes("-baseline")
+  return entryBaseline === preferBaseline ? 2 : 1
 }
-function matchingVariants(prefix, entries, preferMusl) {
+function matchingVariants(prefix, entries, preferMusl, preferBaseline = false) {
   return entries
     .filter((entry) => entry.startsWith(prefix))
-    .sort((a, b) => variantRank(prefix, b, preferMusl) - variantRank(prefix, a, preferMusl))
+    .sort(
+      (a, b) => variantRank(prefix, b, preferMusl, preferBaseline) - variantRank(prefix, a, preferMusl, preferBaseline),
+    )
 }
 
 function main() {
@@ -158,6 +184,7 @@ function main() {
   const base = "openscience-" + platform + "-" + arch
   const scopedBase = "openscience-" + platform + "-" + arch
   const musl = detectMusl()
+  const baseline = cpuSupportsAvx2(os.platform(), os.arch()) === false
 
   // Search this install's node_modules for the matching platform package.
   // This must come before ~/.openscience or Homebrew fallbacks; otherwise an npm
@@ -168,7 +195,7 @@ function main() {
     if (fs.existsSync(modules)) {
       try {
         const entries = fs.readdirSync(modules)
-        for (const entry of matchingVariants(base, entries, musl)) {
+        for (const entry of matchingVariants(base, entries, musl, baseline)) {
           const candidate = path.join(modules, entry, "bin", binary)
           if (isBinary(candidate)) run(candidate)
         }
@@ -176,7 +203,7 @@ function main() {
         const scoped = path.join(modules, "@synsci")
         if (fs.existsSync(scoped)) {
           const scopedEntries = fs.readdirSync(scoped)
-          for (const entry of matchingVariants(scopedBase, scopedEntries, musl)) {
+          for (const entry of matchingVariants(scopedBase, scopedEntries, musl, baseline)) {
             const candidate = path.join(scoped, entry, "bin", binary)
             if (isBinary(candidate)) run(candidate)
           }
@@ -201,6 +228,7 @@ function main() {
 }
 
 module.exports = {
+  cpuSupportsAvx2,
   detectMusl,
   exitCodeForResult,
   expectedPlatformPackages,

--- a/backend/cli/script/postinstall.mjs
+++ b/backend/cli/script/postinstall.mjs
@@ -57,6 +57,28 @@ function detectMusl(platform) {
   }
 }
 
+function cpuSupportsAvx2(platform, arch, linuxInfo) {
+  if (arch !== "x64") return undefined
+  if (platform === "linux") {
+    const info = (() => {
+      if (linuxInfo !== undefined) return linuxInfo
+      try {
+        return fs.readFileSync("/proc/cpuinfo", "utf8")
+      } catch {
+        return undefined
+      }
+    })()
+    if (!info) return undefined
+    const flags = /^(?:flags|features)\s*:\s*(.+)$/im.exec(info)?.[1]
+    if (!flags) return undefined
+    return flags.toLowerCase().split(/\s+/).includes("avx2")
+  }
+  if (platform !== "darwin") return undefined
+  const result = childProcess.spawnSync("sysctl", ["-n", "machdep.cpu.leaf7_features"], { encoding: "utf8" })
+  if (result.status !== 0) return undefined
+  return result.stdout.toLowerCase().split(/\s+/).includes("avx2")
+}
+
 function linuxKernelProblem(platform, release = os.release()) {
   if (platform !== "linux") return undefined
   const match = /^(\d+)\.(\d+)/.exec(release)
@@ -84,11 +106,19 @@ function linuxArm64PageSizeProblem(platform, arch, detectedPageSize) {
   ].join("; ")
 }
 
-function platformPackageNames(platform, arch, musl = detectMusl(platform)) {
+function platformPackageNames(
+  platform,
+  arch,
+  musl = detectMusl(platform),
+  preferBaseline = cpuSupportsAvx2(platform, arch) === false,
+) {
   const base = `openscience-${platform}-${arch}`
   const variants = musl ? [`${base}-musl`] : [base]
   if (arch === "x64") variants.push(musl ? `${base}-baseline-musl` : `${base}-baseline`)
-  return variants.flatMap((name) => [`@synsci/${name}`, name])
+  const ranked = preferBaseline
+    ? variants.sort((a, b) => Number(b.includes("-baseline")) - Number(a.includes("-baseline")))
+    : variants
+  return ranked.flatMap((name) => [`@synsci/${name}`, name])
 }
 
 function findBinary() {
@@ -186,6 +216,7 @@ function main() {
 }
 
 export {
+  cpuSupportsAvx2,
   detectMusl,
   detectPlatformAndArch,
   findBinary,

--- a/backend/cli/test/installation/bin-wrapper.test.ts
+++ b/backend/cli/test/installation/bin-wrapper.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import { createRequire } from "module"
 import {
+  cpuSupportsAvx2 as postinstallCpuSupportsAvx2,
   linuxArm64PageSizeProblem as postinstallPageSizeProblem,
   linuxKernelProblem as postinstallKernelProblem,
   platformPackageNames,
@@ -8,11 +9,12 @@ import {
 
 const require = createRequire(import.meta.url)
 const wrapper = require("../../bin/openscience") as {
+  cpuSupportsAvx2(platform: string, arch: string, linuxInfo?: string): boolean | undefined
   exitCodeForResult(result: { status: number | null; signal: NodeJS.Signals | null }): number
   expectedPlatformPackages(platform: string, arch: string, musl: boolean): string[]
   linuxArm64PageSizeProblem(platform: string, arch: string, pageSize?: string): string | undefined
   linuxKernelProblem(platform: string, release: string): string | undefined
-  matchingVariants(prefix: string, entries: string[], preferMusl: boolean): string[]
+  matchingVariants(prefix: string, entries: string[], preferMusl: boolean, preferBaseline?: boolean): string[]
   parseKernelVersion(release: string): { major: number; minor: number } | undefined
 }
 
@@ -58,6 +60,31 @@ describe("npm bin wrapper", () => {
     expect(wrapper.matchingVariants("openscience-linux-x64", entries, true).slice(0, 2)).toEqual([
       "openscience-linux-x64-musl",
       "openscience-linux-x64-baseline-musl",
+    ])
+  })
+
+  test("prefers the baseline binary when x86-64 lacks AVX2", () => {
+    const modern = "processor: 0\nflags: fpu sse4_2 avx avx2 bmi2\n"
+    const legacy = "processor: 0\nflags: fpu sse4_2\n"
+    expect(wrapper.cpuSupportsAvx2("linux", "x64", modern)).toBe(true)
+    expect(wrapper.cpuSupportsAvx2("linux", "x64", legacy)).toBe(false)
+    expect(wrapper.cpuSupportsAvx2("linux", "arm64", legacy)).toBeUndefined()
+    expect(postinstallCpuSupportsAvx2("linux", "x64", modern)).toBe(true)
+    expect(postinstallCpuSupportsAvx2("linux", "x64", legacy)).toBe(false)
+
+    const entries = [
+      "openscience-linux-x64-baseline-musl",
+      "openscience-linux-x64-baseline",
+      "openscience-linux-x64-musl",
+      "openscience-linux-x64",
+    ]
+    expect(wrapper.matchingVariants("openscience-linux-x64", entries, false, true).slice(0, 2)).toEqual([
+      "openscience-linux-x64-baseline",
+      "openscience-linux-x64",
+    ])
+    expect(platformPackageNames("linux", "x64", false, true).slice(0, 2)).toEqual([
+      "@synsci/openscience-linux-x64-baseline",
+      "openscience-linux-x64-baseline",
     ])
   })
 


### PR DESCRIPTION
## What changed

- detect AVX2 support on Linux and macOS x86-64 hosts
- prefer baseline packages and binaries when AVX2 is unavailable
- keep the optimized binary first when CPU detection is unavailable

Closes #296

## Validation

- 11 launcher and packaging tests pass
- monorepo typecheck passes