### PR TITLE
docs(models): document OrcaRouter gateway provider

### DIFF
--- a/frontend/docs/src/content/openscience/models.mdx
+++ b/frontend/docs/src/content/openscience/models.mdx
@@ -11,11 +11,13 @@ OpenScience is model-agnostic. A **model** is one inference endpoint the agent r
 Set a key from any provider and start working:
 
 ```bash
-export ANTHROPIC_API_KEY=sk-ant-...   # or OPENAI_API_KEY, GEMINI_API_KEY, ...
+export ANTHROPIC_API_KEY=sk-ant-...   # or OPENAI_API_KEY, GEMINI_API_KEY, ORCAROUTER_API_KEY, ...
 openscience
 ```
 
 Keys stay on your machine. Anthropic, OpenAI, Google, OpenRouter, Groq, Mistral, xAI, Meta Model API, DeepSeek, and dozens more work the same way — the catalogue is models.dev-backed, so any `provider/model` id a provider currently exposes is addressable. You can also paste keys into the Credentials panel in the [workspace](/openscience/workspace) instead of exporting them, and OpenAI Codex signs in via OAuth.
+
+Gateways work the same way. Set `ORCAROUTER_API_KEY` and address any [OrcaRouter](https://www.orcarouter.ai) model as `orcarouter/<model>` — the catalogue ids are provider-prefixed, so `orcarouter/anthropic/claude-sonnet-4.6` and `orcarouter/openai/gpt-4o` both work. OrcaRouter is an OpenAI-compatible router: one key serves 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax and xAI behind a single `https://api.orcarouter.ai/v1` endpoint, and it runs gateway-level, zero-trust security for AI agents on the same endpoint. `openscience models orcarouter --flat` lists every id it exposes.
 
 The current frontier families are available on both paths:
 


### PR DESCRIPTION
### What does this PR do?

Documents [OrcaRouter](https://www.orcarouter.ai) as a named gateway in the Models & providers guide (`frontend/docs/src/content/openscience/models.mdx`). With one API key, users get 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax and xAI behind a single endpoint. Because OpenScience's provider layer is a thin base-URL swap — the models.dev catalogue already routes `orcarouter/*` through the bundled OpenAI-compatible SDK — any agent that uses it also inherits OrcaRouter's gateway-level, zero-trust security controls for AI agents, with no application code changes. The gateway screens every prompt and response and governs every tool call on a default-deny basis, across four layers:

- **Scoped keys** — bind a key to specific models, IPs, spend caps, and expiry.
- **Guardrails** — screen for PII, secret leakage, prompt injection, and unsafe output.
- **Agent firewall** — tool allow-lists with per-argument validation.
- **Audit trail** — a record of every match, verdict, and approval decision.

The new section documents the exact setup: `ORCAROUTER_API_KEY`, the `orcarouter/<model>` addressing form (catalogue ids are provider-prefixed, so `orcarouter/anthropic/claude-sonnet-4.6` and `orcarouter/openai/gpt-4o` both work), and the `openscience models orcarouter --flat` listing. No code or dependency changes.

### How did you verify your code works?

- Live, against `https://api.orcarouter.ai/v1` with a real key: `orcarouter/anthropic/claude-sonnet-4.6` → 200, `orcarouter/openai/gpt-4o` → 200, `orcarouter/auto` → 200, bare `auto` → 503 (confirms the namespaced-id requirement).
- Code trace: for providers outside the loader switch, `getLanguage` falls back to `sdk.languageModel(model.api.id)`, where the SDK comes from `BUNDLED_PROVIDERS[model.api.npm]` — orcarouter's catalogue entry pins `npm: @ai-sdk/openai-compatible`, which is already bundled, so no code change is required.
- `bunx prettier@3.6.2 --no-semi --print-width 120 --check frontend/docs/src/content/openscience/models.mdx` is clean.

### Checklist

- [ ] `bun run typecheck` passes — not run (docs-only change)
- [ ] `bun test` (in `backend/cli`) passes — not run (docs-only change)
- [x] `bunx prettier --check .` is clean (verified on the changed file)
- [ ] Linked an issue (e.g. `Fixes #123`)
- [ ] Screenshots or a short video for UI changes

I'm an engineer on the OrcaRouter team.
