### PR TITLE
Fix npm release safety and retire legacy Atlas installs

### DIFF
--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -176,6 +176,24 @@ jobs:
           if (spec !== "@synsci/openscience@test") throw new Error(`synsci@test resolves ${spec}`)
           console.log(`synsci@test resolves ${spec}`)
           NODE
+
+          sdk_probe="$RUNNER_TEMP/openscience-sdk-probe"
+          mkdir -p "$sdk_probe"
+          npm install --prefix "$sdk_probe" \
+            "@synsci/sdk@${{ needs.publish-test.outputs.version }}" \
+            "@synsci/plugin@${{ needs.publish-test.outputs.version }}"
+          cat > "$sdk_probe/probe.mjs" <<'NODE'
+          await import("@synsci/sdk")
+          await import("@synsci/sdk/client")
+          await import("@synsci/sdk/server")
+          await import("@synsci/sdk/v2")
+          await import("@synsci/sdk/v2/client")
+          await import("@synsci/sdk/v2/server")
+          await import("@synsci/plugin")
+          await import("@synsci/plugin/tool")
+          console.log("published SDK and plugin exports resolve")
+          NODE
+          node "$sdk_probe/probe.mjs"
         env:
           HOME: ${{ runner.temp }}/openscience-npm-test-home
           OPENSCIENCE_VERSION: ${{ needs.publish-test.outputs.version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -234,6 +234,10 @@ jobs:
 
       - uses: ./.github/actions/setup-bun
 
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
+
       - name: Restore immutable CLI build
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -256,6 +260,13 @@ jobs:
         env:
           OPENSCIENCE_VERSION: ${{ needs.version.outputs.version }}
           OPENSCIENCE_RELEASE_SOURCE: ${{ needs.version.outputs.source }}
+          OPENSCIENCE_ARTIFACT_SOURCE: ${{ needs.version.outputs.artifact_source }}
+          OPENSCIENCE_NPM_ARTIFACT_DIR: .release/npm/${{ needs.version.outputs.version }}
+
+      - name: Verify packed SDK and plugin exports before publication
+        run: ./tooling/repo/verify-npm-artifacts.ts
+        env:
+          OPENSCIENCE_VERSION: ${{ needs.version.outputs.version }}
           OPENSCIENCE_ARTIFACT_SOURCE: ${{ needs.version.outputs.artifact_source }}
           OPENSCIENCE_NPM_ARTIFACT_DIR: .release/npm/${{ needs.version.outputs.version }}
 

--- a/backend/cli/script/publish.ts
+++ b/backend/cli/script/publish.ts
@@ -4,7 +4,12 @@ import pkg from "../package.json"
 import { Script } from "@synsci/script"
 import { fileURLToPath } from "url"
 import { assertPublicPackageSurface, createWrapperPackageManifest } from "./publish-manifest"
-import { packPackage, publishPackage } from "../../../tooling/repo/npm-release"
+import {
+  packPackage,
+  publishPackage,
+  verifyPublishedPackages,
+  type PackedPackage,
+} from "../../../tooling/repo/npm-release"
 
 const dir = fileURLToPath(new URL("..", import.meta.url))
 process.chdir(dir)
@@ -41,13 +46,15 @@ if (!process.argv.includes("--homebrew-only")) {
   // all 11 in parallel saturates the uplink and npm times out. The shared helper
   // verifies an existing immutable version byte-for-byte before skipping it.
   const results: PromiseSettledResult<string>[] = []
+  const artifacts: PackedPackage[] = []
   for (const [name] of Object.entries(binaries)) {
     try {
       if (!name.includes("windows")) {
         await $`chmod 755 ./dist/${name}/bin/openscience`
       }
       const artifact = await packPackage({ cwd: `${dir}/dist/${name}`, name, version })
-      await publishPackage({ ...artifact, tag: Script.channel })
+      await publishPackage({ ...artifact, deferVerification: true, tag: Script.channel })
+      artifacts.push(artifact)
       results.push({ status: "fulfilled", value: name })
     } catch (e) {
       results.push({ status: "rejected", reason: e })
@@ -64,7 +71,10 @@ if (!process.argv.includes("--homebrew-only")) {
     console.log(`${succeeded.length}/${results.length} binary packages published or verified successfully`)
   }
   const wrapper = await packPackage({ cwd: `${dir}/dist/${pkg.name}`, name: pkg.name, version })
-  await publishPackage({ ...wrapper, tag: Script.channel })
+  await publishPackage({ ...wrapper, deferVerification: true, tag: Script.channel })
+  artifacts.push(wrapper)
+  await verifyPublishedPackages(artifacts)
+  console.log(`${artifacts.length}/${artifacts.length} CLI packages verified on npm`)
 }
 
 // registries (Homebrew tap, AUR) — non-fatal, npm publish above is what matters

--- a/backend/cli/src/index.ts
+++ b/backend/cli/src/index.ts
@@ -50,6 +50,7 @@ import { Global } from "./global"
 import { disposeDataRootOperation, runDataRootMiddleware } from "./cli/cmd/cmd"
 import { ACCOUNT_REQUIRED_MESSAGE, requiresOpenScienceAccount } from "./cli/account-gate"
 import { OutboundTelemetry } from "./telemetry/outbound"
+import { purgeRetiredAtlasAgentInstall } from "./skill/retired-install"
 
 if (process.argv[2] === WINDOWS_JOB_LAUNCHER_ARG) {
   try {
@@ -90,6 +91,15 @@ process.on("uncaughtException", (e) => {
   })
 })
 
+// Yargs handles --help/--version before middleware. Run the exact, fail-safe
+// retirement migration here so the first post-upgrade invocation cleans old
+// agent instructions even when it exits through those built-in paths. Internal
+// process launchers return above and never touch user configuration.
+let retiredAgentInstallCleanupError: unknown
+await purgeRetiredAtlasAgentInstall(Global.Path.home).catch((error) => {
+  retiredAgentInstallCleanupError = error
+})
+
 const cli = yargs(hideBin(process.argv))
   .parserConfiguration({ "populate--": true })
   .scriptName("openscience")
@@ -127,6 +137,10 @@ const cli = yargs(hideBin(process.argv))
         version: Installation.VERSION,
         args: process.argv.slice(2),
       })
+
+      if (retiredAgentInstallCleanupError) {
+        Log.Default.warn("failed to purge retired Atlas agent install", { error: retiredAgentInstallCleanupError })
+      }
 
       // A consent-off write may have been saved while offline. Retry it on
       // every startup, including after logout/401 when only its deletion-only

--- a/backend/cli/src/skill/retired-install.ts
+++ b/backend/cli/src/skill/retired-install.ts
@@ -1,0 +1,254 @@
+import fs from "node:fs/promises"
+import path from "node:path"
+import { RETIRED_ATLAS_SKILL_NAMES } from "./retired"
+
+const BEGIN = "<!-- BEGIN atlas-skills (managed by `atlas install`) -->"
+const END = "<!-- END atlas-skills -->"
+const ATLAS_SKILL_PATH = "/@synsci/atlas/skills/"
+const ATLAS_HOOK_PATH = "/@synsci/atlas/src/atlas-runtime/hooks/web-log-hook.mjs"
+const PUBLISHED_ADAPTER_PREFIXES = [
+  [31_247, "abb989615437fce06013a17f14b3c075fc713a43e4b0c0a130beb04924347e0c"],
+  [39_358, "d2bf1806b6bd53b89fe5368827913447be966e5a8541f00c6d053c595ec0cd28"],
+  [40_920, "5835838cc5e46bb88cfab02dfd3c6c60046007ef5f1ef6ba2baccd6c64ae96d2"],
+  [40_386, "549bb056ba3858f7f57a82e403e1222728cb898ac493d40376ca5e8e8093d656"],
+  [52_629, "d5f5a7241a454cafe8850e40da497488c40a2f3ab5194a7af4a5e1ace88da598"],
+  [53_783, "fcb83b876e3d3dfdcc35217f4025d69163e20f25d71352105caf8d143a34494f"],
+  [53_875, "4858e77f789aedb90314aff091c0783dfcfba6b5257018cd8b80bde99576d111"],
+  [58_112, "d3f883002db3082c9b9874c2c083d83295c5b1ccd671bebe8a991ce9f8a303f1"],
+  [61_641, "bf2fbc172827df22e63c31928b9709ad2586c8422dec574dceafcd437bb14ccd"],
+  [61_737, "4f62d8027d4cbe5b39067a1be6e75eb981d9faa10d1ea9d57683124e31218d69"],
+] as const satisfies readonly (readonly [number, string])[]
+
+type AdapterPrefix = readonly [bytes: number, sha256: string]
+
+function record(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value)
+}
+
+function generatedPrelude(brand: "Atlas" | "Gateway", intro?: string) {
+  return `# ${brand} skills\n\n${intro ? `${intro}\n\n` : ""}${brand} is the research-map CLI from Synthetic Sciences. The skills below`
+}
+
+function generatedAdapterRemainder(
+  source: Uint8Array,
+  kind: "cursor" | "aider" | "continue" | "goose",
+  prefixes: readonly AdapterPrefix[],
+) {
+  let value: string
+  try {
+    value = new TextDecoder("utf-8", { fatal: true }).decode(source)
+  } catch {
+    return
+  }
+  let canonical: string
+  let wrapperBytes: number
+  const brand =
+    value.startsWith("# Atlas skills\n\n") || value.startsWith("---\ndescription: Atlas research-map skills ")
+      ? "Atlas"
+      : "Gateway"
+  if (kind === "cursor") {
+    const frontmatter = `---\ndescription: ${brand} research-map skills (auto-managed by \`atlas install\`)\nalwaysApply: true\n---\n\n`
+    if (!value.startsWith(`${frontmatter}${generatedPrelude(brand)}`)) return
+    canonical = value.slice(frontmatter.length)
+    wrapperBytes = new TextEncoder().encode(frontmatter).byteLength
+  } else if (kind === "aider") {
+    const intro =
+      "Wire this file into Aider by adding `read: ~/.aider-atlas-conventions.md` to your `.aider.conf.yml`, or pass `--read ~/.aider-atlas-conventions.md` on the CLI."
+    if (!value.startsWith(generatedPrelude(brand, intro))) return
+    const header = `# ${brand} skills\n\n`
+    const wrapper = `${intro}\n\n`
+    canonical = `${header}${value.slice(header.length + wrapper.length)}`
+    wrapperBytes = new TextEncoder().encode(wrapper).byteLength
+  } else if (kind === "continue") {
+    const intro = `Reference this file from your Continue config (config.json \`systemMessage\` or a custom rule) to teach ${brand} commands to the assistant.`
+    if (!value.startsWith(generatedPrelude(brand, intro))) return
+    const header = `# ${brand} skills\n\n`
+    const wrapper = `${intro}\n\n`
+    canonical = `${header}${value.slice(header.length + wrapper.length)}`
+    wrapperBytes = new TextEncoder().encode(wrapper).byteLength
+  } else if (!value.startsWith(generatedPrelude(brand))) {
+    return
+  } else {
+    canonical = value
+    wrapperBytes = 0
+  }
+  if (!value.includes("atlas help --format=json") || !value.includes("atlas help <command> --schema --format=json")) {
+    return
+  }
+
+  const canonicalBytes = new TextEncoder().encode(canonical)
+  for (const [bytes, expected] of prefixes) {
+    if (canonicalBytes.byteLength < bytes || source.byteLength < bytes + wrapperBytes) continue
+    const actual = new Bun.CryptoHasher("sha256").update(canonicalBytes.subarray(0, bytes)).digest("hex")
+    if (actual === expected) return source.subarray(bytes + wrapperBytes)
+  }
+}
+
+function strip(source: string) {
+  const newline = source.includes("\r\n") ? "\r\n" : "\n"
+  const begin = source.indexOf(BEGIN)
+  if (begin === -1) return
+  const end = source.indexOf(END, begin + BEGIN.length)
+  if (end === -1) return
+  const before = source.slice(0, begin).replace(/(?:\r?\n)+$/, "")
+  const after = source.slice(end + END.length).replace(/^(?:\r?\n)+/, "")
+  const cleaned = [before, after].filter(Boolean).join(newline)
+  return cleaned ? `${cleaned.replace(/(?:\r?\n)+$/, "")}${newline}` : ""
+}
+
+async function clearOrRemove(file: string, stat: Awaited<ReturnType<typeof fs.lstat>>) {
+  // Dotfile managers commonly make these paths symlinks. Preserve that
+  // topology and clear the exact generated target rather than unlinking it.
+  if (stat.isSymbolicLink()) await Bun.write(file, "")
+  else await fs.rm(file, { force: true })
+}
+
+async function clearAdapter(
+  file: string,
+  stat: Awaited<ReturnType<typeof fs.lstat>>,
+  kind: "cursor" | "aider" | "continue" | "goose",
+) {
+  // Aider and Continue ask users to reference these exact sidecar paths from
+  // separate configuration. Keep an empty regular file so retirement does not
+  // turn those references into missing-file warnings. Cursor and Goose own
+  // their adapter paths outright and can remove exact generated regular files.
+  if (stat.isSymbolicLink() || kind === "aider" || kind === "continue") await Bun.write(file, "")
+  else await fs.rm(file, { force: true })
+}
+
+async function block(file: string) {
+  const source = await Bun.file(file)
+    .text()
+    .catch(() => undefined)
+  if (source === undefined) return 0
+  const cleaned = strip(source)
+  if (cleaned === undefined) return 0
+  if (!cleaned) {
+    const stat = await fs.lstat(file)
+    await clearOrRemove(file, stat)
+  } else await Bun.write(file, cleaned)
+  return 1
+}
+
+async function adapter(
+  file: string,
+  kind: "cursor" | "aider" | "continue" | "goose",
+  prefixes: readonly AdapterPrefix[],
+) {
+  const stat = await fs.lstat(file).catch(() => undefined)
+  if (!stat || (!stat.isFile() && !stat.isSymbolicLink())) return 0
+  const source = await Bun.file(file)
+    .arrayBuffer()
+    .then((value) => new Uint8Array(value))
+    .catch(() => undefined)
+  if (!source) return 0
+  const remainder = generatedAdapterRemainder(source, kind, prefixes)
+  if (remainder === undefined) return 0
+  if (remainder.byteLength > 0) await Bun.write(file, remainder)
+  else await clearAdapter(file, stat, kind)
+  return 1
+}
+
+async function json(file: string) {
+  return Bun.file(file)
+    .json()
+    .then((value) => (record(value) ? value : undefined))
+    .catch(() => undefined)
+}
+
+function command(value: unknown) {
+  if (!record(value) || typeof value.command !== "string") return false
+  const normalized = value.command.replaceAll("\\", "/").toLowerCase()
+  return normalized.includes(ATLAS_HOOK_PATH)
+}
+
+function pointsToRetiredAtlasPackage(target: string): boolean {
+  return target.replaceAll("\\", "/").toLowerCase().includes(ATLAS_SKILL_PATH)
+}
+
+async function claudeSkillLinks(home: string) {
+  let removed = 0
+  for (const name of RETIRED_ATLAS_SKILL_NAMES) {
+    const link = path.join(home, ".claude", "skills", name)
+    const stat = await fs.lstat(link).catch(() => undefined)
+    if (!stat?.isSymbolicLink()) continue
+    const rawTarget = await fs.readlink(link).catch(() => "")
+    if (!rawTarget) continue
+    const resolved = path.resolve(path.dirname(link), rawTarget)
+    const realTarget = await fs.realpath(resolved).catch(() => resolved)
+    if (!pointsToRetiredAtlasPackage(realTarget) && !pointsToRetiredAtlasPackage(resolved)) continue
+    await fs.rm(link, { force: true })
+    removed++
+  }
+  return removed
+}
+
+function group(value: unknown) {
+  if (!record(value) || !Array.isArray(value.hooks)) return value
+  const hooks = value.hooks.filter((entry) => !command(entry))
+  if (hooks.length === value.hooks.length) return value
+  if (hooks.length === 0) return
+  return { ...value, hooks }
+}
+
+function hookCount(values: unknown[]) {
+  return values.reduce<number>((count, value) => {
+    if (!record(value) || !Array.isArray(value.hooks)) return count
+    return count + value.hooks.filter(command).length
+  }, 0)
+}
+
+async function claude(file: string) {
+  const root = await json(file)
+  if (!root) return 0
+  const hooks = record(root.hooks) ? root.hooks : undefined
+  const groups = hooks && Array.isArray(hooks.PostToolUse) ? hooks.PostToolUse : undefined
+  if (!groups || hookCount(groups) === 0) return 0
+  const cleaned = groups.map(group).filter((value) => value !== undefined)
+  const nextHooks = { ...hooks }
+  if (cleaned.length > 0) nextHooks.PostToolUse = cleaned
+  else delete nextHooks.PostToolUse
+  const next = { ...root }
+  if (Object.keys(nextHooks).length > 0) next.hooks = nextHooks
+  else delete next.hooks
+  await Bun.write(file, `${JSON.stringify(next, null, 2)}\n`)
+  return 1
+}
+
+async function cursor(file: string) {
+  const root = await json(file)
+  if (!root) return 0
+  const hooks = record(root.hooks) ? root.hooks : undefined
+  const entries = hooks && Array.isArray(hooks.postToolUse) ? hooks.postToolUse : undefined
+  if (!entries || !entries.some(command)) return 0
+  const cleaned = entries.filter((entry) => !command(entry))
+  const nextHooks = { ...hooks }
+  if (cleaned.length > 0) nextHooks.postToolUse = cleaned
+  else delete nextHooks.postToolUse
+  const next = { ...root }
+  if (Object.keys(nextHooks).length > 0) next.hooks = nextHooks
+  else delete next.hooks
+  await Bun.write(file, `${JSON.stringify(next, null, 2)}\n`)
+  return 1
+}
+
+/** Remove only artifacts written by the retired `atlas install` command.
+ * User-authored same-path files, malformed JSON, and unrelated hooks remain. */
+export async function purgeRetiredAtlasAgentInstall(
+  home: string,
+  options: { adapterPrefixes?: readonly AdapterPrefix[] } = {},
+) {
+  const prefixes = options.adapterPrefixes ?? PUBLISHED_ADAPTER_PREFIXES
+  const actions = [
+    claudeSkillLinks(home),
+    block(path.join(home, ".codex", "AGENTS.md")),
+    block(path.join(home, ".codeium", "windsurf", "memories", "global_rules.md")),
+    adapter(path.join(home, ".cursor", "rules", "atlas.mdc"), "cursor", prefixes),
+    adapter(path.join(home, ".aider-atlas-conventions.md"), "aider", prefixes),
+    adapter(path.join(home, ".continue", "atlas-skills.md"), "continue", prefixes),
+    adapter(path.join(home, ".config", "goose", "instructions", "atlas.md"), "goose", prefixes),
+    claude(path.join(home, ".claude", "settings.json")),
+    cursor(path.join(home, ".cursor", "hooks.json")),
+  ]
+  return Promise.all(actions).then((results) => results.reduce<number>((sum, value) => sum + value, 0))
+}

--- a/backend/cli/src/skill/skill.ts
+++ b/backend/cli/src/skill/skill.ts
@@ -19,12 +19,8 @@ import { ProjectTrust } from "@/project/trust"
 import { BundledSkills } from "./bundled"
 import { lazy } from "@/util/lazy"
 import { Install } from "./install/install"
-import {
-  isRetiredProductSkillName,
-  isRetiredProductSkillPath,
-  RETIRED_ATLAS_SKILL_NAMES,
-  RETIRED_PRODUCT_SKILL_NAMES,
-} from "./retired"
+import { isRetiredProductSkillName, isRetiredProductSkillPath, RETIRED_PRODUCT_SKILL_NAMES } from "./retired"
+import { purgeRetiredAtlasAgentInstall } from "./retired-install"
 
 export namespace Skill {
   const log = Log.create({ service: "skill" })
@@ -74,28 +70,6 @@ export namespace Skill {
   const USER_SKILL_DIR = path.join(Global.Path.data, "user-skills")
   const UserSkillName = z.string().regex(/^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/)
   const priority = { default: 0, installed: 1, user: 2, project: 3 } as const
-
-  function pointsToRetiredAtlasPackage(target: string): boolean {
-    return target.replaceAll("\\", "/").toLowerCase().includes("/@synsci/atlas/skills/")
-  }
-
-  /** `atlas install` created these global Claude symlinks. Remove only exact
-   * links that resolve into the retired npm package; never delete a real
-   * user-owned directory with the same name. */
-  async function purgeRetiredAtlasPackageLinks(globalClaude: string): Promise<void> {
-    for (const name of RETIRED_ATLAS_SKILL_NAMES) {
-      const link = path.join(globalClaude, "skills", name)
-      const stat = await fs.lstat(link).catch(() => undefined)
-      if (!stat?.isSymbolicLink()) continue
-      const rawTarget = await fs.readlink(link).catch(() => "")
-      if (!rawTarget) continue
-      const resolved = path.resolve(path.dirname(link), rawTarget)
-      const realTarget = await fs.realpath(resolved).catch(() => resolved)
-      if (!pointsToRetiredAtlasPackage(realTarget) && !pointsToRetiredAtlasPackage(resolved)) continue
-      await fs.rm(link, { force: true }).catch(() => {})
-      log.info("Removed retired Atlas package skill link", { name, path: link })
-    }
-  }
 
   async function read(match: string, origin: Info["origin"]): Promise<Info | undefined> {
     const md = await ConfigMarkdown.parse(match).catch((err) => {
@@ -200,6 +174,14 @@ export namespace Skill {
           }),
         )
       : []
+    const globalClaude = `${Global.Path.home}/.claude`
+    // Startup performs this before account gating. Keep the catalog boundary
+    // defensive too for SDK consumers that call Skill directly.
+    const retired = await purgeRetiredAtlasAgentInstall(Global.Path.home).catch((error) => {
+      log.warn("failed to purge retired Atlas agent install", { error })
+      return 0
+    })
+    if (retired > 0) log.info("Removed retired Atlas agent install artifacts", { count: retired })
     if (!Flag.OPENSCIENCE_DISABLE_CLAUDE_CODE_SKILLS) {
       for (const dir of claudeDirs) {
         const matches = await Array.fromAsync(
@@ -220,8 +202,6 @@ export namespace Skill {
         }
       }
 
-      const globalClaude = `${Global.Path.home}/.claude`
-      await purgeRetiredAtlasPackageLinks(globalClaude)
       if (await Filesystem.isDir(globalClaude)) {
         for await (const match of CLAUDE_SKILL_GLOB.scan({
           cwd: globalClaude,

--- a/backend/cli/test/installation/npm-release.test.ts
+++ b/backend/cli/test/installation/npm-release.test.ts
@@ -5,6 +5,7 @@ import { mkdir, mkdtemp, rm } from "node:fs/promises"
 import {
   NpmArtifactConflict,
   NpmPermissionError,
+  createCompiledPackageManifest,
   loadReleaseArtifacts,
   packPackage,
   preflightRelease,
@@ -13,6 +14,8 @@ import {
   releasePackageNames,
   releasePromotionNames,
   saveReleaseArtifacts,
+  verifyPackedModuleExports,
+  verifyPublishedPackages,
   type NpmCommandOptions,
   type PackedPackage,
 } from "../../../../tooling/repo/npm-release"
@@ -76,6 +79,7 @@ function options(file: string, spec?: string): NpmCommandOptions {
       FAKE_NPM_SPEC: spec,
       FAKE_NPM_STATE: file,
       OPENSCIENCE_NPM_RETRY_MS: "0",
+      OPENSCIENCE_NPM_VISIBILITY_RETRY_MS: "0",
     },
   }
 }
@@ -91,6 +95,118 @@ test("packPackage uses Bun's supported destination-only form and inspects the re
   expect(artifact.name).toBe("@synsci/release-fixture")
   expect(artifact.version).toBe("2.0.32")
   expect(artifact.integrity).toMatch(/^sha512-/)
+})
+
+test("compiled SDK manifests match the emitted dist/src layout and restore the exact source", async () => {
+  const directory = path.join(root, "compiled-sdk")
+  await mkdir(directory, { recursive: true })
+  const file = path.join(directory, "package.json")
+  const original = `${JSON.stringify(
+    {
+      name: "@synsci/compiled-fixture",
+      version: "2.0.31",
+      files: ["dist"],
+      exports: { ".": "./src/index.ts" },
+    },
+    null,
+    2,
+  )}\n`
+  await Bun.write(file, original)
+  await mkdir(path.join(directory, "dist/src"), { recursive: true })
+  await Bun.write(path.join(directory, "dist/src/index.js"), "export const version = true\n")
+  await Bun.write(path.join(directory, "dist/src/index.d.ts"), "export declare const version: boolean\n")
+
+  const pkg = createCompiledPackageManifest(original, "2.0.32-test.98.1", { preserveSourceDirectory: true })
+  await Bun.write(file, `${JSON.stringify(pkg, null, 2)}\n`)
+  try {
+    const artifact = await packPackage({ cwd: directory, name: pkg.name, version: pkg.version })
+    expect(artifact.name).toBe("@synsci/compiled-fixture")
+    expect(artifact.version).toBe("2.0.32-test.98.1")
+    expect(pkg.exports).toEqual({ ".": { import: "./dist/src/index.js", types: "./dist/src/index.d.ts" } })
+    const entries = await Bun.$`tar -tzf ${artifact.file}`.text()
+    expect(entries).toContain("package/dist/src/index.js")
+  } finally {
+    await Bun.write(file, original)
+  }
+  expect(await Bun.file(file).text()).toBe(original)
+})
+
+test("compiled plugin manifests match the flat dist layout", async () => {
+  const directory = path.join(root, "compiled-plugin")
+  await mkdir(path.join(directory, "dist"), { recursive: true })
+  const file = path.join(directory, "package.json")
+  const original = `${JSON.stringify(
+    {
+      name: "@synsci/plugin-fixture",
+      version: "2.0.31",
+      files: ["dist"],
+      exports: { ".": "./src/index.ts" },
+    },
+    null,
+    2,
+  )}\n`
+  await Bun.write(file, original)
+  await Bun.write(path.join(directory, "dist/index.js"), "export const version = true\n")
+  await Bun.write(path.join(directory, "dist/index.d.ts"), "export declare const version: boolean\n")
+
+  const pkg = createCompiledPackageManifest(original, "2.0.32-test.98.1")
+  await Bun.write(file, `${JSON.stringify(pkg, null, 2)}\n`)
+  try {
+    const artifact = await packPackage({ cwd: directory, name: pkg.name, version: pkg.version })
+    expect(pkg.exports).toEqual({ ".": { import: "./dist/index.js", types: "./dist/index.d.ts" } })
+    const entries = await Bun.$`tar -tzf ${artifact.file}`.text()
+    expect(entries).toContain("package/dist/index.js")
+  } finally {
+    await Bun.write(file, original)
+  }
+  expect(await Bun.file(file).text()).toBe(original)
+})
+
+test("packed SDK and plugin exports must load in Node before publication", async () => {
+  const version = "2.0.32-test.98.1"
+  const sdkDirectory = path.join(root, "node-sdk")
+  await mkdir(path.join(sdkDirectory, "dist/src"), { recursive: true })
+  await Bun.write(
+    path.join(sdkDirectory, "package.json"),
+    `${JSON.stringify({
+      name: "@synsci/sdk",
+      version,
+      type: "module",
+      files: ["dist"],
+      exports: { ".": { import: "./dist/src/index.js" } },
+    })}\n`,
+  )
+  await Bun.write(path.join(sdkDirectory, "dist/src/index.js"), "export const sdk = true\n")
+
+  const pluginDirectory = path.join(root, "node-plugin")
+  await mkdir(path.join(pluginDirectory, "dist"), { recursive: true })
+  await Bun.write(
+    path.join(pluginDirectory, "package.json"),
+    `${JSON.stringify({
+      name: "@synsci/plugin",
+      version,
+      type: "module",
+      files: ["dist"],
+      exports: {
+        ".": { import: "./dist/index.js" },
+        "./tool": { import: "./dist/tool.js" },
+      },
+    })}\n`,
+  )
+  await Bun.write(path.join(pluginDirectory, "dist/tool.js"), "export const tool = true\n")
+  const sdkArtifact = await packPackage({ cwd: sdkDirectory, name: "@synsci/sdk", version })
+
+  await Bun.write(path.join(pluginDirectory, "dist/index.js"), 'export * from "./tool"\n')
+  const broken = await packPackage({ cwd: pluginDirectory, name: "@synsci/plugin", version })
+  await expect(verifyPackedModuleExports([sdkArtifact, broken])).rejects.toThrow("do not load in Node")
+
+  await Bun.write(path.join(pluginDirectory, "dist/index.js"), 'export * from "./tool.js"\n')
+  const pluginArtifact = await packPackage({ cwd: pluginDirectory, name: "@synsci/plugin", version })
+  expect(await verifyPackedModuleExports([sdkArtifact, pluginArtifact])).toEqual([
+    "@synsci/sdk",
+    "@synsci/plugin",
+    "@synsci/plugin/tool",
+  ])
 })
 
 test("preflight authenticates and proves ownership of all 15 packages before mutation", async () => {
@@ -155,18 +271,43 @@ test("publish resumes missing, byte-identical, and content-equivalent artifacts 
   expect((await readState(file)).publishCalls).toBe(1)
 })
 
-test("already-published responses wait for visibility while genuine owner E403 fails immediately", async () => {
+test("successful and existing publishes outwait the short publish retry window", async () => {
   const artifact = await fixturePackage()
   const spec = `${artifact.name}@${artifact.version}`
-  const delayed = await stateFile({ publishMode: "already", publishVisibilityReads: 2 })
+  const delayed = await stateFile({ publishMode: "success", publishVisibilityReads: 7 })
 
-  expect(await publishPackage({ ...artifact, tag: "release-2-0-32" }, options(delayed, spec))).toBe("verified")
+  expect(await publishPackage({ ...artifact, tag: "release-2-0-32" }, options(delayed, spec))).toBe("published")
   expect((await readState(delayed)).publishCalls).toBe(1)
 
+  const existing = await stateFile({ publishMode: "already", publishVisibilityReads: 7 })
+  expect(await publishPackage({ ...artifact, tag: "release-2-0-32" }, options(existing, spec))).toBe("verified")
+  expect((await readState(existing)).publishCalls).toBe(1)
+})
+
+test("deferred publishes verify the complete set concurrently after every upload", async () => {
+  const first = await fixturePackage("@synsci/release-first")
+  const second = await fixturePackage("@synsci/release-second")
+  const firstSpec = `${first.name}@${first.version}`
+  const secondSpec = `${second.name}@${second.version}`
+  const file = await stateFile({ publishMode: "success" })
+
+  await publishPackage({ ...first, deferVerification: true, tag: "release-2-0-32" }, options(file, firstSpec))
+  await publishPackage({ ...second, deferVerification: true, tag: "release-2-0-32" }, options(file, secondSpec))
+
+  const state = await readState(file)
+  expect(state.publishCalls).toBe(2)
+  expect(state.packages[firstSpec]).toBeDefined()
+  expect(state.packages[secondSpec]).toBeDefined()
+  await verifyPublishedPackages([first, second], options(file))
+})
+
+test("genuine owner E403 fails immediately", async () => {
+  const artifact = await fixturePackage()
+
   const denied = await stateFile({ publishMode: "permission" })
-  await expect(publishPackage({ ...artifact, tag: "release-2-0-32" }, options(denied, spec))).rejects.toBeInstanceOf(
-    NpmPermissionError,
-  )
+  await expect(
+    publishPackage({ ...artifact, tag: "release-2-0-32" }, options(denied, `${artifact.name}@${artifact.version}`)),
+  ).rejects.toBeInstanceOf(NpmPermissionError)
   expect((await readState(denied)).publishCalls).toBe(1)
 })
 

--- a/backend/cli/test/installation/release-order.test.ts
+++ b/backend/cli/test/installation/release-order.test.ts
@@ -3,7 +3,7 @@ import path from "path"
 
 test("production publish verifies every package before the one guarded release-tag move", async () => {
   const script = await Bun.file(path.join(import.meta.dir, "../../../../tooling/repo/publish.ts")).text()
-  const verify = script.indexOf("verifyPublishedPackage(artifact)")
+  const verify = script.indexOf("verifyPublishedPackages(ordered)")
   const tag = script.indexOf("git tag -f")
   const release = script.indexOf("gh release edit ${tag} --target ${releaseSha}")
 
@@ -80,14 +80,22 @@ test("production release caches exact builds and packed npm artifacts by version
   expect(workflow.indexOf("Cache immutable CLI build")).toBeLessThan(
     workflow.indexOf("Verify or upload immutable draft assets"),
   )
+  const prepare = workflow.slice(workflow.indexOf("\n  prepare-npm:"), workflow.indexOf("\n  publish:"))
+  expect(prepare).toContain('node-version: "24"')
+  expect(prepare.indexOf("Pack the complete npm release set")).toBeLessThan(
+    prepare.indexOf("Verify packed SDK and plugin exports before publication"),
+  )
+  expect(prepare.indexOf("Verify packed SDK and plugin exports before publication")).toBeLessThan(
+    prepare.indexOf("Cache immutable npm artifacts"),
+  )
 })
 
 test("production npm writes stage the complete set before latest promotion and release publication", async () => {
   const publish = await Bun.file(path.join(import.meta.dir, "../../../../tooling/repo/publish.ts")).text()
   const helper = await Bun.file(path.join(import.meta.dir, "../../../../tooling/repo/npm-release.ts")).text()
 
-  const stage = publish.indexOf("publishPackage({ ...artifact, tag: stagingTag })")
-  const verify = publish.indexOf("verifyPublishedPackage(artifact)")
+  const stage = publish.indexOf("publishPackage({ ...artifact, deferVerification: true, tag: stagingTag })")
+  const verify = publish.indexOf("verifyPublishedPackages(ordered)")
   const tagMove = publish.indexOf("git tag -f")
   const promote = publish.indexOf("promoteRelease(ordered)")
   const undraft = publish.indexOf("--draft=false")
@@ -100,6 +108,14 @@ test("production npm writes stage the complete set before latest promotion and r
   expect(publish).toContain("promotion-only resume")
   expect(helper).toContain('return `release-${version.replaceAll(".", "-")}`')
   expect(helper.indexOf("sdk.name, plugin.name, cli.name, launcher.name")).toBeGreaterThan(-1)
+  expect(helper).toContain("Promise.allSettled(inputs.map((input) => verifyPublishedPackage(input, options)))")
+})
+
+test("large CLI packages upload sequentially and then verify as one concurrent set", async () => {
+  const source = await Bun.file(path.join(import.meta.dir, "../../../../backend/cli/script/publish.ts")).text()
+
+  expect(source).toContain("deferVerification: true")
+  expect(source).toContain("await verifyPublishedPackages(artifacts)")
 })
 
 test("draft release assets are immutable across resumptions", async () => {
@@ -113,17 +129,58 @@ test("draft release assets are immutable across resumptions", async () => {
   expect(workflow).toContain("Verify or upload immutable draft assets")
 })
 
-test("source package versions remain 2.0.31 until the workflow release commit", async () => {
+test("source package versions stay aligned before and after the workflow release commit", async () => {
   const files = [
     "backend/cli/package.json",
     "tooling/sdk/js/package.json",
     "tooling/plugin/package.json",
     "tooling/launcher/package.json",
   ]
+  const versions = []
 
   for (const file of files) {
     const pkg = await Bun.file(path.join(import.meta.dir, "../../../..", file)).json()
-    expect(pkg.version).toBe("2.0.31")
+    versions.push(pkg.version)
+  }
+  expect(new Set(versions).size).toBe(1)
+  expect(versions[0]).toMatch(/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/)
+})
+
+test("preview SDK and plugin publishers transform the live manifest rather than a cached JSON module", async () => {
+  const files = ["tooling/sdk/js/script/publish.ts", "tooling/plugin/script/publish.ts"]
+
+  for (const file of files) {
+    const source = await Bun.file(path.join(import.meta.dir, "../../../..", file)).text()
+    expect(source).toContain("const original = await Bun.file(packageFile).text()")
+    expect(source).toContain("createCompiledPackageManifest(original, Script.version")
+    expect(source).not.toContain('import("../package.json")')
+  }
+  const sdk = await Bun.file(path.join(import.meta.dir, "../../../../tooling/sdk/js/script/publish.ts")).text()
+  expect(sdk).toContain("preserveSourceDirectory: true")
+})
+
+test("packaged npm rehearsal imports every public SDK and plugin export", async () => {
+  const workflow = await Bun.file(path.join(import.meta.dir, "../../../../.github/workflows/npm-test.yml")).text()
+  for (const spec of [
+    "@synsci/sdk",
+    "@synsci/sdk/client",
+    "@synsci/sdk/server",
+    "@synsci/sdk/v2",
+    "@synsci/sdk/v2/client",
+    "@synsci/sdk/v2/server",
+    "@synsci/plugin",
+    "@synsci/plugin/tool",
+  ]) {
+    expect(workflow).toContain(`await import(\"${spec}\")`)
+  }
+})
+
+test("compiled plugin source uses Node-compatible local ESM specifiers", async () => {
+  const directory = path.join(import.meta.dir, "../../../../tooling/plugin/src")
+  for (const file of ["index.ts", "example.ts"]) {
+    const source = await Bun.file(path.join(directory, file)).text()
+    const local = source.matchAll(/(?:from|export \*)\s+["'](\.\/.+?)["']/g)
+    for (const match of local) expect(match[1]).toEndWith(".js")
   }
 })
 

--- a/backend/cli/test/skill/retired-agent-install.test.ts
+++ b/backend/cli/test/skill/retired-agent-install.test.ts
@@ -1,0 +1,326 @@
+import { expect, test } from "bun:test"
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { purgeRetiredAtlasAgentInstall } from "../../src/skill/retired-install"
+
+const BEGIN = "<!-- BEGIN atlas-skills (managed by `atlas install`) -->"
+const END = "<!-- END atlas-skills -->"
+
+function adapter(brand: "Atlas" | "Gateway" = "Gateway", intro?: string) {
+  return `# ${brand} skills
+
+${intro ? `${intro}\n\n` : ""}${brand} is the research-map CLI from Synthetic Sciences. The skills below
+tell you when to use which ${brand} command.
+
+\`\`\`bash
+atlas help --format=json
+atlas help <command> --schema --format=json
+\`\`\`
+
+---
+
+## atlas
+
+Generated Atlas instructions.
+
+---
+
+`
+}
+
+const adapterPrefixes = (["Atlas", "Gateway"] as const).map((brand) => {
+  const bytes = new TextEncoder().encode(adapter(brand))
+  return [bytes.byteLength, new Bun.CryptoHasher("sha256").update(bytes).digest("hex")] as const
+})
+
+function purge(root: string) {
+  return purgeRetiredAtlasAgentInstall(root, { adapterPrefixes })
+}
+
+async function file(root: string, relative: string, content: string) {
+  const target = path.join(root, relative)
+  await fs.mkdir(path.dirname(target), { recursive: true })
+  await Bun.write(target, content)
+  return target
+}
+
+test("purges every exact atlas-install adapter and hook while preserving shared config", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openscience-retired-agent-install-"))
+  try {
+    const codex = await file(root, ".codex/AGENTS.md", `personal before\n\n${BEGIN}\n${adapter()}${END}\nother after\n`)
+    const windsurf = await file(root, ".codeium/windsurf/memories/global_rules.md", `${BEGIN}\n${adapter()}${END}\n`)
+    const cursorRule = await file(
+      root,
+      ".cursor/rules/atlas.mdc",
+      `---\ndescription: Gateway research-map skills (auto-managed by \`atlas install\`)\nalwaysApply: true\n---\n\n${adapter()}`,
+    )
+    const aiderIntro =
+      "Wire this file into Aider by adding `read: ~/.aider-atlas-conventions.md` to your `.aider.conf.yml`, or pass `--read ~/.aider-atlas-conventions.md` on the CLI."
+    const continueIntro =
+      "Reference this file from your Continue config (config.json `systemMessage` or a custom rule) to teach Gateway commands to the assistant."
+    const aider = await file(root, ".aider-atlas-conventions.md", adapter("Gateway", aiderIntro))
+    const continued = await file(root, ".continue/atlas-skills.md", adapter("Gateway", continueIntro))
+    const goose = await file(root, ".config/goose/instructions/atlas.md", adapter())
+    const atlasPackage = path.join(root, "node_modules", "@synsci", "atlas", "skills", "atlas")
+    await fs.mkdir(atlasPackage, { recursive: true })
+    const claudeLink = path.join(root, ".claude", "skills", "atlas")
+    await fs.mkdir(path.dirname(claudeLink), { recursive: true })
+    await fs.symlink(atlasPackage, claudeLink, process.platform === "win32" ? "junction" : "dir")
+    const claude = await file(
+      root,
+      ".claude/settings.json",
+      `${JSON.stringify(
+        {
+          theme: "dark",
+          hooks: {
+            PostToolUse: [
+              {
+                matcher: "WebSearch|WebFetch",
+                hooks: [
+                  {
+                    type: "command",
+                    command: 'node "/usr/lib/node_modules/@synsci/atlas/src/atlas-runtime/hooks/web-log-hook.mjs"',
+                  },
+                  { type: "command", command: "echo keep" },
+                ],
+              },
+            ],
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    )
+    const cursorHooks = await file(
+      root,
+      ".cursor/hooks.json",
+      `${JSON.stringify(
+        {
+          version: 1,
+          note: "keep",
+          hooks: {
+            postToolUse: [
+              {
+                command: 'node "C:\\\\npm\\node_modules\\@synsci\\atlas\\src\\atlas-runtime\\hooks\\web-log-hook.mjs"',
+                matcher: "WebSearch",
+              },
+              { command: "echo keep", matcher: "Shell" },
+            ],
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    )
+
+    expect(await purge(root)).toBe(9)
+    expect(await Bun.file(codex).text()).toBe("personal before\nother after\n")
+    expect(await Bun.file(windsurf).exists()).toBe(false)
+    for (const target of [cursorRule, goose]) expect(await Bun.file(target).exists()).toBe(false)
+    for (const target of [aider, continued]) {
+      expect(await Bun.file(target).exists()).toBe(true)
+      expect(await Bun.file(target).text()).toBe("")
+    }
+    expect(await Bun.file(claudeLink).exists()).toBe(false)
+    expect(await Bun.file(claude).json()).toEqual({
+      theme: "dark",
+      hooks: {
+        PostToolUse: [{ matcher: "WebSearch|WebFetch", hooks: [{ type: "command", command: "echo keep" }] }],
+      },
+    })
+    expect(await Bun.file(cursorHooks).json()).toEqual({
+      version: 1,
+      note: "keep",
+      hooks: { postToolUse: [{ command: "echo keep", matcher: "Shell" }] },
+    })
+    expect(await purge(root)).toBe(0)
+  } finally {
+    await fs.rm(root, { recursive: true, force: true })
+  }
+})
+
+test("preserves user-owned same-path files and malformed shared configuration", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openscience-retired-agent-preserve-"))
+  try {
+    const personalCursor = `# My atlas notes\n\n${adapter()}\nauto-managed by \`atlas install\`\nalwaysApply: true\n`
+    const cursor = await file(root, ".cursor/rules/atlas.mdc", personalCursor)
+    const aider = await file(root, ".aider-atlas-conventions.md", "# Personal conventions\n")
+    const codex = await file(root, ".codex/AGENTS.md", `${BEGIN}\nunterminated personal content\n`)
+    const claude = await file(root, ".claude/settings.json", "{not-json\n")
+    const hooks = await file(
+      root,
+      ".cursor/hooks.json",
+      '{"hooks":{"postToolUse":[{"command":"echo keep"},{"command":"node /personal/web-log-hook.mjs"}]}}\n',
+    )
+    const personalTarget = path.join(root, "personal", "skills", "atlas-lab")
+    await fs.mkdir(personalTarget, { recursive: true })
+    const personalLink = path.join(root, ".claude", "skills", "atlas-lab")
+    await fs.mkdir(path.dirname(personalLink), { recursive: true })
+    await fs.symlink(personalTarget, personalLink, process.platform === "win32" ? "junction" : "dir")
+    await file(root, ".claude/skills/atlas-map/SKILL.md", "# user-owned directory\n")
+
+    expect(await purge(root)).toBe(0)
+    expect(await Bun.file(cursor).text()).toBe(personalCursor)
+    expect(await Bun.file(aider).text()).toBe("# Personal conventions\n")
+    expect(await Bun.file(codex).text()).toContain("unterminated personal content")
+    expect(await Bun.file(claude).text()).toBe("{not-json\n")
+    expect(await Bun.file(hooks).json()).toEqual({
+      hooks: { postToolUse: [{ command: "echo keep" }, { command: "node /personal/web-log-hook.mjs" }] },
+    })
+    expect(await fs.lstat(personalLink).then((value) => value.isSymbolicLink())).toBe(true)
+    expect(await Bun.file(path.join(root, ".claude/skills/atlas-map/SKILL.md")).text()).toBe("# user-owned directory\n")
+  } finally {
+    await fs.rm(root, { recursive: true, force: true })
+  }
+})
+
+test("recognizes Atlas-era adapters and preserves a version-only Cursor hook file", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openscience-retired-agent-atlas-era-"))
+  try {
+    const aiderIntro =
+      "Wire this file into Aider by adding `read: ~/.aider-atlas-conventions.md` to your `.aider.conf.yml`, or pass `--read ~/.aider-atlas-conventions.md` on the CLI."
+    const continueIntro =
+      "Reference this file from your Continue config (config.json `systemMessage` or a custom rule) to teach Atlas commands to the assistant."
+    await file(
+      root,
+      ".cursor/rules/atlas.mdc",
+      `---\ndescription: Atlas research-map skills (auto-managed by \`atlas install\`)\nalwaysApply: true\n---\n\n${adapter("Atlas")}`,
+    )
+    await file(root, ".aider-atlas-conventions.md", adapter("Atlas", aiderIntro))
+    await file(root, ".continue/atlas-skills.md", adapter("Atlas", continueIntro))
+    await file(root, ".config/goose/instructions/atlas.md", adapter("Atlas"))
+    const cursorHooks = await file(
+      root,
+      ".cursor/hooks.json",
+      `${JSON.stringify({
+        version: 1,
+        hooks: {
+          postToolUse: [
+            {
+              command: "node /opt/node_modules/@synsci/atlas/src/atlas-runtime/hooks/web-log-hook.mjs",
+            },
+          ],
+        },
+      })}\n`,
+    )
+
+    expect(await purge(root)).toBe(5)
+    for (const target of [".cursor/rules/atlas.mdc", ".config/goose/instructions/atlas.md"]) {
+      expect(await Bun.file(path.join(root, target)).exists()).toBe(false)
+    }
+    for (const target of [".aider-atlas-conventions.md", ".continue/atlas-skills.md"]) {
+      expect(await Bun.file(path.join(root, target)).exists()).toBe(true)
+      expect(await Bun.file(path.join(root, target)).text()).toBe("")
+    }
+    expect(await Bun.file(cursorHooks).json()).toEqual({ version: 1 })
+  } finally {
+    await fs.rm(root, { recursive: true, force: true })
+  }
+})
+
+test("runs the retirement migration before the account gate", async () => {
+  const source = await Bun.file(path.join(import.meta.dir, "../../src/index.ts")).text()
+  const cleanup = source.indexOf("await purgeRetiredAtlasAgentInstall(Global.Path.home)")
+  const gate = source.indexOf("requiresOpenScienceAccount(command")
+  expect(cleanup).toBeGreaterThan(-1)
+  expect(gate).toBeGreaterThan(cleanup)
+})
+
+test("version and help invocations retire managed instructions before yargs exits", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openscience-retired-agent-builtins-"))
+  try {
+    const codex = path.join(root, ".codex", "AGENTS.md")
+    const cli = path.join(import.meta.dir, "../../src/index.ts")
+    for (const argument of ["--version", "--help"]) {
+      await file(root, ".codex/AGENTS.md", `${BEGIN}\n${adapter("Atlas")}${END}\n`)
+      const proc = Bun.spawn([process.execPath, cli, argument], {
+        env: {
+          ...process.env,
+          HOME: root,
+          OPENSCIENCE_CONFIG_DIR: path.join(root, "config"),
+          OPENSCIENCE_DATA_DIR: path.join(root, "data"),
+          OPENSCIENCE_TEST_HOME: root,
+          XDG_CONFIG_HOME: path.join(root, "xdg-config"),
+          XDG_DATA_HOME: path.join(root, "xdg-data"),
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      })
+      const [stdout, stderr, exitCode] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+      ])
+      expect(exitCode, `${argument}: ${stderr || stdout}`).toBe(0)
+      const remaining = await Bun.file(codex)
+        .text()
+        .catch(() => undefined)
+      expect(remaining, `${argument} left ${JSON.stringify(remaining)}`).toBeUndefined()
+    }
+  } finally {
+    await fs.rm(root, { recursive: true, force: true })
+  }
+})
+
+test("preserves CRLF around a balanced managed block", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openscience-retired-agent-crlf-"))
+  try {
+    const codex = await file(
+      root,
+      ".codex/AGENTS.md",
+      `before\r\n\r\n${BEGIN}\r\n${adapter().replaceAll("\n", "\r\n")}${END}\r\n\r\nafter\r\n`,
+    )
+    expect(await purge(root)).toBe(1)
+    expect(await Bun.file(codex).text()).toBe("before\r\nafter\r\n")
+  } finally {
+    await fs.rm(root, { recursive: true, force: true })
+  }
+})
+
+test("removes a generated adapter prefix while preserving appended user notes", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openscience-retired-agent-appended-"))
+  try {
+    const continueIntro =
+      "Reference this file from your Continue config (config.json `systemMessage` or a custom rule) to teach Gateway commands to the assistant."
+    const continued = await file(
+      root,
+      ".continue/atlas-skills.md",
+      `${adapter("Gateway", continueIntro)}# Personal Continue notes\nKeep this.\n`,
+    )
+    expect(await purge(root)).toBe(1)
+    expect(await Bun.file(continued).text()).toBe("# Personal Continue notes\nKeep this.\n")
+    expect(await purge(root)).toBe(0)
+  } finally {
+    await fs.rm(root, { recursive: true, force: true })
+  }
+})
+
+test.skipIf(process.platform === "win32")(
+  "preserves dotfile symlinks while clearing exact generated targets",
+  async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openscience-retired-agent-symlinks-"))
+    try {
+      const codexTarget = await file(root, "dotfiles/AGENTS.md", `${BEGIN}\n${adapter("Atlas")}${END}\n`)
+      const codexLink = path.join(root, ".codex", "AGENTS.md")
+      await fs.mkdir(path.dirname(codexLink), { recursive: true })
+      await fs.symlink(codexTarget, codexLink)
+
+      const continueIntro =
+        "Reference this file from your Continue config (config.json `systemMessage` or a custom rule) to teach Gateway commands to the assistant."
+      const continueTarget = await file(root, "dotfiles/atlas-skills.md", adapter("Gateway", continueIntro))
+      const continueLink = path.join(root, ".continue", "atlas-skills.md")
+      await fs.mkdir(path.dirname(continueLink), { recursive: true })
+      await fs.symlink(continueTarget, continueLink)
+
+      expect(await purge(root)).toBe(2)
+      expect((await fs.lstat(codexLink)).isSymbolicLink()).toBe(true)
+      expect((await fs.lstat(continueLink)).isSymbolicLink()).toBe(true)
+      expect(await Bun.file(codexTarget).text()).toBe("")
+      expect(await Bun.file(continueTarget).text()).toBe("")
+      expect(await purge(root)).toBe(0)
+    } finally {
+      await fs.rm(root, { recursive: true, force: true })
+    }
+  },
+)

--- a/tooling/plugin/script/publish.ts
+++ b/tooling/plugin/script/publish.ts
@@ -1,26 +1,19 @@
 #!/usr/bin/env bun
 import { Script } from "@synsci/script"
 import { $ } from "bun"
-import { packPackage, publishPackage } from "../../repo/npm-release"
+import { createCompiledPackageManifest, packPackage, publishPackage } from "../../repo/npm-release"
 
 const dir = new URL("..", import.meta.url).pathname
 process.chdir(dir)
 
 await $`bun tsc`
-const pkg = await import("../package.json").then((m) => m.default)
-const original = JSON.parse(JSON.stringify(pkg))
-for (const [key, value] of Object.entries(pkg.exports)) {
-  const file = value.replace("./src/", "./dist/").replace(".ts", "")
-  // @ts-ignore
-  pkg.exports[key] = {
-    import: file + ".js",
-    types: file + ".d.ts",
-  }
-}
-await Bun.write("package.json", JSON.stringify(pkg, null, 2))
+const packageFile = new URL("../package.json", import.meta.url)
+const original = await Bun.file(packageFile).text()
+const pkg = createCompiledPackageManifest(original, Script.version)
+await Bun.write(packageFile, JSON.stringify(pkg, null, 2))
 try {
   const artifact = await packPackage({ cwd: dir, name: pkg.name, version: Script.version })
   await publishPackage({ ...artifact, tag: Script.channel })
 } finally {
-  await Bun.write("package.json", JSON.stringify(original, null, 2))
+  await Bun.write(packageFile, original)
 }

--- a/tooling/plugin/src/example.ts
+++ b/tooling/plugin/src/example.ts
@@ -1,5 +1,5 @@
-import { Plugin } from "./index"
-import { tool } from "./tool"
+import { Plugin } from "./index.js"
+import { tool } from "./tool.js"
 
 export const ExamplePlugin: Plugin = async (ctx) => {
   return {

--- a/tooling/plugin/src/index.ts
+++ b/tooling/plugin/src/index.ts
@@ -11,10 +11,10 @@ import type {
 } from "@synsci/sdk"
 import type { Model, Provider } from "@synsci/sdk/v2"
 
-import type { BunShell } from "./shell"
-import { type ToolDefinition } from "./tool"
+import type { BunShell } from "./shell.js"
+import { type ToolDefinition } from "./tool.js"
 
-export * from "./tool"
+export * from "./tool.js"
 
 export type ProviderContext = {
   source: "env" | "config" | "custom" | "api"

--- a/tooling/repo/npm-release.ts
+++ b/tooling/repo/npm-release.ts
@@ -2,7 +2,7 @@
 
 import path from "path"
 import os from "os"
-import { copyFile, mkdir, mkdtemp, readdir } from "node:fs/promises"
+import { copyFile, mkdir, mkdtemp, readdir, rm } from "node:fs/promises"
 import cli from "../../backend/cli/package.json"
 import { NativeTargets, nativePackageName } from "../../backend/cli/script/native-targets"
 import sdk from "../sdk/js/package.json"
@@ -42,7 +42,8 @@ type ArtifactManifest = {
 export class NpmArtifactConflict extends Error {}
 export class NpmPermissionError extends Error {}
 
-const attempts = [1, 2, 3, 4, 5] as const
+const publishAttempts = [1, 2, 3, 4, 5] as const
+const defaultVisibilityAttempts = 180
 
 async function run(args: string[], options: NpmCommandOptions = {}): Promise<Result> {
   const configured = options.command ?? process.env.OPENSCIENCE_NPM_COMMAND ?? "npm"
@@ -68,6 +69,22 @@ function failure(result: Result) {
 function retryDelay(options: NpmCommandOptions) {
   const value = Number(options.env?.OPENSCIENCE_NPM_RETRY_MS ?? process.env.OPENSCIENCE_NPM_RETRY_MS ?? 1_000)
   return Number.isFinite(value) && value >= 0 ? value : 1_000
+}
+
+function visibilityAttempts(options: NpmCommandOptions) {
+  const value = Number(
+    options.env?.OPENSCIENCE_NPM_VISIBILITY_ATTEMPTS ??
+      process.env.OPENSCIENCE_NPM_VISIBILITY_ATTEMPTS ??
+      defaultVisibilityAttempts,
+  )
+  return Number.isInteger(value) && value > 0 ? value : defaultVisibilityAttempts
+}
+
+function visibilityRetryDelay(options: NpmCommandOptions) {
+  const value = Number(
+    options.env?.OPENSCIENCE_NPM_VISIBILITY_RETRY_MS ?? process.env.OPENSCIENCE_NPM_VISIBILITY_RETRY_MS ?? 2_000,
+  )
+  return Number.isFinite(value) && value >= 0 ? value : 2_000
 }
 
 function isAlreadyPublished(detail: string) {
@@ -139,13 +156,41 @@ async function packedManifest(file: string) {
     proc.exited,
   ])
   if (exitCode !== 0) throw new Error(`Could not inspect npm tarball ${file}: ${stderr.trim()}`)
-  return JSON.parse(stdout) as { name?: string; version?: string }
+  return JSON.parse(stdout) as { exports?: unknown; name?: string; version?: string }
 }
 
 export async function packedIntegrity(file: string) {
   const bytes = await Bun.file(file).arrayBuffer()
   const digest = new Bun.CryptoHasher("sha512").update(bytes).digest("base64")
   return `sha512-${digest}`
+}
+
+export function createCompiledPackageManifest(
+  source: string,
+  version: string,
+  options: { preserveSourceDirectory?: boolean } = {},
+) {
+  const parsed = JSON.parse(source) as Record<string, unknown>
+  if (
+    typeof parsed.name !== "string" ||
+    !parsed.exports ||
+    typeof parsed.exports !== "object" ||
+    Array.isArray(parsed.exports)
+  ) {
+    throw new Error("Compiled npm packages require a name and exports object")
+  }
+  const exports = Object.fromEntries(
+    Object.entries(parsed.exports).map(([key, value]) => {
+      if (typeof value !== "string") throw new Error(`Compiled npm export ${key} must be a source path`)
+      if (!value.startsWith("./src/") || !value.endsWith(".ts")) {
+        throw new Error(`Compiled npm export ${key} must point to a TypeScript file under ./src`)
+      }
+      const output = options.preserveSourceDirectory ? "./dist/src/" : "./dist/"
+      const file = value.replace("./src/", output).replace(/\.ts$/, "")
+      return [key, { import: `${file}.js`, types: `${file}.d.ts` }]
+    }),
+  )
+  return { ...parsed, exports, name: parsed.name, version }
 }
 
 async function assertPackedIdentity(input: { file: string; name: string; version: string }) {
@@ -263,6 +308,77 @@ export async function loadReleaseArtifacts(input: { directory: string; source: s
   return artifacts
 }
 
+function publicImportSpecifiers(manifest: Awaited<ReturnType<typeof packedManifest>>) {
+  if (
+    typeof manifest.name !== "string" ||
+    !manifest.exports ||
+    typeof manifest.exports !== "object" ||
+    Array.isArray(manifest.exports)
+  ) {
+    throw new Error("Packed module requires a package name and exports object")
+  }
+  return Object.keys(manifest.exports).map((key) => {
+    if (key === ".") return manifest.name!
+    if (!key.startsWith("./")) throw new Error(`Unsupported packed module export: ${key}`)
+    return `${manifest.name}/${key.slice(2)}`
+  })
+}
+
+/** Install the exact packed SDK and plugin together, then import every public
+ * export with Node. This runs before caching or publishing, so broken ESM
+ * specifiers and missing packed files cannot become immutable npm releases. */
+export async function verifyPackedModuleExports(
+  artifacts: PackedPackage[],
+  options: { nodeCommand?: string | string[]; npmCommand?: string | string[] } = {},
+) {
+  const targets = [sdk.name, plugin.name].map((name) => {
+    const artifact = artifacts.find((value) => value.name === name)
+    if (!artifact) throw new Error(`Missing packed module for import verification: ${name}`)
+    return artifact
+  })
+  const specifiers = (
+    await Promise.all(targets.map(async (artifact) => publicImportSpecifiers(await packedManifest(artifact.file))))
+  ).flat()
+  const directory = await mkdtemp(path.join(os.tmpdir(), "openscience-packed-modules-"))
+  try {
+    const install = await run(
+      [
+        "install",
+        "--ignore-scripts",
+        "--no-audit",
+        "--no-fund",
+        "--package-lock=false",
+        "--prefix",
+        directory,
+        ...targets.map((artifact) => artifact.file),
+      ],
+      { command: options.npmCommand ?? "npm", cwd: directory },
+    )
+    if (install.exitCode !== 0) throw new Error(`Could not install packed SDK/plugin: ${failure(install)}`)
+    const probe = path.join(directory, "verify-exports.mjs")
+    await Bun.write(probe, `${specifiers.map((value) => `await import(${JSON.stringify(value)})`).join("\n")}\n`)
+    const configured = options.nodeCommand ?? "node"
+    const command = Array.isArray(configured) ? configured : [configured]
+    const proc = Bun.spawn([...command, probe], {
+      cwd: directory,
+      env: process.env,
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ])
+    if (exitCode !== 0) {
+      throw new Error(`Packed SDK/plugin exports do not load in Node: ${(stderr || stdout).trim().slice(-2_000)}`)
+    }
+    return specifiers
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
+}
+
 async function registryIntegrity(input: PackedPackage, options: NpmCommandOptions) {
   const spec = `${input.name}@${input.version}`
   const result = await run(["view", spec, "dist.integrity", "--json"], options)
@@ -296,7 +412,8 @@ async function assertEquivalent(input: PackedPackage, remote: string, options: N
 
 export async function verifyPublishedPackage(input: PackedPackage, options: NpmCommandOptions = {}) {
   const errors: unknown[] = []
-  for (const attempt of attempts) {
+  const attempts = visibilityAttempts(options)
+  for (let attempt = 1; attempt <= attempts; attempt++) {
     try {
       const remote = await registryIntegrity(input, options)
       if (remote) return await assertEquivalent(input, remote, options)
@@ -305,17 +422,30 @@ export async function verifyPublishedPackage(input: PackedPackage, options: NpmC
       if (error instanceof NpmArtifactConflict) throw error
       errors.push(error)
     }
-    if (attempt < attempts.length) await Bun.sleep(retryDelay(options))
+    if (attempt < attempts) await Bun.sleep(visibilityRetryDelay(options))
   }
   throw errors.at(-1)
 }
 
+export async function verifyPublishedPackages(inputs: PackedPackage[], options: NpmCommandOptions = {}) {
+  const results = await Promise.allSettled(inputs.map((input) => verifyPublishedPackage(input, options)))
+  const failures = results.flatMap((result, index) => {
+    if (result.status === "fulfilled") return []
+    const input = inputs[index]
+    return [new Error(`Could not verify ${input.name}@${input.version}`, { cause: result.reason })]
+  })
+  if (failures.length > 0) {
+    throw new AggregateError(failures, `${failures.length}/${inputs.length} packages were not verifiable on npm`)
+  }
+  return results.flatMap((result) => (result.status === "fulfilled" ? [result.value] : []))
+}
+
 export async function publishPackage(
-  input: PackedPackage & { tag: string },
+  input: PackedPackage & { deferVerification?: boolean; tag: string },
   options: NpmCommandOptions = {},
 ): Promise<"published" | "verified"> {
   const errors: unknown[] = []
-  for (const attempt of attempts) {
+  for (const attempt of publishAttempts) {
     try {
       const remote = await registryIntegrity(input, options)
       if (remote) {
@@ -330,8 +460,9 @@ export async function publishPackage(
 
     const result = await run(["publish", input.file, "--access", "public", "--tag", input.tag], options)
     if (result.exitCode === 0) {
-      await verifyPublishedPackage(input, options)
-      console.log(`  published ${input.name}@${input.version} under ${input.tag}`)
+      if (!input.deferVerification) await verifyPublishedPackage(input, options)
+      const status = input.deferVerification ? "submitted" : "published"
+      console.log(`  ${status} ${input.name}@${input.version} under ${input.tag}`)
       return "published"
     }
 
@@ -350,7 +481,7 @@ export async function publishPackage(
       throw new NpmPermissionError(`npm refused ${input.name}@${input.version}: ${failure(result)}`)
     }
 
-    if (attempt < attempts.length) {
+    if (attempt < publishAttempts.length) {
       console.warn(`  retry ${input.name} (attempt ${attempt})`)
       await Bun.sleep(retryDelay(options))
     }

--- a/tooling/repo/prepare-npm.ts
+++ b/tooling/repo/prepare-npm.ts
@@ -5,7 +5,7 @@ import { cp, copyFile, mkdir } from "node:fs/promises"
 import { $ } from "bun"
 import { Script } from "@synsci/script"
 import { assertPublicPackageSurface, createWrapperPackageManifest } from "../../backend/cli/script/publish-manifest"
-import { packPackage, saveReleaseArtifacts, type PackedPackage } from "./npm-release"
+import { createCompiledPackageManifest, packPackage, saveReleaseArtifacts, type PackedPackage } from "./npm-release"
 import { assertReleaseSource, releaseRoot, setWorkspaceVersion } from "./release-workspace"
 
 const source = await assertReleaseSource()
@@ -55,14 +55,10 @@ for (const name of Object.keys(binaries).sort()) {
 }
 artifacts.push(await packPackage({ cwd: wrapperDir, name: cliPackage.name, version }))
 
-async function packCompiledPackage(directory: string) {
+async function packCompiledPackage(directory: string, options: { preserveSourceDirectory?: boolean } = {}) {
   const packageFile = path.join(directory, "package.json")
   const original = await Bun.file(packageFile).text()
-  const pkg = JSON.parse(original)
-  for (const [key, value] of Object.entries(pkg.exports as Record<string, string>)) {
-    const file = value.replace("./src/", "./dist/").replace(".ts", "")
-    pkg.exports[key] = { import: `${file}.js`, types: `${file}.d.ts` }
-  }
+  const pkg = createCompiledPackageManifest(original, version, options)
   await Bun.write(packageFile, JSON.stringify(pkg, null, 2))
   try {
     return await packPackage({ cwd: directory, name: pkg.name, version })
@@ -72,7 +68,7 @@ async function packCompiledPackage(directory: string) {
 }
 
 const sdkDir = path.join(releaseRoot, "tooling/sdk/js")
-artifacts.push(await packCompiledPackage(sdkDir))
+artifacts.push(await packCompiledPackage(sdkDir, { preserveSourceDirectory: true }))
 
 const pluginDir = path.join(releaseRoot, "tooling/plugin")
 await $`bun tsc`.cwd(pluginDir)

--- a/tooling/repo/publish.ts
+++ b/tooling/repo/publish.ts
@@ -10,7 +10,7 @@ import {
   publishPackage,
   releasePromotionNames,
   releaseStagingTag,
-  verifyPublishedPackage,
+  verifyPublishedPackages,
 } from "./npm-release"
 import { assertReleaseSource, releaseRoot, setWorkspaceVersion } from "./release-workspace"
 
@@ -43,16 +43,16 @@ if (Script.preview) {
 
   if (!promotionOnly) {
     console.log(`\n=== publishing ${artifacts.length} packages under ${stagingTag} ===\n`)
-    for (const artifact of ordered) await publishPackage({ ...artifact, tag: stagingTag })
+    for (const artifact of ordered) {
+      await publishPackage({ ...artifact, deferVerification: true, tag: stagingTag })
+    }
   } else {
     console.log(`\n=== promotion-only resume from ${source}; no npm package writes are allowed ===\n`)
   }
 
   console.log("\n=== verifying the complete npm release set ===\n")
-  for (const artifact of ordered) {
-    await verifyPublishedPackage(artifact)
-    console.log(`  verified ${artifact.name}@${artifact.version}`)
-  }
+  await verifyPublishedPackages(ordered)
+  for (const artifact of ordered) console.log(`  verified ${artifact.name}@${artifact.version}`)
   await ensureReleaseStagingTags(ordered, stagingTag)
 
   let releaseSha = source

--- a/tooling/repo/verify-npm-artifacts.ts
+++ b/tooling/repo/verify-npm-artifacts.ts
@@ -1,0 +1,14 @@
+#!/usr/bin/env bun
+
+import { loadReleaseArtifacts, verifyPackedModuleExports } from "./npm-release"
+
+const directory = process.env.OPENSCIENCE_NPM_ARTIFACT_DIR
+const source = process.env.OPENSCIENCE_ARTIFACT_SOURCE
+const version = process.env.OPENSCIENCE_VERSION
+if (!directory) throw new Error("OPENSCIENCE_NPM_ARTIFACT_DIR is required")
+if (!source) throw new Error("OPENSCIENCE_ARTIFACT_SOURCE is required")
+if (!version) throw new Error("OPENSCIENCE_VERSION is required")
+
+const artifacts = await loadReleaseArtifacts({ directory, source, version })
+const specifiers = await verifyPackedModuleExports(artifacts)
+console.log(`Verified ${specifiers.length} packed SDK/plugin exports in Node`)

--- a/tooling/sdk/js/script/publish.ts
+++ b/tooling/sdk/js/script/publish.ts
@@ -1,24 +1,18 @@
 #!/usr/bin/env bun
 
 import { Script } from "@synsci/script"
-import { packPackage, publishPackage } from "../../../repo/npm-release"
+import { createCompiledPackageManifest, packPackage, publishPackage } from "../../../repo/npm-release"
 
 const dir = new URL("..", import.meta.url).pathname
 process.chdir(dir)
 
-const pkg = await import("../package.json").then((m) => m.default)
-const original = JSON.parse(JSON.stringify(pkg))
-for (const [key, value] of Object.entries(pkg.exports)) {
-  const file = value.replace("./src/", "./dist/").replace(".ts", "")
-  pkg.exports[key] = {
-    import: file + ".js",
-    types: file + ".d.ts",
-  }
-}
-await Bun.write("package.json", JSON.stringify(pkg, null, 2))
+const packageFile = new URL("../package.json", import.meta.url)
+const original = await Bun.file(packageFile).text()
+const pkg = createCompiledPackageManifest(original, Script.version, { preserveSourceDirectory: true })
+await Bun.write(packageFile, JSON.stringify(pkg, null, 2))
 try {
   const artifact = await packPackage({ cwd: dir, name: pkg.name, version: Script.version })
   await publishPackage({ ...artifact, tag: Script.channel })
 } finally {
-  await Bun.write("package.json", JSON.stringify(original, null, 2))
+  await Bun.write(packageFile, original)
 }


### PR DESCRIPTION
## Summary

- remove the complete historical Atlas skill/install surface on first OpenScience startup while preserving user-authored agent configuration
- fix SDK/plugin package manifests and Node ESM exports, then verify exact tarballs before caching or publishing
- make npm visibility verification tolerate observed registry lag and verify the complete release set concurrently
- strengthen the fresh npm rehearsal so all SDK/plugin exports are imported after publication

## Validation

- 81 release, install, and retirement tests passed on Bun 1.3.14
- all 7 monorepo typecheck tasks passed
- plugin compile passed
- actionlint passed for production and test publish workflows
- Prettier and git diff checks passed
- independent release, npm, and legacy-installer reviews: no P0/P1/P2 findings

## Release note

Do not resume the partial 2.0.32-test.97.1 registry state. After merge, dispatch a fresh uniquely versioned npm rehearsal with packaged E2E and all OS smoke jobs enabled.