### PR TITLE
test: preserve Windows filesystem timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,10 @@ jobs:
           git config --global user.name "OpenScience CI"
           git config --global init.defaultBranch main
         shell: bash
-      - run: bun test test/file/safe-io.test.ts test/file/rename.test.ts test/file/trash.test.ts
+      # Keep the native Windows slice on the repository's 15-second test
+      # contract. Calling `bun test` directly otherwise restores Bun's 5-second
+      # default, which is too short for NTFS operations on a loaded hosted runner.
+      - run: bun test --timeout 15000 test/file/safe-io.test.ts test/file/rename.test.ts test/file/trash.test.ts
         shell: bash
         working-directory: backend/cli
 

--- a/backend/cli/test/installation/release-order.test.ts
+++ b/backend/cli/test/installation/release-order.test.ts
@@ -126,3 +126,11 @@ test("source package versions remain 2.0.31 until the workflow release commit", 
     expect(pkg.version).toBe("2.0.31")
   }
 })
+
+test("native Windows file tests keep the repository test timeout", async () => {
+  const workflow = await Bun.file(path.join(import.meta.dir, "../../../../.github/workflows/ci.yml")).text()
+
+  expect(workflow).toContain(
+    "bun test --timeout 15000 test/file/safe-io.test.ts test/file/rename.test.ts test/file/trash.test.ts",
+  )
+})


### PR DESCRIPTION
Root cause: the native Windows filesystem job bypassed the repository's 15-second Bun test timeout and reverted to Bun's 5-second default. On one loaded hosted runner, six unchanged NTFS tests timed out at exactly 5 seconds. This aligns the job with the standard timeout and adds a workflow contract regression. Validation: focused contract test 10/10, Prettier, actionlint, diff check, push-hook typecheck 7/7.