### PR TITLE
Fix production release job permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,6 +44,9 @@ jobs:
     needs: release-source
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      # version.ts creates the draft GitHub release before build/publish.
+      contents: write
     steps:
       - name: Require a bump or version input
         if: ${{ !inputs.bump && !inputs.version }}
@@ -72,6 +75,9 @@ jobs:
     needs: version
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    permissions:
+      # build.ts uploads the native archives and checksums to the draft release.
+      contents: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/backend/cli/test/installation/release-order.test.ts
+++ b/backend/cli/test/installation/release-order.test.ts
@@ -23,3 +23,22 @@ test("publish source gates normalize GitHub's case-insensitive repository slug",
     expect(source).not.toContain('[[ "$GITHUB_REPOSITORY" != "synthetic-sciences/OpenScience"')
   }
 })
+
+test("production release preparation jobs can write their draft GitHub release", async () => {
+  const source = await Bun.file(path.join(import.meta.dir, "../../../../.github/workflows/publish.yml")).text()
+  const jobs = [
+    ["version", "build-cli"],
+    ["build-cli", "verify-native-cli"],
+  ]
+
+  for (const item of jobs) {
+    const start = source.indexOf(`\n  ${item[0]}:`)
+    const end = source.indexOf(`\n  ${item[1]}:`)
+
+    expect(start).toBeGreaterThan(-1)
+    expect(end).toBeGreaterThan(start)
+    const job = source.slice(start, end)
+    expect(job).toContain("permissions:")
+    expect(job).toContain("contents: write")
+  }
+})


### PR DESCRIPTION
## Summary

- grant contents: write only to the version job that creates the draft release
- grant contents: write only to build-cli, which uploads native assets and checksums
- keep the workflow default and all unrelated jobs read-only
- add a regression contract for both release-preparation jobs

## Root cause

Production run 32443574829 stopped before build/publish because the least-privilege workflow refactor left version with contents: read. The same refactor would have caused the next job to fail when build.ts uploads draft-release assets.

## Verification

- bun test test/installation/release-order.test.ts (3 passed)
- actionlint -verbose .github/workflows/publish.yml
- repository push typecheck (7/7 packages)
- git diff --check