### PR TITLE
Add optional deployment authentication

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,6 +14,8 @@ Use **Research tools → Action approval** beneath the composer to switch to **A
 
 Server mode is opt-in. The server binds to localhost (127.0.0.1) only and enforces a Host and Origin allowlist to block DNS-rebinding and cross-origin requests. It is not built for remote exposure. If you tunnel or reverse-proxy it yourself, securing that exposure is your responsibility, and anything the server provides in that setup is not a vulnerability.
 
+Self-hosted operators can set `OPENSCIENCE_AUTH_TOKEN` to require `Authorization: Bearer <token>` on network requests as an additional deployment boundary. The health endpoint and browser CORS preflights remain open, and trusted in-process calls are unaffected. A reverse proxy must inject or forward the header on ordinary HTTP, streaming, and WebSocket requests. Leaving the variable unset preserves the local default.
+
 ### Out of scope
 
 | Category                    | Why                                                                  |

--- a/backend/cli/src/server/host-guard.ts
+++ b/backend/cli/src/server/host-guard.ts
@@ -1,5 +1,7 @@
-// The local openscience server only ever binds to loopback. Two independent checks
-// gate every NETWORK request (in-process callers bypass both via a per-process
+import { timingSafeEqual } from "../util/timing-safe"
+
+// The local openscience server only ever binds to loopback. Independent checks
+// gate every NETWORK request (in-process callers bypass them via a per-process
 // nonce header — see Server.internalFetch):
 //
 //   isAllowedHost   — rejects DNS-rebinding. An attacker page on evil.com that
@@ -74,4 +76,19 @@ export function isCrossOrigin(
 ): boolean {
   if (origin !== undefined) return !isAllowedOrigin(origin, extraWhitelist)
   return secFetchSite === "cross-site"
+}
+
+export function isCorsPreflight(
+  method: string,
+  origin: string | undefined,
+  requestedMethod: string | undefined,
+): boolean {
+  return method === "OPTIONS" && origin !== undefined && requestedMethod !== undefined
+}
+
+/** Verify the optional deployment credential without changing local defaults. */
+export function isDeploymentAuthorized(token: string | undefined, authorization: string | undefined): boolean {
+  if (!token) return true
+  if (!authorization || authorization.slice(0, 7).toLowerCase() !== "bearer ") return false
+  return timingSafeEqual(authorization.slice(7), token)
 }

--- a/backend/cli/src/server/server.ts
+++ b/backend/cli/src/server/server.ts
@@ -7,7 +7,7 @@ import { cors } from "hono/cors"
 import { streamSSE } from "hono/streaming"
 import { serveWebAsset, wantsJson } from "../web/serve"
 import { webAssetContentSecurityPolicy } from "../web/csp"
-import { isAllowedHost, isAllowedOrigin, isCrossOrigin } from "./host-guard"
+import { isAllowedHost, isAllowedOrigin, isCorsPreflight, isCrossOrigin, isDeploymentAuthorized } from "./host-guard"
 import { timingSafeEqual } from "../util/timing-safe"
 import { FolderResolveRoutes } from "./routes/folder-resolve"
 import { AtlasBridgeRoutes } from "./routes/atlas-bridge"
@@ -175,6 +175,25 @@ export namespace Server {
           //    (e.g. a no-cors GET) — is rejected. See isCrossOrigin.
           if (isCrossOrigin(c.req.header("origin"), c.req.header("sec-fetch-site"), _corsWhitelist)) {
             return c.json({ error: "Forbidden origin" }, 403)
+          }
+
+          // 3. Optional defense-in-depth for reverse-proxied and co-located
+          //    deployments. Health remains available to liveness probes and
+          //    real CORS preflights proceed to the CORS middleware; the actual
+          //    request must still authenticate.
+          const health = c.req.path === "/global/health"
+          const preflight = isCorsPreflight(
+            c.req.method,
+            c.req.header("origin"),
+            c.req.header("access-control-request-method"),
+          )
+          if (
+            !health &&
+            !preflight &&
+            !isDeploymentAuthorized(process.env["OPENSCIENCE_AUTH_TOKEN"], c.req.header("authorization"))
+          ) {
+            c.header("WWW-Authenticate", 'Bearer realm="openscience"')
+            return c.json({ error: "Unauthorized" }, 401)
           }
           return next()
         })

--- a/backend/cli/test/server/deployment-auth.test.ts
+++ b/backend/cli/test/server/deployment-auth.test.ts
@@ -1,0 +1,68 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test"
+import { Server } from "../../src/server/server"
+
+const key = "OPENSCIENCE_AUTH_TOKEN"
+const previous = process.env[key]
+const token = "shared-lab-secret"
+
+const request = (headers?: HeadersInit) =>
+  Server.App().fetch(
+    new Request("http://localhost/global/project", {
+      method: "POST",
+      headers: { "content-type": "application/json", ...headers },
+      body: "{}",
+    }),
+  )
+
+describe.serial("deployment authentication", () => {
+  beforeAll(() => {
+    process.env[key] = token
+  })
+
+  afterAll(() => {
+    if (previous === undefined) delete process.env[key]
+    if (previous !== undefined) process.env[key] = previous
+  })
+
+  test("rejects an unauthenticated network request", async () => {
+    const response = await request()
+    expect(response.status).toBe(401)
+    expect(response.headers.get("www-authenticate")).toBe('Bearer realm="openscience"')
+  })
+
+  test("accepts the configured bearer token", async () => {
+    const response = await request({ authorization: `Bearer ${token}` })
+    expect(response.status).not.toBe(401)
+  })
+
+  test("keeps health open for liveness probes", async () => {
+    const response = await Server.App().fetch(new Request("http://localhost/global/health"))
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({ healthy: true })
+  })
+
+  test("allows real CORS preflights but not ordinary OPTIONS requests", async () => {
+    const preflight = await Server.App().fetch(
+      new Request("http://localhost/global/project", {
+        method: "OPTIONS",
+        headers: {
+          origin: "https://app.syntheticsciences.ai",
+          "access-control-request-method": "POST",
+        },
+      }),
+    )
+    expect(preflight.status).not.toBe(401)
+
+    const ordinary = await Server.App().fetch(new Request("http://localhost/global/project", { method: "OPTIONS" }))
+    expect(ordinary.status).toBe(401)
+  })
+
+  test("keeps trusted in-process calls exempt", async () => {
+    const response = await Server.internalFetch()("http://openscience.internal/global/project", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    })
+    expect(response.status).not.toBe(401)
+  })
+})

--- a/backend/cli/test/server/host-guard.test.ts
+++ b/backend/cli/test/server/host-guard.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test"
-import { isAllowedHost, isAllowedOrigin, isCrossOrigin } from "../../src/server/host-guard"
+import {
+  isAllowedHost,
+  isAllowedOrigin,
+  isCorsPreflight,
+  isCrossOrigin,
+  isDeploymentAuthorized,
+} from "../../src/server/host-guard"
 
 describe("isAllowedHost", () => {
   test("allows localhost with a port", () => {
@@ -117,5 +123,35 @@ describe("isCrossOrigin", () => {
 
   test("allows non-browser clients (neither Origin nor Sec-Fetch-Site)", () => {
     expect(isCrossOrigin(undefined, undefined)).toBe(false)
+  })
+})
+
+describe("isCorsPreflight", () => {
+  test("recognizes a real browser preflight", () => {
+    expect(isCorsPreflight("OPTIONS", "https://app.syntheticsciences.ai", "POST")).toBe(true)
+  })
+
+  test("does not exempt ordinary OPTIONS requests", () => {
+    expect(isCorsPreflight("OPTIONS", undefined, undefined)).toBe(false)
+    expect(isCorsPreflight("OPTIONS", "https://app.syntheticsciences.ai", undefined)).toBe(false)
+    expect(isCorsPreflight("GET", "https://app.syntheticsciences.ai", "POST")).toBe(false)
+  })
+})
+
+describe("isDeploymentAuthorized", () => {
+  test("preserves existing behavior when no deployment token is configured", () => {
+    expect(isDeploymentAuthorized(undefined, undefined)).toBe(true)
+  })
+
+  test("accepts the configured bearer token", () => {
+    expect(isDeploymentAuthorized("lab-secret", "Bearer lab-secret")).toBe(true)
+    expect(isDeploymentAuthorized("lab-secret", "bearer lab-secret")).toBe(true)
+  })
+
+  test("rejects missing, malformed, and incorrect credentials", () => {
+    expect(isDeploymentAuthorized("lab-secret", undefined)).toBe(false)
+    expect(isDeploymentAuthorized("lab-secret", "Basic lab-secret")).toBe(false)
+    expect(isDeploymentAuthorized("lab-secret", "Bearer wrong-secret")).toBe(false)
+    expect(isDeploymentAuthorized("lab-secret", "Bearer lab-secret-extra")).toBe(false)
   })
 })

--- a/frontend/docs/src/content/openscience/security.mdx
+++ b/frontend/docs/src/content/openscience/security.mdx
@@ -39,6 +39,8 @@ Known credential patterns are redacted from agent output before it lands in a tr
 
 Server mode is opt-in. The server binds to localhost (127.0.0.1) only and enforces a Host and Origin allowlist to block DNS-rebinding and cross-origin requests. It is not built for remote exposure — if you tunnel or reverse-proxy it, securing that exposure is on you.
 
+For defense in depth on a shared host or behind a reverse proxy, set `OPENSCIENCE_AUTH_TOKEN`. Every network request must then include `Authorization: Bearer <token>`, except `/global/health` and browser CORS preflights. In-process calls keep working without the token. Make sure the proxy forwards or injects the credential for HTTP, streaming, and WebSocket traffic.
+
 ## What leaves your machine
 
 - Prompts and responses sent to your model provider, governed by that provider's policy.


### PR DESCRIPTION
## Summary

- add optional OPENSCIENCE_AUTH_TOKEN bearer authentication for network requests
- keep health probes, browser preflights, and trusted in-process calls working
- use constant-time credential comparison and document reverse-proxy behavior

## Verification

- bun test: 2,272 passed, 0 failed
- bun run typecheck
- bun run format:check

Fixes #305