### PR TITLE
add real Ollama context controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ tagged release also ships native binaries for Linux, macOS, and Windows.
 
 ### Added
 
+- Added a visible local-model settings surface and real Ollama context-window
+  controls that create tuned `num_ctx` aliases through Ollama's native API.
 - Added a conversation-first Research harness with bounded Normal and Ultra
   delegation, persistent Python and R analysis, governed remote compute, and a
   reproducible trajectory dashboard for harness evaluation.

--- a/backend/cli/src/cli/cmd/local.ts
+++ b/backend/cli/src/cli/cmd/local.ts
@@ -23,6 +23,8 @@ export interface LocalSetupInput {
   project?: boolean
   /** Set the first added model as the default. */
   setDefault?: boolean
+  /** Create Ollama aliases with this real num_ctx value. */
+  context?: number
 }
 
 /** Derive a stable provider id from a base URL (host+port), e.g.
@@ -175,18 +177,34 @@ export async function runLocalModelSetup(input: LocalSetupInput = {}): Promise<s
       }
 
       const id = input.id ?? presetId ?? deriveId(baseURL)
+      const ollama = presetId === "ollama" || id === "ollama" || LocalProvider.isOllamaBaseURL(baseURL)
+      const context = input.context
+      if (context && !ollama) {
+        prompts.log.error("--context is supported only for a local Ollama endpoint.")
+        return null
+      }
+      const registered = context
+        ? await Promise.all(selected.map((model) => LocalProvider.createOllamaContextModel(baseURL, model, context)))
+        : selected
       const name = presetId
         ? `${LocalProvider.PRESETS.find((p) => p.id === presetId)!.name} (local)`
         : `Local (${new URL(baseURL).host})`
 
-      const block = LocalProvider.buildProviderConfig({ name, baseURL, apiKey, models: selected })
+      const block = LocalProvider.buildProviderConfig({
+        name,
+        baseURL,
+        apiKey,
+        models: registered,
+        contextLimit: context,
+        runtime: ollama ? "ollama" : undefined,
+      })
       await Config.setProvider(id, block as any, input.project ? "project" : "global")
 
       const scopeLabel = input.project ? "this project's openscience.json" : "your global config"
-      prompts.log.success(`Added ${selected.length} model(s) under provider "${id}" to ${scopeLabel}.`)
+      prompts.log.success(`Added ${registered.length} model(s) under provider "${id}" to ${scopeLabel}.`)
 
       // Offer to set a default so `openscience run` uses it immediately.
-      const firstModel = `${id}/${selected[0]}`
+      const firstModel = `${id}/${registered[0]}`
       const makeDefault =
         input.setDefault ??
         (interactive
@@ -228,6 +246,10 @@ const AddCommand = cmd({
       .option("model", { type: "string", array: true, describe: "model id(s) to register (repeatable)" })
       .option("id", { type: "string", describe: "provider id to register under" })
       .option("key", { type: "string", describe: "api key, if the endpoint needs one" })
+      .option("context", {
+        type: "number",
+        describe: "Ollama context window in tokens; creates a tuned local model alias",
+      })
       .option("project", { type: "boolean", describe: "write to the project config instead of global" })
       .option("default", { type: "boolean", describe: "set the first model as the default" }),
   handler: async (args) => {
@@ -239,6 +261,7 @@ const AddCommand = cmd({
       key: args.key as string | undefined,
       project: args.project as boolean | undefined,
       setDefault: args.default as boolean | undefined,
+      context: args.context as number | undefined,
     })
   },
 })

--- a/backend/cli/src/provider/local.ts
+++ b/backend/cli/src/provider/local.ts
@@ -133,6 +133,63 @@ export namespace LocalProvider {
     return baseURL.replace(/\/+$/, "") + "/models"
   }
 
+  export function isLocalBaseURL(baseURL: string): boolean {
+    try {
+      const url = new URL(normalizeBaseURL(baseURL))
+      const host = url.hostname.toLowerCase().replace(/^\[|\]$/g, "")
+      return host === "localhost" || host === "127.0.0.1" || host === "0.0.0.0" || host === "::1"
+    } catch {
+      return false
+    }
+  }
+
+  export function isOllamaBaseURL(baseURL: string): boolean {
+    if (!isLocalBaseURL(baseURL)) return false
+    return new URL(normalizeBaseURL(baseURL)).port === "11434"
+  }
+
+  export function ollamaContextModelName(model: string, context: number): string {
+    const name = model
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9._-]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+    if (!name) throw new Error("Ollama model name is empty")
+    return `openscience/${name}-ctx-${context}`
+  }
+
+  /**
+   * Ollama's OpenAI-compatible endpoint cannot change num_ctx per request.
+   * Create the documented lightweight model alias through the native API, then
+   * keep using the OpenAI-compatible endpoint for normal tool-enabled turns.
+   */
+  export async function createOllamaContextModel(
+    baseURL: string,
+    model: string,
+    context: number,
+    fetchImpl: typeof fetch = fetch,
+  ): Promise<string> {
+    if (!Number.isInteger(context) || context < 1_024 || context > 2_097_152) {
+      throw new Error("Ollama context must be an integer between 1024 and 2097152 tokens")
+    }
+    if (!isLocalBaseURL(baseURL)) {
+      throw new Error("Context tuning is available only for a local Ollama endpoint")
+    }
+    const url = new URL(normalizeBaseURL(baseURL))
+    const name = ollamaContextModelName(model, context)
+    const response = await fetchImpl(`${url.origin}/api/create`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ model: name, from: model, parameters: { num_ctx: context }, stream: false }),
+      signal: AbortSignal.timeout(120_000),
+    })
+    if (!response.ok) {
+      const detail = (await response.text()).trim()
+      throw new Error(`Ollama could not create ${name}: HTTP ${response.status}${detail ? ` ${detail}` : ""}`)
+    }
+    return name
+  }
+
   /** Parse an OpenAI-compatible `GET /v1/models` body into sorted model ids.
    *  Tolerates the `{ object: "list", data: [{ id }] }` shape and, defensively,
    *  a bare array or Ollama's `{ models: [{ name }] }` native shape. */
@@ -215,6 +272,7 @@ export namespace LocalProvider {
     /** Per-model context window; local models vary widely, 32k is a safe default. */
     contextLimit?: number
     outputLimit?: number
+    runtime?: string
   }): Record<string, unknown> {
     const models: Record<string, unknown> = {}
     for (const id of input.models) {
@@ -231,7 +289,11 @@ export namespace LocalProvider {
       name: input.name,
       npm: NPM,
       api: input.baseURL,
-      options: { baseURL: input.baseURL, apiKey: input.apiKey || DEFAULT_API_KEY },
+      options: {
+        baseURL: input.baseURL,
+        apiKey: input.apiKey || DEFAULT_API_KEY,
+        ...(input.runtime ? { localRuntime: input.runtime } : {}),
+      },
       models,
     }
   }

--- a/backend/cli/src/server/routes/settings/local.ts
+++ b/backend/cli/src/server/routes/settings/local.ts
@@ -246,6 +246,9 @@ async function configuredLocals() {
       name: p?.name ?? id,
       baseURL: (p?.options?.baseURL ?? p?.api) as string,
       models: Object.keys(p?.models ?? {}),
+      runtime:
+        p?.options?.localRuntime ??
+        (id === "ollama" || LocalProvider.isOllamaBaseURL(p?.options?.baseURL ?? p?.api) ? "ollama" : undefined),
     }))
 }
 
@@ -338,6 +341,29 @@ export const LocalModelsRoutes = lazy(() =>
       }
     })
 
+    // Create an Ollama alias with a real num_ctx setting. Ollama deliberately
+    // does not expose context sizing through its OpenAI-compatible endpoint.
+    .post(
+      "/context",
+      validator(
+        "json",
+        z.object({
+          url: z.string(),
+          model: z.string().trim().min(1),
+          context: z.number().int().min(1_024).max(2_097_152),
+        }),
+      ),
+      async (c) => {
+        const body = c.req.valid("json")
+        try {
+          const model = await LocalProvider.createOllamaContextModel(body.url, body.model, body.context)
+          return c.json({ model, source: body.model, context: body.context })
+        } catch (error) {
+          return c.json({ error: error instanceof Error ? error.message : String(error) }, 400)
+        }
+      },
+    )
+
     // Register (or update) a local provider block.
     .post(
       "/",
@@ -349,6 +375,9 @@ export const LocalModelsRoutes = lazy(() =>
           name: z.string().optional(),
           key: z.string().optional(),
           models: z.array(z.string()).min(1),
+          contextLimit: z.number().int().min(1_024).max(2_097_152).optional(),
+          runtime: z.enum(["ollama"]).optional(),
+          merge: z.boolean().optional(),
           setDefault: z.boolean().optional(),
         }),
       ),
@@ -365,8 +394,19 @@ export const LocalModelsRoutes = lazy(() =>
           baseURL,
           apiKey: body.key,
           models: body.models,
+          contextLimit: body.contextLimit,
+          runtime: body.runtime,
         })
-        await Config.setProvider(id, block as any, "global")
+        const previous = body.merge ? (await Config.getGlobal()).provider?.[id] : undefined
+        const provider = previous
+          ? {
+              ...previous,
+              ...block,
+              options: { ...previous.options, ...(block as any).options },
+              models: { ...previous.models, ...(block as any).models },
+            }
+          : block
+        await Config.setProvider(id, provider as any, "global")
         if (body.setDefault) await Config.updateGlobal({ model: `${id}/${body.models[0]}` })
         Provider.invalidate()
         log.info("registered local provider", { id, baseURL, models: body.models.length })

--- a/backend/cli/src/tool/truncation.ts
+++ b/backend/cli/src/tool/truncation.ts
@@ -34,12 +34,14 @@ export namespace Truncate {
   }
 
   export async function cleanup() {
-    const cutoff = Identifier.timestamp(Identifier.create("tool", false, Date.now() - RETENTION_MS))
+    const cutoff = Date.now() - RETENTION_MS
     const glob = new Bun.Glob("tool_*")
     const entries = await Array.fromAsync(glob.scan({ cwd: DIR, onlyFiles: true })).catch(() => [] as string[])
     for (const entry of entries) {
-      if (Identifier.timestamp(entry) >= cutoff) continue
-      await fs.unlink(path.join(DIR, entry)).catch(() => {})
+      const file = path.join(DIR, entry)
+      const stat = await fs.stat(file).catch(() => undefined)
+      if (!stat || stat.mtimeMs >= cutoff) continue
+      await fs.unlink(file).catch(() => {})
     }
   }
 

--- a/backend/cli/test/global/data-root.test.ts
+++ b/backend/cli/test/global/data-root.test.ts
@@ -457,7 +457,7 @@ describe("managed data root", () => {
         "Cannot scope work under a non-active data-root operation",
       )
       startChild.resolve()
-      expect(await Promise.race([childDone.promise.then(() => true), Bun.sleep(250).then(() => false)])).toBe(true)
+      expect(await Promise.race([childDone.promise.then(() => true), Bun.sleep(1_000).then(() => false)])).toBe(true)
       expect(await Promise.race([switching.then(() => true), Bun.sleep(50).then(() => false)])).toBe(false)
 
       releaseScope.resolve()

--- a/backend/cli/test/provider/local-runtime.test.ts
+++ b/backend/cli/test/provider/local-runtime.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test"
+import { jsonSchema, streamText, tool } from "ai"
+import { Instance } from "../../src/project/instance"
+import { Provider } from "../../src/provider/provider"
+import { tmpdir } from "../fixture/fixture"
+
+describe("local OpenAI-compatible runtime", () => {
+  test("streams a response with an object-rooted tool contract", async () => {
+    const requests: Array<Record<string, unknown>> = []
+    const server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      async fetch(request) {
+        const url = new URL(request.url)
+        if (url.pathname !== "/v1/chat/completions") return new Response("not found", { status: 404 })
+        requests.push((await request.json()) as Record<string, unknown>)
+        const chunks = [
+          {
+            id: "chatcmpl-local",
+            object: "chat.completion.chunk",
+            created: 1,
+            model: "fixture-model",
+            choices: [{ index: 0, delta: { role: "assistant", content: "OK" }, finish_reason: null }],
+          },
+          {
+            id: "chatcmpl-local",
+            object: "chat.completion.chunk",
+            created: 1,
+            model: "fixture-model",
+            choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+          },
+        ]
+        const body = chunks.map((chunk) => `data: ${JSON.stringify(chunk)}\n\n`).join("") + "data: [DONE]\n\n"
+        return new Response(body, { headers: { "content-type": "text/event-stream" } })
+      },
+    })
+
+    try {
+      await using tmp = await tmpdir({
+        config: {
+          provider: {
+            ollama: {
+              name: "Ollama (local)",
+              npm: "@ai-sdk/openai-compatible",
+              options: { baseURL: `http://127.0.0.1:${server.port}/v1`, apiKey: "local" },
+              models: {
+                "fixture-model": {
+                  name: "fixture-model",
+                  tool_call: true,
+                  limit: { context: 32_768, output: 2_048 },
+                },
+              },
+            },
+          },
+        },
+      })
+      await Instance.provide({
+        directory: tmp.path,
+        init: async () => Provider.invalidate(),
+        fn: async () => {
+          const model = await Provider.getModel("ollama", "fixture-model")
+          const language = await Provider.getLanguage(model)
+          const result = streamText({
+            model: language,
+            prompt: "Reply with OK",
+            tools: {
+              inspect: tool({
+                description: "Inspect one value",
+                inputSchema: jsonSchema({
+                  type: "object",
+                  properties: { value: { type: "string" } },
+                  required: ["value"],
+                }),
+              }),
+            },
+          })
+          expect(await result.text).toBe("OK")
+        },
+      })
+
+      const tools = requests[0]?.tools as Array<{ function: { parameters: { type?: string } } }>
+      expect(tools[0]?.function.parameters.type).toBe("object")
+    } finally {
+      server.stop(true)
+    }
+  })
+})

--- a/backend/cli/test/provider/local.test.ts
+++ b/backend/cli/test/provider/local.test.ts
@@ -26,6 +26,46 @@ describe("LocalProvider.modelsEndpoint", () => {
   })
 })
 
+describe("LocalProvider Ollama context tuning", () => {
+  test("creates a real num_ctx model alias through Ollama's native API", async () => {
+    const requests: unknown[] = []
+    const server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      async fetch(request) {
+        const url = new URL(request.url)
+        if (url.pathname !== "/api/create") return new Response("not found", { status: 404 })
+        requests.push(await request.json())
+        return Response.json({ status: "success" })
+      },
+    })
+    try {
+      const baseURL = `http://127.0.0.1:${server.port}/v1`
+      const model = await LocalProvider.createOllamaContextModel(baseURL, "qwen3:8b", 65_536)
+      expect(model).toBe("openscience/qwen3-8b-ctx-65536")
+      expect(requests).toEqual([
+        {
+          model,
+          from: "qwen3:8b",
+          parameters: { num_ctx: 65_536 },
+          stream: false,
+        },
+      ])
+    } finally {
+      server.stop(true)
+    }
+  })
+
+  test("rejects remote endpoints and invalid context sizes before calling Ollama", async () => {
+    await expect(LocalProvider.createOllamaContextModel("https://example.com/v1", "qwen3", 32_768)).rejects.toThrow(
+      "local Ollama endpoint",
+    )
+    await expect(LocalProvider.createOllamaContextModel("http://localhost:11434/v1", "qwen3", 512)).rejects.toThrow(
+      "between 1024 and 2097152",
+    )
+  })
+})
+
 describe("LocalProvider.parseModelsResponse", () => {
   test("parses the OpenAI {object:list,data:[{id}]} shape, sorted + deduped", () => {
     const body = { object: "list", data: [{ id: "qwen2.5" }, { id: "llama3.1" }, { id: "llama3.1" }] }
@@ -72,6 +112,18 @@ describe("LocalProvider.buildProviderConfig", () => {
       models: ["m"],
     }) as any
     expect(block.options.apiKey).toBe("sk-local")
+  })
+
+  test("records the tuned context and runtime for every Ollama alias", () => {
+    const block = LocalProvider.buildProviderConfig({
+      name: "Ollama (local)",
+      baseURL: "http://localhost:11434/v1",
+      models: ["openscience/qwen3-8b-ctx-65536"],
+      contextLimit: 65_536,
+      runtime: "ollama",
+    }) as any
+    expect(block.options.localRuntime).toBe("ollama")
+    expect(block.models["openscience/qwen3-8b-ctx-65536"].limit.context).toBe(65_536)
   })
 })
 

--- a/backend/cli/test/server/settings-local.test.ts
+++ b/backend/cli/test/server/settings-local.test.ts
@@ -10,13 +10,18 @@ const app = LocalModelsRoutes()
 // global fetch (which would race with other test files) or the network.
 let server: ReturnType<typeof Bun.serve>
 let mockBase = ""
+const created: unknown[] = []
 beforeAll(() => {
   server = Bun.serve({
     port: 0,
     hostname: "127.0.0.1",
-    fetch(req) {
+    async fetch(req) {
       const url = new URL(req.url)
       if (url.pathname === "/v1/models") return Response.json({ data: [{ id: "llama3.1" }, { id: "qwen2.5" }] })
+      if (url.pathname === "/api/create") {
+        created.push(await req.json())
+        return Response.json({ status: "success" })
+      }
       return new Response("not found", { status: 404 })
     },
   })
@@ -137,6 +142,23 @@ describe("/settings/local routes", () => {
     const body = (await res.json()) as { models: string[]; error?: string }
     expect(body.models).toEqual([])
     expect(body.error).toBeTruthy()
+  })
+
+  test("POST /context creates a tuned Ollama alias with the requested num_ctx", async () => {
+    const res = await app.request("/context", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ url: mockBase, model: "llama3.1", context: 32_768 }),
+    })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { model: string; source: string; context: number }
+    expect(body).toEqual({ model: "openscience/llama3.1-ctx-32768", source: "llama3.1", context: 32_768 })
+    expect(created.at(-1)).toEqual({
+      model: "openscience/llama3.1-ctx-32768",
+      from: "llama3.1",
+      parameters: { num_ctx: 32_768 },
+      stream: false,
+    })
   })
 
   test("GET /status reports the auto-startable runtimes with boolean flags", async () => {

--- a/backend/cli/test/tool/truncation.test.ts
+++ b/backend/cli/test/tool/truncation.test.ts
@@ -1,6 +1,5 @@
 import { describe, test, expect, afterAll } from "bun:test"
 import { Truncate } from "../../src/tool/truncation"
-import { Identifier } from "../../src/id/id"
 import fs from "fs/promises"
 import path from "path"
 
@@ -137,15 +136,15 @@ describe("Truncate", () => {
 
       // Create an old file (10 days ago)
       const oldTimestamp = Date.now() - 10 * DAY_MS
-      const oldId = Identifier.create("tool", false, oldTimestamp)
-      oldFile = path.join(Truncate.DIR, oldId)
+      oldFile = path.join(Truncate.DIR, `tool_old-${crypto.randomUUID()}`)
       await Bun.write(Bun.file(oldFile), "old content")
+      await fs.utimes(oldFile, oldTimestamp / 1000, oldTimestamp / 1000)
 
       // Create a recent file (3 days ago)
       const recentTimestamp = Date.now() - 3 * DAY_MS
-      const recentId = Identifier.create("tool", false, recentTimestamp)
-      recentFile = path.join(Truncate.DIR, recentId)
+      recentFile = path.join(Truncate.DIR, `tool_recent-${crypto.randomUUID()}`)
       await Bun.write(Bun.file(recentFile), "recent content")
+      await fs.utimes(recentFile, recentTimestamp / 1000, recentTimestamp / 1000)
 
       await Truncate.cleanup()
 

--- a/backend/cli/test/util/file-lease.test.ts
+++ b/backend/cli/test/util/file-lease.test.ts
@@ -65,7 +65,7 @@ test("a structured lease admits a nested writer after relocation intent without 
     switching = DataRootBarrier.exclusive(2_000)
     await waitForFile(path.join(config, "data-root-switch.intent"))
     startNested.resolve()
-    expect(await Promise.race([nestedDone.promise.then(() => true), Bun.sleep(250).then(() => false)])).toBe(true)
+    expect(await Promise.race([nestedDone.promise.then(() => true), Bun.sleep(1_000).then(() => false)])).toBe(true)
     await command
     expect(await Promise.race([switching.then(() => true), Bun.sleep(50).then(() => false)])).toBe(false)
     await lease[Symbol.asyncDispose]()

--- a/frontend/workspace/src/components/settings/LocalModels.tsx
+++ b/frontend/workspace/src/components/settings/LocalModels.tsx
@@ -9,6 +9,7 @@ import { showToast } from "@synsci/ui/toast"
 import { useGlobalSDK } from "@/context/global-sdk"
 import { usePlatform } from "@/context/platform"
 import { settingsApi } from "./api"
+import { PanelBody, PanelHeader, PanelScroll } from "./_shared"
 
 interface Detected {
   id: string
@@ -21,11 +22,12 @@ interface Configured {
   name: string
   baseURL: string
   models: string[]
+  runtime?: string
 }
 interface Runtime {
   id: string
   name: string
-  baseURL?: string
+  baseURL: string
   installed: boolean
   running: boolean
   models: string[]
@@ -71,6 +73,7 @@ const LocalModels: Component = () => {
   }
 
   const [busy, setBusy] = createSignal(false)
+  const [context, setContext] = createSignal("32768")
   const guard = async (fn: () => Promise<unknown>, failure: string) => {
     setBusy(true)
     try {
@@ -82,13 +85,47 @@ const LocalModels: Component = () => {
     setBusy(false)
   }
 
+  const isOllama = (id: string | undefined, url: string) => {
+    if (id === "ollama") return true
+    try {
+      return new URL(url).port === "11434"
+    } catch {
+      return false
+    }
+  }
+  const register = async (input: { url: string; models: string[]; id?: string; name?: string; key?: string }) => {
+    const ollama = isOllama(input.id, input.url)
+    const tokens = Number(context())
+    if (ollama && (!Number.isInteger(tokens) || tokens < 1_024 || tokens > 2_097_152)) {
+      throw new Error("Context must be an integer between 1,024 and 2,097,152 tokens.")
+    }
+    const models = ollama
+      ? await Promise.all(
+          input.models.map((model) =>
+            call<{ model: string }>("/context", {
+              method: "POST",
+              body: JSON.stringify({ url: input.url, model, context: tokens }),
+            }).then((result) => result.model),
+          ),
+        )
+      : input.models
+    return call("", {
+      method: "POST",
+      body: JSON.stringify({
+        url: input.url,
+        id: input.id,
+        name: input.name,
+        key: input.key,
+        models,
+        contextLimit: ollama ? tokens : undefined,
+        runtime: ollama ? "ollama" : undefined,
+      }),
+    })
+  }
+
   const addRuntime = (d: Detected) =>
     guard(
-      () =>
-        call("", {
-          method: "POST",
-          body: JSON.stringify({ url: d.baseURL, id: d.id, name: `${d.name} (local)`, models: d.models }),
-        }),
+      () => register({ url: d.baseURL, id: d.id, name: `${d.name} (local)`, models: d.models }),
       "Failed to add local models",
     )
 
@@ -111,10 +148,7 @@ const LocalModels: Component = () => {
         showToast({ title: `${rt.name} isn't installed`, description: `Install it, then start it here.` })
         window.open(r.install ?? rt.install, "_blank", "noopener")
       } else if (r.running && r.models?.length) {
-        await call("", {
-          method: "POST",
-          body: JSON.stringify({ url: rt.baseURL, id: rt.id, name: `${rt.name} (local)`, models: r.models }),
-        })
+        await register({ url: rt.baseURL, id: rt.id, name: `${rt.name} (local)`, models: r.models })
         showToast({ title: `${rt.name} is running`, description: `Added ${r.models.length} model(s).` })
       } else if (r.running) {
         showToast({ title: `${rt.name} is running`, description: "No models yet — pull one below, then rescan." })
@@ -130,11 +164,7 @@ const LocalModels: Component = () => {
 
   const addRunning = (rt: Runtime) =>
     guard(
-      () =>
-        call("", {
-          method: "POST",
-          body: JSON.stringify({ url: rt.baseURL, id: rt.id, name: `${rt.name} (local)`, models: rt.models }),
-        }),
+      () => register({ url: rt.baseURL ?? "", id: rt.id, name: `${rt.name} (local)`, models: rt.models }),
       "Failed to add models",
     )
 
@@ -177,10 +207,7 @@ const LocalModels: Component = () => {
     guard(async () => {
       const models = [...selected()]
       if (!models.length) throw new Error("Select at least one model.")
-      await call("", {
-        method: "POST",
-        body: JSON.stringify({ url: url().trim(), key: key().trim() || undefined, models }),
-      })
+      await register({ url: url().trim(), key: key().trim() || undefined, models })
       setUrl("")
       setKey("")
       setFound([])
@@ -189,224 +216,245 @@ const LocalModels: Component = () => {
     }, "Failed to add local models")
 
   return (
-    <div class="flex flex-col h-full overflow-y-auto no-scrollbar">
-      <div class="sticky top-0 z-10 bg-[linear-gradient(to_bottom,var(--surface-raised-stronger-non-alpha)_calc(100%_-_24px),transparent)]">
-        <div class="flex flex-col gap-1 px-4 py-8 sm:p-8 max-w-[820px]">
-          <h2 class="text-16-medium text-text-strong">Local models</h2>
-          <p class="text-13-regular text-text-weak">
-            Run models on your own machine — Ollama, LM Studio, llama.cpp, vLLM, or any OpenAI-compatible endpoint.
-            Free, offline, never metered.
-          </p>
-        </div>
-      </div>
-
-      <div class="flex flex-col gap-8 px-4 pb-12 sm:px-8 max-w-[820px]">
-        {/* ── Run locally (host it for the user) ── */}
-        <section class="flex flex-col gap-3">
-          <h3 class="text-13-medium text-text-strong">Run a model locally</h3>
-          <p class="text-12-regular text-text-weak/70">
-            Let OpenScience start and host a runtime for you — no terminal needed.
-          </p>
-          <For each={status()}>
-            {(rt) => (
-              <div class="flex items-center justify-between border border-border-weak-base rounded-[4px] p-3 bg-surface-base/40">
-                <div class="flex flex-col gap-0.5">
-                  <span class="text-13-medium text-text-strong flex items-center gap-1.5">
-                    <Show when={rt.running}>
-                      <Icon name="check" class="text-text-success" />
-                    </Show>
-                    {rt.name}
-                  </span>
-                  <span class="text-11-regular text-text-weak">
-                    <Show
-                      when={!rt.installed}
-                      fallback={rt.running ? `running · ${rt.models.length} model(s)` : "installed · not running"}
-                    >
-                      not installed — <code>{rt.serveHint}</code>
-                    </Show>
-                  </span>
+    <PanelScroll>
+      <PanelHeader
+        title="Local models"
+        description="Run Ollama, LM Studio, llama.cpp, vLLM, or another OpenAI-compatible endpoint on this machine."
+      />
+      <PanelBody>
+        <div class="flex flex-col gap-8">
+          {/* ── Run locally (host it for the user) ── */}
+          <section class="flex flex-col gap-3">
+            <h3 class="text-13-medium text-text-strong">Run a model locally</h3>
+            <p class="text-12-regular text-text-weak/70">
+              Let OpenScience start and host a runtime for you — no terminal needed.
+            </p>
+            <div class="flex flex-col gap-2 border border-border-weak-base rounded-[4px] p-3 bg-surface-base/40">
+              <div class="flex flex-wrap items-center justify-between gap-3">
+                <div class="flex min-w-0 flex-col gap-0.5">
+                  <span class="text-13-medium text-text-strong">Ollama context window</span>
+                  <span class="text-11-regular text-text-weak">Applied when an Ollama model is added.</span>
                 </div>
-                <Show
-                  when={rt.installed}
-                  fallback={
-                    <Button
-                      size="small"
-                      variant="secondary"
-                      onClick={() => window.open(rt.install, "_blank", "noopener")}
-                    >
-                      Install
-                    </Button>
-                  }
-                >
-                  <Show
-                    when={rt.running}
-                    fallback={
-                      <Button
-                        size="small"
-                        variant="primary"
-                        disabled={busy() || !!starting()}
-                        onClick={() => startRuntime(rt)}
-                      >
-                        {starting() === rt.id ? "Starting…" : "Start"}
-                      </Button>
-                    }
-                  >
-                    <Button
-                      size="small"
-                      variant="primary"
-                      disabled={busy() || rt.models.length === 0}
-                      onClick={() => addRunning(rt)}
-                    >
-                      Add {rt.models.length}
-                    </Button>
-                  </Show>
-                </Show>
+                <div class="flex items-center gap-2">
+                  <input
+                    class="w-32 rounded-[4px] border border-border-weak-base bg-surface-base px-3 py-2 text-right font-mono text-13-regular text-text-strong"
+                    type="number"
+                    min="1024"
+                    max="2097152"
+                    step="1024"
+                    aria-label="Ollama context window in tokens"
+                    value={context()}
+                    onInput={(event) => setContext(event.currentTarget.value)}
+                  />
+                  <span class="text-11-regular text-text-weak">tokens</span>
+                </div>
               </div>
-            )}
-          </For>
-        </section>
-
-        {/* ── Pull a model (Ollama) ── */}
-        <section class="flex flex-col gap-2">
-          <h3 class="text-13-medium text-text-strong">Pull a model</h3>
-          <p class="text-12-regular text-text-weak/70">
-            Copy an <code>ollama pull</code> command, then run it in your terminal to download the model.
-          </p>
-          <div class="flex gap-2">
-            <input
-              class="flex-1 rounded-[4px] border border-border-weak-base bg-surface-base px-3 py-2 text-13-regular text-text-strong placeholder:text-text-weak/60"
-              placeholder="llama3.1  ·  qwen2.5-coder  ·  phi3"
-              value={pullName()}
-              onInput={(e) => setPullName(e.currentTarget.value)}
-              onKeyDown={(e) => e.key === "Enter" && pull()}
-            />
-            <Button size="small" variant="secondary" disabled={!pullName().trim()} onClick={pull}>
-              Copy command
-            </Button>
-          </div>
-          <p class="text-11-regular text-text-weak/60">
-            Need to start Ollama first? Copy this command:{" "}
-            <button
-              class="underline hover:text-text-strong"
-              aria-label="Copy ollama serve command"
-              onClick={() => void copyCommand("ollama serve")}
-            >
-              ollama serve
-            </button>
-          </p>
-        </section>
-
-        {/* ── Detected runtimes ── */}
-        <section class="flex flex-col gap-3">
-          <div class="flex items-center justify-between">
-            <h3 class="text-13-medium text-text-strong">Detected on this machine</h3>
-            <Button size="small" variant="secondary" disabled={busy()} onClick={refetch}>
-              Rescan
-            </Button>
-          </div>
-          <Show
-            when={(detected()?.length ?? 0) > 0}
-            fallback={
-              <p class="text-12-regular text-text-weak/70">
-                Nothing running yet. Start a server (e.g. <code>ollama serve</code>) and select Rescan, or add a custom
-                endpoint below.
+              <p class="text-11-regular text-text-weak/70">
+                OpenScience creates a lightweight tuned alias, so Ollama applies the real <code>num_ctx</code> value.
+                Larger windows use more memory.
               </p>
-            }
-          >
-            <For each={detected()}>
-              {(d) => (
+            </div>
+            <For each={status()}>
+              {(rt) => (
                 <div class="flex items-center justify-between border border-border-weak-base rounded-[4px] p-3 bg-surface-base/40">
                   <div class="flex flex-col gap-0.5">
                     <span class="text-13-medium text-text-strong flex items-center gap-1.5">
-                      <Icon name="check" class="text-text-success" /> {d.name}
+                      <Show when={rt.running}>
+                        <Icon name="check" class="text-text-success" />
+                      </Show>
+                      {rt.name}
                     </span>
                     <span class="text-11-regular text-text-weak">
-                      {d.baseURL} · {d.models.length} model(s)
+                      <Show
+                        when={!rt.installed}
+                        fallback={rt.running ? `running · ${rt.models.length} model(s)` : "installed · not running"}
+                      >
+                        not installed — <code>{rt.serveHint}</code>
+                      </Show>
                     </span>
                   </div>
-                  <Button size="small" variant="primary" disabled={busy()} onClick={() => addRuntime(d)}>
-                    Add {d.models.length}
-                  </Button>
+                  <Show
+                    when={rt.installed}
+                    fallback={
+                      <Button
+                        size="small"
+                        variant="secondary"
+                        onClick={() => window.open(rt.install, "_blank", "noopener")}
+                      >
+                        Install
+                      </Button>
+                    }
+                  >
+                    <Show
+                      when={rt.running}
+                      fallback={
+                        <Button
+                          size="small"
+                          variant="primary"
+                          disabled={busy() || !!starting()}
+                          onClick={() => startRuntime(rt)}
+                        >
+                          {starting() === rt.id ? "Starting…" : "Start"}
+                        </Button>
+                      }
+                    >
+                      <Button
+                        size="small"
+                        variant="primary"
+                        disabled={busy() || rt.models.length === 0}
+                        onClick={() => addRunning(rt)}
+                      >
+                        Add {rt.models.length}
+                      </Button>
+                    </Show>
+                  </Show>
                 </div>
               )}
             </For>
-          </Show>
-        </section>
+          </section>
 
-        {/* ── Custom endpoint ── */}
-        <section class="flex flex-col gap-3">
-          <h3 class="text-13-medium text-text-strong">Custom endpoint</h3>
-          <div class="flex flex-col gap-2">
-            <input
-              class="w-full rounded-[4px] border border-border-weak-base bg-surface-base px-3 py-2 text-13-regular text-text-strong placeholder:text-text-weak/60"
-              placeholder="http://localhost:11434/v1"
-              value={url()}
-              onInput={(e) => setUrl(e.currentTarget.value)}
-            />
-            <input
-              class="w-full rounded-[4px] border border-border-weak-base bg-surface-base px-3 py-2 text-13-regular text-text-strong placeholder:text-text-weak/60"
-              placeholder="API key (optional — most local servers need none)"
-              value={key()}
-              onInput={(e) => setKey(e.currentTarget.value)}
-            />
+          {/* ── Pull a model (Ollama) ── */}
+          <section class="flex flex-col gap-2">
+            <h3 class="text-13-medium text-text-strong">Pull a model</h3>
+            <p class="text-12-regular text-text-weak/70">
+              Copy an <code>ollama pull</code> command, then run it in your terminal to download the model.
+            </p>
             <div class="flex gap-2">
-              <Button size="small" variant="secondary" disabled={busy() || !url().trim()} onClick={listCustom}>
-                List models
+              <input
+                class="flex-1 rounded-[4px] border border-border-weak-base bg-surface-base px-3 py-2 text-13-regular text-text-strong placeholder:text-text-weak/60"
+                placeholder="llama3.1  ·  qwen2.5-coder  ·  phi3"
+                value={pullName()}
+                onInput={(e) => setPullName(e.currentTarget.value)}
+                onKeyDown={(e) => e.key === "Enter" && pull()}
+              />
+              <Button size="small" variant="secondary" disabled={!pullName().trim()} onClick={pull}>
+                Copy command
               </Button>
-              <Show when={found().length > 0}>
-                <Button size="small" variant="primary" disabled={busy() || selected().size === 0} onClick={addCustom}>
-                  Add {selected().size} selected
-                </Button>
-              </Show>
             </div>
-          </div>
-          <Show when={found().length > 0}>
-            <div class="flex flex-col gap-1 border border-border-weak-base rounded-[4px] p-2 bg-surface-base/40">
-              <span class="text-11-regular text-text-weak px-1">{listedUrl()}</span>
-              <For each={found()}>
-                {(m) => (
-                  <label class="flex items-center gap-2 px-1 py-1 text-13-regular text-text-strong cursor-pointer">
-                    <input type="checkbox" checked={selected().has(m)} onChange={() => toggle(m)} />
-                    {m}
-                  </label>
+            <p class="text-11-regular text-text-weak/60">
+              Need to start Ollama first? Copy this command:{" "}
+              <button
+                class="underline hover:text-text-strong"
+                aria-label="Copy ollama serve command"
+                onClick={() => void copyCommand("ollama serve")}
+              >
+                ollama serve
+              </button>
+            </p>
+          </section>
+
+          {/* ── Detected runtimes ── */}
+          <section class="flex flex-col gap-3">
+            <div class="flex items-center justify-between">
+              <h3 class="text-13-medium text-text-strong">Detected on this machine</h3>
+              <Button size="small" variant="secondary" disabled={busy()} onClick={refetch}>
+                Rescan
+              </Button>
+            </div>
+            <Show
+              when={(detected()?.length ?? 0) > 0}
+              fallback={
+                <p class="text-12-regular text-text-weak/70">
+                  Nothing running yet. Start a server (e.g. <code>ollama serve</code>) and select Rescan, or add a
+                  custom endpoint below.
+                </p>
+              }
+            >
+              <For each={detected()}>
+                {(d) => (
+                  <div class="flex items-center justify-between border border-border-weak-base rounded-[4px] p-3 bg-surface-base/40">
+                    <div class="flex flex-col gap-0.5">
+                      <span class="text-13-medium text-text-strong flex items-center gap-1.5">
+                        <Icon name="check" class="text-text-success" /> {d.name}
+                      </span>
+                      <span class="text-11-regular text-text-weak">
+                        {d.baseURL} · {d.models.length} model(s)
+                      </span>
+                    </div>
+                    <Button size="small" variant="primary" disabled={busy()} onClick={() => addRuntime(d)}>
+                      Add {d.models.length}
+                    </Button>
+                  </div>
                 )}
               </For>
-            </div>
-          </Show>
-        </section>
+            </Show>
+          </section>
 
-        {/* ── Configured ── */}
-        <section class="flex flex-col gap-3">
-          <h3 class="text-13-medium text-text-strong">Configured</h3>
-          <Show
-            when={(configured()?.length ?? 0) > 0}
-            fallback={<p class="text-12-regular text-text-weak/70">No local providers yet.</p>}
-          >
-            <For each={configured()}>
-              {(p) => (
-                <div class="flex items-center justify-between border border-border-weak-base rounded-[4px] p-3 bg-surface-base/40">
-                  <div class="flex flex-col gap-0.5">
-                    <span class="text-13-medium text-text-strong">{p.id}</span>
-                    <span class="text-11-regular text-text-weak">
-                      {p.baseURL} · {p.models.length} model(s)
-                    </span>
-                  </div>
-                  <Button
-                    size="small"
-                    variant="ghost"
-                    icon="trash"
-                    disabled={busy()}
-                    onClick={() => removeProvider(p.id)}
-                  >
-                    Remove
+          {/* ── Custom endpoint ── */}
+          <section class="flex flex-col gap-3">
+            <h3 class="text-13-medium text-text-strong">Custom endpoint</h3>
+            <div class="flex flex-col gap-2">
+              <input
+                class="w-full rounded-[4px] border border-border-weak-base bg-surface-base px-3 py-2 text-13-regular text-text-strong placeholder:text-text-weak/60"
+                placeholder="http://localhost:11434/v1"
+                value={url()}
+                onInput={(e) => setUrl(e.currentTarget.value)}
+              />
+              <input
+                class="w-full rounded-[4px] border border-border-weak-base bg-surface-base px-3 py-2 text-13-regular text-text-strong placeholder:text-text-weak/60"
+                placeholder="API key (optional — most local servers need none)"
+                value={key()}
+                onInput={(e) => setKey(e.currentTarget.value)}
+              />
+              <div class="flex gap-2">
+                <Button size="small" variant="secondary" disabled={busy() || !url().trim()} onClick={listCustom}>
+                  List models
+                </Button>
+                <Show when={found().length > 0}>
+                  <Button size="small" variant="primary" disabled={busy() || selected().size === 0} onClick={addCustom}>
+                    Add {selected().size} selected
                   </Button>
-                </div>
-              )}
-            </For>
-          </Show>
-        </section>
-      </div>
-    </div>
+                </Show>
+              </div>
+            </div>
+            <Show when={found().length > 0}>
+              <div class="flex flex-col gap-1 border border-border-weak-base rounded-[4px] p-2 bg-surface-base/40">
+                <span class="text-11-regular text-text-weak px-1">{listedUrl()}</span>
+                <For each={found()}>
+                  {(m) => (
+                    <label class="flex items-center gap-2 px-1 py-1 text-13-regular text-text-strong cursor-pointer">
+                      <input type="checkbox" checked={selected().has(m)} onChange={() => toggle(m)} />
+                      {m}
+                    </label>
+                  )}
+                </For>
+              </div>
+            </Show>
+          </section>
+
+          {/* ── Configured ── */}
+          <section class="flex flex-col gap-3">
+            <h3 class="text-13-medium text-text-strong">Configured</h3>
+            <Show
+              when={(configured()?.length ?? 0) > 0}
+              fallback={<p class="text-12-regular text-text-weak/70">No local providers yet.</p>}
+            >
+              <For each={configured()}>
+                {(p) => (
+                  <div class="flex items-center justify-between border border-border-weak-base rounded-[4px] p-3 bg-surface-base/40">
+                    <div class="flex flex-col gap-0.5">
+                      <span class="text-13-medium text-text-strong">{p.id}</span>
+                      <span class="text-11-regular text-text-weak">
+                        {p.baseURL} · {p.models.length} model(s)
+                      </span>
+                    </div>
+                    <Button
+                      size="small"
+                      variant="ghost"
+                      icon="trash"
+                      disabled={busy()}
+                      onClick={() => removeProvider(p.id)}
+                    >
+                      Remove
+                    </Button>
+                  </div>
+                )}
+              </For>
+            </Show>
+          </section>
+        </div>
+      </PanelBody>
+    </PanelScroll>
   )
 }
 

--- a/frontend/workspace/src/components/settings/registry-contract.test.ts
+++ b/frontend/workspace/src/components/settings/registry-contract.test.ts
@@ -4,6 +4,7 @@ import { SETTINGS_PANELS, SETTINGS_PANEL_IDS, SETTINGS_SECTIONS } from "./regist
 const root = new URL("./", import.meta.url)
 const modules: Record<(typeof SETTINGS_PANEL_IDS)[number], string> = {
   models: "Models",
+  "local-models": "LocalModels",
   skills: "Skills",
   connectors: "Connectors",
   compute: "Compute",

--- a/frontend/workspace/src/components/settings/registry.ts
+++ b/frontend/workspace/src/components/settings/registry.ts
@@ -30,6 +30,7 @@ export type SettingsSection = "inference" | "capabilities" | "runtime" | "app"
 // removed, or left without the shared layout audit silently.
 export const SETTINGS_PANEL_IDS = [
   "models",
+  "local-models",
   "skills",
   "connectors",
   "compute",
@@ -66,6 +67,13 @@ export const SETTINGS_PANELS: SettingsPanel[] = [
     section: "inference",
     component: lazy(() => import("./Models")),
   },
+  {
+    id: "local-models",
+    title: "Local models",
+    icon: "cpu",
+    section: "inference",
+    component: lazy(() => import("./LocalModels")),
+  },
   // ── Capabilities ──
   {
     id: "skills",
@@ -81,8 +89,6 @@ export const SETTINGS_PANELS: SettingsPanel[] = [
     section: "capabilities",
     component: lazy(() => import("./Connectors")),
   },
-  // Local models remain implemented but hidden until chat, tool-call, and
-  // streaming behavior pass a full runtime smoke.
   // ── Runtime ──
   {
     id: "compute",

--- a/frontend/workspace/src/components/settings/truth-pass.test.ts
+++ b/frontend/workspace/src/components/settings/truth-pass.test.ts
@@ -11,15 +11,18 @@ describe("launch settings truth pass", () => {
     expect(DEFAULT_PANEL).toBe("models")
   })
 
-  test("keeps local models, memory, and specialist internals out of Customize for now", () => {
+  test("exposes verified local models while keeping removed internals out of Customize", () => {
     const ids = SETTINGS_PANELS.map((item) => item.id as string)
 
-    expect(ids).not.toContain("local-models")
+    expect(ids).toContain("local-models")
     expect(ids).not.toContain("memory")
     expect(ids).not.toContain("specialists")
     expect(source("LocalModels.tsx")).toContain("const LocalModels: Component = () =>")
+    expect(source("LocalModels.tsx")).toContain('"/context"')
+    expect(source("LocalModels.tsx")).toContain("num_ctx")
     expect(ids).toEqual([
       "models",
+      "local-models",
       "skills",
       "connectors",
       "compute",
@@ -37,7 +40,7 @@ describe("launch settings truth pass", () => {
     const ids = SETTINGS_PANELS.map((item) => item.id)
 
     expect(ids).toContain("skills")
-    expect(ids.indexOf("skills")).toBe(ids.indexOf("models") + 1)
+    expect(ids.indexOf("skills")).toBe(ids.indexOf("local-models") + 1)
     expect(panel.title).toBe("Skills")
     expect(panel.section).toBe("capabilities")
     expect(panel.icon).toBe("flask")


### PR DESCRIPTION
## What changed

- restore Local models as a first-class Settings panel
- add configurable Ollama context windows in Settings and the CLI
- create real num_ctx aliases through the native Ollama API
- verify OpenAI-compatible local tool streaming against an actual in-process server

Closes #297

## Validation

- 31 backend local-model tests pass
- 16 settings contract tests pass
- monorepo typecheck passes
- local settings UI rendered and inspected