### PR TITLE
Harden research harness verification and runtime controls

### DIFF
--- a/backend/cli/src/agent/prompt/research.txt
+++ b/backend/cli/src/agent/prompt/research.txt
@@ -7,10 +7,10 @@ You are the lead Research agent. Own the request through a verified result.
   sensitive access, external action, or an expensive pipeline needs agreement.
 - Inspect inputs first. Define the result and minimum evidence. Distinguish observed, sourced,
   computed, inferred, and unknown claims; preserve units, filters, and exclusions.
-- For multi-stage work, define `research_contract` before compute. Record material branches as
-  trials, invalid candidates as failures, and stages/checks only with observed evidence. Use
-  `learn` for reusable methods; treat tentative lessons as hypotheses and `unlearn`
-  contradictions. Never store a task-specific conclusion as guidance.
+- For multi-stage work, define `research_contract` first. Record material trials and failures.
+  Settled checks and advanced/regressed trials require runtime-verified `evidence_refs`; prose only
+  explains. Include a directed baseline metric for comparisons. Learn reusable methods only;
+  retest lessons and `unlearn` contradictions.
 - Before stochastic or expensive work, preserve anything later called frozen or predeclared as a
   durable Result or provenance node linked to its run, code, inputs, and outputs. A post-run hash
   does not prove preregistration.
@@ -51,6 +51,8 @@ You are the lead Research agent. Own the request through a verified result.
   failures, and limitations in the observable execution record.
 - Before completion, run the saved entry point fresh without a filtering pipeline; parse machine
   outputs, reload saved state, and inspect figures and reports against metrics.
+- Honor contract limits for model calls, tools, tokens, time, and cost. Active contracts may tighten
+  but never raise or reset them.
 - Gateway graph state is optional, never a local-work prerequisite. Finish with outcome,
   saved outputs, verification, and confidence-changing limitations.
 </system-reminder>

--- a/backend/cli/src/agent/prompt/reviewer.txt
+++ b/backend/cli/src/agent/prompt/reviewer.txt
@@ -64,6 +64,13 @@ node it concerns using `provenance_review`:
   - plus `claim`, `issue`, `evidence`
 This leaves an append-only audit trail linked into the DAG. It does not modify the artifact.
 
+For every durable Result target you can inspect, record at least one structured disposition with
+`provenance_review`. A clean review is not the absence of findings: record a `supports` disposition
+that names the checks actually performed and their concrete evidence. Record each defect separately
+with `refutes`. Merely returning reviewer prose does not complete the review gate. If bytes or
+evidence are unavailable, report `NO VERDICT` and leave the gate pending rather than manufacturing a
+passing disposition.
+
 ## Phase 1: OUTPUT INVENTORY
 Catalog what you are auditing. For each item:
 - Type: report | results section | claim list | figure | notebook | table

--- a/backend/cli/src/session/processor.ts
+++ b/backend/cli/src/session/processor.ts
@@ -322,6 +322,7 @@ export namespace SessionProcessor {
     let needsCompaction = false
     let overflow = false
     let creditDecision: "allow" | "finalize" | "block" | undefined
+    let runtimeDecision: Awaited<ReturnType<typeof SessionResearch.runtimePreflight>> | undefined
 
     const toolOutcomes = createToolOutcomeCoordinator({
       abort: input.abort,
@@ -404,6 +405,13 @@ export namespace SessionProcessor {
               }
             }
 
+            runtimeDecision = await SessionResearch.runtimePreflight(input.sessionID)
+            if (runtimeDecision.decision === "block") {
+              throw new Error(
+                `The research contract runtime budget is exhausted: ${runtimeDecision.reason ?? "configured limit reached"}. Existing Results and checkpoints are preserved. Begin a new user-approved bounded run to continue.`,
+              )
+            }
+
             const requestContext = {
               sessionID: input.sessionID,
               messageID: input.assistantMessage.id,
@@ -411,16 +419,18 @@ export namespace SessionProcessor {
             }
             let currentText: MessageV2.TextPart | undefined
             let reasoningMap: Record<string, MessageV2.ReasoningPart> = {}
-            const request =
-              creditDecision === "finalize"
-                ? {
-                    ...streamInput,
-                    system: [
-                      ...streamInput.system,
-                      "Managed-credit reserve is active. Do not begin new analysis. Save current machine outputs and checkpoints, update the research contract truthfully, and return the best verified result now.",
-                    ],
-                  }
-                : streamInput
+            const finalizing = creditDecision === "finalize" || runtimeDecision.decision === "finalize"
+            const request = finalizing
+              ? {
+                  ...streamInput,
+                  system: [
+                    ...streamInput.system,
+                    creditDecision === "finalize"
+                      ? "Managed-credit reserve is active. Do not begin new analysis. Save current machine outputs and checkpoints, update the research contract truthfully, and return the best verified result now."
+                      : `The research contract runtime budget is at its finalization boundary (${runtimeDecision.reason ?? "configured limit reached"}). Do not open new branches or launch optional work. Preserve machine outputs and return the best verified result or explicit partial result now.`,
+                  ],
+                }
+              : streamInput
             const stream = await Provider.withRequestContext(requestContext, () =>
               LLM.stream({
                 ...request,

--- a/backend/cli/src/session/research.ts
+++ b/backend/cli/src/session/research.ts
@@ -3,6 +3,8 @@ import path from "node:path"
 import { createHash } from "node:crypto"
 import { Global } from "@/global"
 import { JsonStore } from "@/util/jsonstore"
+import type { MessageV2 } from "@/session/message-v2"
+import { SessionTraceStore } from "@/session/trace-store"
 import z from "zod"
 
 export namespace SessionResearch {
@@ -18,6 +20,42 @@ export namespace SessionResearch {
 
   export const Status = z.enum(["pending", "running", "completed", "blocked"])
   export type Status = z.infer<typeof Status>
+
+  const Reference = {
+    ref: z.string().trim().min(1).max(1_000),
+    note: z.string().trim().max(1_000).optional(),
+    verifiedAt: z.number().int().nonnegative(),
+  }
+
+  export const EvidenceReference = z.discriminatedUnion("kind", [
+    z.object({
+      ...Reference,
+      kind: z.literal("artifact"),
+      artifactID: z.string().trim().min(1),
+      versionID: z.string().trim().min(1),
+      path: z.string().trim().min(1),
+      sha256: z.string().regex(/^[a-f0-9]{64}$/),
+    }),
+    z.object({
+      ...Reference,
+      kind: z.literal("tool"),
+      tool: z.string().trim().min(1),
+      callID: z.string().trim().min(1),
+      status: z.enum(["completed", "error"]),
+      outputHash: z.string().regex(/^[a-f0-9]{64}$/),
+    }),
+  ])
+  export type EvidenceReference = z.infer<typeof EvidenceReference>
+
+  export const Metric = z.object({
+    name: z.string().trim().min(1).max(120),
+    value: z.number().finite(),
+    direction: z.enum(["maximize", "minimize"]),
+    baseline: z.number().finite().optional(),
+    target: z.number().finite().optional(),
+    unit: z.string().trim().min(1).max(40).optional(),
+  })
+  export type Metric = z.infer<typeof Metric>
 
   export const Stage = z.object({
     id: z.string().regex(/^[a-z0-9][a-z0-9_-]{0,63}$/),
@@ -40,6 +78,7 @@ export namespace SessionResearch {
     label: z.string().trim().min(1).max(120),
     status: z.enum(["pending", "passed", "failed"]),
     evidence: z.string().trim().max(2_000).optional(),
+    evidenceRefs: z.array(EvidenceReference).max(20).default([]),
     detail: z.string().trim().max(1_000).optional(),
     updatedAt: z.number(),
   })
@@ -67,11 +106,21 @@ export namespace SessionResearch {
       outcome: Outcome,
       summary: z.string().trim().min(1).max(2_000),
       evidence: z.string().trim().max(2_000).optional(),
+      evidenceRefs: z.array(EvidenceReference).max(20).default([]),
+      metric: Metric.optional(),
       recordedAt: z.number(),
     })
     .superRefine((value, ctx) => {
-      if ((value.outcome === "advanced" || value.outcome === "regressed") && !value.evidence) {
-        ctx.addIssue({ code: "custom", path: ["evidence"], message: `${value.outcome} trials require evidence` })
+      if (value.metric?.baseline === undefined) return
+      const improved =
+        value.metric.direction === "maximize"
+          ? value.metric.value > value.metric.baseline
+          : value.metric.value < value.metric.baseline
+      if (value.outcome === "advanced" && !improved) {
+        ctx.addIssue({ code: "custom", path: ["metric"], message: "Advanced outcome contradicts the metric" })
+      }
+      if (value.outcome === "regressed" && (improved || value.metric.value === value.metric.baseline)) {
+        ctx.addIssue({ code: "custom", path: ["metric"], message: "Regressed outcome contradicts the metric" })
       }
     })
   export type Trial = z.infer<typeof Trial>
@@ -81,6 +130,7 @@ export namespace SessionResearch {
     trialID: z.string(),
     outcome: Outcome,
     evidence: z.string().trim().min(1).max(2_000),
+    evidenceRefs: z.array(EvidenceReference).max(20).default([]),
     note: z.string().trim().min(1).max(2_000),
     recordedAt: z.number(),
   })
@@ -112,6 +162,40 @@ export namespace SessionResearch {
     finalizing: z.boolean().default(false),
     exhausted: z.boolean().default(false),
     lastBalanceUsd: z.number().optional(),
+    limits: z
+      .object({
+        modelCalls: z.number().int().positive().max(10_000).default(128),
+        toolCalls: z.number().int().positive().max(100_000).default(1_024),
+        tokens: z.number().int().positive().max(1_000_000_000).default(5_000_000),
+        wallClockMs: z
+          .number()
+          .int()
+          .positive()
+          .max(30 * 24 * 60 * 60_000)
+          .default(24 * 60 * 60_000),
+        costUsd: z.number().positive().max(100_000).default(200),
+      })
+      .default({
+        modelCalls: 128,
+        toolCalls: 1_024,
+        tokens: 5_000_000,
+        wallClockMs: 24 * 60 * 60_000,
+        costUsd: 200,
+      }),
+    runtimeFinalizationCalls: z.number().int().nonnegative().default(0),
+    runtimeModelCalls: z.number().int().nonnegative().default(0),
+    runtimeFinalizing: z.boolean().default(false),
+    runtimeExhausted: z.boolean().default(false),
+    runtimeReason: z.string().optional(),
+    lastUsage: z
+      .object({
+        modelCalls: z.number().int().nonnegative(),
+        toolCalls: z.number().int().nonnegative(),
+        tokens: z.number().int().nonnegative(),
+        wallClockMs: z.number().int().nonnegative(),
+        costUsd: z.number().nonnegative(),
+      })
+      .optional(),
     updatedAt: z.number(),
   })
   export type Budget = z.infer<typeof Budget>
@@ -293,6 +377,7 @@ export namespace SessionResearch {
     template: Template
     deliverables?: Deliverable[]
     reserveUsd?: number
+    limits?: Partial<Budget["limits"]>
   }): Contract {
     const now = Date.now()
     return Contract.parse({
@@ -313,6 +398,11 @@ export namespace SessionResearch {
         finalizationCalls: 0,
         finalizing: false,
         exhausted: false,
+        limits: input.limits ?? {},
+        runtimeFinalizationCalls: 0,
+        runtimeModelCalls: 0,
+        runtimeFinalizing: false,
+        runtimeExhausted: false,
         updatedAt: now,
       },
       createdAt: now,
@@ -333,6 +423,7 @@ export namespace SessionResearch {
       template: Template
       deliverables?: Deliverable[]
       reserveUsd?: number
+      limits?: Partial<Budget["limits"]>
     },
   ): Promise<Contract> {
     const next = initial(input)
@@ -347,7 +438,32 @@ export namespace SessionResearch {
         checks,
         failures: current.data.failures,
         trials: current.data.trials,
-        budget: { ...current.data.budget, reserveUsd: input.reserveUsd ?? current.data.budget.reserveUsd },
+        budget: {
+          ...current.data.budget,
+          reserveUsd: input.reserveUsd ?? current.data.budget.reserveUsd,
+          limits: {
+            modelCalls: Math.min(
+              current.data.budget.limits.modelCalls,
+              input.limits?.modelCalls ?? current.data.budget.limits.modelCalls,
+            ),
+            toolCalls: Math.min(
+              current.data.budget.limits.toolCalls,
+              input.limits?.toolCalls ?? current.data.budget.limits.toolCalls,
+            ),
+            tokens: Math.min(
+              current.data.budget.limits.tokens,
+              input.limits?.tokens ?? current.data.budget.limits.tokens,
+            ),
+            wallClockMs: Math.min(
+              current.data.budget.limits.wallClockMs,
+              input.limits?.wallClockMs ?? current.data.budget.limits.wallClockMs,
+            ),
+            costUsd: Math.min(
+              current.data.budget.limits.costUsd,
+              input.limits?.costUsd ?? current.data.budget.limits.costUsd,
+            ),
+          },
+        },
         createdAt: current.data.createdAt,
         updatedAt: Date.now(),
       })
@@ -388,10 +504,25 @@ export namespace SessionResearch {
 
   export async function check(
     sessionID: string,
-    input: { id: string; label?: string; status: "pending" | "passed" | "failed"; evidence?: string; detail?: string },
+    input: {
+      id: string
+      label?: string
+      status: "pending" | "passed" | "failed"
+      evidence?: string
+      evidenceRefs?: EvidenceReference[]
+      detail?: string
+    },
   ): Promise<Contract> {
-    if (input.status !== "pending" && !input.evidence?.trim()) {
-      throw new Error(`Research check ${input.id} requires observed evidence before it can be marked ${input.status}`)
+    if (input.status !== "pending" && !input.evidenceRefs?.length) {
+      throw new Error(
+        `Research check ${input.id} requires a verified artifact or tool reference before it can be marked ${input.status}`,
+      )
+    }
+    if (
+      input.status === "passed" &&
+      input.evidenceRefs?.some((item) => item.kind === "tool" && item.status === "error")
+    ) {
+      throw new Error(`Research check ${input.id} cannot pass with an errored tool as evidence`)
     }
     await JsonStore.update(file(sessionID), (data) => {
       const current = Contract.parse(data)
@@ -401,6 +532,7 @@ export namespace SessionResearch {
         label: input.label ?? known?.label ?? input.id,
         status: input.status,
         evidence: input.evidence,
+        evidenceRefs: input.status === "pending" ? [] : input.evidenceRefs,
         detail: input.detail,
         updatedAt: Date.now(),
       })
@@ -435,9 +567,12 @@ export namespace SessionResearch {
 
   export async function trial(
     sessionID: string,
-    input: Omit<Trial, "id" | "recordedAt">,
+    input: Omit<Trial, "id" | "recordedAt" | "evidenceRefs"> & { evidenceRefs?: EvidenceReference[] },
     key?: string,
   ): Promise<Contract> {
+    if ((input.outcome === "advanced" || input.outcome === "regressed") && !input.evidenceRefs?.length) {
+      throw new Error(`${input.outcome} trials require verified evidence references`)
+    }
     const item = Trial.parse({
       ...input,
       id: `trial-${key ?? crypto.randomUUID()}`,
@@ -461,6 +596,8 @@ export namespace SessionResearch {
     outcome: Outcome
     summary: string
     evidence?: string
+    evidenceRefs: EvidenceReference[]
+    metric?: Metric
     recordedAt: number
   }
 
@@ -474,6 +611,7 @@ export namespace SessionResearch {
         outcome: "failed" as const,
         summary: failure.message,
         evidence: failure.disposition,
+        evidenceRefs: [],
         recordedAt: failure.recordedAt,
       })),
     ]
@@ -506,7 +644,8 @@ export namespace SessionResearch {
   }
 
   function confidence(supports: Observation[]) {
-    return new Set(supports.map((item) => item.sessionID)).size > 1 ? ("supported" as const) : ("tentative" as const)
+    const verified = supports.filter((item) => item.evidenceRefs.length)
+    return new Set(verified.map((item) => item.sessionID)).size > 1 ? ("supported" as const) : ("tentative" as const)
   }
 
   export async function experience(projectID: string, domain?: Domain): Promise<Lesson[]> {
@@ -514,6 +653,7 @@ export namespace SessionResearch {
     if (!parsed.success) return []
     return parsed.data.lessons
       .filter((lesson) => !domain || lesson.domain === domain)
+      .map((lesson) => ({ ...lesson, confidence: confidence(lesson.supports) }))
       .toSorted((a, b) => {
         const rank = Number(b.confidence === "supported") - Number(a.confidence === "supported")
         return rank || b.updatedAt - a.updatedAt
@@ -523,7 +663,13 @@ export namespace SessionResearch {
   export async function learn(
     projectID: string,
     sessionID: string,
-    input: { sourceTrial: string; situation: string; guidance: string; evidence?: string },
+    input: {
+      sourceTrial: string
+      situation: string
+      guidance: string
+      evidence?: string
+      evidenceRefs?: EvidenceReference[]
+    },
   ): Promise<Lesson> {
     const contract = await read(sessionID)
     if (!contract) throw new Error("No research completion contract has been defined for this session")
@@ -532,10 +678,11 @@ export namespace SessionResearch {
     if (trial.outcome === "inconclusive") {
       throw new Error("An inconclusive trial cannot create reusable project experience")
     }
-    const evidence = input.evidence ?? trial.evidence
-    if (!evidence?.trim()) {
+    const evidenceRefs = input.evidenceRefs?.length ? input.evidenceRefs : trial.evidenceRefs
+    if (!evidenceRefs.length) {
       throw new Error(`Research trial ${trial.id} needs observed evidence before it can create project experience`)
     }
+    const evidence = input.evidence?.trim() || trial.evidence?.trim() || evidenceRefs.map((item) => item.ref).join(", ")
     const now = Date.now()
     const situation = compact(input.situation)
     const guidance = compact(input.guidance)
@@ -545,6 +692,7 @@ export namespace SessionResearch {
       trialID: trial.id,
       outcome: trial.outcome,
       evidence,
+      evidenceRefs,
       note: trial.summary,
       recordedAt: now,
     })
@@ -587,7 +735,13 @@ export namespace SessionResearch {
   export async function unlearn(
     projectID: string,
     sessionID: string,
-    input: { lesson: string; sourceTrial: string; reason: string; evidence: string },
+    input: {
+      lesson: string
+      sourceTrial: string
+      reason: string
+      evidence: string
+      evidenceRefs?: EvidenceReference[]
+    },
   ): Promise<Lesson> {
     const contract = await read(sessionID)
     if (!contract) throw new Error("No research completion contract has been defined for this session")
@@ -596,12 +750,18 @@ export namespace SessionResearch {
     if (trial.outcome === "inconclusive") {
       throw new Error("An inconclusive trial cannot reject reusable project experience")
     }
+    if (!input.evidenceRefs?.length) {
+      throw new Error(
+        `Research trial ${trial.id} needs verified counterevidence before it can reject project experience`,
+      )
+    }
     const now = Date.now()
     const observation = Observation.parse({
       sessionID,
       trialID: trial.id,
       outcome: trial.outcome,
       evidence: input.evidence,
+      evidenceRefs: input.evidenceRefs,
       note: input.reason,
       recordedAt: now,
     })
@@ -649,7 +809,8 @@ export namespace SessionResearch {
       contract.stages.find((item) => item.status === "running")?.id ??
       contract.stages.find((item) => item.status === "pending")?.id
     const history = entries(contract, stage)
-    const negatives = history.filter((entry) => entry.outcome !== "advanced")
+    const advancing = (entry: Entry) => entry.outcome === "advanced" && entry.evidenceRefs.length > 0
+    const negatives = history.filter((entry) => !advancing(entry))
     const counts = negatives.reduce<Record<string, { label: string; count: number }>>((all, entry) => {
       const key = signature(entry.candidate)
       const current = all[key]
@@ -659,15 +820,14 @@ export namespace SessionResearch {
       .filter((item) => item.count > 1)
       .map((item) => item.label)
     const recent = history.slice(-3)
-    const stalled = recent.length === 3 && recent.every((entry) => entry.outcome !== "advanced")
+    const stalled = recent.length === 3 && recent.every((entry) => !advancing(entry))
     const last = history.at(-1)
     const repeated =
-      last?.outcome !== "advanced" &&
+      last !== undefined &&
+      !advancing(last) &&
       repeatedCandidates.some((candidate) => signature(candidate) === signature(last?.candidate ?? ""))
     const improved = new Set(
-      history
-        .filter((entry) => entry.outcome === "advanced" && entry.branch !== "failure")
-        .map((entry) => entry.branch),
+      history.filter((entry) => advancing(entry) && entry.branch !== "failure").map((entry) => entry.branch),
     )
     const complete = contract.stages.every((item) => item.status === "completed")
     const mode = complete
@@ -729,10 +889,10 @@ export namespace SessionResearch {
   }
 
   export type Evidence = {
-    artifacts: Array<{ path?: string }>
+    artifacts: Array<{ artifactID?: string; versionID?: string; path?: string; sha256?: string }>
     jobs: Array<{ status: string }>
     kernels: Array<{ status: string }>
-    findings: Array<{ verdict?: string; status?: string; severity?: string }>
+    findings: Array<{ target?: string; verdict?: string; status?: string; severity?: string }>
     reviewed: boolean
     busy: boolean
   }
@@ -762,7 +922,7 @@ export namespace SessionResearch {
     const paths = evidence.artifacts.flatMap((item) => (item.path ? [item.path] : []))
     const missing = required.filter((item) => !paths.some((value) => match(item.path, value)))
     const stages = contract.stages.filter((stage) => stage.status === "completed").length
-    const checks = contract.checks.filter((check) => check.status === "passed" && !!check.evidence?.trim()).length
+    const checks = contract.checks.filter((check) => check.status === "passed" && check.evidenceRefs.length).length
     const failed = contract.checks.filter((check) => check.status === "failed").length
     const open = evidence.findings.filter(
       (finding) =>
@@ -770,6 +930,23 @@ export namespace SessionResearch {
         finding.status !== "confirmed" &&
         (finding.severity === "blocking" || finding.severity === "major"),
     ).length
+    const requiredArtifacts = required.flatMap((item) =>
+      evidence.artifacts.filter((artifact) => artifact.path && match(item.path, artifact.path)),
+    )
+    const targets = [
+      ...new Set(
+        requiredArtifacts.map((artifact) =>
+          artifact.versionID && artifact.sha256
+            ? `artifact-version:${artifact.versionID}:${artifact.sha256.slice(0, 16)}`
+            : `unversioned:${artifact.path ?? "unknown"}`,
+        ),
+      ),
+    ]
+    const reviewedTargets = new Set(
+      evidence.findings.flatMap((finding) => (finding.verdict && finding.target ? [finding.target] : [])),
+    )
+    const unreviewed = targets.filter((target) => !reviewedTargets.has(target))
+    const reviewed = targets.length ? unreviewed.length === 0 : evidence.reviewed
     const running = evidence.jobs.filter((job) => job.status === "queued" || job.status === "running").length
     const jobFailures = evidence.jobs.filter(
       (job) => job.status === "failed" || job.status === "interrupted" || job.status === "cancelled",
@@ -786,7 +963,7 @@ export namespace SessionResearch {
       missing.length === 0 &&
       checks === contract.checks.length &&
       failed === 0 &&
-      evidence.reviewed &&
+      reviewed &&
       open === 0
     const gates: Gate[] = [
       {
@@ -820,14 +997,16 @@ export namespace SessionResearch {
       {
         id: "review",
         label: "Independent review",
-        status: open ? "failed" : evidence.reviewed ? "passed" : "pending",
-        complete: open || !evidence.reviewed ? 0 : 1,
+        status: open ? "failed" : reviewed ? "passed" : "pending",
+        complete: open || !reviewed ? 0 : 1,
         total: 1,
         detail: open
           ? `${open} blocking or major ${open === 1 ? "finding" : "findings"} remain open`
-          : evidence.reviewed
-            ? "Independent review completed without open major findings"
-            : "Independent review has not completed",
+          : reviewed
+            ? "Independent review recorded a disposition for every required Result"
+            : unreviewed.length
+              ? `${unreviewed.length} required ${unreviewed.length === 1 ? "Result has" : "Results have"} no structured review disposition`
+              : "Independent review has not recorded a structured disposition",
       },
       {
         id: "runtime",
@@ -912,14 +1091,170 @@ export namespace SessionResearch {
     })
   }
 
+  export type RuntimeUsage = NonNullable<Budget["lastUsage"]>
+  export type RuntimeDecision = {
+    decision: "allow" | "finalize" | "block"
+    usage?: RuntimeUsage
+    reason?: string
+  }
+
+  function messageTokens(message: MessageV2.Assistant) {
+    return (
+      message.tokens.input +
+      message.tokens.output +
+      message.tokens.reasoning +
+      message.tokens.cache.read +
+      message.tokens.cache.write
+    )
+  }
+
+  export async function runtimeUsage(sessionID: string): Promise<RuntimeUsage> {
+    const { Session } = await import("@/session")
+    const seen = new Set<string>()
+    const intervals: Array<[number, number]> = []
+    const visit = async (id: string): Promise<RuntimeUsage> => {
+      if (seen.has(id)) return { modelCalls: 0, toolCalls: 0, tokens: 0, wallClockMs: 0, costUsd: 0 }
+      seen.add(id)
+      const [messages, children, trace] = await Promise.all([
+        Session.messages({ sessionID: id }),
+        Session.children(id),
+        SessionTraceStore.read(id),
+      ])
+      const completed = messages.filter(
+        (message) =>
+          message.info.role === "assistant" &&
+          (message.info.time.completed !== undefined || message.info.error !== undefined),
+      ).length
+      const local = messages.reduce<RuntimeUsage>(
+        (total, message) => {
+          const assistant = message.info.role === "assistant" ? message.info : undefined
+          const tools = message.parts.filter((part) => part.type === "tool").length
+          if (assistant?.time.completed !== undefined)
+            intervals.push([assistant.time.created, assistant.time.completed])
+          return {
+            modelCalls: total.modelCalls,
+            toolCalls: total.toolCalls + tools,
+            tokens: total.tokens + (assistant ? messageTokens(assistant) : 0),
+            wallClockMs: total.wallClockMs,
+            costUsd: total.costUsd + (assistant?.cost ?? 0),
+          }
+        },
+        {
+          modelCalls: Math.max(completed + trace.retries.length, trace.harness.length),
+          toolCalls: 0,
+          tokens: 0,
+          wallClockMs: 0,
+          costUsd: 0,
+        },
+      )
+      const descendants = await Promise.all(children.map((child) => visit(child.id)))
+      return descendants.reduce(
+        (total, item) => ({
+          modelCalls: total.modelCalls + item.modelCalls,
+          toolCalls: total.toolCalls + item.toolCalls,
+          tokens: total.tokens + item.tokens,
+          wallClockMs: total.wallClockMs + item.wallClockMs,
+          costUsd: total.costUsd + item.costUsd,
+        }),
+        local,
+      )
+    }
+    const usage = await visit(sessionID)
+    const elapsed = intervals
+      .toSorted((a, b) => a[0] - b[0])
+      .reduce(
+        (total, interval) => {
+          if (interval[0] >= total.end) return { end: interval[1], value: total.value + interval[1] - interval[0] }
+          const end = Math.max(total.end, interval[1])
+          return { end, value: total.value + end - total.end }
+        },
+        { end: 0, value: 0 },
+      ).value
+    return { ...usage, wallClockMs: elapsed }
+  }
+
+  async function runtimeContract(sessionID: string) {
+    const { Session } = await import("@/session")
+    const seen = new Set<string>()
+    const visit = async (id: string, found?: string): Promise<string | undefined> => {
+      if (seen.has(id)) return found
+      seen.add(id)
+      const contract = await read(id)
+      const anchor = contract ? id : found
+      const session = await Session.get(id).catch(() => undefined)
+      if (!session?.parentID) return anchor
+      return visit(session.parentID, anchor)
+    }
+    return visit(sessionID)
+  }
+
+  export async function runtimePreflight(sessionID: string): Promise<RuntimeDecision> {
+    const anchor = await runtimeContract(sessionID)
+    if (!anchor) return { decision: "allow" as const }
+    const observed = await runtimeUsage(anchor)
+    const result: RuntimeDecision = { decision: "allow", usage: observed }
+    await JsonStore.update(file(anchor), (data) => {
+      const current = Contract.parse(data)
+      const used = Math.max(current.budget.runtimeModelCalls, observed.modelCalls)
+      const usage = { ...observed, modelCalls: used }
+      const limits = current.budget.limits
+      const hard =
+        used >= limits.modelCalls ||
+        usage.toolCalls >= limits.toolCalls ||
+        usage.tokens >= limits.tokens ||
+        usage.wallClockMs >= limits.wallClockMs ||
+        usage.costUsd >= limits.costUsd
+      const reasons = [
+        ...(used >= Math.max(1, limits.modelCalls - 2) ? [`model-call limit (${used}/${limits.modelCalls})`] : []),
+        ...(usage.toolCalls >= limits.toolCalls * 0.9
+          ? [`tool-call limit (${usage.toolCalls}/${limits.toolCalls})`]
+          : []),
+        ...(usage.tokens >= limits.tokens * 0.9 ? [`token limit (${usage.tokens}/${limits.tokens})`] : []),
+        ...(usage.wallClockMs >= limits.wallClockMs * 0.9
+          ? [`wall-clock limit (${usage.wallClockMs}/${limits.wallClockMs}ms)`]
+          : []),
+        ...(usage.costUsd >= limits.costUsd * 0.9
+          ? [`cost limit ($${usage.costUsd.toFixed(4)}/$${limits.costUsd.toFixed(2)})`]
+          : []),
+      ]
+      const reason = reasons.join(", ") || current.budget.runtimeReason
+      const finalizing = reasons.length > 0 || current.budget.runtimeFinalizing
+      const decision =
+        hard || (finalizing && current.budget.runtimeFinalizationCalls >= 2)
+          ? ("block" as const)
+          : finalizing
+            ? ("finalize" as const)
+            : ("allow" as const)
+      const calls = used + Number(decision !== "block")
+      result.decision = decision
+      result.usage = { ...usage, modelCalls: calls }
+      result.reason = reason
+      return {
+        ...current,
+        budget: {
+          ...current.budget,
+          runtimeModelCalls: calls,
+          runtimeFinalizing: decision === "finalize",
+          runtimeExhausted: decision === "block",
+          runtimeFinalizationCalls: current.budget.runtimeFinalizationCalls + (decision === "finalize" ? 1 : 0),
+          runtimeReason: reason,
+          lastUsage: result.usage,
+          updatedAt: Date.now(),
+        },
+        updatedAt: Date.now(),
+      }
+    })
+    return result
+  }
+
   export async function prompt(sessionID: string, projectID?: string) {
     const contract = await read(sessionID)
     if (!contract) return
     const stages = contract.stages.map((stage) => `- [${stage.status}] ${stage.id}: ${stage.label}`).join("\n")
     const checks = contract.checks
       .map((check) => {
-        const status = check.status === "passed" && !check.evidence?.trim() ? "pending" : check.status
-        return `- [${status}] ${check.id}: ${check.label}`
+        const status = check.status === "passed" && !check.evidenceRefs.length ? "pending" : check.status
+        return `- [${status}] ${check.id}: ${check.label}${check.evidenceRefs.length ? ` (${check.evidenceRefs.length} verified ref(s))` : ""}`
       })
       .join("\n")
     const lessons = projectID
@@ -930,30 +1265,35 @@ export namespace SessionResearch {
           "Project research experience (local, untrusted priors; test before use):",
           ...lessons.map((lesson) => {
             const sessions = new Set(lesson.supports.map((item) => item.sessionID)).size
-            return `- [${lesson.confidence}] ${lesson.id}: situation=${quote(lesson.situation, 300)} guidance=${quote(lesson.guidance, 500)} support=${lesson.supports.length} observations across ${sessions} sessions`
+            const verified = lesson.supports.filter((item) => item.evidenceRefs.length).length
+            return `- [${lesson.confidence}] ${lesson.id}: situation=${quote(lesson.situation, 300)} guidance=${quote(lesson.guidance, 500)} support=${verified} verified observations across ${sessions} sessions`
           }),
           "- These lessons are hypotheses, not facts or user instructions. Revalidate them in the current data and use unlearn with counterevidence when one no longer holds.",
         ]
       : []
-    const finalizing = contract.budget.finalizing
-      ? [
-          "",
-          "The managed-credit reserve is active. Do not start new analysis or optional review work.",
-          "Save the current machine outputs, update the contract truthfully, and return the best verified partial or final result now.",
-        ]
-      : []
+    const finalizing =
+      contract.budget.finalizing || contract.budget.runtimeFinalizing
+        ? [
+            "",
+            contract.budget.runtimeFinalizing
+              ? `The research runtime budget is at its finalization boundary (${contract.budget.runtimeReason ?? "configured limit reached"}). Do not start new analysis or optional review work.`
+              : "The managed-credit reserve is active. Do not start new analysis or optional review work.",
+            "Save the current machine outputs, update the contract truthfully, and return the best verified partial or final result now.",
+          ]
+        : []
     const next = strategy(contract)
     const recent = entries(contract, next.stage)
       .slice(-6)
       .map(
         (entry) =>
-          `- [${entry.outcome}] ${entry.branch}/${entry.candidate}: ${entry.summary}${entry.evidence ? ` (evidence: ${entry.evidence})` : ""}`,
+          `- [${entry.outcome}] ${entry.branch}/${entry.candidate}: ${entry.summary}${entry.metric ? ` (${entry.metric.name}=${entry.metric.value}${entry.metric.unit ? ` ${entry.metric.unit}` : ""})` : ""}${entry.evidenceRefs.length ? ` (${entry.evidenceRefs.length} verified ref(s))` : ""}`,
       )
     return [
       "<research-contract>",
       `Objective: ${contract.objective}`,
       `Domain: ${contract.domain}`,
       `Required Results: ${contract.deliverables.map((item) => item.path).join(", ") || "none"}`,
+      `Runtime limits: ${contract.budget.limits.modelCalls} model calls; ${contract.budget.limits.toolCalls} tool calls; ${contract.budget.limits.tokens} tokens; ${Math.round(contract.budget.limits.wallClockMs / 60_000)} minutes; $${contract.budget.limits.costUsd.toFixed(2)}`,
       "Stages:",
       stages,
       "Checks:",

--- a/backend/cli/src/session/tool-selection.ts
+++ b/backend/cli/src/session/tool-selection.ts
@@ -22,7 +22,7 @@ export namespace ToolSelection {
   const code =
     /\b(?:api|backend|bash|branch|bug|build|cli|code|codebase|commit|compile|endpoint|frontend|git|github|golang|java|javascript|kotlin|lint|package manager|php|pull request|python|refactor|repo|repository|ruby|rust|sdk|server|shell|source code|swift|test suite|typecheck|typescript|working tree)\b/i
   const science =
-    /\b(?:bioinformatics|biology|cell|chemistry|clinical|data analysis|dataset|evidence|experiment|gene|genomic|hypothesis|literature|machine learning|molecule|neural|paper|physics|protein|research|rna|science|scientific|simulation|statistics?|study)\b/i
+    /\b(?:benchmark|bioinformatics|biology|cell|chemistry|clinical|data analysis|dataset|evidence|evaluation|experiment|gene|genomic|hypothesis|literature|machine learning|metric|model comparison|molecule|neural|paper|physics|protein|reproducibility|research|rna|science|scientific|simulation|statistics?|study|validation)\b/i
   const work =
     /\b(?:analy[sz]e|attached|calculate|cite|create|current|dataset|document|download|fetch|file|find|inspect|latest|load|look up|open|paper|plot|read|review|run|save|search|source|today|verify|write)\b|https?:\/\/|\.[a-z0-9]{1,5}\b/i
   const browse = new Set(["glob", "grep", "invalid", "read"])

--- a/backend/cli/src/session/trace.ts
+++ b/backend/cli/src/session/trace.ts
@@ -724,20 +724,12 @@ export namespace SessionTrace {
       jobs,
       kernels,
       findings: reviewerFindings.map((item) => ({
+        target: item.target,
         verdict: item.relation,
         status: item.status,
         severity: item.severity,
       })),
-      reviewed:
-        reviewerFindings.length > 0 ||
-        inference.some(
-          (item) => (item.agent === "reviewer" || item.agent === "artifact-reviewer") && item.completedAt !== undefined,
-        ) ||
-        children.some(
-          (item) =>
-            (item.agent === "review" || item.agent === "reviewer" || item.agent === "artifact-reviewer") &&
-            item.status === "completed",
-        ),
+      reviewed: reviewerFindings.some((item) => item.relation === "supports" || item.relation === "refutes"),
       busy: SessionStatus.get(sessionID).type !== "idle",
     })
     const harnessReport = SessionHarness.analyze({

--- a/backend/cli/src/tool/research-contract.ts
+++ b/backend/cli/src/tool/research-contract.ts
@@ -1,12 +1,33 @@
 import { SessionResearch } from "@/session/research"
 import { Instance } from "@/project/instance"
+import { ArtifactStore } from "@/artifact/store"
+import { Session } from "@/session"
+import type { MessageV2 } from "@/session/message-v2"
 import { Tool } from "./tool"
 import z from "zod"
+
+const EvidenceRequests = z
+  .array(z.string().trim().min(3).max(1_000))
+  .min(1)
+  .max(8)
+  .describe("Runtime-verified refs: artifact:<id>, artifact-path:<path>, tool:<name>, or tool-call:<id>.")
+
+const Domain = z.enum([
+  "general",
+  "statistics",
+  "biology",
+  "physics",
+  "chemistry",
+  "ml",
+  "weather",
+  "posttrain",
+  "evidence",
+])
 
 const Define = z.object({
   action: z.literal("define"),
   objective: z.string().trim().min(1).max(2_000),
-  domain: SessionResearch.Domain.default("general"),
+  domain: Domain.default("general"),
   template: SessionResearch.Template.default("empirical"),
   deliverables: z
     .array(
@@ -17,9 +38,17 @@ const Define = z.object({
       }),
     )
     .max(40)
-    .describe("Required Results; omit for template defaults.")
     .optional(),
   reserve_usd: z.number().min(0).max(100).optional(),
+  max_model_calls: z.number().int().positive().max(10_000).optional(),
+  max_tool_calls: z.number().int().positive().max(100_000).optional(),
+  max_tokens: z.number().int().positive().max(1_000_000_000).optional(),
+  max_minutes: z
+    .number()
+    .positive()
+    .max(30 * 24 * 60)
+    .optional(),
+  max_cost_usd: z.number().positive().max(100_000).optional(),
 })
 
 const Stage = z.object({
@@ -42,11 +71,16 @@ const Check = z
     label: z.string().trim().min(1).max(120).optional(),
     status: z.enum(["pending", "passed", "failed"]),
     evidence: z.string().trim().min(1).max(2_000).optional(),
+    evidence_refs: EvidenceRequests.optional(),
     detail: z.string().trim().max(1_000).optional(),
   })
   .superRefine((value, ctx) => {
-    if (value.status !== "pending" && !value.evidence) {
-      ctx.addIssue({ code: "custom", path: ["evidence"], message: `${value.status} checks require observed evidence` })
+    if (value.status !== "pending" && !value.evidence_refs?.length) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["evidence_refs"],
+        message: `${value.status} checks require runtime-verified evidence references`,
+      })
     }
   })
 
@@ -65,31 +99,36 @@ const Trial = z
       .string()
       .regex(/^[a-z0-9][a-z0-9_-]{0,63}$/)
       .describe("Contract stage ID that produced this attempt."),
-    branch: z
-      .string()
-      .regex(/^[a-z0-9][a-z0-9_-]{0,63}$/)
-      .describe("Approach-family ID; reuse for refinements, change for a new approach."),
+    branch: z.string().regex(/^[a-z0-9][a-z0-9_-]{0,63}$/),
     candidate: z.string().trim().min(1).max(240).describe("Unique label for the concrete candidate."),
     outcome: SessionResearch.Outcome.describe("Observed result."),
-    summary: z.string().trim().min(1).max(2_000).describe("Attempt and observed result."),
+    summary: z.string().trim().min(1).max(2_000),
     evidence: z
       .string()
       .trim()
       .max(2_000)
       .describe("Supporting artifact, metric, source, or check; required for advanced/regressed.")
       .optional(),
+    evidence_refs: EvidenceRequests.optional(),
+    metric: SessionResearch.Metric.optional().describe(
+      "Optional quantitative result. When baseline is supplied, the runtime rejects an outcome that contradicts the metric direction.",
+    ),
   })
   .superRefine((value, ctx) => {
-    if ((value.outcome === "advanced" || value.outcome === "regressed") && !value.evidence) {
-      ctx.addIssue({ code: "custom", path: ["evidence"], message: `${value.outcome} trials require evidence` })
+    if ((value.outcome === "advanced" || value.outcome === "regressed") && !value.evidence_refs?.length) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["evidence_refs"],
+        message: `${value.outcome} trials require runtime-verified evidence references`,
+      })
     }
   })
 
 const Learn = z.object({
   action: z.literal("learn"),
-  source_trial: z.string().trim().min(1).max(200).describe("Prior material trial ID."),
-  situation: z.string().trim().min(1).max(500).describe("Reusable project condition, never a scientific conclusion."),
-  guidance: z.string().trim().min(1).max(1_000).describe("Reusable method guidance to test later."),
+  source_trial: z.string().trim().min(1).max(200),
+  situation: z.string().trim().min(1).max(500),
+  guidance: z.string().trim().min(1).max(1_000),
   evidence: z
     .string()
     .trim()
@@ -97,6 +136,7 @@ const Learn = z.object({
     .max(2_000)
     .describe("Support for the lesson; defaults to source-trial evidence.")
     .optional(),
+  evidence_refs: EvidenceRequests.optional(),
 })
 
 const Unlearn = z.object({
@@ -105,23 +145,138 @@ const Unlearn = z.object({
   source_trial: z.string().trim().min(1).max(200).describe("Current trial contradicting the lesson."),
   reason: z.string().trim().min(1).max(1_000),
   evidence: z.string().trim().min(1).max(2_000).describe("Counterevidence invalidating the lesson."),
+  evidence_refs: EvidenceRequests,
 })
 
 const Status = z.object({ action: z.literal("status") })
+
+function hash(value: string) {
+  return new Bun.CryptoHasher("sha256").update(value).digest("hex")
+}
+
+async function evidenceContext(sessionID: string) {
+  const sessions = new Set<string>()
+  const visit = async (id: string): Promise<MessageV2.WithParts[]> => {
+    if (sessions.has(id)) return []
+    sessions.add(id)
+    const [messages, children] = await Promise.all([Session.messages({ sessionID: id }), Session.children(id)])
+    return [messages, ...(await Promise.all(children.map((child) => visit(child.id))))].flat()
+  }
+  const [messages, artifacts] = await Promise.all([visit(sessionID), ArtifactStore.list(Instance.project.id)])
+  return { sessions, messages, artifacts }
+}
+
+async function evidence(
+  requests: z.infer<typeof EvidenceRequests> | undefined,
+  sessionID: string,
+): Promise<SessionResearch.EvidenceReference[]> {
+  if (!requests?.length) return []
+  const context = await evidenceContext(sessionID)
+  return Promise.all(
+    requests.map(async (request) => {
+      const parsed = (() => {
+        if (request.startsWith("artifact-path:")) {
+          return { kind: "artifact" as const, path: request.slice("artifact-path:".length) }
+        }
+        if (request.startsWith("artifact:")) {
+          return { kind: "artifact" as const, artifactID: request.slice("artifact:".length) }
+        }
+        if (request.startsWith("tool-call:")) {
+          return { kind: "tool" as const, callID: request.slice("tool-call:".length) }
+        }
+        if (request.startsWith("tool:")) return { kind: "tool" as const, tool: request.slice("tool:".length) }
+        throw new Error(
+          `Invalid evidence reference ${JSON.stringify(request)}; use artifact:<id>, artifact-path:<path>, tool:<name>, or tool-call:<id>`,
+        )
+      })()
+      if (!Object.values(parsed).every((value) => value)) {
+        throw new Error(`Evidence reference ${JSON.stringify(request)} has an empty selector`)
+      }
+      if (parsed.kind === "artifact") {
+        const current = context.artifacts.find(
+          (item) =>
+            item.state === "active" &&
+            context.sessions.has(item.current.sessionID) &&
+            (!("artifactID" in parsed) || item.id === parsed.artifactID) &&
+            (!("path" in parsed) || item.current.sourcePath === parsed.path),
+        )
+        if (!current) {
+          throw new Error(`No active durable Result in this session tree matches ${request}`)
+        }
+        const detail = await ArtifactStore.get(Instance.project.id, current.id)
+        const version = detail?.current
+        if (!version || !context.sessions.has(version.sessionID)) {
+          throw new Error(`Artifact version ${current.currentVersionID} is not in this session tree`)
+        }
+        const snapshot = await ArtifactStore.read(Instance.project.id, current.id, version.id)
+        if (!snapshot || snapshot.info.sha256 !== version.sha256) {
+          throw new Error(`Artifact ${current.id} version ${version.id} failed immutable blob verification`)
+        }
+        return SessionResearch.EvidenceReference.parse({
+          kind: "artifact",
+          ref: `${current.id}:${version.id}`,
+          artifactID: current.id,
+          versionID: version.id,
+          path: version.sourcePath,
+          sha256: version.sha256,
+          verifiedAt: Date.now(),
+        })
+      }
+
+      const tools = context.messages
+        .flatMap((message) => message.parts)
+        .filter(
+          (
+            part,
+          ): part is MessageV2.ToolPart & {
+            state: MessageV2.ToolStateCompleted | MessageV2.ToolStateError
+          } =>
+            part.type === "tool" &&
+            (part.state.status === "completed" || part.state.status === "error") &&
+            part.tool !== "research_contract",
+        )
+        .toSorted((a, b) => a.state.time.end - b.state.time.end)
+      const found = tools.findLast(
+        (part) =>
+          (!("callID" in parsed) || part.callID === parsed.callID) &&
+          (!("tool" in parsed) || part.tool === parsed.tool),
+      )
+      if (!found) {
+        throw new Error(`No terminal tool call matches ${request}`)
+      }
+      const output = found.state.status === "completed" ? found.state.output : found.state.error
+      return SessionResearch.EvidenceReference.parse({
+        kind: "tool",
+        ref: found.callID,
+        tool: found.tool,
+        callID: found.callID,
+        status: found.state.status,
+        outputHash: hash(output),
+        verifiedAt: Date.now(),
+      })
+    }),
+  )
+}
 
 const Params = z
   .object({
     action: z.enum(["define", "stage", "check", "trial", "failure", "learn", "unlearn", "status"]),
     objective: Define.shape.objective.optional(),
-    domain: SessionResearch.Domain.optional(),
+    domain: Domain.optional(),
     template: SessionResearch.Template.optional(),
     deliverables: Define.shape.deliverables,
     reserve_usd: Define.shape.reserve_usd,
+    max_model_calls: Define.shape.max_model_calls,
+    max_tool_calls: Define.shape.max_tool_calls,
+    max_tokens: Define.shape.max_tokens,
+    max_minutes: Define.shape.max_minutes,
+    max_cost_usd: Define.shape.max_cost_usd,
     stage: Stage.shape.stage.optional(),
     check: Check.shape.check.optional(),
     label: Check.shape.label,
     status: z.enum(["pending", "running", "completed", "blocked", "passed", "failed"]).optional(),
     evidence: Check.shape.evidence,
+    evidence_refs: EvidenceRequests.optional(),
     detail: Check.shape.detail,
     candidate: Failure.shape.candidate.optional(),
     message: Failure.shape.message.optional(),
@@ -129,6 +284,7 @@ const Params = z
     branch: Trial.shape.branch.optional(),
     outcome: SessionResearch.Outcome.optional(),
     summary: Trial.shape.summary.optional(),
+    metric: SessionResearch.Metric.optional(),
     source_trial: Learn.shape.source_trial.optional(),
     situation: Learn.shape.situation.optional(),
     guidance: Learn.shape.guidance.optional(),
@@ -136,25 +292,35 @@ const Params = z
     reason: Unlearn.shape.reason.optional(),
   })
   .superRefine((value, ctx) => {
-    const parsed = [Define, Stage, Check, Trial, Failure, Learn, Unlearn, Status].find(
-      (schema) => schema.safeParse(value).success,
-    )
-    if (parsed) return
-    ctx.addIssue({ code: "custom", message: `Invalid fields for research contract action ${value.action}` })
+    const schema = {
+      define: Define,
+      stage: Stage,
+      check: Check,
+      trial: Trial,
+      failure: Failure,
+      learn: Learn,
+      unlearn: Unlearn,
+      status: Status,
+    }[value.action]
+    const parsed = schema.safeParse(value)
+    if (parsed.success) return
+    parsed.error.issues.forEach((issue) => ctx.addIssue({ code: "custom", path: issue.path, message: issue.message }))
   })
 
 export const ResearchContractTool = Tool.define("research_contract", {
   description: [
-    "Durable completion contract for multi-stage research.",
-    "Use define before expensive work; stage at lifecycle boundaries; check after deterministic verification;",
-    "trial for each material hypothesis, method, fit, simulation, or evidence attempt; failure for an invalid candidate; status to inspect.",
-    "Do not record commands or transient tool errors as trials. Trial requires stage, branch, candidate, outcome, summary, plus evidence for advanced/regressed.",
-    "A decision stage requires a material trial. Stage evidence is detail, never a passed check; checks need observed evidence.",
-    "Learn only reusable method guidance from an evidence-backed trial; omitted evidence inherits from it and stays tentative until independently supported. Reinforce with the stored situation and guidance. Unlearn with counterevidence.",
-    "State survives provider interruptions and guides explore, refine, pivot, fuse, and verify.",
+    "Durable state for multi-stage research. Define first; update stages; record candidates with trial and invalid ones with failure.",
+    "Settled checks and advanced/regressed trials need runtime-verified evidence_refs. Free text is explanation only.",
+    "Add metric plus baseline when quantitative; contradictory outcomes fail.",
+    "Learn methods only from verified trials; unlearn with verified counterevidence.",
+    "Optional max_* fields bound the session tree; omitted limits are generous. Status inspects state.",
   ].join(" "),
   parameters: Params,
+  formatValidationError(error) {
+    return error.issues[0]?.message ?? "Invalid research contract input"
+  },
   async execute(params, ctx) {
+    const refs = await evidence(params.evidence_refs, ctx.sessionID)
     const lesson = await (async () => {
       if (params.action === "learn") {
         const input = Learn.parse(params)
@@ -163,6 +329,7 @@ export const ResearchContractTool = Tool.define("research_contract", {
           situation: input.situation,
           guidance: input.guidance,
           evidence: input.evidence,
+          evidenceRefs: refs,
         })
       }
       if (params.action === "unlearn") {
@@ -172,6 +339,7 @@ export const ResearchContractTool = Tool.define("research_contract", {
           sourceTrial: input.source_trial,
           reason: input.reason,
           evidence: input.evidence,
+          evidenceRefs: refs,
         })
       }
     })()
@@ -184,6 +352,16 @@ export const ResearchContractTool = Tool.define("research_contract", {
           template: input.template,
           deliverables: input.deliverables,
           reserveUsd: input.reserve_usd,
+          limits:
+            input.max_model_calls || input.max_tool_calls || input.max_tokens || input.max_minutes || input.max_cost_usd
+              ? {
+                  ...(input.max_model_calls ? { modelCalls: input.max_model_calls } : {}),
+                  ...(input.max_tool_calls ? { toolCalls: input.max_tool_calls } : {}),
+                  ...(input.max_tokens ? { tokens: input.max_tokens } : {}),
+                  ...(input.max_minutes ? { wallClockMs: input.max_minutes * 60_000 } : {}),
+                  ...(input.max_cost_usd ? { costUsd: input.max_cost_usd } : {}),
+                }
+              : undefined,
         })
       }
       if (params.action === "stage") {
@@ -201,6 +379,7 @@ export const ResearchContractTool = Tool.define("research_contract", {
           label: input.label,
           status: input.status,
           evidence: input.evidence,
+          evidenceRefs: refs,
           detail: input.detail,
         })
       }
@@ -228,6 +407,8 @@ export const ResearchContractTool = Tool.define("research_contract", {
             outcome: input.outcome,
             summary: input.summary,
             evidence: input.evidence,
+            evidenceRefs: refs,
+            metric: input.metric,
           },
           ctx.callID,
         )
@@ -237,7 +418,7 @@ export const ResearchContractTool = Tool.define("research_contract", {
       return current
     })()
     const completed = contract.stages.filter((stage) => stage.status === "completed").length
-    const passed = contract.checks.filter((check) => check.status === "passed" && !!check.evidence?.trim()).length
+    const passed = contract.checks.filter((check) => check.status === "passed" && check.evidenceRefs.length).length
     const failed = contract.checks.filter((check) => check.status === "failed").length
     const strategy = SessionResearch.strategy(contract)
     const lessons = await SessionResearch.experience(Instance.project.id, contract.domain)
@@ -264,7 +445,13 @@ export const ResearchContractTool = Tool.define("research_contract", {
         `Recorded candidate failures: ${contract.failures.length}`,
         `Recorded material attempts: ${contract.trials.length}`,
         ...(recent.length
-          ? ["Recent trial IDs:", ...recent.map((item) => `- ${item.id}: ${item.candidate} [${item.outcome}]`)]
+          ? [
+              "Recent trial IDs:",
+              ...recent.map(
+                (item) =>
+                  `- ${item.id}: ${item.candidate} [${item.outcome}]${item.metric ? ` ${item.metric.name}=${item.metric.value}${item.metric.unit ? ` ${item.metric.unit}` : ""}` : ""} · ${item.evidenceRefs.length} verified ref(s)`,
+              ),
+            ]
           : []),
         `Trajectory mode: ${strategy.mode} - ${strategy.reason}`,
         `Active project lessons: ${active.length} (${active.filter((item) => item.confidence === "supported").length} independently supported)`,
@@ -274,6 +461,9 @@ export const ResearchContractTool = Tool.define("research_contract", {
             ]
           : []),
         `Managed-credit finalization reserve: $${contract.budget.reserveUsd.toFixed(2)}`,
+        `Runtime limits: ${contract.budget.limits.modelCalls} model calls, ${contract.budget.limits.toolCalls} tool calls, ${contract.budget.limits.tokens} tokens, ${Math.round(contract.budget.limits.wallClockMs / 60_000)} minutes, $${contract.budget.limits.costUsd.toFixed(2)}`,
+        `Runtime usage: ${contract.budget.runtimeModelCalls} model calls reserved${contract.budget.lastUsage ? `, ${contract.budget.lastUsage.toolCalls} tools, ${contract.budget.lastUsage.tokens} tokens, ${Math.round(contract.budget.lastUsage.wallClockMs / 1_000)} seconds, $${contract.budget.lastUsage.costUsd.toFixed(4)}` : ""}`,
+        ...(refs.length ? [`Verified evidence references recorded: ${refs.map((item) => item.ref).join(", ")}`] : []),
       ].join("\n"),
       metadata: {
         researchContract: {

--- a/backend/cli/test/session/research-budget.test.ts
+++ b/backend/cli/test/session/research-budget.test.ts
@@ -1,0 +1,139 @@
+import { expect, test } from "bun:test"
+import { Instance } from "../../src/project/instance"
+import { Session } from "../../src/session"
+import type { MessageV2 } from "../../src/session/message-v2"
+import { SessionResearch } from "../../src/session/research"
+import { SessionTraceStore } from "../../src/session/trace-store"
+import { tmpdir } from "../fixture/fixture"
+
+function assistant(sessionID: string, id: string, tokens = 100): MessageV2.Assistant {
+  const now = Date.now()
+  return {
+    id,
+    sessionID,
+    role: "assistant",
+    parentID: `msg_user_${id}`,
+    modelID: "test-model",
+    providerID: "test-provider",
+    mode: "research",
+    agent: "research",
+    path: { cwd: Instance.directory, root: Instance.worktree },
+    cost: 0.1,
+    tokens: { input: tokens, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    time: { created: now - 10, completed: now },
+    finish: "stop",
+  }
+}
+
+test("runtime limits count the complete session tree and preserve two finalization calls", async () => {
+  await using tmp = await tmpdir({ git: true })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const root = await Session.create({ title: "bounded research" })
+      const child = await Session.create({ title: "bounded child", parentID: root.id })
+      try {
+        await SessionResearch.define(root.id, {
+          objective: "Bound the complete run",
+          domain: "general",
+          template: "minimal",
+          limits: { modelCalls: 5, toolCalls: 20, tokens: 10_000, wallClockMs: 60_000, costUsd: 10 },
+        })
+        await SessionResearch.define(root.id, {
+          objective: "Cannot reset the bound",
+          domain: "general",
+          template: "minimal",
+          limits: { modelCalls: 40, toolCalls: 10 },
+        })
+        expect((await SessionResearch.read(root.id))?.budget.limits).toMatchObject({ modelCalls: 5, toolCalls: 10 })
+        expect((await SessionResearch.runtimePreflight(child.id)).decision).toBe("allow")
+
+        await Promise.all([
+          Session.updateMessage(assistant(root.id, "msg_assistant_root")),
+          Session.updateMessage(assistant(child.id, "msg_assistant_child")),
+        ])
+        await SessionTraceStore.recordRetry({
+          sessionID: child.id,
+          messageID: "msg_assistant_child",
+          attempt: 1,
+          message: "retryable provider failure",
+          delayMs: 1,
+        })
+        const first = await SessionResearch.runtimePreflight(root.id)
+        const usage = first.usage
+        if (!usage) throw new Error("Expected finalization usage")
+        expect(usage.wallClockMs).toBeGreaterThanOrEqual(0)
+        expect(usage.wallClockMs).toBeLessThan(20)
+        expect(first).toMatchObject({
+          decision: "finalize",
+          usage: { modelCalls: 4, tokens: 200, costUsd: 0.2 },
+        })
+        expect(first.reason).toContain("model-call limit")
+        expect((await SessionResearch.runtimePreflight(root.id)).decision).toBe("finalize")
+        expect((await SessionResearch.runtimePreflight(root.id)).decision).toBe("block")
+        expect((await SessionResearch.read(root.id))?.budget).toMatchObject({
+          runtimeFinalizationCalls: 2,
+          runtimeModelCalls: 5,
+          runtimeFinalizing: false,
+          runtimeExhausted: true,
+        })
+      } finally {
+        await SessionResearch.remove(root.id)
+        await Session.remove(root.id)
+      }
+    },
+  })
+})
+
+test("ordinary sessions without a research contract are never budget-gated", async () => {
+  await using tmp = await tmpdir({ git: true })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const session = await Session.create({ title: "ordinary chat" })
+      try {
+        expect(await SessionResearch.runtimePreflight(session.id)).toEqual({ decision: "allow" })
+      } finally {
+        await Session.remove(session.id)
+      }
+    },
+  })
+})
+
+test("parallel child preflights reserve model calls atomically against the parent contract", async () => {
+  await using tmp = await tmpdir({ git: true })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const root = await Session.create({ title: "parallel bounded research" })
+      const child = await Session.create({ title: "parallel bounded child", parentID: root.id })
+      try {
+        await SessionResearch.define(root.id, {
+          objective: "Bound parallel work",
+          domain: "general",
+          template: "minimal",
+          limits: { modelCalls: 4 },
+        })
+        await SessionResearch.define(child.id, {
+          objective: "A child contract cannot bypass its parent",
+          domain: "general",
+          template: "minimal",
+          limits: { modelCalls: 100 },
+        })
+        const decisions = await Promise.all(Array.from({ length: 8 }, () => SessionResearch.runtimePreflight(child.id)))
+        expect(decisions.filter((item) => item.decision === "allow")).toHaveLength(2)
+        expect(decisions.filter((item) => item.decision === "finalize")).toHaveLength(2)
+        expect(decisions.filter((item) => item.decision === "block")).toHaveLength(4)
+        expect((await SessionResearch.read(root.id))?.budget).toMatchObject({
+          runtimeModelCalls: 4,
+          runtimeFinalizationCalls: 2,
+          runtimeExhausted: true,
+        })
+      } finally {
+        await SessionResearch.remove(child.id)
+        await SessionResearch.remove(root.id)
+        await Session.remove(root.id)
+      }
+    },
+  })
+})

--- a/backend/cli/test/session/research.test.ts
+++ b/backend/cli/test/session/research.test.ts
@@ -1,6 +1,28 @@
 import { expect, test } from "bun:test"
 import { SessionResearch } from "../../src/session/research"
 
+function verified(label: string): SessionResearch.EvidenceReference {
+  return {
+    kind: "tool",
+    ref: `call-${label}`,
+    tool: "bash",
+    callID: `call-${label}`,
+    status: "completed",
+    outputHash: new Bun.CryptoHasher("sha256").update(label).digest("hex"),
+    verifiedAt: 1,
+  }
+}
+
+function artifact(path: string, index: number) {
+  const sha256 = index.toString(16).padStart(64, "0")
+  const versionID = `ver-${index}`
+  return { path, artifactID: `art-${index}`, versionID, sha256 }
+}
+
+function target(item: ReturnType<typeof artifact>) {
+  return `artifact-version:${item.versionID}:${item.sha256.slice(0, 16)}`
+}
+
 test("explicit deliverables replace generic template filenames", async () => {
   const sessionID = `ses_research_${crypto.randomUUID()}`
   try {
@@ -46,6 +68,7 @@ test("persists, resumes, and truthfully assesses a research completion contract"
       outcome: "advanced",
       summary: "Produced finite calibration metrics",
       evidence: "metrics.json",
+      evidenceRefs: [verified("calibration")],
     })
     for (const stage of created.stages) {
       await SessionResearch.stage(sessionID, { id: stage.id, status: "completed", detail: "verified" })
@@ -55,6 +78,7 @@ test("persists, resumes, and truthfully assesses a research completion contract"
         id: check.id,
         status: "passed",
         evidence: "clean process output",
+        evidenceRefs: [verified(check.id)],
       })
     }
     await SessionResearch.fail(sessionID, {
@@ -65,33 +89,34 @@ test("persists, resumes, and truthfully assesses a research completion contract"
     })
 
     const contract = (await SessionResearch.read(sessionID))!
+    const artifacts = [
+      artifact("analysis.py", 1),
+      artifact("metrics.json", 2),
+      artifact("report.md", 3),
+      artifact("REPRODUCE.md", 4),
+      artifact("figures/calibration.png", 5),
+    ]
+    const findings = artifacts.map((item) => ({
+      target: target(item),
+      verdict: "supports",
+      status: undefined,
+      severity: "info",
+    }))
     const assessment = SessionResearch.assess(contract, {
-      artifacts: [
-        { path: "analysis.py" },
-        { path: "metrics.json" },
-        { path: "report.md" },
-        { path: "REPRODUCE.md" },
-        { path: "figures/calibration.png" },
-      ],
+      artifacts,
       jobs: [{ status: "completed" }],
       kernels: [{ status: "completed" }],
-      findings: [{ verdict: "supports", status: undefined, severity: "info" }],
+      findings,
       reviewed: true,
       busy: false,
     })
     expect(assessment).toMatchObject({ status: "ready", readiness: 100, failedCandidates: 1 })
 
     const recovered = SessionResearch.assess(contract, {
-      artifacts: [
-        { path: "analysis.py" },
-        { path: "metrics.json" },
-        { path: "report.md" },
-        { path: "REPRODUCE.md" },
-        { path: "figures/calibration.png" },
-      ],
+      artifacts,
       jobs: [{ status: "failed" }, { status: "completed" }],
       kernels: [{ status: "error" }, { status: "completed" }],
-      findings: [{ verdict: "supports", status: "confirmed", severity: "info" }],
+      findings: findings.map((item) => ({ ...item, status: "confirmed" })),
       reviewed: true,
       busy: false,
     })
@@ -131,6 +156,37 @@ test("blocks readiness on unresolved review findings and runtime failures", asyn
     expect(assessment.status).toBe("blocked")
     expect(assessment.gates.find((gate) => gate.id === "review")?.status).toBe("failed")
     expect(assessment.gates.find((gate) => gate.id === "runtime")?.detail).toContain("2 kernel or compute failures")
+  } finally {
+    await SessionResearch.remove(sessionID)
+  }
+})
+
+test("review coverage requires a structured disposition for every required immutable Result", async () => {
+  const sessionID = `ses_research_${crypto.randomUUID()}`
+  try {
+    const contract = await SessionResearch.define(sessionID, {
+      objective: "Review every result",
+      domain: "general",
+      template: "minimal",
+      deliverables: [
+        { path: "report.md", label: "Report", required: true },
+        { path: "metrics.json", label: "Metrics", required: true },
+      ],
+    })
+    const report = artifact("report.md", 20)
+    const metrics = artifact("metrics.json", 21)
+    const assessment = SessionResearch.assess(contract, {
+      artifacts: [report, metrics],
+      jobs: [],
+      kernels: [],
+      findings: [{ target: target(report), verdict: "supports", severity: "info" }],
+      reviewed: true,
+      busy: false,
+    })
+    expect(assessment.gates.find((gate) => gate.id === "review")).toMatchObject({
+      status: "pending",
+      detail: "1 required Result has no structured review disposition",
+    })
   } finally {
     await SessionResearch.remove(sessionID)
   }
@@ -191,6 +247,7 @@ test("persists material attempts and changes trajectory strategy without repeati
       outcome: "advanced",
       summary: "Reduced error under the frozen contamination case",
       evidence: "metrics.json:trimmed_mae",
+      evidenceRefs: [verified("trimmed")],
     })
     const fused = await SessionResearch.trial(sessionID, {
       stage: "scope",
@@ -199,6 +256,7 @@ test("persists material attempts and changes trajectory strategy without repeati
       outcome: "advanced",
       summary: "Improved the heavy-tail control independently",
       evidence: "metrics.json:mom_mae",
+      evidenceRefs: [verified("mom")],
     })
     expect(SessionResearch.strategy(fused)).toMatchObject({ mode: "fuse", attempts: 4, branches: 3 })
 
@@ -215,6 +273,7 @@ test("persists material attempts and changes trajectory strategy without repeati
       outcome: "advanced",
       summary: "Combined the independent robust branches",
       evidence: "metrics.json:fused_mae",
+      evidenceRefs: [verified("fused")],
     })
     for (const stage of fused.stages) {
       await SessionResearch.stage(sessionID, { id: stage.id, status: "completed" })
@@ -248,6 +307,7 @@ test("requires a material trial before the domain decision stage can complete", 
       outcome: "advanced",
       summary: "Reduced contaminated RMSE",
       evidence: "metrics.json:sample_median.rmse",
+      evidenceRefs: [verified("sample-median")],
     })
     expect(
       await SessionResearch.stage(sessionID, {
@@ -285,16 +345,36 @@ test("retains stage boundary evidence without treating it as a verification chec
   }
 })
 
-test("loads pre-trajectory contracts with an empty attempt ledger", () => {
+test("loads pre-verification contracts without treating prose as verified", () => {
   const parsed = SessionResearch.Contract.parse({
     version: 1,
     objective: "Legacy contract",
     domain: "general",
     template: "minimal",
-    stages: [],
+    stages: [{ id: "scope", label: "Scope", status: "pending", updatedAt: 1 }],
     deliverables: [],
-    checks: [],
+    checks: [
+      {
+        id: "legacy-check",
+        label: "Legacy check",
+        status: "passed",
+        evidence: "verification.log",
+        updatedAt: 1,
+      },
+    ],
     failures: [],
+    trials: [
+      {
+        id: "legacy-trial",
+        stage: "scope",
+        branch: "legacy",
+        candidate: "legacy candidate",
+        outcome: "advanced",
+        summary: "Legacy claimed improvement",
+        evidence: "metrics.json:score",
+        recordedAt: 1,
+      },
+    ],
     budget: {
       reserveUsd: 1,
       finalizationCalls: 0,
@@ -305,10 +385,12 @@ test("loads pre-trajectory contracts with an empty attempt ledger", () => {
     createdAt: 1,
     updatedAt: 1,
   })
-  expect(parsed.trials).toEqual([])
+  expect(parsed.checks[0]?.evidenceRefs).toEqual([])
+  expect(parsed.trials[0]?.evidenceRefs).toEqual([])
+  expect(SessionResearch.strategy(parsed).mode).toBe("explore")
 })
 
-test("requires evidence before a trial may claim advancement or regression", () => {
+test("loads legacy prose-only trials but requires verified evidence for new advancement claims", async () => {
   expect(
     SessionResearch.Trial.safeParse({
       id: "trial-1",
@@ -317,9 +399,10 @@ test("requires evidence before a trial may claim advancement or regression", () 
       candidate: "trimmed mean",
       outcome: "advanced",
       summary: "Lower error",
+      evidence: "legacy metrics note",
       recordedAt: 1,
     }).success,
-  ).toBe(false)
+  ).toBe(true)
   expect(
     SessionResearch.Trial.safeParse({
       id: "trial-2",
@@ -329,9 +412,31 @@ test("requires evidence before a trial may claim advancement or regression", () 
       outcome: "advanced",
       summary: "Lower error",
       evidence: "metrics.json:mae",
+      evidenceRefs: [verified("trial-2")],
       recordedAt: 1,
     }).success,
   ).toBe(true)
+
+  const sessionID = `ses_research_${crypto.randomUUID()}`
+  try {
+    await SessionResearch.define(sessionID, {
+      objective: "Reject unverified advancement",
+      domain: "general",
+      template: "minimal",
+    })
+    await expect(
+      SessionResearch.trial(sessionID, {
+        stage: "scope",
+        branch: "legacy",
+        candidate: "prose-only claim",
+        outcome: "advanced",
+        summary: "Claimed improvement",
+        evidence: "metrics.json:score",
+      }),
+    ).rejects.toThrow("require verified evidence references")
+  } finally {
+    await SessionResearch.remove(sessionID)
+  }
 })
 
 test("requires observed evidence before a verification check may settle", async () => {
@@ -344,8 +449,17 @@ test("requires observed evidence before a verification check may settle", async 
     })
     const check = contract.checks[0]
     await expect(SessionResearch.check(sessionID, { id: check.id, status: "passed" })).rejects.toThrow(
-      "requires observed evidence",
+      "requires a verified artifact or tool reference",
     )
+    const errored = verified("errored")
+    if (errored.kind !== "tool") throw new Error("Expected tool evidence")
+    await expect(
+      SessionResearch.check(sessionID, {
+        id: check.id,
+        status: "passed",
+        evidenceRefs: [{ ...errored, status: "error" }],
+      }),
+    ).rejects.toThrow("cannot pass with an errored tool")
 
     const legacy = {
       ...contract,
@@ -366,6 +480,7 @@ test("requires observed evidence before a verification check may settle", async 
         id: check.id,
         status: "passed",
         evidence: "verification.log: exit 0",
+        evidenceRefs: [verified("verification")],
       }),
     ).toMatchObject({ checks: [expect.objectContaining({ id: check.id, status: "passed" })] })
   } finally {
@@ -404,6 +519,7 @@ test("promotes project research lessons across independent sessions and retires 
         outcome: "advanced",
         summary: "Reduced error under the frozen contamination sweep",
         evidence: "metrics-first.json:huber.rmse",
+        evidenceRefs: [verified("first")],
       },
       "support-first",
     )
@@ -432,6 +548,7 @@ test("promotes project research lessons across independent sessions and retires 
         outcome: "advanced",
         summary: "Confirmed the method-family advantage on an independent session",
         evidence: "metrics-second.json:tukey.rmse",
+        evidenceRefs: [verified("second")],
       },
       "support-second",
     )
@@ -463,6 +580,7 @@ test("promotes project research lessons across independent sessions and retires 
         outcome: "advanced",
         summary: "The frozen-grid solver met its convergence criterion",
         evidence: "physics-metrics.json:order",
+        evidenceRefs: [verified("physics")],
       },
       "physics-support",
     )
@@ -472,6 +590,7 @@ test("promotes project research lessons across independent sessions and retires 
         sourceTrial: "trial-physics-support",
         reason: "A physics trial must not mutate statistics experience",
         evidence: "physics-metrics.json:order",
+        evidenceRefs: [verified("physics-counter")],
       }),
     ).rejects.toThrow("belongs to the statistics domain")
 
@@ -484,6 +603,7 @@ test("promotes project research lessons across independent sessions and retires 
         outcome: "regressed",
         summary: "The robust estimator lost efficiency after contamination was ruled out",
         evidence: "metrics-third.json:efficiency",
+        evidenceRefs: [verified("third")],
       },
       "contradiction",
     )
@@ -492,6 +612,7 @@ test("promotes project research lessons across independent sessions and retires 
       sourceTrial: "trial-contradiction",
       reason: "The prior is invalid after contamination is ruled out",
       evidence: "metrics-third.json:efficiency",
+      evidenceRefs: [verified("third-counter")],
     })
     expect(rejected).toMatchObject({ status: "rejected", contradictions: [{ sessionID: thirdID }] })
     expect(await SessionResearch.prompt(thirdID, projectID)).not.toContain(`[supported] ${supported.id}`)

--- a/backend/cli/test/session/tool-selection.test.ts
+++ b/backend/cli/test/session/tool-selection.test.ts
@@ -56,6 +56,12 @@ describe("tool selection", () => {
     expect(ToolSelection.relevant("science_search", { agent: "research", message: "Summarize this source." })).toBe(
       true,
     )
+    expect(
+      ToolSelection.relevant("research_contract", {
+        agent: "research",
+        message: "Update the Python harness and benchmark the model against a baseline metric.",
+      }),
+    ).toBe(true)
   })
 
   test("keeps explicitly named or enabled domain capabilities", () => {

--- a/backend/cli/test/session/trace.test.ts
+++ b/backend/cli/test/session/trace.test.ts
@@ -426,7 +426,7 @@ test("parent readiness includes findings recorded by a delegated reviewer", asyn
   })
 })
 
-test("a completed delegated review satisfies the review gate without findings", async () => {
+test("a completed delegated review cannot satisfy the review gate without a structured disposition", async () => {
   await using tmp = await tmpdir({ git: true })
   await Instance.provide({
     directory: tmp.path,
@@ -485,7 +485,10 @@ test("a completed delegated review satisfies the review gate without findings", 
       const trace = await SessionTrace.build(session.id)
       expect(trace.children[0]).toMatchObject({ agent: "review", status: "completed" })
       expect(trace.reviewerFindings).toHaveLength(0)
-      expect(trace.research.gates.find((gate) => gate.id === "review")?.status).toBe("passed")
+      expect(trace.research.gates.find((gate) => gate.id === "review")).toMatchObject({
+        status: "pending",
+        detail: "Independent review has not recorded a structured disposition",
+      })
       await Session.remove(session.id)
     },
   })

--- a/backend/cli/test/tool/research-contract.test.ts
+++ b/backend/cli/test/tool/research-contract.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, expect, test } from "bun:test"
+import { ArtifactStore } from "../../src/artifact/store"
+import { Instance } from "../../src/project/instance"
+import { SessionResearch } from "../../src/session/research"
+import { ResearchContractTool } from "../../src/tool/research-contract"
+import { executionSession, tmpdir } from "../fixture/fixture"
+
+beforeEach(() => ArtifactStore.reset())
+afterEach(() => ArtifactStore.reset())
+
+const context = (sessionID: string) => ({
+  sessionID,
+  messageID: "msg_research_contract",
+  callID: "call_research_contract",
+  agent: "research",
+  abort: new AbortController().signal,
+  messages: [],
+  metadata() {},
+  async ask() {},
+})
+
+test("research checks settle only from a runtime-verified immutable Result", async () => {
+  await using tmp = await tmpdir({ git: true })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const session = await executionSession()
+      const tool = await ResearchContractTool.init()
+      try {
+        await tool.execute(
+          { action: "define", objective: "Verify the report", domain: "general", template: "minimal" },
+          context(session.id),
+        )
+        await expect(
+          tool.execute(
+            {
+              action: "check",
+              check: "artifact-inspection",
+              status: "passed",
+              evidence: "report.md looks correct",
+            },
+            context(session.id),
+          ),
+        ).rejects.toThrow("runtime-verified evidence references")
+
+        const saved = await ArtifactStore.save({
+          projectID: Instance.project.id,
+          sessionID: session.id,
+          sourcePath: "report.md",
+          filename: "report.md",
+          kind: "report",
+          content: new Blob(["# Verified report\n"]),
+        })
+        const checked = await tool.execute(
+          {
+            action: "check",
+            check: "artifact-inspection",
+            status: "passed",
+            evidence: "Inspected the immutable report",
+            evidence_refs: [`artifact:${saved.id}`],
+          },
+          context(session.id),
+        )
+        expect(checked.metadata.researchContract).toMatchObject({ passedChecks: 1 })
+        expect((await SessionResearch.read(session.id))?.checks[0]).toMatchObject({
+          status: "passed",
+          evidenceRefs: [
+            {
+              kind: "artifact",
+              artifactID: saved.id,
+              versionID: saved.current.id,
+              path: "report.md",
+              sha256: saved.current.sha256,
+            },
+          ],
+        })
+      } finally {
+        await SessionResearch.remove(session.id)
+      }
+    },
+  })
+})
+
+test("quantitative trials reject outcome labels that contradict a directed metric", async () => {
+  await using tmp = await tmpdir({ git: true })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const session = await executionSession()
+      const tool = await ResearchContractTool.init()
+      try {
+        await tool.execute(
+          { action: "define", objective: "Improve validation accuracy", domain: "ml", template: "minimal" },
+          context(session.id),
+        )
+        const saved = await ArtifactStore.save({
+          projectID: Instance.project.id,
+          sessionID: session.id,
+          sourcePath: "metrics.json",
+          filename: "metrics.json",
+          kind: "dataset",
+          content: new Blob(['{"accuracy":0.81}\n']),
+        })
+        await expect(
+          tool.execute(
+            {
+              action: "trial",
+              stage: "select",
+              branch: "candidate",
+              candidate: "new classifier",
+              outcome: "advanced",
+              summary: "Candidate evaluation",
+              evidence_refs: [`artifact:${saved.id}`],
+              metric: { name: "accuracy", value: 0.81, baseline: 0.84, direction: "maximize" },
+            },
+            context(session.id),
+          ),
+        ).rejects.toThrow("Advanced outcome contradicts the metric")
+      } finally {
+        await SessionResearch.remove(session.id)
+      }
+    },
+  })
+})

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -79,6 +79,34 @@ Research runs also fail closed around completion:
 - Bash and Zsh pipelines use `pipefail`, so a failed analysis cannot be hidden by `tail`, `tee`, or
   another successful downstream formatter.
 
+## Research completion contracts
+
+Multi-stage research can define a durable completion contract without changing the fast path for
+ordinary questions or code work. Contracted runs add three fail-closed guarantees:
+
+- settled checks and advancing or regressing trials cite runtime-verified evidence references. The
+  runtime resolves `artifact:<id>` and `artifact-path:<path>` to an immutable Result version and
+  SHA-256, or `tool:<name>` and `tool-call:<id>` to an exact terminal tool call and output hash.
+  Free-text evidence remains useful explanation, but cannot pass a gate;
+- independent review completes only after a reviewer records a structured `supports` or `refutes`
+  disposition. When required Results are immutable, every Result version must have a disposition;
+  an empty reviewer response or completed child session does not count; and
+- the complete session tree has configurable model-call, tool-call, token, wall-clock, and cost
+  ceilings. Model calls, including provider retries and delegated child calls, are reserved
+  atomically against the parent contract. Defaults are intentionally generous. Near a ceiling, two
+  finalization calls remain for preserving outputs and returning a verified or explicitly partial
+  result; further inference fails closed while Results and checkpoints remain available.
+  Redefining an active contract can tighten limits but cannot raise them or reset recorded usage.
+
+Quantitative trials may also record a named metric, direction, baseline, target, and unit. When a
+baseline is present, the runtime rejects an `advanced` or `regressed` label that contradicts the
+observed direction. Reusable project lessons become independently supported only from verified
+observations across more than one session; legacy prose-only observations remain tentative.
+
+These controls make runs bounded and auditable. They deliberately do not provide benchmark
+datasets, official graders, leaderboard claims, or a candidate optimizer; those remain separate
+evaluation concerns.
+
 ## Non-goals
 
 - No external agent harness is installed or invoked.


### PR DESCRIPTION
## Summary

- require settled research checks and advancing/regressing trials to cite runtime-verified immutable Result versions or exact terminal tool calls
- validate directed quantitative metrics against their baselines and keep legacy prose-only records readable without treating them as verified
- require structured review dispositions for every immutable required Result instead of passing review when a reviewer merely completes
- add configurable session-tree budgets for model calls, tools, tokens, active wall time, and cost, with atomic accounting across retries and delegated children plus a bounded finalization reserve
- prevent active contracts from raising/resetting their own limits, expose usage in contract status, and keep ordinary non-contract sessions on the existing fast path
- retain research tools for benchmark/evaluation/reproducibility-shaped engineering requests and document the hardened contract behavior

## Scope

This is general research-harness hardening only. It intentionally does not add benchmark datasets, task adapters, official graders, leaderboard claims, or candidate-optimization infrastructure.

## Verification

- `bun test` from `backend/cli`: 2,384 passed, 19 platform skips, 0 failed (2,403 tests across 299 files)
- `bun run typecheck`
- `bun run build`
- `bun run eval:launch:validate`
- Prettier check on every touched source, test, and documentation file
