### PR TITLE
fix: make npm test releases atomic

### DIFF
--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -9,12 +9,12 @@ on:
         required: false
         type: string
       run_packaged_e2e:
-        description: "Install @synsci/openscience@test and run packaged browser e2e"
+        description: "Install the exact candidate version and run packaged browser e2e"
         required: false
         type: boolean
         default: true
       run_os_smoke:
-        description: "Install @synsci/openscience@test on Linux, macOS, and Windows"
+        description: "Install the exact candidate on Linux, macOS, Windows, and musl"
         required: false
         type: boolean
         default: true
@@ -47,17 +47,23 @@ jobs:
     timeout-minutes: 10
     outputs:
       version: ${{ steps.version.outputs.version }}
+      source: ${{ steps.version.outputs.source }}
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - id: version
         shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          if [ -n "${{ inputs.version }}" ]; then
-            version="${{ inputs.version }}"
+          source="$(git rev-parse HEAD)"
+          if [ -n "$INPUT_VERSION" ]; then
+            version="$INPUT_VERSION"
           else
-            latest="$(npm view @synsci/openscience@latest version)"
-            IFS=. read -r major minor patch <<< "$latest"
-            version="${major}.${minor}.$((patch + 1))-test.${GITHUB_RUN_NUMBER}.${GITHUB_RUN_ATTEMPT}"
+            current="$(node -p 'require("./backend/cli/package.json").version')"
+            core="${current%%-*}"
+            IFS=. read -r major minor patch <<< "$core"
+            version="${major}.${minor}.$((patch + 1))-test.${GITHUB_RUN_ID}"
           fi
 
           if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+-test\.[0-9A-Za-z.-]+$ ]]; then
@@ -66,7 +72,8 @@ jobs:
           fi
 
           echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "Publishing npm test version $version"
+          echo "source=$source" >> "$GITHUB_OUTPUT"
+          echo "Preparing immutable npm test version $version from $source"
 
   build-cli:
     needs: version
@@ -74,49 +81,133 @@ jobs:
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.version.outputs.source }}
       - uses: ./.github/actions/setup-bun
+      - name: Look up immutable npm test artifacts
+        id: npm-artifacts-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .release/npm-test/${{ needs.version.outputs.version }}
+          key: npm-test-artifacts-v2-${{ needs.version.outputs.source }}-${{ needs.version.outputs.version }}
+          lookup-only: true
+      - name: Restore immutable CLI build
+        id: cli-build-cache
+        if: steps.npm-artifacts-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            backend/cli/dist
+            frontend/workspace/dist/version.json
+          key: npm-test-cli-v2-${{ needs.version.outputs.source }}-${{ needs.version.outputs.version }}
       - name: Build all npm CLI packages
+        if: steps.npm-artifacts-cache.outputs.cache-hit != 'true' && steps.cli-build-cache.outputs.cache-hit != 'true'
         run: ./backend/cli/script/build.ts
         env:
           OPENSCIENCE_CHANNEL: test
           OPENSCIENCE_VERSION: ${{ needs.version.outputs.version }}
           GH_TOKEN: ${{ github.token }}
-      - name: Cache CLI build
+      - name: Cache immutable CLI build
+        if: steps.npm-artifacts-cache.outputs.cache-hit != 'true' && steps.cli-build-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: backend/cli/dist
-          key: npm-test-cli-build-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            backend/cli/dist
+            frontend/workspace/dist/version.json
+          key: npm-test-cli-v2-${{ needs.version.outputs.source }}-${{ needs.version.outputs.version }}
 
-  publish-test:
+  prepare-npm:
     needs:
       - version
       - build-cli
     runs-on: ubuntu-latest
-    timeout-minutes: 60
-    outputs:
-      version: ${{ needs.version.outputs.version }}
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          ref: ${{ needs.version.outputs.source }}
+      - uses: ./.github/actions/setup-bun
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
+      - name: Restore immutable npm test artifacts
+        id: npm-artifacts-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .release/npm-test/${{ needs.version.outputs.version }}
+          key: npm-test-artifacts-v2-${{ needs.version.outputs.source }}-${{ needs.version.outputs.version }}
+      - name: Restore immutable CLI build
+        if: steps.npm-artifacts-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            backend/cli/dist
+            frontend/workspace/dist/version.json
+          key: npm-test-cli-v2-${{ needs.version.outputs.source }}-${{ needs.version.outputs.version }}
+          fail-on-cache-miss: true
+      - name: Fail closed if an uncached version is occupied
+        if: steps.npm-artifacts-cache.outputs.cache-hit != 'true'
+        run: ./tooling/repo/npm-test-release.ts assert-empty
+        env:
+          OPENSCIENCE_VERSION: ${{ needs.version.outputs.version }}
+          OPENSCIENCE_RELEASE_SOURCE: ${{ needs.version.outputs.source }}
+          OPENSCIENCE_ARTIFACT_SOURCE: ${{ needs.version.outputs.source }}
+      - name: Pack the complete 15-package candidate once
+        if: steps.npm-artifacts-cache.outputs.cache-hit != 'true'
+        run: ./tooling/repo/prepare-npm.ts
+        env:
+          HUSKY: "0"
+          OPENSCIENCE_CHANNEL: test
+          OPENSCIENCE_VERSION: ${{ needs.version.outputs.version }}
+          OPENSCIENCE_RELEASE_SOURCE: ${{ needs.version.outputs.source }}
+          OPENSCIENCE_ARTIFACT_SOURCE: ${{ needs.version.outputs.source }}
+          OPENSCIENCE_NPM_ARTIFACT_DIR: .release/npm-test/${{ needs.version.outputs.version }}
+      - name: Verify immutable manifest and packed module exports
+        run: ./tooling/repo/verify-npm-artifacts.ts
+        env:
+          OPENSCIENCE_VERSION: ${{ needs.version.outputs.version }}
+          OPENSCIENCE_ARTIFACT_SOURCE: ${{ needs.version.outputs.source }}
+          OPENSCIENCE_NPM_ARTIFACT_DIR: .release/npm-test/${{ needs.version.outputs.version }}
+      - name: Cache immutable source, version, integrity, and tarballs
+        if: steps.npm-artifacts-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .release/npm-test/${{ needs.version.outputs.version }}
+          key: npm-test-artifacts-v2-${{ needs.version.outputs.source }}-${{ needs.version.outputs.version }}
+
+  publish-test:
+    needs:
+      - version
+      - prepare-npm
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    outputs:
+      version: ${{ needs.version.outputs.version }}
+      source: ${{ needs.version.outputs.source }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.version.outputs.source }}
       - uses: ./.github/actions/setup-bun
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
-      - name: Restore CLI build
+      - name: Restore immutable npm test artifacts
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: backend/cli/dist
-          key: npm-test-cli-build-${{ github.run_id }}-${{ github.run_attempt }}
+          path: .release/npm-test/${{ needs.version.outputs.version }}
+          key: npm-test-artifacts-v2-${{ needs.version.outputs.source }}-${{ needs.version.outputs.version }}
           fail-on-cache-miss: true
-      - name: Publish npm test packages
-        run: ./tooling/repo/publish.ts
+      - name: Stage and verify the complete npm candidate
+        run: ./tooling/repo/npm-test-release.ts stage
         env:
-          HUSKY: "0"
-          OPENSCIENCE_CHANNEL: test
           OPENSCIENCE_VERSION: ${{ needs.version.outputs.version }}
-          OPENSCIENCE_REQUIRE_LAUNCHER_PUBLISH: "true"
+          OPENSCIENCE_RELEASE_SOURCE: ${{ needs.version.outputs.source }}
+          OPENSCIENCE_ARTIFACT_SOURCE: ${{ needs.version.outputs.source }}
+          OPENSCIENCE_NPM_ARTIFACT_DIR: .release/npm-test/${{ needs.version.outputs.version }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"
 
@@ -130,6 +221,8 @@ jobs:
         shell: bash
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.publish-test.outputs.source }}
       - uses: ./.github/actions/setup-bun
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -378,3 +471,76 @@ jobs:
           } finally {
             Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
           }
+
+  musl-baseline-smoke:
+    needs: publish-test
+    if: inputs.run_os_smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    container: node:24-alpine
+    steps:
+      - name: Install Alpine smoke dependencies
+        shell: sh
+        run: apk add --no-cache curl libstdc++
+      - name: Install and smoke the exact x64 musl baseline
+        shell: sh
+        run: |
+          set -eu
+          prefix="$RUNNER_TEMP/openscience-musl-baseline"
+          npm install --prefix "$prefix" "@synsci/openscience-linux-x64-baseline-musl@${{ needs.publish-test.outputs.version }}"
+          bin="$prefix/node_modules/@synsci/openscience-linux-x64-baseline-musl/bin/openscience"
+          "$bin" --version > "$RUNNER_TEMP/openscience-musl-version.txt"
+          grep -Fx "${{ needs.publish-test.outputs.version }}" "$RUNNER_TEMP/openscience-musl-version.txt"
+          OPENSCIENCE_DISABLE_SHARE=true \
+            OPENSCIENCE_DISABLE_LSP_DOWNLOAD=true \
+            OPENSCIENCE_DISABLE_DEFAULT_PLUGINS=true \
+            OPENSCIENCE_EXPERIMENTAL_DISABLE_FILEWATCHER=true \
+            "$bin" serve --port 4096 > "$RUNNER_TEMP/openscience-musl-smoke.log" 2>&1 &
+          pid=$!
+          trap 'kill "$pid" 2>/dev/null || true' EXIT
+          i=0
+          while [ "$i" -lt 90 ]; do
+            if curl -fsS "http://127.0.0.1:4096/global/health" > /dev/null; then
+              exit 0
+            fi
+            i=$((i + 1))
+            sleep 1
+          done
+          echo "musl baseline server never became healthy" >&2
+          sed -n '1,200p' "$RUNNER_TEMP/openscience-musl-smoke.log" >&2 || true
+          exit 1
+
+  promote-test:
+    needs:
+      - version
+      - publish-test
+      - packaged-e2e
+      - os-smoke
+      - musl-baseline-smoke
+    if: inputs.run_packaged_e2e && inputs.run_os_smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.version.outputs.source }}
+      - uses: ./.github/actions/setup-bun
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+      - name: Restore immutable npm test artifacts
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .release/npm-test/${{ needs.version.outputs.version }}
+          key: npm-test-artifacts-v2-${{ needs.version.outputs.source }}-${{ needs.version.outputs.version }}
+          fail-on-cache-miss: true
+      - name: Promote the verified snapshot to test
+        run: ./tooling/repo/npm-test-release.ts promote-test
+        env:
+          OPENSCIENCE_VERSION: ${{ needs.version.outputs.version }}
+          OPENSCIENCE_RELEASE_SOURCE: ${{ needs.version.outputs.source }}
+          OPENSCIENCE_ARTIFACT_SOURCE: ${{ needs.version.outputs.source }}
+          OPENSCIENCE_NPM_ARTIFACT_DIR: .release/npm-test/${{ needs.version.outputs.version }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/backend/cli/test/installation/fixtures/fake-npm.ts
+++ b/backend/cli/test/installation/fixtures/fake-npm.ts
@@ -3,10 +3,13 @@ type State = {
   failTagReadAfterAdd?: string
   failTagReadOnce?: boolean
   identity: string
+  optionalDependencies?: Record<string, Record<string, string>>
   owners: string[]
   packages: Record<string, { integrity: string; visibilityReads?: number }>
   publishCalls: number
-  publishMode?: "already" | "permission" | "success"
+  publishFailures?: Record<string, number>
+  publishMode?: "already" | "ghost" | "permission" | "success"
+  publishSpecs?: string[]
   publishVisibilityReads?: number
   tagAdds?: string[]
   tags: Record<string, Record<string, string>>
@@ -48,6 +51,11 @@ if (args[0] === "view" && args[2] === "dist.integrity") {
   process.exit(0)
 }
 
+if (args[0] === "view" && args[2] === "optionalDependencies") {
+  console.log(JSON.stringify(state.optionalDependencies?.[args[1]] ?? {}))
+  process.exit(0)
+}
+
 if (args[0] === "diff") {
   if (state.diff) console.log(state.diff)
   process.exit(0)
@@ -55,8 +63,25 @@ if (args[0] === "diff") {
 
 if (args[0] === "publish") {
   state.publishCalls++
-  const spec = process.env.FAKE_NPM_SPEC
-  if (!spec) throw new Error("FAKE_NPM_SPEC is required for publish")
+  const archive = Bun.spawn(["tar", "-xOzf", args[1], "package/package.json"], {
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  const manifest = JSON.parse(await new Response(archive.stdout).text()) as { name: string; version: string }
+  if ((await archive.exited) !== 0) throw new Error("Could not inspect fake npm package")
+  const spec = process.env.FAKE_NPM_SPEC ?? `${manifest.name}@${manifest.version}`
+  state.publishSpecs ??= []
+  state.publishSpecs.push(spec)
+  if ((state.publishFailures?.[spec] ?? 0) > 0) {
+    state.publishFailures![spec]--
+    await save()
+    fail("npm error code E500\ntransient publish failure")
+  }
+  if (state.publishMode === "ghost") {
+    await save()
+    console.log(`+ ${spec}`)
+    process.exit(0)
+  }
   if (state.publishMode === "permission") {
     await save()
     fail("npm error code E403\nYou do not have permission to publish this package")

--- a/backend/cli/test/installation/npm-release.test.ts
+++ b/backend/cli/test/installation/npm-release.test.ts
@@ -5,17 +5,24 @@ import { mkdir, mkdtemp, rm } from "node:fs/promises"
 import {
   NpmArtifactConflict,
   NpmPermissionError,
+  assertReleaseVersionUnoccupied,
   createCompiledPackageManifest,
   loadReleaseArtifacts,
   packPackage,
   preflightRelease,
   promoteRelease,
+  promoteReleaseToTag,
   publishPackage,
   releasePackageNames,
+  releaseCandidateTag,
   releasePromotionNames,
   saveReleaseArtifacts,
+  sanitizeNpmDiagnostic,
+  stageCandidateRelease,
   verifyPackedModuleExports,
+  verifyPublishedPackageIntegrities,
   verifyPublishedPackages,
+  verifyReleaseOptionalDependencies,
   type NpmCommandOptions,
   type PackedPackage,
 } from "../../../../tooling/repo/npm-release"
@@ -24,10 +31,13 @@ type FakeState = {
   diff?: string
   failTagReadAfterAdd?: string
   identity: string
+  optionalDependencies?: Record<string, Record<string, string>>
   owners: string[]
   packages: Record<string, { integrity: string; visibilityReads?: number }>
   publishCalls: number
-  publishMode?: "already" | "permission" | "success"
+  publishFailures?: Record<string, number>
+  publishMode?: "already" | "ghost" | "permission" | "success"
+  publishSpecs?: string[]
   publishVisibilityReads?: number
   tagAdds?: string[]
   tags: Record<string, Record<string, string>>
@@ -80,6 +90,16 @@ function options(file: string, spec?: string): NpmCommandOptions {
       FAKE_NPM_STATE: file,
       OPENSCIENCE_NPM_RETRY_MS: "0",
       OPENSCIENCE_NPM_VISIBILITY_RETRY_MS: "0",
+    },
+  }
+}
+
+function fastOptions(file: string): NpmCommandOptions {
+  return {
+    ...options(file),
+    env: {
+      ...options(file).env,
+      OPENSCIENCE_NPM_VISIBILITY_ATTEMPTS: "1",
     },
   }
 }
@@ -244,6 +264,93 @@ test("release artifacts persist exact packed bytes and reject a different source
   await expect(loadReleaseArtifacts({ directory, source, version: "2.0.32" })).rejects.toThrow("expected 2.0.32")
 })
 
+test("a missing artifact cache fails closed when any package version already exists", async () => {
+  const version = "2.0.32-test.12345"
+  const occupied = `${releasePackageNames()[0]}@${version}`
+  const file = await stateFile({ packages: { [occupied]: { integrity: "sha512-existing" } } })
+
+  await expect(assertReleaseVersionUnoccupied(version, options(file))).rejects.toThrow(
+    "Immutable npm artifact cache is missing",
+  )
+  expect((await readState(file)).publishCalls).toBe(0)
+
+  const empty = await stateFile()
+  await assertReleaseVersionUnoccupied(version, options(empty))
+})
+
+test("test candidate tags cannot collide across distinct valid versions", () => {
+  const versions = ["2.0.32-test.a.b", "2.0.32-test.a-b", "2.0.32-test.A-B"]
+  expect(new Set(versions.map(releaseCandidateTag)).size).toBe(versions.length)
+})
+
+test("test candidates use one repair round for only absent immutable artifacts", async () => {
+  const version = "2.0.32-test.12345"
+  const artifacts: PackedPackage[] = []
+  for (const name of releasePackageNames()) artifacts.push(await fixturePackage(name, version))
+  const repairName = "@synsci/sdk"
+  const native = releasePackageNames().filter((name) => name.startsWith("@synsci/openscience-"))
+  const optionalDependencies = Object.fromEntries(native.map((name) => [name, version]))
+  const file = await stateFile({
+    optionalDependencies: { [`@synsci/openscience@${version}`]: optionalDependencies },
+    publishFailures: { [`${repairName}@${version}`]: 1 },
+  })
+
+  const result = await stageCandidateRelease(artifacts, fastOptions(file))
+
+  expect(result).toEqual({ tag: releaseCandidateTag(version), version })
+  const state = await readState(file)
+  expect(state.publishCalls).toBe(16)
+  expect(state.publishSpecs?.filter((spec) => spec === `${repairName}@${version}`)).toHaveLength(2)
+  for (const name of releasePackageNames()) {
+    expect(state.tags[name][releaseCandidateTag(version)]).toBe(version)
+  }
+  expect(await verifyReleaseOptionalDependencies(artifacts, options(file))).toHaveLength(11)
+
+  const unrepaired = await stateFile({
+    optionalDependencies: { [`@synsci/openscience@${version}`]: optionalDependencies },
+    publishFailures: { [`${repairName}@${version}`]: 2 },
+  })
+  await expect(stageCandidateRelease(artifacts, fastOptions(unrepaired))).rejects.toThrow(
+    "remains incomplete after one repair round",
+  )
+  expect(
+    (await readState(unrepaired)).publishSpecs?.filter((spec) => spec === `${repairName}@${version}`),
+  ).toHaveLength(2)
+
+  const ghostPackages = Object.fromEntries(
+    artifacts
+      .filter((artifact) => artifact.name !== repairName)
+      .map((artifact) => [`${artifact.name}@${version}`, { integrity: artifact.integrity }]),
+  )
+  const previousTags = Object.fromEntries(releasePackageNames().map((name) => [name, { test: "2.0.31-test.safe" }]))
+  const acknowledgedButMissing = await stateFile({
+    optionalDependencies: { [`@synsci/openscience@${version}`]: optionalDependencies },
+    packages: ghostPackages,
+    publishMode: "ghost",
+    tags: previousTags,
+  })
+  await expect(stageCandidateRelease(artifacts, fastOptions(acknowledgedButMissing))).rejects.toThrow(
+    "remains incomplete after one repair round",
+  )
+  const ghostState = await readState(acknowledgedButMissing)
+  expect(ghostState.publishCalls).toBe(2)
+  for (const name of releasePackageNames()) expect(ghostState.tags[name].test).toBe("2.0.31-test.safe")
+})
+
+test("npm diagnostics redact configured and recognizable credentials", () => {
+  const configured = "npm_configured_secret_123456789"
+  const diagnostic = [
+    `NODE_AUTH_TOKEN=${configured}`,
+    "npm token npm_abcdefghijklmnopqrstuvwxyz012345",
+    "https://publisher:password@registry.npmjs.org/package",
+  ].join("\n")
+
+  const sanitized = sanitizeNpmDiagnostic(diagnostic, { NODE_AUTH_TOKEN: configured })
+  expect(sanitized).not.toContain(configured)
+  expect(sanitized).not.toContain("password")
+  expect(sanitized).not.toContain("npm_abcdefghijklmnopqrstuvwxyz012345")
+})
+
 test("publish resumes missing, byte-identical, and content-equivalent artifacts without overwriting conflicts", async () => {
   const artifact = await fixturePackage()
   const spec = `${artifact.name}@${artifact.version}`
@@ -269,6 +376,18 @@ test("publish resumes missing, byte-identical, and content-equivalent artifacts 
     NpmArtifactConflict,
   )
   expect((await readState(file)).publishCalls).toBe(1)
+})
+
+test("candidate verification requires the registry integrity from the immutable manifest", async () => {
+  const artifact = await fixturePackage()
+  const spec = `${artifact.name}@${artifact.version}`
+  const exact = await stateFile({ packages: { [spec]: { integrity: artifact.integrity } } })
+  await verifyPublishedPackageIntegrities([artifact], fastOptions(exact))
+
+  const repacked = await stateFile({ diff: "", packages: { [spec]: { integrity: "sha512-repacked" } } })
+  await expect(verifyPublishedPackageIntegrities([artifact], fastOptions(repacked))).rejects.toBeInstanceOf(
+    NpmArtifactConflict,
+  )
 })
 
 test("successful and existing publishes outwait the short publish retry window", async () => {
@@ -324,6 +443,24 @@ test("latest promotion is ordered with launcher last", async () => {
   expect(state.tagAdds?.at(-1)).toBe("synsci@2.0.32:latest")
 })
 
+test("test promotion moves the full snapshot in release order without changing latest", async () => {
+  const base = await fixturePackage()
+  const artifacts = releasePackageNames().map((name) => ({ ...base, name }))
+  const tags = Object.fromEntries(
+    artifacts.map((artifact) => [artifact.name, { latest: "2.0.31", test: "2.0.30-test.1" }]),
+  )
+  const file = await stateFile({ tags })
+
+  await promoteReleaseToTag(artifacts, "test", options(file))
+
+  const state = await readState(file)
+  expect(state.tagAdds).toEqual(releasePromotionNames().map((name) => `${name}@2.0.32:test`))
+  for (const name of releasePackageNames()) {
+    expect(state.tags[name].test).toBe("2.0.32")
+    expect(state.tags[name].latest).toBe("2.0.31")
+  }
+})
+
 test("promotion rolls the full snapshot back when mutation succeeds but verification read fails", async () => {
   const base = await fixturePackage()
   const artifacts = releasePackageNames().map((name) => ({ ...base, name }))
@@ -335,4 +472,17 @@ test("promotion rolls the full snapshot back when mutation succeeds but verifica
 
   const restored = await readState(file)
   for (const name of releasePackageNames()) expect(restored.tags[name].latest).toBe("2.0.31")
+})
+
+test("test promotion rolls the full snapshot back on a verified tag-write failure", async () => {
+  const base = await fixturePackage()
+  const artifacts = releasePackageNames().map((name) => ({ ...base, name }))
+  const tags = Object.fromEntries(artifacts.map((artifact) => [artifact.name, { test: "2.0.30-test.1" }]))
+  const first = releasePromotionNames()[0]
+  const file = await stateFile({ failTagReadAfterAdd: first, tags })
+
+  await expect(promoteReleaseToTag(artifacts, "test", options(file))).rejects.toThrow("transient dist-tag read failure")
+
+  const restored = await readState(file)
+  for (const name of releasePackageNames()) expect(restored.tags[name].test).toBe("2.0.30-test.1")
 })

--- a/backend/cli/test/installation/release-order.test.ts
+++ b/backend/cli/test/installation/release-order.test.ts
@@ -175,6 +175,46 @@ test("packaged npm rehearsal imports every public SDK and plugin export", async 
   }
 })
 
+test("npm test rehearsal stages immutable exact artifacts and promotes only after every smoke gate", async () => {
+  const workflow = await Bun.file(path.join(import.meta.dir, "../../../../.github/workflows/npm-test.yml")).text()
+  const helper = await Bun.file(path.join(import.meta.dir, "../../../../tooling/repo/npm-test-release.ts")).text()
+  const release = await Bun.file(path.join(import.meta.dir, "../../../../tooling/repo/npm-release.ts")).text()
+  const versionJob = workflow.slice(workflow.indexOf("\n  version:"), workflow.indexOf("\n  build-cli:"))
+  const build = workflow.slice(workflow.indexOf("\n  build-cli:"), workflow.indexOf("\n  prepare-npm:"))
+  const prepare = workflow.slice(workflow.indexOf("\n  prepare-npm:"), workflow.indexOf("\n  publish-test:"))
+  const stage = workflow.slice(workflow.indexOf("\n  publish-test:"), workflow.indexOf("\n  packaged-e2e:"))
+  const promotion = workflow.slice(workflow.indexOf("\n  promote-test:"))
+
+  expect(versionJob).toContain("-test.${GITHUB_RUN_ID}")
+  expect(versionJob).not.toContain("GITHUB_RUN_ATTEMPT")
+  expect(build).toContain("lookup-only: true")
+  expect(build).toContain(
+    "if: steps.npm-artifacts-cache.outputs.cache-hit != 'true' && steps.cli-build-cache.outputs.cache-hit != 'true'",
+  )
+  expect(prepare).toContain(
+    "key: npm-test-artifacts-v2-${{ needs.version.outputs.source }}-${{ needs.version.outputs.version }}",
+  )
+  expect(prepare.indexOf("Fail closed if an uncached version is occupied")).toBeLessThan(
+    prepare.indexOf("Pack the complete 15-package candidate once"),
+  )
+  expect(prepare.indexOf("Restore immutable npm test artifacts")).toBeLessThan(
+    prepare.indexOf("Restore immutable CLI build"),
+  )
+  expect(prepare).toContain("run: ./tooling/repo/prepare-npm.ts")
+  expect(stage).toContain("run: ./tooling/repo/npm-test-release.ts stage")
+  expect(stage).not.toContain("./tooling/repo/publish.ts")
+  expect(workflow).toContain("@synsci/openscience-linux-x64-baseline-musl@${{ needs.publish-test.outputs.version }}")
+  expect(promotion).toContain("- packaged-e2e")
+  expect(promotion).toContain("- os-smoke")
+  expect(promotion).toContain("- musl-baseline-smoke")
+  expect(promotion).toContain("run: ./tooling/repo/npm-test-release.ts promote-test")
+  expect(helper.indexOf("verifyReleaseTags(artifacts, releaseCandidateTag(version))")).toBeLessThan(
+    helper.indexOf('promoteReleaseToTag(artifacts, "test")'),
+  )
+  expect(release).toContain('createHash("sha256").update(version).digest("hex").slice(0, 12)')
+  expect(release).toContain('await promoteReleaseToTag(artifacts, "latest", options)')
+})
+
 test("compiled plugin source uses Node-compatible local ESM specifiers", async () => {
   const directory = path.join(import.meta.dir, "../../../../tooling/plugin/src")
   for (const file of ["index.ts", "example.ts"]) {

--- a/tooling/repo/npm-release.ts
+++ b/tooling/repo/npm-release.ts
@@ -2,6 +2,7 @@
 
 import path from "path"
 import os from "os"
+import { createHash } from "node:crypto"
 import { copyFile, mkdir, mkdtemp, readdir, rm } from "node:fs/promises"
 import cli from "../../backend/cli/package.json"
 import { NativeTargets, nativePackageName } from "../../backend/cli/script/native-targets"
@@ -62,8 +63,28 @@ async function run(args: string[], options: NpmCommandOptions = {}): Promise<Res
   return { exitCode, stdout, stderr }
 }
 
+/** npm normally redacts credentials, but release failures are copied into CI
+ * annotations and exceptions. Redact the common token shapes, authenticated
+ * URLs, npmrc assignments, and the exact configured secrets before retaining
+ * the bounded diagnostic tail. */
+export function sanitizeNpmDiagnostic(value: string, env: Record<string, string | undefined> = process.env) {
+  let output = value
+    .replace(/\b(?:npm|gh[opurs]|github_pat)_[A-Za-z0-9_=-]{16,}\b/g, "[redacted-token]")
+    .replace(/(https?:\/\/)[^\s/@:]+:[^\s/@]+@/gi, "$1[redacted]@")
+    .replace(/((?:_authToken|npm-token|authorization)\s*[=:]\s*)[^\s]+/gi, "$1[redacted]")
+  for (const key of ["NODE_AUTH_TOKEN", "NPM_TOKEN", "NPM_CONFIG_TOKEN"]) {
+    const secret = env[key]
+    if (secret && secret.length >= 8) output = output.replaceAll(secret, "[redacted-token]")
+  }
+  return output
+}
+
+function diagnostic(result: Result) {
+  return sanitizeNpmDiagnostic([result.stdout, result.stderr].filter(Boolean).join("\n")).trim().slice(-2_000)
+}
+
 function failure(result: Result) {
-  return (result.stderr || result.stdout).trim().slice(-2_000) || `exit ${result.exitCode}`
+  return diagnostic(result) || `exit ${result.exitCode}`
 }
 
 function retryDelay(options: NpmCommandOptions) {
@@ -113,6 +134,18 @@ export function releaseStagingTag(version: string) {
   if (!/^\d+\.\d+\.\d+$/.test(version))
     throw new Error(`Release staging tags require stable semver, received ${version}`)
   return `release-${version.replaceAll(".", "-")}`
+}
+
+export function releaseCandidateTag(version: string) {
+  if (!/^\d+\.\d+\.\d+-test\.[0-9A-Za-z.-]+$/.test(version)) {
+    throw new Error(`Test candidate tags require a test prerelease, received ${version}`)
+  }
+  const slug = version
+    .toLowerCase()
+    .replace(/[^0-9a-z]+/g, "-")
+    .slice(0, 80)
+  const digest = createHash("sha256").update(version).digest("hex").slice(0, 12)
+  return `candidate-${slug}-${digest}`
 }
 
 export async function preflightRelease(options: NpmCommandOptions = {}) {
@@ -379,8 +412,8 @@ export async function verifyPackedModuleExports(
   }
 }
 
-async function registryIntegrity(input: PackedPackage, options: NpmCommandOptions) {
-  const spec = `${input.name}@${input.version}`
+async function registryVersionIntegrity(name: string, version: string, options: NpmCommandOptions) {
+  const spec = `${name}@${version}`
   const result = await run(["view", spec, "dist.integrity", "--json"], options)
   if (result.exitCode !== 0) {
     const detail = `${result.stdout}\n${result.stderr}`
@@ -392,6 +425,10 @@ async function registryIntegrity(input: PackedPackage, options: NpmCommandOption
     throw new Error(`npm returned no usable dist.integrity for ${spec}`)
   }
   return value
+}
+
+async function registryIntegrity(input: PackedPackage, options: NpmCommandOptions) {
+  return await registryVersionIntegrity(input.name, input.version, options)
 }
 
 async function assertEquivalent(input: PackedPackage, remote: string, options: NpmCommandOptions) {
@@ -438,6 +475,175 @@ export async function verifyPublishedPackages(inputs: PackedPackage[], options: 
     throw new AggregateError(failures, `${failures.length}/${inputs.length} packages were not verifiable on npm`)
   }
   return results.flatMap((result) => (result.status === "fulfilled" ? [result.value] : []))
+}
+
+async function inspectPublishedPackage(input: PackedPackage, options: NpmCommandOptions) {
+  const remote = await registryIntegrity(input, options)
+  if (!remote) return false
+  if (remote !== input.integrity) {
+    throw new NpmArtifactConflict(
+      `${input.name}@${input.version} registry integrity ${remote} does not match the immutable manifest ${input.integrity}`,
+    )
+  }
+  return true
+}
+
+async function waitForPublishedSet(inputs: PackedPackage[], options: NpmCommandOptions) {
+  const attempts = visibilityAttempts(options)
+  let missing = inputs
+  let errors: unknown[] = []
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    const results = await Promise.allSettled(inputs.map((input) => inspectPublishedPackage(input, options)))
+    missing = []
+    errors = []
+    for (const [index, result] of results.entries()) {
+      if (result.status === "fulfilled") {
+        if (!result.value) missing.push(inputs[index])
+        continue
+      }
+      if (result.reason instanceof NpmArtifactConflict) throw result.reason
+      errors.push(
+        new Error(`Could not inspect ${inputs[index].name}@${inputs[index].version}`, { cause: result.reason }),
+      )
+    }
+    if (missing.length === 0 && errors.length === 0) return []
+    if (attempt === 1 || attempt === attempts || attempt % 15 === 0) {
+      console.log(
+        `  npm visibility ${attempt}/${attempts}: ${missing.length} absent, ${errors.length} read errors` +
+          `${missing.length ? ` (${missing.map((item) => item.name).join(", ")})` : ""}`,
+      )
+    }
+    if (attempt < attempts) await Bun.sleep(visibilityRetryDelay(options))
+  }
+  if (errors.length > 0) {
+    throw new AggregateError(errors, `npm registry inspection failed for ${errors.length}/${inputs.length} packages`)
+  }
+  return missing
+}
+
+export async function verifyPublishedPackageIntegrities(inputs: PackedPackage[], options: NpmCommandOptions = {}) {
+  const missing = await waitForPublishedSet(inputs, options)
+  if (missing.length > 0) {
+    throw new Error(`npm packages are not visible: ${missing.map((item) => `${item.name}@${item.version}`).join(", ")}`)
+  }
+}
+
+async function submitCandidatePackageOnce(
+  input: PackedPackage,
+  tag: string,
+  options: NpmCommandOptions,
+  phase: "initial" | "repair",
+) {
+  const result = await run(["publish", input.file, "--access", "public", "--tag", tag], options)
+  if (result.exitCode === 0) {
+    console.log(`  ${phase} submission accepted for ${input.name}@${input.version}`)
+    const response = diagnostic(result)
+    if (response) console.log(`  sanitized npm response for ${input.name}:\n${response}`)
+    return true
+  }
+  const detail = `${result.stdout}\n${result.stderr}`
+  if (isPermissionFailure(detail) && !isAlreadyPublished(detail)) {
+    throw new NpmPermissionError(`npm refused ${input.name}@${input.version}: ${failure(result)}`)
+  }
+  // A failed request can still have committed at the registry. Do not infer
+  // absence from the npm process exit code; the visibility pass below is the
+  // authoritative result and the only input to the single repair round.
+  console.warn(`  ${phase} submission uncertain for ${input.name}@${input.version}: ${failure(result)}`)
+  return false
+}
+
+function exactReleaseArtifacts(inputs: PackedPackage[]) {
+  const expected = releasePackageNames()
+  const names = inputs.map((input) => input.name)
+  const versions = new Set(inputs.map((input) => input.version))
+  if (
+    inputs.length !== expected.length ||
+    new Set(names).size !== names.length ||
+    expected.some((name) => !names.includes(name))
+  ) {
+    throw new Error(`Expected the exact ${expected.length}-package npm release set`)
+  }
+  if (versions.size !== 1) throw new Error("Every npm release artifact must have the same version")
+  const byName = new Map(inputs.map((input) => [input.name, input]))
+  return releasePromotionNames().map((name) => byName.get(name)!)
+}
+
+/** Fail closed before building a replacement artifact set. Once even one
+ * package for a version exists, only the cached source/version/integrity
+ * manifest can prove that a resume is byte-identical. */
+export async function assertReleaseVersionUnoccupied(version: string, options: NpmCommandOptions = {}) {
+  const names = releasePackageNames()
+  const results = await Promise.allSettled(names.map((name) => registryVersionIntegrity(name, version, options)))
+  const present: string[] = []
+  const failures: unknown[] = []
+  for (const [index, result] of results.entries()) {
+    if (result.status === "rejected") {
+      failures.push(new Error(`Could not inspect ${names[index]}@${version}`, { cause: result.reason }))
+    } else if (result.value) {
+      present.push(names[index])
+    }
+  }
+  if (failures.length > 0) {
+    throw new AggregateError(failures, "Cannot prove that the npm test version is unoccupied")
+  }
+  if (present.length > 0) {
+    throw new Error(
+      `Immutable npm artifact cache is missing, but ${present.length}/${names.length} packages already exist for ${version}: ${present.join(", ")}`,
+    )
+  }
+}
+
+export async function verifyReleaseOptionalDependencies(artifacts: PackedPackage[], options: NpmCommandOptions = {}) {
+  const ordered = exactReleaseArtifacts(artifacts)
+  const version = ordered[0].version
+  const result = await run(["view", `${cli.name}@${version}`, "optionalDependencies", "--json"], options)
+  if (result.exitCode !== 0) {
+    throw new Error(`Could not inspect ${cli.name}@${version} optional dependencies: ${failure(result)}`)
+  }
+  const value = JSON.parse(result.stdout || "{}") as unknown
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`npm returned invalid optional dependencies for ${cli.name}@${version}`)
+  }
+  const actual = value as Record<string, unknown>
+  const expected = nativeReleasePackageNames()
+  const unexpectedNative = Object.keys(actual).filter(
+    (name) => name.startsWith(`${cli.name}-`) && !expected.includes(name),
+  )
+  const invalid = expected.filter((name) => actual[name] !== version)
+  if (invalid.length > 0 || unexpectedNative.length > 0 || "@synsci/atlas" in actual) {
+    throw new Error(
+      `${cli.name}@${version} optional dependency matrix is invalid` +
+        `${invalid.length ? `; wrong or missing: ${invalid.join(", ")}` : ""}` +
+        `${unexpectedNative.length ? `; unexpected: ${unexpectedNative.join(", ")}` : ""}`,
+    )
+  }
+  return expected
+}
+
+/** Publish under an isolated per-version candidate tag. Every missing package
+ * gets one initial submission and, after a full visibility window, at most one
+ * repair submission from the same cached tgz. */
+export async function stageCandidateRelease(artifacts: PackedPackage[], options: NpmCommandOptions = {}) {
+  const ordered = exactReleaseArtifacts(artifacts)
+  const version = ordered[0].version
+  const tag = releaseCandidateTag(version)
+  const inspected = await Promise.all(ordered.map((artifact) => inspectPublishedPackage(artifact, options)))
+  const absent = ordered.filter((_, index) => !inspected[index])
+
+  for (const artifact of absent) await submitCandidatePackageOnce(artifact, tag, options, "initial")
+  const repair = await waitForPublishedSet(ordered, options)
+  for (const artifact of repair) await submitCandidatePackageOnce(artifact, tag, options, "repair")
+  const unresolved = repair.length > 0 ? await waitForPublishedSet(ordered, options) : []
+  if (unresolved.length > 0) {
+    throw new Error(
+      `npm candidate remains incomplete after one repair round: ${unresolved.map((item) => item.name).join(", ")}`,
+    )
+  }
+
+  await verifyPublishedPackageIntegrities(ordered, options)
+  await verifyReleaseOptionalDependencies(ordered, options)
+  await ensureReleaseStagingTags(ordered, tag, options)
+  return { tag, version }
 }
 
 export async function publishPackage(
@@ -529,37 +735,51 @@ export async function ensureReleaseStagingTags(
   }
 }
 
-export async function promoteRelease(artifacts: PackedPackage[], options: NpmCommandOptions = {}) {
-  const byName = new Map(artifacts.map((artifact) => [artifact.name, artifact]))
-  const ordered = releasePromotionNames().map((name) => {
-    const artifact = byName.get(name)
-    if (!artifact) throw new Error(`Missing release artifact for promotion: ${name}`)
-    return artifact
-  })
+export async function verifyReleaseTags(artifacts: PackedPackage[], tag: string, options: NpmCommandOptions = {}) {
+  const ordered = exactReleaseArtifacts(artifacts)
+  const failures: string[] = []
+  for (const artifact of ordered) {
+    const tags = await distTags(artifact.name, options)
+    if (tags[tag] !== artifact.version) {
+      failures.push(`${artifact.name}=${tags[tag] ?? "unset"}`)
+    }
+  }
+  if (failures.length > 0) {
+    throw new Error(`npm ${tag} snapshot does not match the candidate: ${failures.join(", ")}`)
+  }
+}
+
+export async function promoteReleaseToTag(artifacts: PackedPackage[], tag: string, options: NpmCommandOptions = {}) {
+  if (!/^[a-z][a-z0-9._-]*$/i.test(tag)) throw new Error(`Invalid npm promotion tag: ${tag}`)
+  const ordered = exactReleaseArtifacts(artifacts)
   const previous = new Map<string, string | undefined>()
-  for (const artifact of ordered) previous.set(artifact.name, (await distTags(artifact.name, options)).latest)
+  for (const artifact of ordered) previous.set(artifact.name, (await distTags(artifact.name, options))[tag])
   try {
     for (const artifact of ordered) {
       if (previous.get(artifact.name) === artifact.version) continue
-      await addDistTag(artifact.name, artifact.version, "latest", options)
-      console.log(`  promoted ${artifact.name}@${artifact.version} to latest`)
+      await addDistTag(artifact.name, artifact.version, tag, options)
+      console.log(`  promoted ${artifact.name}@${artifact.version} to ${tag}`)
     }
   } catch (error) {
     const rollbackErrors: unknown[] = []
     for (const artifact of [...ordered].reverse()) {
       try {
         const prior = previous.get(artifact.name)
-        if (prior) await addDistTag(artifact.name, prior, "latest", options)
-        else await removeDistTag(artifact.name, "latest", options)
+        if (prior) await addDistTag(artifact.name, prior, tag, options)
+        else await removeDistTag(artifact.name, tag, options)
       } catch (rollbackError) {
         rollbackErrors.push(rollbackError)
       }
     }
     if (rollbackErrors.length > 0) {
-      throw new AggregateError([error, ...rollbackErrors], "npm latest promotion failed and rollback was incomplete")
+      throw new AggregateError([error, ...rollbackErrors], `npm ${tag} promotion failed and rollback was incomplete`)
     }
     throw error
   }
+}
+
+export async function promoteRelease(artifacts: PackedPackage[], options: NpmCommandOptions = {}) {
+  await promoteReleaseToTag(artifacts, "latest", options)
 }
 
 if (import.meta.main) {

--- a/tooling/repo/npm-test-release.ts
+++ b/tooling/repo/npm-test-release.ts
@@ -1,0 +1,51 @@
+#!/usr/bin/env bun
+
+import {
+  assertReleaseVersionUnoccupied,
+  loadReleaseArtifacts,
+  preflightRelease,
+  promoteReleaseToTag,
+  releaseCandidateTag,
+  stageCandidateRelease,
+  verifyPublishedPackageIntegrities,
+  verifyReleaseOptionalDependencies,
+  verifyReleaseTags,
+} from "./npm-release"
+import { assertReleaseSource } from "./release-workspace"
+
+const command = process.argv[2]
+if (!command || !["assert-empty", "stage", "promote-test"].includes(command)) {
+  throw new Error("Usage: npm-test-release.ts <assert-empty|stage|promote-test>")
+}
+
+const version = process.env.OPENSCIENCE_VERSION
+const source = process.env.OPENSCIENCE_ARTIFACT_SOURCE
+if (!version) throw new Error("OPENSCIENCE_VERSION is required")
+if (!source || !/^[0-9a-f]{40}$/i.test(source)) {
+  throw new Error("OPENSCIENCE_ARTIFACT_SOURCE must be an immutable commit SHA")
+}
+await assertReleaseSource(source)
+
+if (command === "assert-empty") {
+  await assertReleaseVersionUnoccupied(version)
+  console.log(`Confirmed that all npm package slots for ${version} are empty`)
+  process.exit(0)
+}
+
+const directory = process.env.OPENSCIENCE_NPM_ARTIFACT_DIR
+if (!directory) throw new Error("OPENSCIENCE_NPM_ARTIFACT_DIR is required")
+const artifacts = await loadReleaseArtifacts({ directory, source, version })
+await preflightRelease()
+
+if (command === "stage") {
+  const candidate = await stageCandidateRelease(artifacts)
+  console.log(`Staged and verified all ${artifacts.length} immutable packages under ${candidate.tag}`)
+  process.exit(0)
+}
+
+await verifyPublishedPackageIntegrities(artifacts)
+await verifyReleaseOptionalDependencies(artifacts)
+await verifyReleaseTags(artifacts, releaseCandidateTag(version))
+await promoteReleaseToTag(artifacts, "test")
+await verifyReleaseTags(artifacts, "test")
+console.log(`Promoted the verified ${artifacts.length}-package snapshot to npm test`)


### PR DESCRIPTION
## Summary
- cache one immutable 15-package artifact set per source and test version
- stage candidates without moving `test`, repair one acknowledged-but-missing upload from the same tarball, and fail closed without the cache
- promote `test` only after exact-version browser, OS, and Alpine musl smoke tests pass

## Validation
- 34 focused release tests on Bun 1.3.14
- full installation suite 64/64 during implementation
- root typecheck 7/7
- actionlint, Prettier, and diff check

`latest` is never touched by this workflow.