### PR TITLE
Add safe workspace trash and rename

### DIFF
--- a/backend/cli/src/file/ignore.ts
+++ b/backend/cli/src/file/ignore.ts
@@ -24,6 +24,7 @@ export namespace FileIgnore {
     "desktop",
     ".sst",
     ".cache",
+    ".openscience-trash",
     ".webkit-cache",
     "__pycache__",
     ".pytest_cache",

--- a/backend/cli/src/file/index.ts
+++ b/backend/cli/src/file/index.ts
@@ -21,6 +21,8 @@ import { PublicationReview } from "./review"
 import { SessionFilesystem } from "../session/filesystem"
 import { Filesystem } from "../util/filesystem"
 import { SafeFileIO } from "./safe-io"
+import { FileTrash } from "./trash"
+import { Lock } from "@/util/lock"
 
 export namespace File {
   const log = Log.create({ service: "file" })
@@ -87,6 +89,13 @@ export namespace File {
       ref: "FileContent",
     })
   export type Content = z.infer<typeof Content>
+
+  export const Rename = z.object({
+    from: z.string(),
+    to: z.string(),
+    type: z.enum(["file", "directory"]),
+  })
+  export type Rename = z.infer<typeof Rename>
 
   async function shouldEncode(file: { type?: string }): Promise<boolean> {
     const type = file.type?.toLowerCase()
@@ -227,14 +236,19 @@ export namespace File {
 
   async function contained(file: string, access: SessionFilesystem.Access, options?: AccessOptions): Promise<string> {
     if (options?.sessionID) {
-      return SessionFilesystem.authorize({
+      const target = await SessionFilesystem.authorize({
         sessionID: options.sessionID,
         path: file,
         access,
       }).then((result) => result.path)
+      if (FileTrash.protectedPath(target)) throw new HTTPException(403, { message: "Recovery data is protected" })
+      return target
     }
     const full = path.isAbsolute(file) ? file : path.resolve(Instance.directory, file)
     const canonical = await Filesystem.canonical(full)
+    if (canonical && FileTrash.protectedPath(canonical)) {
+      throw new HTTPException(403, { message: "Recovery data is protected" })
+    }
     if (canonical && (await Instance.containsCanonicalPath(canonical))) return canonical
     throw new Error(`Access denied: path escapes project directory`)
   }
@@ -459,8 +473,54 @@ export namespace File {
     return readPath(file, full)
   }
 
+  export async function rename(input: { from: string; to: string; sessionID: string }): Promise<Rename> {
+    const source = await SessionFilesystem.authorize({ sessionID: input.sessionID, path: input.from, access: "write" })
+    if (source.path === Instance.directory || source.path === source.grant.path) {
+      throw new HTTPException(409, { message: "The workspace root cannot be renamed" })
+    }
+    const target = await SessionFilesystem.authorize({ sessionID: input.sessionID, path: input.to, access: "write" })
+    if (FileTrash.protectedPath(source.path) || FileTrash.protectedPath(target.path)) {
+      throw new HTTPException(403, { message: "Recovery data is protected" })
+    }
+    if (source.path === target.path) {
+      const stat = await fs.promises.lstat(source.path)
+      return Rename.parse({ from: source.path, to: target.path, type: stat.isDirectory() ? "directory" : "file" })
+    }
+    if (source.grant.path !== target.grant.path) {
+      throw new HTTPException(409, { message: "Files cannot be renamed across workspace sources" })
+    }
+    const parent = await fs.promises.stat(path.dirname(target.path)).catch(() => undefined)
+    if (!parent?.isDirectory()) throw new HTTPException(400, { message: "The destination folder does not exist" })
+
+    using _ = await Lock.write(`file-rename:${Instance.project.id}`)
+    if (await fs.promises.lstat(target.path).catch(() => undefined)) {
+      throw new HTTPException(409, { message: `Refusing to overwrite ${target.path}` })
+    }
+    const stat = await fs.promises.lstat(source.path)
+    const type = stat.isDirectory() ? "directory" : stat.isFile() ? "file" : undefined
+    if (!type || stat.isSymbolicLink())
+      throw new HTTPException(400, { message: "Only files and folders can be renamed" })
+    if (type === "directory" && Filesystem.contains(source.path, target.path)) {
+      throw new HTTPException(409, { message: "A folder cannot be moved inside itself" })
+    }
+    await fs.promises.rename(source.path, target.path).catch((error: NodeJS.ErrnoException) => {
+      if (error.code === "EEXIST" || error.code === "ENOTEMPTY") {
+        throw new HTTPException(409, { message: `Refusing to overwrite ${target.path}` })
+      }
+      if (error.code === "EXDEV") {
+        throw new HTTPException(409, { message: "Files cannot be renamed across filesystems" })
+      }
+      throw error
+    })
+    await Promise.all([
+      Bus.publish(FileWatcher.Event.Updated, { file: source.path, event: "unlink" }),
+      Bus.publish(FileWatcher.Event.Updated, { file: target.path, event: "add" }),
+    ])
+    return Rename.parse({ from: source.path, to: target.path, type })
+  }
+
   export async function list(dir?: string, options?: AccessOptions) {
-    const exclude = [".git", ".DS_Store"]
+    const exclude = [".git", ".DS_Store", FileTrash.FOLDER]
     const project = Instance.project
     let ignored = (_: string) => false
     if (project.vcs === "git") {

--- a/backend/cli/src/file/ripgrep.ts
+++ b/backend/cli/src/file/ripgrep.ts
@@ -212,7 +212,7 @@ export namespace Ripgrep {
   }) {
     input.signal?.throwIfAborted()
 
-    const args = [await filepath(), "--files", "--glob=!.git/*"]
+    const args = [await filepath(), "--files", "--glob=!.git/*", "--glob=!.openscience-trash/**"]
     if (input.follow !== false) args.push("--follow")
     if (input.hidden !== false) args.push("--hidden")
     if (input.maxDepth !== undefined) args.push(`--max-depth=${input.maxDepth}`)

--- a/backend/cli/src/file/trash.ts
+++ b/backend/cli/src/file/trash.ts
@@ -1,18 +1,21 @@
 import crypto from "node:crypto"
-import path from "node:path"
+import { createReadStream, constants as FS } from "node:fs"
 import fs from "node:fs/promises"
-import { constants as FS } from "node:fs"
+import path from "node:path"
+import { HTTPException } from "hono/http-exception"
 import z from "zod"
 import { Global } from "@/global"
+import { Instance } from "@/project/instance"
 import { SessionFilesystem } from "@/session/filesystem"
-import { Lock } from "@/util/lock"
 import { Filesystem } from "@/util/filesystem"
+import { Lock } from "@/util/lock"
 
-/** Recoverable trash for source/workspace files deleted by agent edit tools.
- * Bytes live outside the project so a later project command cannot mutate the
- * recovery copy. Records expire after 30 days and are purged opportunistically. */
+/** Recoverable trash for source and workspace files. Recovery metadata stays
+ * in the protected data root; new payloads stay beside their authorized source
+ * so moving even a large directory is an atomic, same-volume rename. */
 export namespace FileTrash {
   export const RETENTION_MS = 30 * 24 * 60 * 60 * 1000
+  export const FOLDER = ".openscience-trash"
 
   export const Record = z.object({
     id: z.string().startsWith("ftr_"),
@@ -21,8 +24,14 @@ export namespace FileTrash {
     originalPath: z.string(),
     filename: z.string(),
     size: z.number().int().nonnegative(),
-    sha256: z.string().regex(/^[a-f0-9]{64}$/),
+    sha256: z
+      .string()
+      .regex(/^[a-f0-9]{64}$/)
+      .optional(),
     mode: z.number().int().nonnegative(),
+    kind: z.enum(["file", "directory"]).default("file"),
+    store: z.enum(["data", "workspace"]).default("data"),
+    payloadPath: z.string().optional(),
     state: z.enum(["trash", "restored"]),
     trashedAt: z.number().int().positive(),
     expiresAt: z.number().int().positive(),
@@ -35,14 +44,43 @@ export namespace FileTrash {
   const projectRoot = (projectID: string) => path.join(root, segment(projectID))
   const entryRoot = (projectID: string, id: string) => path.join(projectRoot(projectID), id)
   const metadata = (projectID: string, id: string) => path.join(entryRoot(projectID, id), "record.json")
-  const payload = (projectID: string, id: string) => path.join(entryRoot(projectID, id), "payload")
+  const legacyPayload = (projectID: string, id: string) => path.join(entryRoot(projectID, id), "payload")
   const lock = (projectID: string) => `file-trash:${segment(projectID)}`
+  const localEntry = (record: Record) => {
+    if (!record.payloadPath || !path.isAbsolute(record.payloadPath) || !path.isAbsolute(record.originalPath)) return
+    const entry = path.dirname(record.payloadPath)
+    const trash = path.dirname(entry)
+    const source = path.dirname(trash)
+    if (
+      path.basename(record.payloadPath) !== "payload" ||
+      path.basename(entry) !== record.id ||
+      path.basename(trash) !== FOLDER ||
+      !Filesystem.contains(source, record.originalPath)
+    )
+      return
+    return entry
+  }
+  const payload = (record: Record) => {
+    if (!record.payloadPath) return legacyPayload(record.projectID, record.id)
+    if (localEntry(record)) return record.payloadPath
+  }
 
-  async function writeRecord(record: Record) {
-    const target = metadata(record.projectID, record.id)
+  export function protectedPath(value: string) {
+    return path.resolve(value).split(path.sep).includes(FOLDER)
+  }
+
+  async function atomicJson(target: string, record: Record) {
     const temp = `${target}.${crypto.randomUUID()}.tmp`
     await fs.writeFile(temp, JSON.stringify(record, null, 2), { mode: 0o600 })
     await fs.rename(temp, target)
+  }
+
+  async function writeRecord(record: Record, local = true) {
+    const trusted = metadata(record.projectID, record.id)
+    await fs.mkdir(path.dirname(trusted), { recursive: true, mode: 0o700 })
+    await atomicJson(trusted, record)
+    const entry = localEntry(record)
+    if (local && entry) await atomicJson(path.join(entry, "record.json"), record)
   }
 
   async function read(projectID: string, id: string) {
@@ -53,25 +91,41 @@ export namespace FileTrash {
       .catch(() => undefined)
   }
 
-  async function records(projectID: string) {
+  async function parsed(projectID: string) {
     const names = await fs.readdir(projectRoot(projectID)).catch(() => [] as string[])
-    const parsed = (await Promise.all(names.map((id) => read(projectID, id)))).filter(
-      (value): value is Record => !!value && value.projectID === projectID,
-    )
-    // A crash after metadata is persisted but before the source inode is moved
-    // must not advertise a recovery record whose payload never existed.
-    const available = await Promise.all(
-      parsed.map(async (record) => {
-        const stat = await fs.lstat(payload(projectID, record.id)).catch(() => undefined)
-        return stat?.isFile() && !stat.isSymbolicLink() ? record : undefined
-      }),
-    )
-    return available.filter((value): value is Record => !!value).toSorted((a, b) => b.trashedAt - a.trashedAt)
+    const records = await Promise.all(names.map((id) => read(projectID, id)))
+    return records.filter((value): value is Record => !!value && value.projectID === projectID)
+  }
+
+  async function available(record: Record) {
+    const target = payload(record)
+    if (!target) return false
+    const stat = await fs.lstat(target).catch(() => undefined)
+    if (!stat || stat.isSymbolicLink()) return false
+    return record.kind === "directory" ? stat.isDirectory() : stat.isFile()
+  }
+
+  async function records(projectID: string) {
+    const records = await parsed(projectID)
+    const states = await Promise.all(records.map((record) => available(record)))
+    return records.filter((_, index) => states[index]).toSorted((a, b) => b.trashedAt - a.trashedAt)
+  }
+
+  async function remove(record: Record) {
+    const entry = localEntry(record)
+    if (entry) {
+      const trash = await fs.lstat(path.dirname(entry)).catch(() => undefined)
+      const current = await fs.lstat(entry).catch(() => undefined)
+      if (trash?.isDirectory() && !trash.isSymbolicLink() && current?.isDirectory() && !current.isSymbolicLink()) {
+        await fs.rm(entry, { recursive: true, force: true })
+      }
+    }
+    await fs.rm(entryRoot(record.projectID, record.id), { recursive: true, force: true })
   }
 
   async function purgeExpiredUnlocked(projectID: string, now = Date.now()) {
-    const expired = (await records(projectID)).filter((record) => record.expiresAt <= now)
-    await Promise.all(expired.map((record) => fs.rm(entryRoot(projectID, record.id), { recursive: true, force: true })))
+    const expired = (await parsed(projectID)).filter((record) => record.expiresAt <= now)
+    await Promise.all(expired.map(remove))
     return expired.length
   }
 
@@ -81,41 +135,52 @@ export namespace FileTrash {
     return (await records(projectID)).filter((record) => record.state === "trash")
   }
 
-  async function openRegular(filepath: string) {
-    const handle = await fs.open(filepath, FS.O_RDONLY | FS.O_NOFOLLOW)
-    try {
-      const stat = await handle.stat()
-      if (!stat.isFile()) throw new Error(`Only canonical regular files can be trashed: ${filepath}`)
-      return { stat, content: await handle.readFile() }
-    } finally {
-      await handle.close()
-    }
+  async function hash(filepath: string) {
+    const digest = crypto.createHash("sha256")
+    for await (const chunk of createReadStream(filepath)) digest.update(chunk)
+    return digest.digest("hex")
   }
 
-  async function restoreMovedPayload(record: Record, removeEntry: boolean) {
-    const source = payload(record.projectID, record.id)
-    await fs.mkdir(path.dirname(record.originalPath), { recursive: true })
-    await fs.chmod(source, record.mode)
-    try {
-      // Hard-link installation is exclusive: unlike rename(), it cannot
-      // overwrite a file that appeared at the restore path after approval.
-      await fs.link(source, record.originalPath)
-    } catch (error) {
-      const code = (error as NodeJS.ErrnoException).code
-      if (code === "EEXIST") {
-        throw new Error(`Refusing to overwrite ${record.originalPath}; recovery payload retained at ${source}`)
-      }
-      throw new Error(`Could not restore ${record.originalPath}; recovery payload retained at ${source}: ${error}`)
-    }
-    if (!removeEntry) return
-    await fs.unlink(source)
-    await fs.rm(entryRoot(record.projectID, record.id), { recursive: true, force: true })
+  async function owner(input: { root?: string; sessionID?: string }, target: string) {
+    const workspace = input.sessionID
+      ? await SessionFilesystem.workspace(input.sessionID).catch(() => undefined)
+      : undefined
+    const grants = input.sessionID ? await SessionFilesystem.list(input.sessionID).catch(() => []) : []
+    const writable = grants.filter((grant) => grant.access === "write" && !grant.time.revoked && !grant.time.consumed)
+    const roots = [input.root, workspace, Instance.directory, ...writable.map((grant) => grant.path)].filter(
+      (value): value is string => !!value,
+    )
+    const canonical = await Promise.all(
+      [...new Set(roots)].map((value) => Filesystem.canonical(value).catch(() => undefined)),
+    )
+    const candidates = await Promise.all(
+      canonical
+        .filter((value): value is string => !!value && value !== target && Filesystem.contains(value, target))
+        .map(async (value) => ((await fs.stat(value).catch(() => undefined))?.isDirectory() ? value : undefined)),
+    )
+    return candidates.filter((value): value is string => !!value).toSorted((a, b) => b.length - a.length)[0]
+  }
+
+  async function workspaceStore(root: string, id: string) {
+    const trash = path.join(root, FOLDER)
+    const entry = path.join(trash, id)
+    await fs.mkdir(trash, { recursive: true, mode: 0o700 })
+    const stat = await fs.lstat(trash)
+    if (!stat.isDirectory() || stat.isSymbolicLink()) throw new Error(`Invalid workspace trash root: ${trash}`)
+    await fs
+      .writeFile(path.join(trash, ".gitignore"), "*\n", { flag: "wx", mode: 0o600 })
+      .catch((error: NodeJS.ErrnoException) => {
+        if (error.code !== "EEXIST") throw error
+      })
+    await fs.mkdir(entry, { recursive: false, mode: 0o700 })
+    return path.join(entry, "payload")
   }
 
   export async function trash(input: {
     projectID: string
     sessionID?: string
     path: string
+    root?: string
     expectedContent?: string | Uint8Array
     now?: number
   }): Promise<Record> {
@@ -124,26 +189,42 @@ export namespace FileTrash {
     if (requestedStat.isSymbolicLink()) throw new Error(`Refusing to trash a symbolic link: ${requested}`)
     const canonical = await Filesystem.canonical(input.path)
     if (!canonical) throw new Error(`Cannot trash an ambiguous path: ${input.path}`)
-    const { stat, content } = await openRegular(canonical)
-    if (input.expectedContent !== undefined) {
-      const expected =
-        typeof input.expectedContent === "string" ? Buffer.from(input.expectedContent, "utf8") : input.expectedContent
-      if (!Buffer.from(expected).equals(content)) {
-        throw new Error(`Refusing to delete ${canonical}: the file changed after approval`)
-      }
+    if (canonical === Instance.directory) throw new Error(`Refusing to trash the project root: ${canonical}`)
+    if (protectedPath(canonical)) throw new Error(`Refusing to trash recovery data: ${canonical}`)
+    const stat = await fs.lstat(canonical)
+    const kind = stat.isDirectory() ? "directory" : stat.isFile() ? "file" : undefined
+    if (!kind) throw new Error(`Only canonical files and folders can be trashed: ${canonical}`)
+    if (kind === "directory" && input.expectedContent !== undefined) {
+      throw new Error(`Expected content cannot be supplied for a directory: ${canonical}`)
     }
 
     const id = `ftr_${crypto.randomUUID()}`
     const now = input.now ?? Date.now()
+    const home = await owner(input, canonical)
+    const target = home ? await workspaceStore(home, id) : legacyPayload(input.projectID, id)
+    const expected =
+      input.expectedContent === undefined
+        ? undefined
+        : crypto
+            .createHash("sha256")
+            .update(
+              typeof input.expectedContent === "string"
+                ? Buffer.from(input.expectedContent, "utf8")
+                : input.expectedContent,
+            )
+            .digest("hex")
     const record = Record.parse({
       id,
       projectID: input.projectID,
       sessionID: input.sessionID,
       originalPath: canonical,
       filename: path.basename(canonical),
-      size: content.byteLength,
-      sha256: crypto.createHash("sha256").update(content).digest("hex"),
+      size: kind === "file" ? stat.size : 0,
+      sha256: expected,
       mode: stat.mode & 0o777,
+      kind,
+      store: home ? "workspace" : "data",
+      payloadPath: home ? target : undefined,
       state: "trash",
       trashedAt: now,
       expiresAt: now + RETENTION_MS,
@@ -151,92 +232,127 @@ export namespace FileTrash {
 
     using _ = await Lock.write(lock(input.projectID))
     await purgeExpiredUnlocked(input.projectID, now)
-    const directory = entryRoot(input.projectID, id)
-    await fs.mkdir(projectRoot(input.projectID), { recursive: true, mode: 0o700 })
-    await fs.mkdir(directory, { recursive: false, mode: 0o700 })
-    let moved = false
+    if (!home) await fs.mkdir(entryRoot(input.projectID, id), { recursive: true, mode: 0o700 })
+    const state = { moved: false }
     try {
-      // Persist recovery metadata before moving the inode. The project lock
-      // keeps the transient record private from list/restore calls, and a
-      // crash after rename still leaves a discoverable recovery record.
       await writeRecord(record)
-      try {
-        // Same-filesystem rename is the deletion primitive. It atomically
-        // removes the pathname and preserves the exact inode; there is no
-        // lstat/read/unlink pathname race.
-        await fs.rename(canonical, payload(input.projectID, id))
-        moved = true
-      } catch (error) {
-        if ((error as NodeJS.ErrnoException).code === "EXDEV") {
-          throw new Error(
-            `Recoverable deletion requires the trash and ${canonical} to share a filesystem; refusing to delete`,
-          )
-        }
-        throw error
-      }
+      await fs.rename(canonical, target).catch((error: NodeJS.ErrnoException) => {
+        if (error.code !== "EXDEV") throw error
+        throw new Error(`Recoverable deletion requires ${canonical} and its trash to share a filesystem`)
+      })
+      state.moved = true
 
-      const movedFile = await openRegular(payload(input.projectID, id))
-      if (movedFile.stat.dev !== stat.dev || movedFile.stat.ino !== stat.ino) {
+      const moved = await fs.lstat(target)
+      if (moved.dev !== stat.dev || moved.ino !== stat.ino) {
         throw new Error(`Refusing to delete ${canonical}: the file identity changed after approval`)
       }
-      if (!movedFile.content.equals(content)) {
+      if (expected && (await hash(target)) !== expected) {
         throw new Error(`Refusing to delete ${canonical}: the file changed after approval`)
       }
-      await fs.chmod(payload(input.projectID, id), 0o600)
+      if (kind === "file") await fs.chmod(target, 0o600)
       return record
     } catch (error) {
-      if (moved) {
-        try {
-          await restoreMovedPayload(record, true)
-        } catch (rollbackError) {
-          throw new AggregateError(
-            [error, rollbackError],
-            `Trash operation failed; recovery payload retained for ${canonical}`,
-          )
-        }
-      } else {
-        await fs.rm(directory, { recursive: true, force: true })
+      if (!state.moved) {
+        await remove(record)
+        throw error
       }
+      const conflict = await fs.lstat(canonical).catch(() => undefined)
+      if (conflict) {
+        throw new AggregateError([error], `Trash operation failed; recovery payload retained for ${canonical}`)
+      }
+      await fs.rename(target, canonical)
+      await remove(record)
       throw error
     }
+  }
+
+  async function validateWorkspaceRecord(record: Record) {
+    if (record.store !== "workspace" || !record.payloadPath) return
+    const entry = localEntry(record)
+    if (!entry) throw new Error(`Invalid workspace trash metadata for ${record.id}`)
+    const trash = await fs.lstat(path.dirname(entry)).catch(() => undefined)
+    const current = await fs.lstat(entry).catch(() => undefined)
+    if (!trash?.isDirectory() || trash.isSymbolicLink() || !current?.isDirectory() || current.isSymbolicLink()) {
+      throw new Error(`Invalid workspace trash metadata for ${record.id}`)
+    }
+    const local = await Bun.file(path.join(entry, "record.json"))
+      .json()
+      .then((value) => Record.parse(value))
+      .catch(() => undefined)
+    if (!local || JSON.stringify(local) !== JSON.stringify(record)) {
+      throw new Error(`Workspace trash metadata mismatch for ${record.id}`)
+    }
+  }
+
+  async function authorize(record: Record, sessionID: string) {
+    const authorized = await SessionFilesystem.authorize({
+      sessionID,
+      path: record.originalPath,
+      access: "write",
+    })
+    if (authorized.path !== record.originalPath) throw new Error("Trash restore path changed after authorization")
+    await validateWorkspaceRecord(record)
   }
 
   export async function restore(input: { projectID: string; sessionID: string; id: string }) {
     using _ = await Lock.write(lock(input.projectID))
     const record = await read(input.projectID, input.id)
-    if (!record || record.state !== "trash") return
+    if (!record || record.state !== "trash" || !(await available(record))) return
     if (record.expiresAt <= Date.now()) {
-      await fs.rm(entryRoot(input.projectID, input.id), { recursive: true, force: true })
+      await remove(record)
       return
     }
-    const authorized = await SessionFilesystem.authorize({
-      sessionID: input.sessionID,
-      path: record.originalPath,
-      access: "write",
-    })
-    if (authorized.path !== record.originalPath) throw new Error("Trash restore path changed after authorization")
+    await authorize(record, input.sessionID)
     await fs.mkdir(path.dirname(record.originalPath), { recursive: true })
-    const temp = path.join(path.dirname(record.originalPath), `.openscience-restore-${record.id}.tmp`)
-    try {
-      await fs.copyFile(payload(input.projectID, input.id), temp, FS.COPYFILE_EXCL)
-      await fs.chmod(temp, record.mode)
-      const restored = await fs.readFile(temp)
-      const digest = crypto.createHash("sha256").update(restored).digest("hex")
-      if (digest !== record.sha256) throw new Error(`Trash payload checksum mismatch for ${record.id}`)
-      try {
-        await fs.link(temp, record.originalPath)
-      } catch (error) {
-        if ((error as NodeJS.ErrnoException).code === "EEXIST") {
-          throw new Error(`Refusing to overwrite an existing file while restoring ${record.originalPath}`)
+    if (await fs.lstat(record.originalPath).catch(() => undefined)) {
+      throw new HTTPException(409, { message: `Refusing to overwrite ${record.originalPath}` })
+    }
+    const source = payload(record)
+    if (!source) throw new Error(`Invalid trash payload for ${record.id}`)
+    if (record.sha256 && record.kind === "file" && (await hash(source)) !== record.sha256) {
+      throw new Error(`Trash payload checksum mismatch for ${record.id}`)
+    }
+
+    if (record.store === "workspace") {
+      await fs.rename(source, record.originalPath).catch((error: NodeJS.ErrnoException) => {
+        if (error.code === "EEXIST" || error.code === "ENOTEMPTY") {
+          throw new HTTPException(409, { message: `Refusing to overwrite ${record.originalPath}` })
         }
         throw error
-      }
+      })
+      if (record.kind === "file") await fs.chmod(record.originalPath, record.mode)
+      const result = Record.parse({ ...record, state: "restored", restoredAt: Date.now() })
+      await writeRecord(result, false)
+      const entry = localEntry(record)
+      if (entry) await fs.rm(entry, { recursive: true, force: true })
+      return result
+    }
+
+    const temp = path.join(path.dirname(record.originalPath), `.openscience-restore-${record.id}.tmp`)
+    try {
+      await fs.copyFile(source, temp, FS.COPYFILE_EXCL)
+      await fs.chmod(temp, record.mode)
+      await fs.link(temp, record.originalPath).catch((error: NodeJS.ErrnoException) => {
+        if (error.code === "EEXIST") {
+          throw new HTTPException(409, { message: `Refusing to overwrite ${record.originalPath}` })
+        }
+        throw error
+      })
     } finally {
       await fs.rm(temp, { force: true })
     }
     const result = Record.parse({ ...record, state: "restored", restoredAt: Date.now() })
     await writeRecord(result)
     return result
+  }
+
+  export async function purge(input: { projectID: string; sessionID: string; id: string }) {
+    using _ = await Lock.write(lock(input.projectID))
+    const record = await read(input.projectID, input.id)
+    if (!record || record.state !== "trash" || !(await available(record))) return
+    await authorize(record, input.sessionID)
+    await remove(record)
+    return record
   }
 
   /** Roll back a just-created trash record when a larger single-file edit
@@ -247,7 +363,20 @@ export namespace FileTrash {
     if (!stored || stored.state !== "trash" || stored.originalPath !== record.originalPath) {
       throw new Error(`Cannot roll back unknown trash record ${record.id}`)
     }
-    await restoreMovedPayload(stored, true)
+    const source = payload(stored)
+    if (!source) throw new Error(`Invalid trash payload for ${stored.id}`)
+    if (await fs.lstat(stored.originalPath).catch(() => undefined)) {
+      throw new Error(`Refusing to overwrite ${stored.originalPath}; recovery payload retained at ${source}`)
+    }
+    if (stored.store === "workspace") {
+      await fs.rename(source, stored.originalPath)
+      if (stored.kind === "file") await fs.chmod(stored.originalPath, stored.mode)
+    }
+    if (stored.store === "data") {
+      await fs.chmod(source, stored.mode)
+      await fs.link(source, stored.originalPath)
+    }
+    await remove(stored)
   }
 
   export async function purgeExpired(projectID: string, now = Date.now()) {

--- a/backend/cli/src/server/routes/file.ts
+++ b/backend/cli/src/server/routes/file.ts
@@ -17,6 +17,7 @@ import { PublicationReview } from "../../file/review"
 import { Identifier } from "../../id/id"
 import { ArtifactStore } from "../../artifact/store"
 import { FileTrash } from "../../file/trash"
+import { SessionFilesystem } from "../../session/filesystem"
 
 const LineageRun = z.object({
   id: z.string(),
@@ -262,6 +263,47 @@ export const FileRoutes = lazy(() =>
       async (c) => c.json(await FileTrash.list(Instance.project.id)),
     )
     .post(
+      "/file/trash",
+      describeRoute({
+        summary: "Move a workspace file or folder to trash",
+        description:
+          "Move a local file or folder into recoverable same-volume trash without loading its contents into memory.",
+        operationId: "file.trash.create",
+        responses: {
+          200: {
+            description: "Recoverable file record",
+            content: { "application/json": { schema: resolver(FileTrash.Record) } },
+          },
+          409: { description: "The workspace root cannot be trashed" },
+        },
+      }),
+      validator(
+        "json",
+        z.object({
+          path: z.string().min(1),
+          sessionID: Identifier.schema("session"),
+        }),
+      ),
+      async (c) => {
+        const body = c.req.valid("json")
+        const authorized = await SessionFilesystem.authorize({
+          sessionID: body.sessionID,
+          path: body.path,
+          access: "write",
+        })
+        if (authorized.path === Instance.directory || authorized.path === authorized.grant.path) {
+          throw new HTTPException(409, { message: "The workspace root cannot be moved to trash" })
+        }
+        const record = await FileTrash.trash({
+          projectID: Instance.project.id,
+          sessionID: body.sessionID,
+          path: authorized.path,
+          root: authorized.grant.path,
+        })
+        return c.json(record)
+      },
+    )
+    .post(
       "/file/trash/:id/restore",
       describeRoute({
         summary: "Restore a deleted source file",
@@ -274,6 +316,7 @@ export const FileRoutes = lazy(() =>
             content: { "application/json": { schema: resolver(FileTrash.Record) } },
           },
           404: { description: "Recoverable file not found" },
+          409: { description: "A file or folder already exists at the restore path" },
         },
       }),
       validator("param", z.object({ id: z.string().startsWith("ftr_") })),
@@ -287,6 +330,56 @@ export const FileRoutes = lazy(() =>
         if (!result) return c.json({ error: "Recoverable file not found" }, 404)
         return c.json(result)
       },
+    )
+    .delete(
+      "/file/trash/:id",
+      describeRoute({
+        summary: "Permanently delete a trashed workspace item",
+        description: "Permanently remove a recoverable file or folder after rechecking write authorization.",
+        operationId: "file.trash.purge",
+        responses: {
+          200: {
+            description: "Purged file record",
+            content: { "application/json": { schema: resolver(FileTrash.Record) } },
+          },
+          404: { description: "Recoverable file not found" },
+        },
+      }),
+      validator("param", z.object({ id: z.string().startsWith("ftr_") })),
+      validator("json", z.object({ sessionID: Identifier.schema("session") })),
+      async (c) => {
+        const result = await FileTrash.purge({
+          projectID: Instance.project.id,
+          sessionID: c.req.valid("json").sessionID,
+          id: c.req.valid("param").id,
+        })
+        if (!result) return c.json({ error: "Recoverable file not found" }, 404)
+        return c.json(result)
+      },
+    )
+    .post(
+      "/file/rename",
+      describeRoute({
+        summary: "Rename a workspace file or folder",
+        description: "Rename a local file or folder without overwriting an existing destination.",
+        operationId: "file.rename",
+        responses: {
+          200: {
+            description: "Renamed file",
+            content: { "application/json": { schema: resolver(File.Rename) } },
+          },
+          409: { description: "The destination exists or the source is a workspace root" },
+        },
+      }),
+      validator(
+        "json",
+        z.object({
+          from: z.string().min(1),
+          to: z.string().min(1),
+          sessionID: Identifier.schema("session"),
+        }),
+      ),
+      async (c) => c.json(await File.rename(c.req.valid("json"))),
     )
     .get(
       "/file/inspect",

--- a/backend/cli/test/file/rename.test.ts
+++ b/backend/cli/test/file/rename.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test"
+import fs from "node:fs/promises"
+import path from "node:path"
+import { FileRoutes } from "../../src/server/routes/file"
+import { Instance } from "../../src/project/instance"
+import { executionSession, tmpdir } from "../fixture/fixture"
+
+const rename = (from: string, to: string, sessionID: string) =>
+  FileRoutes().request("/file/rename", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ from, to, sessionID }),
+  })
+
+describe("workspace rename", () => {
+  test("renames files and folders without overwriting", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await executionSession()
+        const source = path.join(tmp.path, "draft.txt")
+        const target = path.join(tmp.path, "final.txt")
+        await fs.writeFile(source, "result\n")
+
+        const response = await rename(source, target, session.id)
+        expect(response.status).toBe(200)
+        expect(await response.json()).toMatchObject({ from: source, to: target, type: "file" })
+        expect(await fs.readFile(target, "utf8")).toBe("result\n")
+        await expect(fs.stat(source)).rejects.toThrow()
+
+        const folder = path.join(tmp.path, "old-folder")
+        const renamed = path.join(tmp.path, "new-folder")
+        await fs.mkdir(folder)
+        expect((await rename(folder, renamed, session.id)).status).toBe(200)
+        expect((await fs.stat(renamed)).isDirectory()).toBe(true)
+        const nested = await rename(renamed, path.join(renamed, "nested"), session.id)
+        expect(nested.status).toBe(409)
+        expect((await fs.stat(renamed)).isDirectory()).toBe(true)
+
+        await fs.writeFile(source, "replacement\n")
+        const conflict = await rename(source, target, session.id)
+        expect(conflict.status).toBe(409)
+        expect(await fs.readFile(source, "utf8")).toBe("replacement\n")
+        expect(await fs.readFile(target, "utf8")).toBe("result\n")
+      },
+    })
+  })
+
+  test("refuses to rename the workspace root", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await executionSession()
+        const response = await rename(tmp.path, `${tmp.path}-renamed`, session.id)
+        expect(response.status).toBe(409)
+        expect((await fs.stat(tmp.path)).isDirectory()).toBe(true)
+      },
+    })
+  })
+})

--- a/backend/cli/test/file/trash.test.ts
+++ b/backend/cli/test/file/trash.test.ts
@@ -88,6 +88,18 @@ describe("recoverable source file trash", () => {
           ).rejects.toThrow("symbolic link")
           expect(await fs.readlink(linked)).toBe(target)
           expect(await fs.readFile(target, "utf8")).toBe("new bytes\n")
+
+          const redirected = path.join(tmp.path, "redirected-trash")
+          const trash = path.join(tmp.path, FileTrash.FOLDER)
+          await fs.rm(trash, { recursive: true })
+          await fs.mkdir(redirected)
+          await fs.symlink(redirected, trash)
+          await expect(
+            FileTrash.trash({ projectID: Instance.project.id, sessionID: session.id, path: target }),
+          ).rejects.toThrow("Invalid workspace trash root")
+          expect(await fs.readFile(target, "utf8")).toBe("new bytes\n")
+          await fs.unlink(trash)
+          await fs.rm(redirected, { recursive: true })
         }
 
         const trashed = await FileTrash.trash({
@@ -157,6 +169,132 @@ describe("recoverable source file trash", () => {
         )
         expect(await FileTrash.list(projectID)).toEqual([])
         await fs.rm(entry, { recursive: true, force: true })
+      },
+    })
+  })
+
+  test("moves folders into same-volume workspace trash and restores them through the routes", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await executionSession()
+        const target = path.join(tmp.path, "dataset")
+        await fs.mkdir(path.join(target, "nested"), { recursive: true })
+        await fs.writeFile(path.join(target, "nested", "sample.csv"), "x,y\n1,2\n")
+
+        const response = await FileRoutes().request("/file/trash", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ path: target, sessionID: session.id }),
+        })
+        expect(response.status).toBe(200)
+        const record = (await response.json()) as FileTrash.Record
+        expect(record).toMatchObject({ filename: "dataset", kind: "directory", store: "workspace" })
+        expect(record.payloadPath).toContain(`${path.sep}${FileTrash.FOLDER}${path.sep}${record.id}${path.sep}payload`)
+        expect(await fs.readFile(path.join(tmp.path, FileTrash.FOLDER, ".gitignore"), "utf8")).toBe("*\n")
+        await expect(fs.stat(target)).rejects.toThrow()
+
+        const second = path.join(tmp.path, "second.txt")
+        await fs.writeFile(second, "second\n")
+        const secondRecord = await FileTrash.trash({
+          projectID: Instance.project.id,
+          sessionID: session.id,
+          path: second,
+        })
+        expect(await fs.readFile(path.join(tmp.path, FileTrash.FOLDER, ".gitignore"), "utf8")).toBe("*\n")
+        await FileTrash.purge({ projectID: Instance.project.id, sessionID: session.id, id: secondRecord.id })
+
+        const listing = await FileRoutes().request(
+          `/file?path=${encodeURIComponent(tmp.path)}&sessionID=${encodeURIComponent(session.id)}`,
+        )
+        expect(listing.status).toBe(200)
+        expect((await listing.json()) as Array<{ name: string }>).not.toContainEqual({ name: FileTrash.FOLDER })
+
+        const restored = await FileRoutes().request(`/file/trash/${record.id}/restore`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ sessionID: session.id }),
+        })
+        expect(restored.status).toBe(200)
+        expect(await fs.readFile(path.join(target, "nested", "sample.csv"), "utf8")).toBe("x,y\n1,2\n")
+      },
+    })
+  })
+
+  test("permanently purges a recoverable file through the route", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await executionSession()
+        const target = path.join(tmp.path, "discard.txt")
+        await fs.writeFile(target, "discard\n")
+        const trashed = await FileTrash.trash({
+          projectID: Instance.project.id,
+          sessionID: session.id,
+          path: target,
+        })
+
+        const response = await FileRoutes().request(`/file/trash/${trashed.id}`, {
+          method: "DELETE",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ sessionID: session.id }),
+        })
+        expect(response.status).toBe(200)
+        expect(await FileTrash.list(Instance.project.id)).toEqual([])
+        await expect(fs.stat(target)).rejects.toThrow()
+        if (trashed.payloadPath) await expect(fs.stat(trashed.payloadPath)).rejects.toThrow()
+      },
+    })
+  })
+
+  test("rollback restores the original file mode", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await executionSession()
+        const target = path.join(tmp.path, "rollback.txt")
+        await fs.writeFile(target, "rollback\n", { mode: 0o640 })
+        const record = await FileTrash.trash({
+          projectID: Instance.project.id,
+          sessionID: session.id,
+          path: target,
+        })
+
+        await FileTrash.rollback(record)
+        expect(await fs.readFile(target, "utf8")).toBe("rollback\n")
+        if (process.platform !== "win32") expect((await fs.stat(target)).mode & 0o777).toBe(0o640)
+        expect(await FileTrash.list(Instance.project.id)).toEqual([])
+      },
+    })
+  })
+
+  test("rejects forged workspace metadata before restore", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await executionSession()
+        const target = path.join(tmp.path, "trusted.txt")
+        const forged = path.join(tmp.path, "forged.txt")
+        await fs.writeFile(target, "trusted\n")
+        const record = await FileTrash.trash({
+          projectID: Instance.project.id,
+          sessionID: session.id,
+          path: target,
+        })
+        expect(record.payloadPath).toBeString()
+        const local = path.join(path.dirname(record.payloadPath!), "record.json")
+        await fs.writeFile(local, JSON.stringify({ ...record, originalPath: forged }))
+
+        await expect(
+          FileTrash.restore({ projectID: Instance.project.id, sessionID: session.id, id: record.id }),
+        ).rejects.toThrow("metadata mismatch")
+        await expect(fs.stat(forged)).rejects.toThrow()
+        await expect(fs.stat(target)).rejects.toThrow()
+        expect(await fs.readFile(record.payloadPath!, "utf8")).toBe("trusted\n")
       },
     })
   })

--- a/frontend/workspace/src/atlas/FilesPane.test.ts
+++ b/frontend/workspace/src/atlas/FilesPane.test.ts
@@ -92,6 +92,21 @@ const saved = (id: string, title: string) => ({
   current: { ...trashed(id, title).current, size: 2048, sourcePath: `/store/${title}` },
 })
 
+const deletedFile = (id: string, filename: string, kind: "file" | "directory" = "file") => ({
+  id,
+  projectID: "prj_1",
+  sessionID: SESSION,
+  originalPath: `${DIRECTORY}/${filename}`,
+  filename,
+  size: kind === "file" ? 12 : 0,
+  mode: 0o600,
+  kind,
+  store: "workspace",
+  state: "trash",
+  trashedAt: Date.now() - 1000,
+  expiresAt: Date.now() + 100_000,
+})
+
 const DIRECTORY = "/home/keertan/proj"
 const SESSION = "ses_1"
 
@@ -710,6 +725,95 @@ describe("files pane", () => {
 
     expect(calls).toContainEqual({ path: "/file/artifact-store/art_1/restore", method: "POST" })
     expect(host.querySelector('[data-trash-row="art_1"]')).toBeNull()
+  })
+
+  test("restores and permanently deletes workspace items from the shared Trash view", async () => {
+    startOn("trash")
+    const calls: Array<{ path: string; method?: string }> = []
+    const store = { files: [deletedFile("ftr_restore", "notes.txt"), deletedFile("ftr_purge", "raw", "directory")] }
+    const host = mount(() =>
+      subject.FilesPane({
+        session: SESSION,
+        directory: DIRECTORY,
+        request: async (path, init) => {
+          calls.push({ path, method: init?.method })
+          if (path === `/session/${SESSION}/filesystem`) return listing(snapshot([]))
+          if (path === "/file/trash" && !init?.method) return listing(store.files)
+          if (path === "/file/trash/ftr_restore/restore") {
+            store.files = store.files.filter((file) => file.id !== "ftr_restore")
+            return listing(deletedFile("ftr_restore", "notes.txt"))
+          }
+          if (path === "/file/trash/ftr_purge" && init?.method === "DELETE") {
+            store.files = store.files.filter((file) => file.id !== "ftr_purge")
+            return listing(deletedFile("ftr_purge", "raw", "directory"))
+          }
+          if (path.startsWith("/file/artifact-store")) return listing([])
+          return listing([])
+        },
+        onPurgeFile: (_file, submit) => void submit(),
+      }),
+    )
+    await settle()
+
+    expect(host.querySelector('[data-file-trash-row="ftr_restore"] [data-file-trash-name]')?.textContent).toBe(
+      "notes.txt",
+    )
+    expect(host.querySelector('[data-file-trash-row="ftr_purge"]')?.textContent).toContain("Folder")
+
+    host.querySelector<HTMLButtonElement>('[data-file-trash-restore="ftr_restore"]')?.click()
+    await settle()
+    host.querySelector<HTMLButtonElement>('[data-file-trash-purge="ftr_purge"]')?.click()
+    await settle()
+
+    expect(calls).toContainEqual({ path: "/file/trash/ftr_restore/restore", method: "POST" })
+    expect(calls).toContainEqual({ path: "/file/trash/ftr_purge", method: "DELETE" })
+    expect(host.querySelector("[data-file-trash-row]")).toBeNull()
+  })
+
+  test("wires rename and recoverable trash actions for writable local rows", async () => {
+    startOn("project")
+    const bodies: Array<{ path: string; body: Record<string, unknown> }> = []
+    const host = mount(() =>
+      subject.FilesPane({
+        session: SESSION,
+        directory: DIRECTORY,
+        request: async (path, init) => {
+          if (path === `/session/${SESSION}/filesystem`) return listing(snapshot([]))
+          if (path.startsWith("/file/artifact-store") || (path === "/file/trash" && !init?.method)) return listing([])
+          if (path === "/file/rename" || (path === "/file/trash" && init?.method === "POST")) {
+            bodies.push({ path, body: JSON.parse(String(init?.body)) as Record<string, unknown> })
+            return listing({ ok: true })
+          }
+          if (path === "/file")
+            return listing([
+              {
+                name: "draft.md",
+                type: "file",
+                size: 12,
+                absolute: `${DIRECTORY}/draft.md`,
+              },
+            ])
+          return listing([])
+        },
+        onRenameFile: (_file, submit) => void submit("report.md"),
+        onTrashFile: (_file, submit) => void submit(),
+      }),
+    )
+    await settle()
+
+    host.querySelector<HTMLButtonElement>('[data-file-rename="draft.md"]')?.click()
+    await settle()
+    host.querySelector<HTMLButtonElement>('[data-file-trash="draft.md"]')?.click()
+    await settle()
+
+    expect(bodies).toContainEqual({
+      path: "/file/rename",
+      body: { from: `${DIRECTORY}/draft.md`, to: `${DIRECTORY}/report.md`, sessionID: SESSION },
+    })
+    expect(bodies).toContainEqual({
+      path: "/file/trash",
+      body: { path: `${DIRECTORY}/draft.md`, sessionID: SESSION },
+    })
   })
 
   test("lists saved Results under Results rather than reporting an empty folder", async () => {

--- a/frontend/workspace/src/atlas/FilesPane.tsx
+++ b/frontend/workspace/src/atlas/FilesPane.tsx
@@ -20,7 +20,7 @@ import { useServer } from "@/context/server"
 import { SourceMenu } from "@/atlas/files/SourceMenu"
 import { ArtifactGrid } from "@/atlas/files/ArtifactGrid"
 import { FileTable, type FileRow } from "@/atlas/files/FileTable"
-import { TrashList } from "@/atlas/files/TrashList"
+import { TrashList, type TrashedFile } from "@/atlas/files/TrashList"
 import { buildSources, type PaneSource } from "@/atlas/files/sources"
 import { readSource, writeSource } from "@/atlas/files/last-source"
 import { RemoteFileView, type RemoteFile } from "@/atlas/files/RemoteFileView"
@@ -41,6 +41,7 @@ import {
 } from "@/atlas/file-sources"
 import "@/atlas/files/FilesPane.css"
 import { NativeDirectoryPickerUnavailable } from "@/utils/native-picker"
+import { confirmDialog, promptDialog } from "@/atlas/dialogs"
 
 export type Transport = (path: string, init?: RequestInit, query?: Record<string, string>) => Promise<Response>
 
@@ -90,6 +91,33 @@ const concise = (value: unknown) => {
     .replace(/^Error:\s*/, "")
     .trim()
   return line.length > 160 ? `${line.slice(0, 159)}…` : line
+}
+
+const normalizeTrash = (value: unknown): TrashedFile[] => {
+  if (!Array.isArray(value)) return []
+  return value.flatMap((item) => {
+    if (!item || typeof item !== "object") return []
+    const row = item as Record<string, unknown>
+    if (
+      typeof row.id !== "string" ||
+      typeof row.filename !== "string" ||
+      typeof row.originalPath !== "string" ||
+      (row.kind !== "file" && row.kind !== "directory") ||
+      typeof row.trashedAt !== "number" ||
+      typeof row.expiresAt !== "number"
+    )
+      return []
+    return [
+      {
+        id: row.id,
+        filename: row.filename,
+        originalPath: row.originalPath,
+        kind: row.kind,
+        trashedAt: row.trashedAt,
+        expiresAt: row.expiresAt,
+      },
+    ]
+  })
 }
 
 // FileExplorer.tsx:57-77 keeps equivalent readAccess/grantAccess/revokeAccess
@@ -189,6 +217,9 @@ export function FilesPane(
     /** Bounded test/integration seam. Production downloads through a direct browser navigation. */
     onDownload?: (name: string, blob: Blob) => void
     onRenameArtifact?: (artifact: StoredArtifact, submit: (title: string) => Promise<unknown>) => void
+    onRenameFile?: (file: FileRow, submit: (name: string) => Promise<unknown>) => void
+    onTrashFile?: (file: FileRow, submit: () => Promise<unknown>) => void
+    onPurgeFile?: (file: TrashedFile, submit: () => Promise<unknown>) => void
   } = {},
 ): JSX.Element {
   // The `request` prop is a standalone test seam (see FilesPane.test.ts) that
@@ -233,6 +264,21 @@ export function FilesPane(
   // needs no session identity — only the project root as a refetch key.
   const ask = (path: string, init?: RequestInit) => transport(path, init)
   const [artifacts, { refetch: refetchArtifacts }] = createArtifactsResource(ask, () => sdk?.directory ?? true)
+  const [trashError, setTrashError] = createSignal("")
+  const [deleted, { refetch: refetchDeleted }] = createResource(
+    () => projectRoot() || true,
+    () =>
+      transport("/file/trash")
+        .then(json)
+        .then((value) => {
+          setTrashError("")
+          return normalizeTrash(value)
+        })
+        .catch((value) => {
+          setTrashError(concise(value))
+          return [] as TrashedFile[]
+        }),
+  )
 
   const [snapshot, { refetch: refetchSnapshot }] = createResource(identity, (current) =>
     readAccess(transport, current).catch(() => undefined),
@@ -418,7 +464,9 @@ export function FilesPane(
 
   const sourceLoading = createMemo(() => {
     const kind = current().kind
-    return kind === "artifacts" || kind === "trash" ? artifacts.loading : entries.loading
+    if (kind === "artifacts") return artifacts.loading
+    if (kind === "trash") return artifacts.loading || deleted.loading
+    return entries.loading
   })
 
   const sourceError = createMemo(() => {
@@ -428,7 +476,7 @@ export function FilesPane(
       return message ? `Results could not be loaded. ${message}` : ""
     }
     if (kind === "trash") {
-      const message = artifacts.latest?.errors.trash
+      const message = artifacts.latest?.errors.trash ?? trashError()
       return message ? `Trash could not be loaded. ${message}` : ""
     }
     return listingError()
@@ -438,6 +486,7 @@ export function FilesPane(
     const kind = current().kind
     if (kind === "artifacts" || kind === "trash") {
       void refetchArtifacts()
+      if (kind === "trash") void refetchDeleted()
       return
     }
     setListingError("")
@@ -450,10 +499,16 @@ export function FilesPane(
     return query ? list.filter((row) => row.name.toLowerCase().includes(query)) : list
   })
 
-  const trash = createMemo(() => {
+  const artifactTrash = createMemo(() => {
     const query = filter().trim().toLowerCase()
     const list = artifacts.latest?.trash ?? []
     return query ? list.filter((item) => item.title.toLowerCase().includes(query)) : list
+  })
+
+  const fileTrash = createMemo(() => {
+    const query = filter().trim().toLowerCase()
+    const list = deleted.latest ?? []
+    return query ? list.filter((item) => item.filename.toLowerCase().includes(query)) : list
   })
 
   // The grid takes artifacts whole. Projecting them into FileRow threw away the
@@ -641,7 +696,7 @@ export function FilesPane(
     // root, even when the picker is browsing the project or a connected
     // folder. Preserve the API's canonical handle so the preview and Details
     // requests do not accidentally read an empty same-named scratch path.
-    const target = row.absolute ?? row.path ?? [where(), row.name].filter(Boolean).join("/")
+    const target = filePath(row)
     const file: PaneFile = {
       name: row.name,
       path: target,
@@ -650,6 +705,74 @@ export function FilesPane(
     }
     if (props.onOpenFile) return props.onOpenFile(file)
     uiStore.openFile(projectRoot(), file.path)
+  }
+
+  const filePath = (row: FileRow) => row.absolute ?? row.path ?? [where(), row.name].filter(Boolean).join("/")
+
+  const mutable = createMemo(() => {
+    const kind = current().kind
+    return Boolean(
+      sessionID() && !current().readonly && (kind === "project" || kind === "session" || kind === "connected"),
+    )
+  })
+
+  const renameFile = (row: FileRow) => {
+    const submit = async (name: string) => {
+      const next = name.trim()
+      if (!next || next === row.name) return
+      if (next === "." || next === ".." || /[\\/\u0000]/u.test(next)) {
+        setError("A file name cannot contain a path separator.")
+        return
+      }
+      const session = sessionID()
+      if (!session) return setError("Start a session before renaming workspace files.")
+      const target = [current().root, ...path(), next].filter(Boolean).join("/")
+      setBusy(true)
+      return transport("/file/rename", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ from: filePath(row), to: target, sessionID: session }),
+      })
+        .then(json)
+        .then(() => refetchEntries())
+        .then(() => setError(""))
+        .catch((value) => setError(`${row.name} could not be renamed. ${concise(value)}`))
+        .finally(() => setBusy(false))
+    }
+    if (props.onRenameFile) return props.onRenameFile(row, submit)
+    if (!dialog) return
+    void promptDialog(dialog, {
+      title: `Rename ${row.type === "directory" ? "folder" : "file"}`,
+      message: "Enter a new name. Existing files will never be replaced.",
+      initial: row.name,
+      confirmLabel: "Rename",
+    }).then((name) => (name === null ? undefined : submit(name)))
+  }
+
+  const trashFile = (row: FileRow) => {
+    const submit = async () => {
+      const session = sessionID()
+      if (!session) return setError("Start a session before changing workspace files.")
+      setBusy(true)
+      return transport("/file/trash", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ path: filePath(row), sessionID: session }),
+      })
+        .then(json)
+        .then(() => Promise.all([refetchEntries(), refetchDeleted()]))
+        .then(() => setError(""))
+        .catch((value) => setError(`${row.name} could not be moved to Trash. ${concise(value)}`))
+        .finally(() => setBusy(false))
+    }
+    if (props.onTrashFile) return props.onTrashFile(row, submit)
+    if (!dialog) return
+    void confirmDialog(dialog, {
+      title: `Move ${row.name} to Trash?`,
+      message: "You can restore it from Files for 30 days.",
+      confirmLabel: "Move to Trash",
+      danger: true,
+    }).then((confirmed) => (confirmed ? submit() : undefined))
   }
 
   const openRemote = (remote: RemoteFile) => setRemoteOpen(remote)
@@ -710,7 +833,7 @@ export function FilesPane(
       })
   }
 
-  const restore = (artifact: StoredArtifact) => {
+  const restoreArtifact = (artifact: StoredArtifact) => {
     if (busy()) return
     setBusy(true)
     restoreStoredArtifact(ask, artifact.id)
@@ -723,6 +846,48 @@ export function FilesPane(
         setBusy(false)
         setError(errorMessage(cause))
       })
+  }
+
+  const restoreFile = (file: TrashedFile) => {
+    const session = sessionID()
+    if (!session || busy()) return
+    setBusy(true)
+    transport(`/file/trash/${encodeURIComponent(file.id)}/restore`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ sessionID: session }),
+    })
+      .then(json)
+      .then(() => Promise.all([refetchDeleted(), refetchEntries()]))
+      .then(() => setError(""))
+      .catch((value) => setError(`${file.filename} could not be restored. ${concise(value)}`))
+      .finally(() => setBusy(false))
+  }
+
+  const purgeFile = (file: TrashedFile) => {
+    const submit = async () => {
+      const session = sessionID()
+      if (!session) return setError("Start a session before changing workspace files.")
+      setBusy(true)
+      return transport(`/file/trash/${encodeURIComponent(file.id)}`, {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sessionID: session }),
+      })
+        .then(json)
+        .then(() => refetchDeleted())
+        .then(() => setError(""))
+        .catch((value) => setError(`${file.filename} could not be deleted. ${concise(value)}`))
+        .finally(() => setBusy(false))
+    }
+    if (props.onPurgeFile) return props.onPurgeFile(file, submit)
+    if (!dialog) return
+    void confirmDialog(dialog, {
+      title: `Delete ${file.filename} permanently?`,
+      message: "This cannot be undone.",
+      confirmLabel: "Delete permanently",
+      danger: true,
+    }).then((confirmed) => (confirmed ? submit() : undefined))
   }
 
   const browser = () => (
@@ -945,12 +1110,15 @@ export function FilesPane(
       <Switch>
         <Match when={current().kind === "trash"}>
           <TrashList
-            rows={trash()}
+            rows={artifactTrash()}
+            files={fileTrash()}
             busy={busy()}
             filtered={Boolean(filter().trim())}
             loading={sourceLoading()}
             unavailable={Boolean(sourceError())}
-            onRestore={restore}
+            onRestore={restoreArtifact}
+            onRestoreFile={restoreFile}
+            onPurgeFile={purgeFile}
           />
         </Match>
 
@@ -975,9 +1143,12 @@ export function FilesPane(
             rows={rows()}
             depth={path().length}
             busy={sourceLoading()}
+            mutable={mutable()}
             filtered={Boolean(filter().trim())}
             loading={sourceLoading()}
             unavailable={Boolean(sourceError())}
+            onRename={renameFile}
+            onTrash={trashFile}
             onUp={() => {
               setPath(path().slice(0, -1))
               // Symmetric with descending: a query typed for the folder being

--- a/frontend/workspace/src/atlas/files/FileTable.test.ts
+++ b/frontend/workspace/src/atlas/files/FileTable.test.ts
@@ -121,4 +121,30 @@ describe("file table", () => {
     expect(loading.textContent).not.toContain("This folder is empty.")
     expect(unavailable.textContent).not.toContain("This folder is empty.")
   })
+
+  test("shows compact rename and trash actions only for mutable sources", () => {
+    const actions: string[] = []
+    const writable = mount(() =>
+      subject.FileTable({
+        rows: ROWS,
+        depth: 0,
+        mutable: true,
+        onOpen: () => actions.push("open"),
+        onUp: () => {},
+        onRename: (row) => actions.push(`rename:${row.name}`),
+        onTrash: (row) => actions.push(`trash:${row.name}`),
+      }),
+    )
+
+    writable.querySelector<HTMLButtonElement>('[data-file-rename="train_lr.py"]')?.click()
+    writable.querySelector<HTMLButtonElement>('[data-file-trash="train_lr.py"]')?.click()
+    expect(actions).toEqual(["rename:train_lr.py", "trash:train_lr.py"])
+    expect(writable.querySelector('[data-file-row="train_lr.py"]')).not.toBeNull()
+
+    const readonly = mount(() =>
+      subject.FileTable({ rows: ROWS, depth: 0, onOpen: () => {}, onUp: () => {}, mutable: false }),
+    )
+    expect(readonly.querySelector("[data-file-rename]")).toBeNull()
+    expect(readonly.querySelector("[data-file-trash]")).toBeNull()
+  })
 })

--- a/frontend/workspace/src/atlas/files/FileTable.tsx
+++ b/frontend/workspace/src/atlas/files/FileTable.tsx
@@ -1,5 +1,5 @@
 import { For, Show, createMemo, type JSX } from "solid-js"
-import { IconArrowUp, IconFile, IconFolder } from "@/atlas/shared/Icon"
+import { IconArrowUp, IconEdit, IconFile, IconFolder, IconTrash } from "@/atlas/shared/Icon"
 import { bytes } from "./bytes"
 
 export interface FileRow {
@@ -28,6 +28,10 @@ export function FileTable(props: {
   loading?: boolean
   /** Suppresses a false empty state when the listing could not be read. */
   unavailable?: boolean
+  /** Local write-capable sources expose lightweight row actions. */
+  mutable?: boolean
+  onRename?: (row: FileRow) => void
+  onTrash?: (row: FileRow) => void
   /**
    * A listing is in flight. The rows on screen still describe the folder being
    * left, so they are shown but not clickable: clicking one would append its
@@ -84,31 +88,61 @@ export function FileTable(props: {
       >
         <For each={sorted()}>
           {(row) => (
-            <button
-              type="button"
-              class="files-row"
-              classList={{ "files-row--ignored": row.ignored }}
-              data-file-row={row.name}
-              data-file-kind={row.type}
-              aria-label={`${row.type === "directory" ? "Open folder" : "Open file"} ${row.name}`}
-              title={row.ignored ? `${row.name} is ignored by the project` : row.name}
-              disabled={props.busy}
-              onClick={() => props.onOpen(row)}
+            <div
+              class="files-row files-row--entry"
+              classList={{ "files-row--ignored": row.ignored, "files-row--mutable": props.mutable }}
+              data-file-entry={row.name}
             >
-              <span class="files-row__glyph" aria-hidden="true">
-                {row.type === "directory" ? (
-                  <IconFolder size={15} strokeWidth={1.45} />
-                ) : (
-                  <IconFile size={15} strokeWidth={1.45} />
-                )}
-              </span>
-              <span class="files-row__name" data-file-name>
-                {row.name}
-              </span>
-              <span class="files-row__size" data-file-size>
-                {row.type === "directory" ? "" : bytes(row.size)}
-              </span>
-            </button>
+              <button
+                type="button"
+                class="files-row__open"
+                data-file-row={row.name}
+                data-file-kind={row.type}
+                aria-label={`${row.type === "directory" ? "Open folder" : "Open file"} ${row.name}`}
+                title={row.ignored ? `${row.name} is ignored by the project` : row.name}
+                disabled={props.busy}
+                onClick={() => props.onOpen(row)}
+              >
+                <span class="files-row__glyph" aria-hidden="true">
+                  {row.type === "directory" ? (
+                    <IconFolder size={15} strokeWidth={1.45} />
+                  ) : (
+                    <IconFile size={15} strokeWidth={1.45} />
+                  )}
+                </span>
+                <span class="files-row__name" data-file-name>
+                  {row.name}
+                </span>
+                <span class="files-row__size" data-file-size>
+                  {row.type === "directory" ? "" : bytes(row.size)}
+                </span>
+              </button>
+              <Show when={props.mutable}>
+                <span class="files-row__actions">
+                  <button
+                    type="button"
+                    data-file-rename={row.name}
+                    aria-label={`Rename ${row.name}`}
+                    title="Rename"
+                    disabled={props.busy}
+                    onClick={() => props.onRename?.(row)}
+                  >
+                    <IconEdit size={13} strokeWidth={1.5} />
+                  </button>
+                  <button
+                    type="button"
+                    class="files-row__trash"
+                    data-file-trash={row.name}
+                    aria-label={`Move ${row.name} to Trash`}
+                    title="Move to Trash"
+                    disabled={props.busy}
+                    onClick={() => props.onTrash?.(row)}
+                  >
+                    <IconTrash size={13} strokeWidth={1.5} />
+                  </button>
+                </span>
+              </Show>
+            </div>
           )}
         </For>
       </Show>

--- a/frontend/workspace/src/atlas/files/FilesPane.css
+++ b/frontend/workspace/src/atlas/files/FilesPane.css
@@ -281,6 +281,77 @@
   outline: 2px solid var(--color-border-base);
   outline-offset: -2px;
 }
+.files-row--entry {
+  position: relative;
+  display: block;
+  padding: 0;
+}
+.files-row__open {
+  display: grid;
+  grid-template-columns: 20px 1fr auto;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  min-height: 40px;
+  padding: 5px 8px;
+  border: 0;
+  border-radius: inherit;
+  background: none;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+.files-row__open:focus-visible {
+  outline: 2px solid var(--color-border-base);
+  outline-offset: -2px;
+}
+.files-row__actions {
+  position: absolute;
+  top: 50%;
+  right: 5px;
+  display: inline-flex;
+  gap: 2px;
+  padding: 2px;
+  border-radius: var(--atlas-radius-xs);
+  background: var(--color-bg-subtle);
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(-50%);
+  transition: opacity 120ms ease;
+}
+.files-row__actions button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  border: 0;
+  border-radius: calc(var(--atlas-radius-xs) - 2px);
+  background: transparent;
+  color: var(--color-text-muted);
+  cursor: pointer;
+}
+.files-row__actions button:hover:not(:disabled),
+.files-row__actions button:focus-visible {
+  background: var(--color-bg-base);
+  color: var(--color-text);
+  outline: none;
+}
+.files-row__actions .files-row__trash:hover:not(:disabled),
+.files-row__actions .files-row__trash:focus-visible {
+  color: var(--color-icon-critical-base);
+}
+.files-row--mutable:hover .files-row__actions,
+.files-row--mutable:focus-within .files-row__actions {
+  opacity: 1;
+  pointer-events: auto;
+}
+.files-row--mutable:hover .files-row__size,
+.files-row--mutable:focus-within .files-row__size {
+  opacity: 0;
+}
 .files-row__glyph {
   display: inline-flex;
   align-items: center;
@@ -330,6 +401,19 @@
   font-size: 11.5px;
   line-height: 1.5;
 }
+.files-trash__section {
+  padding: 12px 8px 4px;
+  color: var(--color-text-faint);
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.files-trash__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
 .files-restore {
   display: inline-flex;
   align-items: center;
@@ -351,6 +435,35 @@
 .files-restore:hover:not(:disabled) {
   background: var(--color-bg-subtle);
   color: var(--color-text);
+}
+.files-purge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: 0;
+  border-radius: calc(var(--atlas-radius-xs) - 2px);
+  background: none;
+  color: var(--color-text-faint);
+  cursor: pointer;
+}
+.files-purge:hover:not(:disabled),
+.files-purge:focus-visible {
+  background: var(--color-bg-subtle);
+  color: var(--color-icon-critical-base);
+  outline: none;
+}
+
+@media (hover: none) {
+  .files-row--mutable .files-row__actions {
+    opacity: 1;
+    pointer-events: auto;
+  }
+  .files-row--mutable .files-row__size {
+    opacity: 0;
+  }
 }
 .files-restore:focus-visible {
   outline: 1px solid var(--color-text);

--- a/frontend/workspace/src/atlas/files/TrashList.tsx
+++ b/frontend/workspace/src/atlas/files/TrashList.tsx
@@ -1,6 +1,6 @@
 import { For, Show, type JSX } from "solid-js"
 import type { StoredArtifact } from "@/artifacts/store"
-import { IconFile, IconRefresh } from "@/atlas/shared/Icon"
+import { IconFile, IconFolder, IconRefresh, IconTrash } from "@/atlas/shared/Icon"
 import { ago } from "./ago"
 
 /**
@@ -10,18 +10,21 @@ import { ago } from "./ago"
  */
 export function TrashList(props: {
   rows: StoredArtifact[]
+  files: TrashedFile[]
   busy?: boolean
   filtered?: boolean
   loading?: boolean
   unavailable?: boolean
   onRestore: (artifact: StoredArtifact) => void
+  onRestoreFile: (file: TrashedFile) => void
+  onPurgeFile: (file: TrashedFile) => void
 }): JSX.Element {
   return (
     <div class="files-table" data-trash-list>
-      <p class="files-trash__note">Deleted artifacts remain recoverable for 30 days, including saved versions.</p>
+      <p class="files-trash__note">Deleted files, folders, and saved results remain recoverable for 30 days.</p>
 
       <Show
-        when={props.rows.length}
+        when={props.rows.length + props.files.length}
         fallback={
           <Show when={!props.loading && !props.unavailable}>
             <div class="files-empty">
@@ -30,36 +33,95 @@ export function TrashList(props: {
           </Show>
         }
       >
-        <For each={props.rows}>
-          {(artifact) => (
-            <div class="files-row files-row--trash" data-trash-row={artifact.id}>
-              <span class="files-row__glyph" aria-hidden="true">
-                <IconFile size={15} strokeWidth={1.45} />
-              </span>
-              <span class="files-row__name files-row__identity">
-                <span data-trash-name>{artifact.title}</span>
-                <span class="files-row__meta" data-trash-meta>
-                  {artifact.versionCount} {artifact.versionCount === 1 ? "version" : "versions"}
-                  <Show when={artifact.trashedAt ?? artifact.updatedAt}>
-                    {(deleted) => <> · Deleted {ago(deleted())}</>}
-                  </Show>
+        <Show when={props.files.length}>
+          <div class="files-trash__section">Files and folders</div>
+          <For each={props.files}>
+            {(file) => (
+              <div class="files-row files-row--trash" data-file-trash-row={file.id}>
+                <span class="files-row__glyph" aria-hidden="true">
+                  {file.kind === "directory" ? (
+                    <IconFolder size={15} strokeWidth={1.45} />
+                  ) : (
+                    <IconFile size={15} strokeWidth={1.45} />
+                  )}
                 </span>
-              </span>
-              <button
-                type="button"
-                class="files-restore"
-                data-trash-restore={artifact.id}
-                aria-label={`Restore ${artifact.title}`}
-                disabled={props.busy}
-                onClick={() => props.onRestore(artifact)}
-              >
-                <IconRefresh size={13} strokeWidth={1.5} />
-                Restore
-              </button>
-            </div>
-          )}
-        </For>
+                <span class="files-row__name files-row__identity">
+                  <span data-file-trash-name>{file.filename}</span>
+                  <span class="files-row__meta">
+                    {file.kind === "directory" ? "Folder" : "File"} · Deleted {ago(file.trashedAt)}
+                  </span>
+                </span>
+                <span class="files-trash__actions">
+                  <button
+                    type="button"
+                    class="files-restore"
+                    data-file-trash-restore={file.id}
+                    aria-label={`Restore ${file.filename}`}
+                    disabled={props.busy}
+                    onClick={() => props.onRestoreFile(file)}
+                  >
+                    <IconRefresh size={13} strokeWidth={1.5} />
+                    Restore
+                  </button>
+                  <button
+                    type="button"
+                    class="files-purge"
+                    data-file-trash-purge={file.id}
+                    aria-label={`Delete ${file.filename} permanently`}
+                    title="Delete permanently"
+                    disabled={props.busy}
+                    onClick={() => props.onPurgeFile(file)}
+                  >
+                    <IconTrash size={13} strokeWidth={1.5} />
+                  </button>
+                </span>
+              </div>
+            )}
+          </For>
+        </Show>
+
+        <Show when={props.rows.length}>
+          <div class="files-trash__section">Saved results</div>
+          <For each={props.rows}>
+            {(artifact) => (
+              <div class="files-row files-row--trash" data-trash-row={artifact.id}>
+                <span class="files-row__glyph" aria-hidden="true">
+                  <IconFile size={15} strokeWidth={1.45} />
+                </span>
+                <span class="files-row__name files-row__identity">
+                  <span data-trash-name>{artifact.title}</span>
+                  <span class="files-row__meta" data-trash-meta>
+                    {artifact.versionCount} {artifact.versionCount === 1 ? "version" : "versions"}
+                    <Show when={artifact.trashedAt ?? artifact.updatedAt}>
+                      {(deleted) => <> · Deleted {ago(deleted())}</>}
+                    </Show>
+                  </span>
+                </span>
+                <button
+                  type="button"
+                  class="files-restore"
+                  data-trash-restore={artifact.id}
+                  aria-label={`Restore ${artifact.title}`}
+                  disabled={props.busy}
+                  onClick={() => props.onRestore(artifact)}
+                >
+                  <IconRefresh size={13} strokeWidth={1.5} />
+                  Restore
+                </button>
+              </div>
+            )}
+          </For>
+        </Show>
       </Show>
     </div>
   )
+}
+
+export interface TrashedFile {
+  id: string
+  filename: string
+  originalPath: string
+  kind: "file" | "directory"
+  trashedAt: number
+  expiresAt: number
 }

--- a/tooling/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/tooling/sdk/js/src/v2/gen/sdk.gen.ts
@@ -62,6 +62,8 @@ import type {
   FilePublicationResponses,
   FileRawResponses,
   FileReadResponses,
+  FileRenameErrors,
+  FileRenameResponses,
   FileReproducibilityResponses,
   FileReviewsCurrentErrors,
   FileReviewsCurrentResponses,
@@ -72,7 +74,11 @@ import type {
   FileReviewsResolveResponses,
   FileReviewsRunResponses,
   FileStatusResponses,
+  FileTrashCreateErrors,
+  FileTrashCreateResponses,
   FileTrashListResponses,
+  FileTrashPurgeErrors,
+  FileTrashPurgeResponses,
   FileTrashRestoreErrors,
   FileTrashRestoreResponses,
   FileWriteResponses,
@@ -4449,6 +4455,43 @@ export class Trash extends HeyApiClient {
   }
 
   /**
+   * Move a workspace file or folder to trash
+   *
+   * Move a local file or folder into recoverable same-volume trash without loading its contents into memory.
+   */
+  public create<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      path?: string
+      sessionID?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "body", key: "path" },
+            { in: "body", key: "sessionID" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<FileTrashCreateResponses, FileTrashCreateErrors, ThrowOnError>({
+      url: "/file/trash",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
+  /**
    * Restore a deleted source file
    *
    * Restore a source or workspace file during its 30-day recovery window without overwriting an existing path.
@@ -4475,6 +4518,43 @@ export class Trash extends HeyApiClient {
     )
     return (options?.client ?? this.client).post<FileTrashRestoreResponses, FileTrashRestoreErrors, ThrowOnError>({
       url: "/file/trash/{id}/restore",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
+  /**
+   * Permanently delete a trashed workspace item
+   *
+   * Permanently remove a recoverable file or folder after rechecking write authorization.
+   */
+  public purge<ThrowOnError extends boolean = false>(
+    parameters: {
+      id: string
+      directory?: string
+      sessionID?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "id" },
+            { in: "query", key: "directory" },
+            { in: "body", key: "sessionID" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).delete<FileTrashPurgeResponses, FileTrashPurgeErrors, ThrowOnError>({
+      url: "/file/trash/{id}",
       ...options,
       ...params,
       headers: {
@@ -5219,6 +5299,45 @@ export class File extends HeyApiClient {
     )
     return (options?.client ?? this.client).put<FileWriteResponses, unknown, ThrowOnError>({
       url: "/file/content",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
+  /**
+   * Rename a workspace file or folder
+   *
+   * Rename a local file or folder without overwriting an existing destination.
+   */
+  public rename<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      from?: string
+      to?: string
+      sessionID?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "body", key: "from" },
+            { in: "body", key: "to" },
+            { in: "body", key: "sessionID" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<FileRenameResponses, FileRenameErrors, ThrowOnError>({
+      url: "/file/rename",
       ...options,
       ...params,
       headers: {

--- a/tooling/sdk/js/src/v2/gen/types.gen.ts
+++ b/tooling/sdk/js/src/v2/gen/types.gen.ts
@@ -10923,8 +10923,11 @@ export type FileTrashListResponses = {
     originalPath: string
     filename: string
     size: number
-    sha256: string
+    sha256?: string
     mode: number
+    kind?: "file" | "directory"
+    store?: "data" | "workspace"
+    payloadPath?: string
     state: "trash" | "restored"
     trashedAt: number
     expiresAt: number
@@ -10933,6 +10936,50 @@ export type FileTrashListResponses = {
 }
 
 export type FileTrashListResponse = FileTrashListResponses[keyof FileTrashListResponses]
+
+export type FileTrashCreateData = {
+  body?: {
+    path: string
+    sessionID: string
+  }
+  path?: never
+  query?: {
+    directory?: string
+  }
+  url: "/file/trash"
+}
+
+export type FileTrashCreateErrors = {
+  /**
+   * The workspace root cannot be trashed
+   */
+  409: unknown
+}
+
+export type FileTrashCreateResponses = {
+  /**
+   * Recoverable file record
+   */
+  200: {
+    id: string
+    projectID: string
+    sessionID?: string
+    originalPath: string
+    filename: string
+    size: number
+    sha256?: string
+    mode: number
+    kind?: "file" | "directory"
+    store?: "data" | "workspace"
+    payloadPath?: string
+    state: "trash" | "restored"
+    trashedAt: number
+    expiresAt: number
+    restoredAt?: number
+  }
+}
+
+export type FileTrashCreateResponse = FileTrashCreateResponses[keyof FileTrashCreateResponses]
 
 export type FileTrashRestoreData = {
   body?: {
@@ -10952,6 +10999,10 @@ export type FileTrashRestoreErrors = {
    * Recoverable file not found
    */
   404: unknown
+  /**
+   * A file or folder already exists at the restore path
+   */
+  409: unknown
 }
 
 export type FileTrashRestoreResponses = {
@@ -10965,8 +11016,11 @@ export type FileTrashRestoreResponses = {
     originalPath: string
     filename: string
     size: number
-    sha256: string
+    sha256?: string
     mode: number
+    kind?: "file" | "directory"
+    store?: "data" | "workspace"
+    payloadPath?: string
     state: "trash" | "restored"
     trashedAt: number
     expiresAt: number
@@ -10975,6 +11029,84 @@ export type FileTrashRestoreResponses = {
 }
 
 export type FileTrashRestoreResponse = FileTrashRestoreResponses[keyof FileTrashRestoreResponses]
+
+export type FileTrashPurgeData = {
+  body?: {
+    sessionID: string
+  }
+  path: {
+    id: string
+  }
+  query?: {
+    directory?: string
+  }
+  url: "/file/trash/{id}"
+}
+
+export type FileTrashPurgeErrors = {
+  /**
+   * Recoverable file not found
+   */
+  404: unknown
+}
+
+export type FileTrashPurgeResponses = {
+  /**
+   * Purged file record
+   */
+  200: {
+    id: string
+    projectID: string
+    sessionID?: string
+    originalPath: string
+    filename: string
+    size: number
+    sha256?: string
+    mode: number
+    kind?: "file" | "directory"
+    store?: "data" | "workspace"
+    payloadPath?: string
+    state: "trash" | "restored"
+    trashedAt: number
+    expiresAt: number
+    restoredAt?: number
+  }
+}
+
+export type FileTrashPurgeResponse = FileTrashPurgeResponses[keyof FileTrashPurgeResponses]
+
+export type FileRenameData = {
+  body?: {
+    from: string
+    to: string
+    sessionID: string
+  }
+  path?: never
+  query?: {
+    directory?: string
+  }
+  url: "/file/rename"
+}
+
+export type FileRenameErrors = {
+  /**
+   * The destination exists or the source is a workspace root
+   */
+  409: unknown
+}
+
+export type FileRenameResponses = {
+  /**
+   * Renamed file
+   */
+  200: {
+    from: string
+    to: string
+    type: "file" | "directory"
+  }
+}
+
+export type FileRenameResponse = FileRenameResponses[keyof FileRenameResponses]
 
 export type FileInspectData = {
   body?: never

--- a/tooling/sdk/openapi.json
+++ b/tooling/sdk/openapi.json
@@ -26028,6 +26028,25 @@
                         "minimum": 0,
                         "maximum": 9007199254740991
                       },
+                      "kind": {
+                        "default": "file",
+                        "type": "string",
+                        "enum": [
+                          "file",
+                          "directory"
+                        ]
+                      },
+                      "store": {
+                        "default": "data",
+                        "type": "string",
+                        "enum": [
+                          "data",
+                          "workspace"
+                        ]
+                      },
+                      "payloadPath": {
+                        "type": "string"
+                      },
                       "state": {
                         "type": "string",
                         "enum": [
@@ -26057,7 +26076,6 @@
                       "originalPath",
                       "filename",
                       "size",
-                      "sha256",
                       "mode",
                       "state",
                       "trashedAt",
@@ -26073,6 +26091,148 @@
           {
             "lang": "js",
             "source": "import { createOpenScienceClient } from \"@synsci/sdk\"\n\nconst client = createOpenScienceClient()\nawait client.file.trash.list({\n  ...\n})"
+          }
+        ]
+      },
+      "post": {
+        "operationId": "file.trash.create",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Move a workspace file or folder to trash",
+        "description": "Move a local file or folder into recoverable same-volume trash without loading its contents into memory.",
+        "responses": {
+          "200": {
+            "description": "Recoverable file record",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "pattern": "^ftr_.*"
+                    },
+                    "projectID": {
+                      "type": "string"
+                    },
+                    "sessionID": {
+                      "type": "string"
+                    },
+                    "originalPath": {
+                      "type": "string"
+                    },
+                    "filename": {
+                      "type": "string"
+                    },
+                    "size": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
+                    },
+                    "sha256": {
+                      "type": "string",
+                      "pattern": "^[a-f0-9]{64}$"
+                    },
+                    "mode": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
+                    },
+                    "kind": {
+                      "default": "file",
+                      "type": "string",
+                      "enum": [
+                        "file",
+                        "directory"
+                      ]
+                    },
+                    "store": {
+                      "default": "data",
+                      "type": "string",
+                      "enum": [
+                        "data",
+                        "workspace"
+                      ]
+                    },
+                    "payloadPath": {
+                      "type": "string"
+                    },
+                    "state": {
+                      "type": "string",
+                      "enum": [
+                        "trash",
+                        "restored"
+                      ]
+                    },
+                    "trashedAt": {
+                      "type": "integer",
+                      "exclusiveMinimum": 0,
+                      "maximum": 9007199254740991
+                    },
+                    "expiresAt": {
+                      "type": "integer",
+                      "exclusiveMinimum": 0,
+                      "maximum": 9007199254740991
+                    },
+                    "restoredAt": {
+                      "type": "integer",
+                      "exclusiveMinimum": 0,
+                      "maximum": 9007199254740991
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "projectID",
+                    "originalPath",
+                    "filename",
+                    "size",
+                    "mode",
+                    "state",
+                    "trashedAt",
+                    "expiresAt"
+                  ]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The workspace root cannot be trashed"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "sessionID": {
+                    "type": "string",
+                    "pattern": "^ses.*"
+                  }
+                },
+                "required": [
+                  "path",
+                  "sessionID"
+                ]
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpenScienceClient } from \"@synsci/sdk\"\n\nconst client = createOpenScienceClient()\nawait client.file.trash.create({\n  ...\n})"
           }
         ]
       }
@@ -26138,6 +26298,25 @@
                       "minimum": 0,
                       "maximum": 9007199254740991
                     },
+                    "kind": {
+                      "default": "file",
+                      "type": "string",
+                      "enum": [
+                        "file",
+                        "directory"
+                      ]
+                    },
+                    "store": {
+                      "default": "data",
+                      "type": "string",
+                      "enum": [
+                        "data",
+                        "workspace"
+                      ]
+                    },
+                    "payloadPath": {
+                      "type": "string"
+                    },
                     "state": {
                       "type": "string",
                       "enum": [
@@ -26167,7 +26346,157 @@
                     "originalPath",
                     "filename",
                     "size",
-                    "sha256",
+                    "mode",
+                    "state",
+                    "trashedAt",
+                    "expiresAt"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Recoverable file not found"
+          },
+          "409": {
+            "description": "A file or folder already exists at the restore path"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "sessionID": {
+                    "type": "string",
+                    "pattern": "^ses.*"
+                  }
+                },
+                "required": [
+                  "sessionID"
+                ]
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpenScienceClient } from \"@synsci/sdk\"\n\nconst client = createOpenScienceClient()\nawait client.file.trash.restore({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/file/trash/{id}": {
+      "delete": {
+        "operationId": "file.trash.purge",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "pattern": "^ftr_.*"
+            },
+            "required": true
+          }
+        ],
+        "summary": "Permanently delete a trashed workspace item",
+        "description": "Permanently remove a recoverable file or folder after rechecking write authorization.",
+        "responses": {
+          "200": {
+            "description": "Purged file record",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "pattern": "^ftr_.*"
+                    },
+                    "projectID": {
+                      "type": "string"
+                    },
+                    "sessionID": {
+                      "type": "string"
+                    },
+                    "originalPath": {
+                      "type": "string"
+                    },
+                    "filename": {
+                      "type": "string"
+                    },
+                    "size": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
+                    },
+                    "sha256": {
+                      "type": "string",
+                      "pattern": "^[a-f0-9]{64}$"
+                    },
+                    "mode": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
+                    },
+                    "kind": {
+                      "default": "file",
+                      "type": "string",
+                      "enum": [
+                        "file",
+                        "directory"
+                      ]
+                    },
+                    "store": {
+                      "default": "data",
+                      "type": "string",
+                      "enum": [
+                        "data",
+                        "workspace"
+                      ]
+                    },
+                    "payloadPath": {
+                      "type": "string"
+                    },
+                    "state": {
+                      "type": "string",
+                      "enum": [
+                        "trash",
+                        "restored"
+                      ]
+                    },
+                    "trashedAt": {
+                      "type": "integer",
+                      "exclusiveMinimum": 0,
+                      "maximum": 9007199254740991
+                    },
+                    "expiresAt": {
+                      "type": "integer",
+                      "exclusiveMinimum": 0,
+                      "maximum": 9007199254740991
+                    },
+                    "restoredAt": {
+                      "type": "integer",
+                      "exclusiveMinimum": 0,
+                      "maximum": 9007199254740991
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "projectID",
+                    "originalPath",
+                    "filename",
+                    "size",
                     "mode",
                     "state",
                     "trashedAt",
@@ -26202,7 +26531,92 @@
         "x-codeSamples": [
           {
             "lang": "js",
-            "source": "import { createOpenScienceClient } from \"@synsci/sdk\"\n\nconst client = createOpenScienceClient()\nawait client.file.trash.restore({\n  ...\n})"
+            "source": "import { createOpenScienceClient } from \"@synsci/sdk\"\n\nconst client = createOpenScienceClient()\nawait client.file.trash.purge({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/file/rename": {
+      "post": {
+        "operationId": "file.rename",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Rename a workspace file or folder",
+        "description": "Rename a local file or folder without overwriting an existing destination.",
+        "responses": {
+          "200": {
+            "description": "Renamed file",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "from": {
+                      "type": "string"
+                    },
+                    "to": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "file",
+                        "directory"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "from",
+                    "to",
+                    "type"
+                  ]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The destination exists or the source is a workspace root"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "from": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "to": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "sessionID": {
+                    "type": "string",
+                    "pattern": "^ses.*"
+                  }
+                },
+                "required": [
+                  "from",
+                  "to",
+                  "sessionID"
+                ]
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpenScienceClient } from \"@synsci/sdk\"\n\nconst client = createOpenScienceClient()\nawait client.file.rename({\n  ...\n})"
           }
         ]
       }


### PR DESCRIPTION
## Summary

- add recoverable same-volume trash for workspace files and folders with restore and permanent delete
- add non-overwriting workspace rename with authorization and root protections
- add compact Files pane row actions and a shared Trash view
- hide and protect recovery data from file listings and search

## Verification

- backend suite: 2,268 passed, 20 skipped, 0 failed
- Files UI tests: 51 passed, 0 failed
- typecheck and format checks
- generated SDK consistency
- workspace production build

Fixes #307