### PR TITLE
Fix malformed research tool calls and harness recovery

### DIFF
--- a/backend/cli/skills/coding/exploratory-data-analysis/SKILL.md
+++ b/backend/cli/skills/coding/exploratory-data-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exploratory-data-analysis
-description: Perform comprehensive exploratory data analysis on scientific data files across 200+ file formats. This skill should be used when analyzing any scientific data file to understand its structure, content, quality, and characteristics. Automatically detects file type and generates detailed markdown reports with format-specific analysis, quality metrics, and downstream analysis recommendations. Covers chemistry, bioinformatics, microscopy, spectroscopy, proteomics, metabolomics, and general scientific data formats.
+description: Analyze scientific data files across 200+ formats at the depth the user requests. Detect file type, assess structure, quality, and statistics, and create reports or visualizations only when they are requested or materially needed. Covers chemistry, bioinformatics, microscopy, spectroscopy, proteomics, metabolomics, and general scientific data formats.
 category: coding
 license: MIT license
 metadata:
@@ -11,7 +11,15 @@ metadata:
 
 ## Overview
 
-Perform comprehensive exploratory data analysis (EDA) on scientific data files across multiple domains. This skill provides automated file type detection, format-specific analysis, data quality assessment, and generates detailed markdown reports suitable for documentation and downstream analysis planning.
+Perform exploratory data analysis (EDA) on scientific data files across multiple domains. Match the depth and output to the request: a narrow calculation should stay a narrow calculation, while a requested full audit can include broader quality assessment and documentation.
+
+## Scope and output contract
+
+- The user's requested scope and output format take precedence over this workflow.
+- Do not create a report, figure, artifact, directory, or sidecar file by default.
+- Do not write to disk unless the user requested a saved deliverable or the task inherently requires one.
+- For a bounded question, inspect only the necessary data and answer inline with the decisive calculation and caveats.
+- Recommend a visualization only when it materially clarifies the result; generate one only when requested or necessary for the requested deliverable.
 
 **Key Capabilities:**
 - Automatic detection and analysis of 200+ scientific file formats
@@ -152,11 +160,11 @@ For arrays (NPY, HDF5):
 - Calculate statistical summaries
 - Check for missing/invalid values
 
-### Step 4: Generate Comprehensive Report
+### Step 4: Present the requested result
 
-Create a markdown report with the following sections:
+For a narrow request, return the result inline and stop. If the user explicitly requests a comprehensive report, create a markdown report with the following sections as relevant:
 
-#### Required Sections:
+#### Suggested report sections:
 1. **Title and Metadata**
    - Filename and timestamp
    - File size and location
@@ -191,9 +199,9 @@ Create a markdown report with the following sections:
 #### Template Location
 Use `assets/report_template.md` as a guide for report structure.
 
-### Step 5: Save Report
+### Step 5: Save only when requested
 
-Save the markdown report with a descriptive filename:
+When the user requests a saved report, use a descriptive filename:
 - Pattern: `{original_filename}_eda_report.md`
 - Example: `experiment_data.fastq` → `experiment_data_eda_report.md`
 
@@ -442,4 +450,3 @@ Based on data characteristics, recommend:
 
 ### assets/
 - `report_template.md`: Comprehensive markdown template for EDA reports
-

--- a/backend/cli/src/agent/prompt/explore.txt
+++ b/backend/cli/src/agent/prompt/explore.txt
@@ -1,18 +1,10 @@
-You are a file search specialist. You excel at thoroughly navigating and exploring codebases.
+You are the internal Explore profile. Find the exact repository or source evidence needed for one
+bounded question and return a decision-ready handoff to the lead Research agent.
 
-Your strengths:
-- Rapidly finding files using glob patterns
-- Searching code and text with powerful regex patterns
-- Reading and analyzing file contents
-
-Guidelines:
-- Use Glob for broad file pattern matching
-- Use Grep for searching file contents with regex
-- Use Read when you know the specific file path you need to read
-- Use Bash for file operations like copying, moving, or listing directory contents
-- Adapt your search approach based on the thoroughness level specified by the caller
-- Return file paths as absolute paths in your final response
-- For clear communication, avoid using emojis
-- Do not create any files, or run bash commands that modify the user's system state in any way
-
-Complete the user's search request efficiently and report your findings clearly.
+- Stay read-only. Use file listing, search, and targeted reads; use shell only for non-mutating
+  inspection when the dedicated tools cannot answer the question.
+- Start from the named inputs and widen only when evidence is missing. Adapt depth to the assignment.
+- Report concrete paths, symbols, line locations, values, and relationships. Distinguish observation
+  from inference and name important gaps.
+- Do not narrate every command, copy or move files, propose unrelated redesigns, or restate the task.
+- End with the finding that matters to the lead and the smallest useful next action, if one remains.

--- a/backend/cli/src/agent/prompt/write.txt
+++ b/backend/cli/src/agent/prompt/write.txt
@@ -1,81 +1,34 @@
 <system-reminder>
-You are in write mode — a scientific and technical writing agent.
+You are the scientific writing specialist. Produce the document the user asked for while preserving
+the underlying evidence and the author's intent.
 
-## Mission
-Produce publication-ready scientific documents: research papers, literature reviews,
-grant proposals, clinical reports, and technical writing — backed by real, verifiable
-citations and rich visual content.
+## Scope and output
 
-## CRITICAL: Real Citations Only
-- ZERO tolerance for placeholder or invented citations
-- Every citation must be found and verified through research-lookup skill
-- Use research-lookup BEFORE writing each section to find 5-10 real papers
-- If you cannot verify a citation, mark it [CITATION NEEDED] — never fabricate
-- After finding papers, verify metadata (DOI, volume, pages) via WebSearch
+- Follow the requested venue, format, page limit, files, and degree of revision. A format-only task
+  preserves wording, citations, results, and figures unless a change is required for compliance.
+- Do not invent a report, directory tree, graphical abstract, figure quota, or intermediate draft
+  series. Create only requested deliverables and files that are necessary to produce them.
+- Use flowing academic prose where appropriate, but preserve an existing paper's voice and notation.
+  Do not replace substantive content with generic filler.
 
-## Default Output: LaTeX + BibTeX
-Unless the user specifies otherwise, produce LaTeX documents with BibTeX citations.
-Compile with: pdflatex → bibtex → pdflatex × 2
+## Skills and citations
 
-## Writing Skills (load before writing)
-Load relevant skills via the `skill` tool based on document type:
+- Load only the skills that materially help. For ML papers use `ml-paper-writing`; for venue rules use
+  `venue-templates`; for citation repair use `citation-management` and `research-lookup`; for technical
+  diagrams use `scientific-schematics`; for illustrations use `generate-image`; for final critique use
+  `peer-review` when the risk justifies it.
+- Every citation must resolve to a real source and support the attached claim. Verify suspicious or
+  changed entries against primary metadata. Never fabricate a reference or silently substitute a
+  related paper. Mark unresolved support explicitly.
+- Figures are evidence-bearing content. Add or replace one only when requested or when it materially
+  improves the document; verify labels, values, captions, attribution, and source files.
 
-| Document Type | Skills to Load |
-|--------------|----------------|
-| ML/AI paper | ml-paper-writing, research-lookup, citation-management, venue-templates |
-| Literature review | literature-review, research-lookup, citation-management |
-| Grant proposal | research-grants, research-lookup, citation-management |
-| Conference poster | latex-posters, scientific-schematics, research-lookup |
-| Presentation | scientific-slides, scientific-schematics, generate-image |
-| Clinical report | clinical-reports, research-lookup, citation-management |
-| General paper | scientific-writing, research-lookup, citation-management, venue-templates |
+## Verification
 
-Always load: research-lookup, citation-management (for any writing task)
-For figures: scientific-schematics (diagrams), generate-image (illustrations). Both
-skills use the native `generate_image` tool so connected BYOK or funded managed
-wallet Credits work without exposing credentials to a shell script.
-For review: peer-review (after draft is complete)
-
-## Multi-Pass Writing Workflow
-1. **Research** — For documents requiring extensive citations (literature reviews, survey
-   papers, grant proposals), delegate to `literature-review` sub-agents via the Task tool.
-   Spawn one agent per major section or theme — they run in parallel and each returns
-   verified papers with BibTeX. For shorter documents, load research-lookup skill and
-   find 5-10 real papers per major section inline.
-2. **Skeleton** — Create full LaTeX document structure with all sections/subsections.
-3. **Write** — Fill sections one at a time, integrating only verified citations.
-4. **Figures** — Generate graphical abstract + figures using scientific-schematics and generate-image.
-5. **Compile** — pdflatex → bibtex → pdflatex × 2. Review PDF for formatting issues.
-6. **Review** — Load peer-review skill. Conduct systematic review. Fix issues. Iterate.
-
-## Academic Prose Requirements
-- Flowing paragraphs with proper transitions — NO bullet points in paper body
-- Use commas or parentheses for parenthetical statements — NO em dashes (— or –)
-- Complete sentences connected by transitional phrases
-- Formal academic register throughout
-
-## File Organization
-All writing outputs in: writing_outputs/<timestamp>_<description>/
-  drafts/      — v1_draft.tex, v2_draft.tex (never overwrite, increment versions)
-  references/  — references.bib
-  figures/     — generated diagrams and images
-  final/       — compiled PDFs
-  sources/     — context materials provided by user
-
-## Figure Requirements
-- Every document MUST include a graphical abstract (Figure 1)
-- Research papers: minimum 5 figures
-- Use scientific-schematics for: flowcharts, architecture diagrams, CONSORT/PRISMA
-- Use generate-image for: illustrations, visualizations, cover images
-- When in doubt, add a figure — visual content enhances all scientific communication
-
-## PDF Review (after compilation)
-Never read PDFs as text. Convert to images first, then inspect each page:
-  python scripts/pdf_to_images.py document.pdf review/page --dpi 150
-Check for: text overlaps, figure placement, margins, caption spacing, bibliography formatting.
-Fix issues and recompile (max 3 iterations). Clean up: rm -rf review/
-
-## Key Principle: Complete Tasks Fully
-Write the ENTIRE document without stopping to ask "Would you like me to continue?"
-Never offer abbreviated versions. Token usage is unlimited — complete from start to finish.
+- Inspect the source before editing. Keep a claim-to-source map for citation-sensitive revisions.
+- Compile with the repository's own entry point when available. Check warnings, bibliography
+  resolution, page count, margins, title placement, figure legibility, and links. Render and inspect
+  the final PDF visually rather than trusting a successful compiler exit.
+- Return the requested final files with concise verification and any unresolved limitation. Never
+  claim submission readiness when venue compliance, citations, or rendered pages were not checked.
 </system-reminder>

--- a/backend/cli/src/mcp/index.ts
+++ b/backend/cli/src/mcp/index.ts
@@ -1,4 +1,5 @@
 import { dynamicTool, type Tool, jsonSchema, type JSONSchema7 } from "ai"
+import { AjvJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/ajv"
 import { Client } from "@modelcontextprotocol/sdk/client/index.js"
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js"
@@ -244,25 +245,46 @@ export namespace MCP {
   }
 
   // Convert MCP tool definition to AI SDK Tool type
+  const validator = new AjvJsonSchemaValidator()
+
+  /** MCP publishes JSON Schema rather than Zod. Attach the SDK's own AJV
+   * validator so malformed model calls reach the AI SDK repair hook before a
+   * permission prompt or remote MCP request can start. */
+  export function inputSchema(name: string, schema: JSONSchema7) {
+    const validate = validator.getValidator<Record<string, unknown>>(schema as never)
+    return jsonSchema(schema, {
+      validate(input) {
+        const result = validate(input)
+        if (result.valid) return { success: true, value: result.data }
+        return {
+          success: false,
+          error: new Error(
+            `The ${name} MCP tool received invalid arguments or incomplete input. No action was taken. Retry with all required fields.`,
+          ),
+        }
+      },
+    })
+  }
+
   async function convertMcpTool(
     mcpTool: MCPToolDef,
     client: MCPClient,
     timeout?: number,
     projectOwned = false,
   ): Promise<Tool> {
-    const inputSchema = mcpTool.inputSchema
+    const published = mcpTool.inputSchema
 
     // Spread first, then override type to ensure it's always "object"
     const schema: JSONSchema7 = {
-      ...(inputSchema as JSONSchema7),
+      ...(published as JSONSchema7),
       type: "object",
-      properties: (inputSchema.properties ?? {}) as JSONSchema7["properties"],
+      properties: (published.properties ?? {}) as JSONSchema7["properties"],
       additionalProperties: false,
     }
 
     return dynamicTool({
       description: mcpTool.description ?? "",
-      inputSchema: jsonSchema(schema),
+      inputSchema: inputSchema(mcpTool.name, schema),
       execute: async (args: unknown) => {
         if (projectOwned) await ProjectTrust.require(Instance.project, "project_mcp")
         return client.callTool(

--- a/backend/cli/src/provider/provider.ts
+++ b/backend/cli/src/provider/provider.ts
@@ -1786,6 +1786,12 @@ export namespace Provider {
     const env = Env.all()
     for (const [providerID, provider] of Object.entries(database)) {
       if (disabled.has(providerID)) continue
+      // models.dev lists GITHUB_TOKEN for Copilot, but OpenScience also uses
+      // that variable for ordinary repository access. A GitHub PAT or App
+      // server token is not a Copilot inference credential and advertising it
+      // here produces a connected provider that fails before inference. Real
+      // Copilot access is loaded below through the OAuth plugin.
+      if (providerID.startsWith("github-copilot")) continue
       const credential = provider.env.map((name) => ({ name, value: env[name] })).find((item) => item.value)
       if (!credential?.value) continue
       mergeProvider(providerID, {

--- a/backend/cli/src/session/llm.ts
+++ b/backend/cli/src/session/llm.ts
@@ -11,7 +11,7 @@ import {
   tool,
   jsonSchema,
 } from "ai"
-import { clone, mergeDeep, pipe } from "remeda"
+import { clone, mergeDeep } from "remeda"
 import { ProviderTransform } from "@/provider/transform"
 import { Config } from "@/config/config"
 import { Instance } from "@/project/instance"
@@ -123,12 +123,12 @@ export namespace LLM {
           sessionID: input.sessionID,
           providerOptions: provider.options,
         })
-    const options: Record<string, any> = pipe(
-      base,
-      mergeDeep(input.model.options),
-      mergeDeep(tier.options),
-      mergeDeep(input.agent.options),
-      mergeDeep(variant),
+    // Keeping five deeply inferred Remeda pipe stages here can exceed
+    // TypeScript's instantiation limit as provider option unions grow. The
+    // runtime operation is a straightforward left-to-right deep merge.
+    const options = [input.model.options, tier.options, input.agent.options, variant].reduce<Record<string, any>>(
+      (result, layer) => mergeDeep(result, layer ?? {}) as Record<string, any>,
+      base as Record<string, any>,
     )
     if (isCodex) {
       options.instructions = SystemPrompt.instructions(input.direct, input.inspection)
@@ -240,11 +240,19 @@ export namespace LLM {
             toolName: lower,
           }
         }
+        const name = tools[failed.toolCall.toolName] ? failed.toolCall.toolName : lower
+        const message = tools[name]
+          ? `OpenScience caught an incomplete ${name} call before execution. ${failed.error.message}`
+          : `OpenScience caught a call to the unavailable tool ${failed.toolCall.toolName}. No action was taken.`
+        l.warn("replacing invalid tool call", {
+          tool: failed.toolCall.toolName,
+          error: failed.error.message,
+        })
         return {
           ...failed.toolCall,
           input: JSON.stringify({
             tool: failed.toolCall.toolName,
-            error: failed.error.message,
+            error: message,
           }),
           toolName: "invalid",
         }

--- a/backend/cli/src/session/message-v2.ts
+++ b/backend/cli/src/session/message-v2.ts
@@ -263,6 +263,7 @@ export namespace MessageV2 {
     .object({
       status: z.literal("running"),
       input: z.record(z.string(), z.any()),
+      raw: z.string().optional(),
       title: z.string().optional(),
       metadata: z.record(z.string(), z.any()).optional(),
       time: z.object({
@@ -278,6 +279,7 @@ export namespace MessageV2 {
     .object({
       status: z.literal("completed"),
       input: z.record(z.string(), z.any()),
+      raw: z.string().optional(),
       output: z.string(),
       title: z.string(),
       metadata: z.record(z.string(), z.any()),
@@ -297,6 +299,7 @@ export namespace MessageV2 {
     .object({
       status: z.literal("error"),
       input: z.record(z.string(), z.any()),
+      raw: z.string().optional(),
       error: z.string(),
       metadata: z.record(z.string(), z.any()).optional(),
       time: z.object({

--- a/backend/cli/src/session/processor.ts
+++ b/backend/cli/src/session/processor.ts
@@ -66,6 +66,15 @@ export namespace SessionProcessor {
     )
   }
 
+  /** Collect all assistant parts produced for one user request. The prompt loop
+   * creates a new assistant message after every tool step, so checking only the
+   * current message misses the most common repeated-call failure mode. */
+  export function turnParts(messages: MessageV2.WithParts[], parentID: string): MessageV2.Part[] {
+    return messages
+      .filter((message) => message.info.role === "assistant" && message.info.parentID === parentID)
+      .flatMap((message) => message.parts)
+  }
+
   function sharedPrefixLen(a: string, b: string): number {
     const n = Math.min(a.length, b.length)
     let i = 0
@@ -168,6 +177,7 @@ export namespace SessionProcessor {
             state: {
               status: "completed",
               input: outcome.input ?? match.state.input,
+              ...(match.state.raw ? { raw: match.state.raw } : {}),
               output: outcome.output.output,
               metadata: outcome.output.metadata ?? {},
               title: outcome.output.title,
@@ -182,6 +192,7 @@ export namespace SessionProcessor {
             state: {
               status: "error",
               input: outcome.input ?? match.state.input,
+              ...(match.state.raw ? { raw: match.state.raw } : {}),
               error: outcome.error instanceof Error ? outcome.error.message : String(outcome.error),
               ...(metadata ? { metadata } : {}),
               time,
@@ -209,6 +220,19 @@ export namespace SessionProcessor {
       },
       pending(part: MessageV2.ToolPart) {
         toolcalls[part.callID] = part
+      },
+      async delta(callID: string, delta: string) {
+        const match = toolcalls[callID]
+        if (!match || match.state.status !== "pending") return
+        const updated: MessageV2.ToolPart = {
+          ...match,
+          state: {
+            ...match.state,
+            raw: match.state.raw + delta,
+          },
+        }
+        toolcalls[callID] = updated
+        await input.updatePart(updated)
       },
       async running(part: MessageV2.ToolPart) {
         toolcalls[part.callID] = part
@@ -521,6 +545,7 @@ export namespace SessionProcessor {
                   break
 
                 case "tool-input-delta":
+                  await toolOutcomes.delta(value.id, value.delta)
                   break
 
                 case "tool-input-end":
@@ -535,6 +560,7 @@ export namespace SessionProcessor {
                       state: {
                         status: "running",
                         input: value.input,
+                        ...(match.state.status === "pending" && match.state.raw ? { raw: match.state.raw } : {}),
                         time: {
                           start: Date.now(),
                         },
@@ -547,9 +573,28 @@ export namespace SessionProcessor {
                     // reconcile it as soon as the call part exists.
                     await toolOutcomes.running(part as MessageV2.ToolPart)
 
-                    const parts = await MessageV2.parts(input.assistantMessage.id)
+                    const history = await Array.fromAsync(MessageV2.stream(input.sessionID))
+                    const parts = turnParts(history, input.assistantMessage.parentID)
+                    const threshold = value.toolName === "invalid" ? 2 : DOOM_LOOP_THRESHOLD
 
-                    if (isDoomLoop(parts, value.toolName, value.input)) {
+                    if (isDoomLoop(parts, value.toolName, value.input, threshold)) {
+                      if (value.toolName === "invalid") {
+                        const source =
+                          value.input && typeof value.input === "object" && "tool" in value.input
+                            ? String(value.input.tool)
+                            : "tool"
+                        blocked = true
+                        await Session.updatePart({
+                          id: Identifier.ascending("part"),
+                          messageID: input.assistantMessage.id,
+                          sessionID: input.sessionID,
+                          type: "text",
+                          synthetic: true,
+                          text: `OpenScience stopped two repeated incomplete ${source} calls before execution. No action was taken.`,
+                          time: { start: Date.now(), end: Date.now() },
+                        } satisfies MessageV2.TextPart)
+                        break
+                      }
                       const agent = await Agent.get(input.assistantMessage.agent)
                       await PermissionNext.ask({
                         permission: "doom_loop",

--- a/backend/cli/src/session/prompt.ts
+++ b/backend/cli/src/session/prompt.ts
@@ -85,6 +85,16 @@ export namespace SessionPrompt {
   // Science agents that dispatch GPU/compute work and should honor billing.compute.
   const SKILL_ROUTING_AGENTS = new Set(["research", "biology", "physics", "ml"])
 
+  /** Build the provider schema and keep the executable Zod contract attached. */
+  export function toolInputSchema(model: Provider.Model, item: Tool.Contract & { id: string }) {
+    const schema = ProviderTransform.schema(model, z.toJSONSchema(item.parameters))
+    return jsonSchema(schema as any, {
+      validate(args) {
+        return Tool.validate(item.id, item, args)
+      },
+    })
+  }
+
   const state = Instance.state(
     () => {
       const data: Record<
@@ -1233,11 +1243,16 @@ export namespace SessionPrompt {
           direct: input.direct,
         }),
     )) {
-      const schema = ProviderTransform.schema(input.model, z.toJSONSchema(item.parameters))
       tools[item.id] = tool({
         id: item.id as any,
         description: ToolSelection.description(item.id, item.description, input.inspection),
-        inputSchema: jsonSchema(schema as any),
+        // Provider-facing JSON Schema is only a description. Without a runtime
+        // validator the AI SDK accepts any syntactically valid JSON (including
+        // the `{}` fallback emitted by some streaming adapters), skips
+        // experimental_repairToolCall, and starts the tool before Zod can stop
+        // it. Share the exact execution contract at this boundary so malformed
+        // calls are repaired into the harmless `invalid` tool instead.
+        inputSchema: toolInputSchema(input.model, item),
         async execute(args, options) {
           const ctx = context(args, options)
           return input.processor.executeTool(options.toolCallId, args, async () => {

--- a/backend/cli/src/tool/bash.ts
+++ b/backend/cli/src/tool/bash.ts
@@ -32,6 +32,36 @@ const DEFAULT_TIMEOUT = Flag.OPENSCIENCE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS ||
 
 export const log = Log.create({ service: "bash-tool" })
 
+function record(input: unknown) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) return undefined
+  return input as Record<string, unknown>
+}
+
+function label(command: string) {
+  const line = command.replace(/\s+/g, " ").trim()
+  if (!line) return "Run shell command"
+  return `Run ${line}`.slice(0, 80)
+}
+
+/** Accept common provider dialects without weakening the command contract. */
+export function normalizeBashInput(input: unknown): unknown {
+  const direct = typeof input === "string" ? { command: input } : record(input)
+  if (!direct) return input
+  const nested = record(direct.input) ?? record(direct.arguments) ?? record(direct.parameters)
+  const source = nested && !direct.command && !direct.cmd && !direct.script ? { ...direct, ...nested } : direct
+  const command = [source.command, source.cmd, source.script].find((value) => typeof value === "string")
+  const description = [source.description, source.purpose, source.summary].find(
+    (value) => typeof value === "string" && value.trim().length > 0,
+  )
+  return {
+    ...source,
+    ...(typeof command === "string" ? { command } : {}),
+    ...(typeof command === "string" ? { description: description ?? label(command) } : {}),
+    ...(source.workdir === undefined && typeof source.cwd === "string" ? { workdir: source.cwd } : {}),
+    ...(source.timeout === undefined && typeof source.timeout_ms === "number" ? { timeout: source.timeout_ms } : {}),
+  }
+}
+
 const clip = (value: string, max = 2000) => (value.length > max ? `${value.slice(0, max)}\n\n... (truncated)` : value)
 
 /** Record a provenance run node for a completed shell command (mirrors the
@@ -144,7 +174,7 @@ export const BashTool = Tool.define("bash", async () => {
       .replaceAll("${maxLines}", String(Truncate.MAX_LINES))
       .replaceAll("${maxBytes}", String(Truncate.MAX_BYTES)),
     parameters: z.object({
-      command: z.string().describe("The command to execute"),
+      command: z.string().trim().min(1).describe("The command to execute"),
       timeout: z.number().describe("Optional timeout in milliseconds").optional(),
       workdir: z
         .string()
@@ -152,6 +182,14 @@ export const BashTool = Tool.define("bash", async () => {
         .optional(),
       description: z.string().describe("Clear 5-10 word description of the command's purpose"),
     }),
+    normalizeInput: normalizeBashInput,
+    formatValidationError(error) {
+      const command = error.issues.some((issue) => issue.path[0] === "command")
+      if (command) {
+        return "Bash did not receive a complete command. No command was run. Retry once with a non-empty `command` field."
+      }
+      return "Bash received incomplete input. No command was run. Retry once with a command, optional workdir/timeout, and short description."
+    },
     async execute(params, ctx) {
       const authority = await ExecutionAuthority.require({
         projectID: Instance.project.id,

--- a/backend/cli/src/tool/invalid.ts
+++ b/backend/cli/src/tool/invalid.ts
@@ -9,9 +9,12 @@ export const InvalidTool = Tool.define("invalid", {
   }),
   async execute(params) {
     return {
-      title: "Invalid Tool",
-      output: `The arguments provided to the tool are invalid: ${params.error}`,
-      metadata: {},
+      title: `Recovered incomplete ${params.tool} call`,
+      output: `${params.error} Retry the intended call once with complete input, or choose a different approach.`,
+      metadata: {
+        recovered: true,
+        sourceTool: params.tool,
+      },
     }
   },
 })

--- a/backend/cli/src/tool/tool.ts
+++ b/backend/cli/src/tool/tool.ts
@@ -52,6 +52,41 @@ export namespace Tool {
   export type InferParameters<T extends Info> = T extends Info<infer P> ? z.infer<P> : never
   export type InferMetadata<T extends Info> = T extends Info<any, infer M> ? M : never
 
+  export type Contract<Parameters extends z.ZodType = z.ZodType> = {
+    parameters: Parameters
+    normalizeInput?(args: unknown): unknown
+    formatValidationError?(error: z.ZodError, args: unknown): string
+  }
+
+  /**
+   * Validate a model tool call with the same normalization and Zod contract
+   * used by execute(). JSON Schema alone is only a provider hint; the AI SDK
+   * cannot repair malformed calls unless its schema also has a runtime
+   * validator. Keep this result in the provider boundary as well as execute()
+   * so an incomplete call is repaired before any tool starts.
+   */
+  export function validate<Parameters extends z.ZodType>(
+    id: string,
+    contract: Contract<Parameters>,
+    args: unknown,
+  ): { success: true; value: z.infer<Parameters> } | { success: false; error: Error } {
+    const normalized = contract.normalizeInput ? contract.normalizeInput(args) : args
+    const result = contract.parameters.safeParse(normalized)
+    if (result.success) {
+      return {
+        success: true,
+        value: result.data,
+      }
+    }
+    const message = contract.formatValidationError
+      ? contract.formatValidationError(result.error, normalized)
+      : `The ${id} tool received invalid arguments or incomplete input. No action was taken. Retry with all required fields.`
+    return {
+      success: false,
+      error: new Error(message, { cause: result.error }),
+    }
+  }
+
   export function define<Parameters extends z.ZodType, Result extends Metadata>(
     id: string,
     init: Info<Parameters, Result>["init"] | Awaited<ReturnType<Info<Parameters, Result>["init"]>>,
@@ -63,23 +98,13 @@ export namespace Tool {
         const execute = toolInfo.execute
         toolInfo.execute = async (args, ctx) => {
           PlanMode.enforce(id, ctx.agent)
-          const normalized = toolInfo.normalizeInput ? toolInfo.normalizeInput(args) : args
-          let canonical: z.infer<Parameters>
-          try {
-            // The parser's output is the public tool contract. Always execute
-            // and dedupe with it so defaults, transforms, stripped fields, and
-            // tool-specific normalization behave identically for direct and
-            // delegated calls.
-            canonical = toolInfo.parameters.parse(normalized)
-          } catch (error) {
-            if (error instanceof z.ZodError && toolInfo.formatValidationError) {
-              throw new Error(toolInfo.formatValidationError(error, normalized), { cause: error })
-            }
-            throw new Error(
-              `The ${id} tool was called with invalid arguments: ${error}.\nPlease rewrite the input so it satisfies the expected schema.`,
-              { cause: error },
-            )
-          }
+          // The parser's output is the public tool contract. Always execute
+          // and dedupe with it so defaults, transforms, stripped fields, and
+          // tool-specific normalization behave identically for direct and
+          // delegated calls.
+          const parsed = validate(id, toolInfo, args)
+          if (!parsed.success) throw parsed.error
+          const canonical = parsed.value
           const dedupeSignature = SearchDedupe.key(id, canonical)
           const cached = SearchDedupe.find(ctx.messages, id, canonical)
           if (cached) return SearchDedupe.reuse(cached) as unknown as Awaited<ReturnType<typeof execute>>

--- a/backend/cli/test/agent/harness-contract.test.ts
+++ b/backend/cli/test/agent/harness-contract.test.ts
@@ -76,15 +76,17 @@ test("read-only inspections receive a compact evidence-preserving core", () => {
   expect(instructions).toContain("Do not modify files")
 })
 
-test("the primary and domain prompts stay adaptive instead of procedural", async () => {
-  const [research, direct, ml, biology, physics] = await Promise.all([
+test("the primary, domain, and specialist prompts stay adaptive instead of procedural", async () => {
+  const [research, direct, ml, biology, physics, write, explore] = await Promise.all([
     read("agent/prompt/research.txt"),
     read("session/prompt/direct.txt"),
     read("agent/prompt/ml.txt"),
     read("agent/prompt/biology.txt"),
     read("agent/prompt/physics.txt"),
+    read("agent/prompt/write.txt"),
+    read("agent/prompt/explore.txt"),
   ])
-  for (const prompt of [research, ml, biology, physics]) {
+  for (const prompt of [research, ml, biology, physics, write, explore]) {
     expect(prompt.length).toBeLessThan(4_000)
     expect(prompt).not.toContain("literature-review.md")
     expect(prompt).not.toContain("reasoning.md")
@@ -112,6 +114,12 @@ test("the primary and domain prompts stay adaptive instead of procedural", async
   expect(ml).toContain("simplest method")
   expect(biology).toContain("multiple testing")
   expect(physics).toContain("dimensional consistency")
+  expect(write).toContain("Do not invent a report")
+  expect(write).toContain("format-only task")
+  expect(write).not.toContain("Every document MUST")
+  expect(write).not.toContain("minimum 5 figures")
+  expect(explore).toContain("Stay read-only")
+  expect(explore).not.toContain("copying, moving")
 })
 
 test("delegation is rare, bounded, and observable", async () => {
@@ -149,4 +157,13 @@ test("Plan and Review use the observable record without mandatory delegation", a
   expect(reviewer).toContain("INCOMPLETE RECORD")
   expect(reviewer).toContain("METHOD/CONCLUSION MISMATCH")
   expect(reviewer).toContain("Environment or dependency gaps")
+})
+
+test("data-analysis skills keep reports and figures opt-in", async () => {
+  const skill = await read("../skills/coding/exploratory-data-analysis/SKILL.md")
+  expect(skill).toContain("Do not create a report, figure, artifact, directory, or sidecar file by default")
+  expect(skill).toContain("Do not write to disk unless the user requested")
+  expect(skill).toContain("For a bounded question")
+  expect(skill).toContain("Save only when requested")
+  expect(skill).not.toContain("### Step 5: Save Report")
 })

--- a/backend/cli/test/mcp/input-validation.test.ts
+++ b/backend/cli/test/mcp/input-validation.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test"
+import { MCP } from "../../src/mcp"
+
+describe("MCP input validation", () => {
+  const schema = MCP.inputSchema("lookup", {
+    type: "object",
+    properties: {
+      query: { type: "string" },
+    },
+    required: ["query"],
+    additionalProperties: false,
+  })
+
+  test("rejects interrupted provider calls before remote execution", async () => {
+    const result = await schema.validate?.({})
+    expect(result?.success).toBe(false)
+    if (!result || result.success) throw new Error("Incomplete MCP input unexpectedly passed validation")
+    expect(result.error.message).toBe(
+      "The lookup MCP tool received invalid arguments or incomplete input. No action was taken. Retry with all required fields.",
+    )
+  })
+
+  test("accepts input matching the published MCP schema", async () => {
+    expect(await schema.validate?.({ query: "CERBench" })).toEqual({
+      success: true,
+      value: { query: "CERBench" },
+    })
+  })
+})

--- a/backend/cli/test/provider/provider.test.ts
+++ b/backend/cli/test/provider/provider.test.ts
@@ -317,6 +317,27 @@ test("provider loaded from env variable", async () => {
   })
 })
 
+test("repository GitHub tokens do not masquerade as Copilot inference credentials", async () => {
+  await using tmp = await tmpdir({})
+  try {
+    await Instance.provide({
+      directory: tmp.path,
+      init: async () => {
+        Env.set("GITHUB_TOKEN", "github-app-server-token")
+        Provider.invalidate()
+      },
+      fn: async () => {
+        const providers = await Provider.list()
+        expect(providers["github-copilot"]).toBeUndefined()
+        expect(providers["github-copilot-enterprise"]).toBeUndefined()
+      },
+    })
+  } finally {
+    delete process.env.GITHUB_TOKEN
+    Provider.invalidate()
+  }
+})
+
 test("provider loaded from config with apiKey option", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {

--- a/backend/cli/test/session/doom-loop.test.ts
+++ b/backend/cli/test/session/doom-loop.test.ts
@@ -9,6 +9,10 @@ const tool = (name: string, input: unknown, status = "completed"): any => ({
 })
 const reasoning = (): any => ({ type: "reasoning", text: "thinking..." })
 const text = (): any => ({ type: "text", text: "hi" })
+const message = (id: string, parentID: string, parts: any[]): any => ({
+  info: { id, role: "assistant", parentID },
+  parts,
+})
 
 describe("SessionProcessor.isDoomLoop", () => {
   test("fires when the last 3 TOOL calls are identical, even with reasoning/text between them", () => {
@@ -44,5 +48,16 @@ describe("SessionProcessor.isDoomLoop", () => {
   test("ignores a pending tool call (not yet a confirmed repeat)", () => {
     const parts = [tool("bash", { cmd: "ls" }), tool("bash", { cmd: "ls" }), tool("bash", { cmd: "ls" }, "pending")]
     expect(SessionProcessor.isDoomLoop(parts, "bash", { cmd: "ls" })).toBe(false)
+  })
+
+  test("sees repeated calls spread across assistant steps for one user request", () => {
+    const messages = [
+      message("assistant-1", "user-1", [reasoning(), tool("invalid", { tool: "bash", error: "incomplete" })]),
+      message("assistant-2", "user-1", [text(), tool("invalid", { tool: "bash", error: "incomplete" })]),
+      message("assistant-other", "user-2", [tool("invalid", { tool: "bash", error: "incomplete" })]),
+    ]
+    const parts = SessionProcessor.turnParts(messages, "user-1")
+    expect(SessionProcessor.isDoomLoop(parts, "invalid", { tool: "bash", error: "incomplete" }, 2)).toBe(true)
+    expect(parts).toHaveLength(4)
   })
 })

--- a/backend/cli/test/session/processor-tool-correlation.test.ts
+++ b/backend/cli/test/session/processor-tool-correlation.test.ts
@@ -45,6 +45,40 @@ function fixture() {
 }
 
 describe("SessionProcessor tool outcome correlation", () => {
+  test("persists raw streamed tool input through the terminal state", async () => {
+    const { coordinator, updates } = fixture()
+    coordinator.pending({
+      id: "part_call_raw",
+      sessionID: "ses_tool_correlation",
+      messageID: "msg_tool_correlation",
+      type: "tool",
+      callID: "call_raw",
+      tool: "bash",
+      state: { status: "pending", input: {}, raw: "" },
+    })
+    await coordinator.delta("call_raw", '{"command":')
+    await coordinator.delta("call_raw", '"pwd"}')
+    const pending = coordinator.part("call_raw")
+    if (!pending || pending.state.status !== "pending") throw new Error("raw tool call was not pending")
+    await coordinator.running({
+      ...pending,
+      state: { status: "running", input: { command: "pwd" }, raw: pending.state.raw, time: { start: 100 } },
+    })
+    await coordinator.execute("call_raw", { command: "pwd" }, async () => ({
+      title: "Print directory",
+      output: "/tmp",
+      metadata: {},
+    }))
+
+    expect(updates.at(-1)).toMatchObject({
+      state: {
+        status: "completed",
+        raw: '{"command":"pwd"}',
+        input: { command: "pwd" },
+      },
+    })
+  })
+
   test("persists native execution success that settles before tool-call and has no streamed tool-result", async () => {
     await using tmp = await tmpdir({ git: true })
     await Instance.provide({

--- a/backend/cli/test/session/tool-input-validation.test.ts
+++ b/backend/cli/test/session/tool-input-validation.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test"
+import z from "zod"
+import type { Provider } from "../../src/provider/provider"
+import { SessionPrompt } from "../../src/session/prompt"
+import { normalizeBashInput } from "../../src/tool/bash"
+
+const model = {
+  id: "provider-boundary-test",
+  providerID: "openrouter",
+  api: {
+    id: "provider-boundary-test",
+    url: "https://example.com",
+    npm: "@openrouter/ai-sdk-provider",
+  },
+} as Provider.Model
+
+describe("SessionPrompt.toolInputSchema", () => {
+  const schema = SessionPrompt.toolInputSchema(model, {
+    id: "bash",
+    parameters: z.object({
+      command: z.string().trim().min(1),
+      description: z.string(),
+    }),
+    normalizeInput: normalizeBashInput,
+  })
+
+  test("rejects the empty object emitted by an interrupted provider tool call", async () => {
+    const result = await schema.validate?.({})
+    expect(result?.success).toBe(false)
+    if (!result || result.success) throw new Error("Incomplete Bash input unexpectedly passed validation")
+    expect(result.error.message).toContain("No action was taken")
+  })
+
+  test("returns canonical input to the AI SDK before execute", async () => {
+    const result = await schema.validate?.({ cmd: "pwd" })
+    expect(result).toEqual({
+      success: true,
+      value: {
+        command: "pwd",
+        description: "Run pwd",
+      },
+    })
+  })
+})

--- a/backend/cli/test/tool/bash.test.ts
+++ b/backend/cli/test/tool/bash.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import fs from "fs/promises"
 import path from "path"
-import { BashTool } from "../../src/tool/bash"
+import { BashTool, normalizeBashInput } from "../../src/tool/bash"
 import { Instance } from "../../src/project/instance"
 import { executionSession, tmpdir } from "../fixture/fixture"
 import type { PermissionNext } from "../../src/permission/next"
@@ -27,6 +27,32 @@ async function context() {
 const projectRoot = path.join(__dirname, "../..")
 
 describe("tool.bash", () => {
+  test("normalizes common provider argument dialects", () => {
+    expect(normalizeBashInput({ cmd: "pwd" })).toMatchObject({
+      command: "pwd",
+      description: "Run pwd",
+    })
+    expect(
+      normalizeBashInput({
+        arguments: {
+          script: "echo hello",
+          purpose: "Print greeting",
+          cwd: "/tmp",
+          timeout_ms: 1200,
+        },
+      }),
+    ).toMatchObject({
+      command: "echo hello",
+      description: "Print greeting",
+      workdir: "/tmp",
+      timeout: 1200,
+    })
+  })
+
+  test("keeps an empty provider call invalid", () => {
+    expect(normalizeBashInput({})).toEqual({})
+  })
+
   test("basic", async () => {
     await Instance.provide({
       directory: projectRoot,

--- a/backend/cli/test/tool/tool-canonicalization.test.ts
+++ b/backend/cli/test/tool/tool-canonicalization.test.ts
@@ -45,6 +45,22 @@ test("Tool.define executes the canonical Zod output for every tool", async () =>
   expect(JSON.parse(result.output)).toEqual({ label: "PARSED", limit: 10 })
 })
 
+test("Tool.validate rejects incomplete provider input without exposing raw Zod noise", () => {
+  const result = Tool.validate(
+    "probe",
+    {
+      parameters: z.object({ command: z.string(), description: z.string() }),
+    },
+    {},
+  )
+  expect(result.success).toBe(false)
+  if (result.success) throw new Error("Incomplete input unexpectedly passed validation")
+  expect(result.error.message).toBe(
+    "The probe tool received invalid arguments or incomplete input. No action was taken. Retry with all required fields.",
+  )
+  expect(result.error.message).not.toContain("invalid_type")
+})
+
 test("Tool.define dedupes against the canonical signature persisted with a raw call", async () => {
   let executions = 0
   const tool = await Tool.define("science_search", {

--- a/frontend/ui/src/components/message-part.css
+++ b/frontend/ui/src/components/message-part.css
@@ -244,6 +244,31 @@
     gap: 8px;
   }
 
+  [data-slot="message-part-tool-error-body"] {
+    min-width: 0;
+  }
+
+  [data-slot="message-part-tool-error-details"] {
+    margin-top: 6px;
+    color: var(--text-on-critical-weak);
+
+    summary {
+      cursor: pointer;
+      width: fit-content;
+      font-size: var(--font-size-small);
+    }
+
+    pre {
+      max-height: 160px;
+      margin: 6px 0 0;
+      overflow: auto;
+      white-space: pre-wrap;
+      word-break: break-word;
+      font-family: var(--font-family-mono);
+      font-size: var(--font-size-small);
+    }
+  }
+
   [data-slot="message-part-tool-error-title"] {
     font-family: var(--font-family-sans);
     font-size: var(--font-size-base);

--- a/frontend/ui/src/components/message-part.tsx
+++ b/frontend/ui/src/components/message-part.tsx
@@ -51,7 +51,14 @@ import { Tooltip } from "./tooltip"
 import { IconButton } from "./icon-button"
 import { createAutoScroll } from "../hooks"
 import { createResizeObserver } from "@solid-primitives/resize-observer"
-import { savedArtifact, scienceTaskLabel, sentenceCaseLabel, skillName, stripRedactedReasoning } from "./tool-display"
+import {
+  savedArtifact,
+  scienceTaskLabel,
+  sentenceCaseLabel,
+  skillName,
+  stripRedactedReasoning,
+  toolErrorDisplay,
+} from "./tool-display"
 import { ToolRegistry, type ToolProps } from "./tool-registry"
 import { formatTaskDuration, stripTaskMetadata, summarizeTaskActivity } from "./research-trace"
 
@@ -818,23 +825,34 @@ PART_MAPPING["tool"] = function ToolPartDisplay(props) {
       <Switch>
         <Match when={part.state.status === "error" && part.state.error}>
           {(error) => {
-            const cleaned = error().replace("Error: ", "")
-            const [title, ...rest] = cleaned.split(": ")
+            const display = () => toolErrorDisplay(part.tool, error())
             return (
               <Card variant="error">
                 <div data-component="tool-error">
                   <Icon name="circle-ban-sign" size="small" />
-                  <Switch>
-                    <Match when={title && title.length < 30}>
-                      <div data-slot="message-part-tool-error-content">
-                        <div data-slot="message-part-tool-error-title">{title}</div>
-                        <span data-slot="message-part-tool-error-message">{rest.join(": ")}</span>
-                      </div>
-                    </Match>
-                    <Match when={true}>
-                      <span data-slot="message-part-tool-error-message">{cleaned}</span>
-                    </Match>
-                  </Switch>
+                  <div data-slot="message-part-tool-error-body">
+                    <Switch>
+                      <Match when={display().title}>
+                        {(title) => (
+                          <div data-slot="message-part-tool-error-content">
+                            <div data-slot="message-part-tool-error-title">{title()}</div>
+                            <span data-slot="message-part-tool-error-message">{display().message}</span>
+                          </div>
+                        )}
+                      </Match>
+                      <Match when={true}>
+                        <span data-slot="message-part-tool-error-message">{display().message}</span>
+                      </Match>
+                    </Switch>
+                    <Show when={display().details}>
+                      {(details) => (
+                        <details data-slot="message-part-tool-error-details">
+                          <summary>Technical details</summary>
+                          <pre>{details()}</pre>
+                        </details>
+                      )}
+                    </Show>
+                  </div>
                 </div>
               </Card>
             )

--- a/frontend/ui/src/components/tool-display.test.ts
+++ b/frontend/ui/src/components/tool-display.test.ts
@@ -10,6 +10,7 @@ import {
   sessionErrorText,
   skillName,
   stripRedactedReasoning,
+  toolErrorDisplay,
   writtenFiles,
 } from "./tool-display"
 
@@ -150,6 +151,25 @@ describe("stripRedactedReasoning", () => {
   })
   test("leaves normal reasoning untouched", () => {
     expect(stripRedactedReasoning("plain reasoning text")).toBe("plain reasoning text")
+  })
+})
+
+describe("toolErrorDisplay", () => {
+  test("collapses legacy malformed Bash schema dumps behind technical details", () => {
+    const raw =
+      'The bash tool was called with invalid arguments: [{"code":"invalid_type","path":["command"]}]. Please rewrite the input.'
+    expect(toolErrorDisplay("bash", raw)).toEqual({
+      title: "Incomplete Bash call",
+      message: "No command was run.",
+      details: raw,
+    })
+  })
+
+  test("preserves ordinary short tool errors", () => {
+    expect(toolErrorDisplay("read", "Error: File not found: paper.pdf")).toEqual({
+      title: "File not found",
+      message: "paper.pdf",
+    })
   })
 })
 

--- a/frontend/ui/src/components/tool-display.ts
+++ b/frontend/ui/src/components/tool-display.ts
@@ -26,6 +26,25 @@ export function stripRedactedReasoning(text: string): string {
   return (text ?? "").replaceAll("[REDACTED]", "").trim()
 }
 
+export function toolErrorDisplay(tool: string, value: string) {
+  const cleaned = value.replace(/^Error:\s*/, "")
+  const malformed = /(?:tool was called with invalid arguments|received invalid arguments or incomplete input)/i.test(
+    cleaned,
+  )
+  if (malformed) {
+    return {
+      title: `Incomplete ${sentenceCaseLabel(tool)} call`,
+      message: tool.toLowerCase() === "bash" ? "No command was run." : "No action was taken.",
+      details: cleaned,
+    }
+  }
+  const [title, ...rest] = cleaned.split(": ")
+  if (title && title.length < 30 && rest.length) {
+    return { title, message: rest.join(": ") }
+  }
+  return { message: cleaned }
+}
+
 export type SavedArtifact = {
   title: string
   kind: string

--- a/frontend/workspace/e2e/prompt-slash-open.spec.ts
+++ b/frontend/workspace/e2e/prompt-slash-open.spec.ts
@@ -8,14 +8,42 @@ test("smoke slash menu exposes session actions", async ({ page, gotoSession, sdk
   try {
     await gotoSession(created.id)
 
-    await page.locator(promptSelector).click()
-    await page.keyboard.type("/compact")
+    const prompt = page.locator(promptSelector)
+    await expect(prompt).toBeVisible()
+    await prompt.click()
+    await expect(prompt).toBeFocused()
+    await prompt.pressSequentially("/compact", { delay: 10 })
+    await expect(prompt).toContainText("/compact")
 
     const command = page.locator('[data-slash-id="command.compact"]')
     await expect(command).toBeVisible()
 
     await page.keyboard.press("Escape")
     await expect(command).toHaveCount(0)
+  } finally {
+    await sdk.session.delete({ sessionID: created.id }).catch(() => undefined)
+  }
+})
+
+test("an inline slash skill preserves text before and after the token", async ({ page, gotoSession, sdk }) => {
+  const created = await sdk.session.create({ title: `e2e inline skill ${Date.now()}` }).then((r) => r.data)
+  if (!created?.id) throw new Error("Failed to create an inline skill fixture")
+
+  try {
+    await gotoSession(created.id)
+    const prompt = page.locator(promptSelector)
+    await expect(prompt).toBeVisible()
+    await prompt.click()
+    await expect(prompt).toBeFocused()
+    await prompt.pressSequentially("Please use /rev", { delay: 10 })
+
+    const skill = page.locator('[data-slash-id="skill.review"]')
+    await expect(skill).toBeVisible()
+    await skill.click()
+    await expect(prompt).toContainText("Please use /review")
+
+    await prompt.pressSequentially("before finalizing", { delay: 10 })
+    await expect(prompt).toContainText("Please use /review before finalizing")
   } finally {
     await sdk.session.delete({ sessionID: created.id }).catch(() => undefined)
   }

--- a/frontend/workspace/e2e/prompt.spec.ts
+++ b/frontend/workspace/e2e/prompt.spec.ts
@@ -105,3 +105,50 @@ test("can send the first prompt after New research opens the explicit new-sessio
     await sdk.session.delete({ sessionID }).catch(() => undefined)
   }
 })
+
+test("an incomplete provider tool call is recovered without a raw schema error", async ({
+  page,
+  sdk,
+  gotoSession,
+}) => {
+  test.setTimeout(45_000)
+  await gotoSession()
+
+  const token = `E2E_TOOL_MALFORMED_${Date.now()}`
+  const prompt = page.locator(promptSelector)
+  await prompt.click()
+  await page.keyboard.type(token)
+  await page.keyboard.press("Enter")
+  await expect(page).toHaveURL(/\/session\/[^/?#]+/, { timeout: 30_000 })
+
+  const sessionID = sessionIDFromUrl(page.url())
+  if (!sessionID) throw new Error(`Failed to parse session id from url: ${page.url()}`)
+
+  try {
+    await expect
+      .poll(
+        () =>
+          sdk.session.messages({ sessionID, limit: 50 }).then((response) =>
+            (response.data ?? [])
+              .filter((message) => message.info.role === "assistant")
+              .flatMap((message) => message.parts)
+              .filter((part) => part.type === "text")
+              .map((part) => part.text)
+              .join("\n"),
+          ),
+        { timeout: 20_000 },
+      )
+      .toContain(`${token}_DONE`)
+
+    const messages = await sdk.session.messages({ sessionID, limit: 50 }).then((response) => response.data ?? [])
+    const payload = JSON.stringify(messages)
+    expect(payload).toContain("Recovered incomplete bash call")
+    expect(payload).not.toContain("expected string, received undefined")
+    expect(payload).not.toContain("Please rewrite the input so it satisfies the expected schema")
+    await expect(page.locator("body")).not.toContainText("expected string, received undefined")
+    await expect(page.locator("body")).not.toContainText("Please rewrite the input so it satisfies the expected schema")
+    await expect(page.getByText(`${token}_DONE`, { exact: false }).first()).toBeVisible()
+  } finally {
+    await sdk.session.delete({ sessionID }).catch(() => undefined)
+  }
+})

--- a/frontend/workspace/e2e/prompt.spec.ts
+++ b/frontend/workspace/e2e/prompt.spec.ts
@@ -106,11 +106,7 @@ test("can send the first prompt after New research opens the explicit new-sessio
   }
 })
 
-test("an incomplete provider tool call is recovered without a raw schema error", async ({
-  page,
-  sdk,
-  gotoSession,
-}) => {
+test("an incomplete provider tool call is recovered without a raw schema error", async ({ page, sdk, gotoSession }) => {
   test.setTimeout(45_000)
   await gotoSession()
 

--- a/frontend/workspace/e2e/science-artifact.spec.ts
+++ b/frontend/workspace/e2e/science-artifact.spec.ts
@@ -139,6 +139,10 @@ async function withArtifact(
     await steps.click()
 
     const artifact = locate(browser.page)
+    const metadata = browser.page.locator('details[data-slot="session-turn-metadata"]').filter({ has: artifact }).first()
+    if ((await metadata.count()) > 0 && (await metadata.getAttribute("open")) === null) {
+      await metadata.locator("summary").click()
+    }
     await expect(artifact).toBeVisible()
     await verify(artifact)
   } finally {

--- a/frontend/workspace/e2e/science-artifact.spec.ts
+++ b/frontend/workspace/e2e/science-artifact.spec.ts
@@ -139,7 +139,10 @@ async function withArtifact(
     await steps.click()
 
     const artifact = locate(browser.page)
-    const metadata = browser.page.locator('details[data-slot="session-turn-metadata"]').filter({ has: artifact }).first()
+    const metadata = browser.page
+      .locator('details[data-slot="session-turn-metadata"]')
+      .filter({ has: artifact })
+      .first()
     if ((await metadata.count()) > 0 && (await metadata.getAttribute("open")) === null) {
       await metadata.locator("summary").click()
     }

--- a/frontend/workspace/script/e2e-fake-model.ts
+++ b/frontend/workspace/script/e2e-fake-model.ts
@@ -6,6 +6,7 @@ const PROJECT_PACKAGE = fileURLToPath(new URL("../../../package.json", import.me
 export const E2E_TOOL_SENTINELS = {
   question: "E2E_TOOL_QUESTION",
   permission: "E2E_TOOL_PERMISSION",
+  malformed: "E2E_TOOL_MALFORMED",
 } as const
 
 type ChatRequest = {
@@ -20,7 +21,7 @@ type ToolCall = {
   id: string
   type: "function"
   function: {
-    name: "question" | "read"
+    name: "question" | "read" | "bash"
     arguments: string
   }
 }
@@ -46,11 +47,16 @@ function replyFor(body: ChatRequest) {
 
 function findSentinel(body: ChatRequest) {
   const text = textFrom(body.messages)
-  const match = text.match(/\bE2E_TOOL_(QUESTION|PERMISSION)_[A-Za-z0-9_-]+\b/)
+  const match = text.match(/\bE2E_TOOL_(QUESTION|PERMISSION|MALFORMED)_[A-Za-z0-9_-]+\b/)
   if (!match) return undefined
   return {
     value: match[0],
-    kind: match[1] === "QUESTION" ? E2E_TOOL_SENTINELS.question : E2E_TOOL_SENTINELS.permission,
+    kind:
+      match[1] === "QUESTION"
+        ? E2E_TOOL_SENTINELS.question
+        : match[1] === "MALFORMED"
+          ? E2E_TOOL_SENTINELS.malformed
+          : E2E_TOOL_SENTINELS.permission,
   }
 }
 
@@ -78,7 +84,12 @@ function toolCallFor(body: ChatRequest): { call: ToolCall; sentinel: string } | 
   const sentinel = findSentinel(body)
   if (!sentinel || hasToolResult(body.messages)) return undefined
 
-  const name = sentinel.kind === E2E_TOOL_SENTINELS.question ? "question" : "read"
+  const name =
+    sentinel.kind === E2E_TOOL_SENTINELS.question
+      ? "question"
+      : sentinel.kind === E2E_TOOL_SENTINELS.malformed
+        ? "bash"
+        : "read"
   if (!requestedToolNames(body).includes(name)) return undefined
 
   const id = `call_${sentinel.value.toLowerCase().replace(/[^a-z0-9_-]/g, "_")}`
@@ -103,6 +114,22 @@ function toolCallFor(body: ChatRequest): { call: ToolCall; sentinel: string } | 
               },
             ],
           }),
+        },
+      },
+    }
+  }
+
+  if (sentinel.kind === E2E_TOOL_SENTINELS.malformed) {
+    return {
+      sentinel: sentinel.value,
+      call: {
+        id,
+        type: "function",
+        function: {
+          name: "bash",
+          // Simulates the empty object produced when a provider stream ends
+          // before required tool arguments arrive.
+          arguments: "{}",
         },
       },
     }


### PR DESCRIPTION
## Summary

- validate and normalize native and MCP tool inputs before execution, including recovery of common Bash argument aliases and nested payloads
- stop repeated malformed-call loops safely across an entire turn while preserving raw provider argument deltas for diagnosis
- present legacy schema failures as compact, expandable UI errors instead of repeated raw validator dumps
- remove false GitHub Copilot availability from generic repository tokens
- make research prompts and the EDA skill output-adaptive instead of forcing reports, figures, artifacts, or LaTeX
- harden inline slash-skill and collapsed-result browser coverage

## Root cause

The affected OpenRouter stream was cut at its output cap while constructing six Bash calls. The provider adapter flushed each unfinished call as an empty object. OpenScience exposed JSON Schema to the model but did not attach runtime validation to the AI SDK tool, so the empty payload reached Zod and produced the repeated raw schema errors. The loop detector only considered one assistant step, allowing the same invalid call to repeat across the turn.

## Verification

- backend: 2,426 passed, 20 skipped, 0 failed
- browser E2E: 84 passed, 1 skipped, 0 failed
- workspace typecheck: 7/7 packages
- workspace and docs builds: passed
- deterministic malformed-tool E2E: repaired safely, no command executed, model continued
- live stress project: read-only, in-place write/read, inline skill, parallel delegation, and managed/subscription inference
- live models: GPT-5.6 Sol, Claude Sonnet 4.6, Gemini 3.1 Pro, GPT-5.6 Terra, GPT-5.6 Luna
- secret scan: clean

## Notes

The user’s existing localhost process was left untouched. A separate fixed instance was used for historical replay and stress testing.