### PR TITLE
fix: root npm release artifacts at checkout

### DIFF
--- a/backend/cli/test/installation/release-order.test.ts
+++ b/backend/cli/test/installation/release-order.test.ts
@@ -1,5 +1,16 @@
 import { expect, test } from "bun:test"
 import path from "path"
+import { releaseRoot, resolveReleasePath } from "../../../../tooling/repo/release-workspace"
+
+test("npm artifact output remains rooted at the release checkout after nested builds change cwd", async () => {
+  const relative = ".release/npm-test/2.0.32-test.example"
+  const absolute = path.join(releaseRoot, relative)
+  const prepare = await Bun.file(path.join(import.meta.dir, "../../../../tooling/repo/prepare-npm.ts")).text()
+
+  expect(resolveReleasePath(relative)).toBe(absolute)
+  expect(resolveReleasePath(absolute)).toBe(absolute)
+  expect(prepare).toContain("const output = resolveReleasePath(outputInput)")
+})
 
 test("production publish verifies every package before the one guarded release-tag move", async () => {
   const script = await Bun.file(path.join(import.meta.dir, "../../../../tooling/repo/publish.ts")).text()

--- a/tooling/repo/prepare-npm.ts
+++ b/tooling/repo/prepare-npm.ts
@@ -6,7 +6,7 @@ import { $ } from "bun"
 import { Script } from "@synsci/script"
 import { assertPublicPackageSurface, createWrapperPackageManifest } from "../../backend/cli/script/publish-manifest"
 import { createCompiledPackageManifest, packPackage, saveReleaseArtifacts, type PackedPackage } from "./npm-release"
-import { assertReleaseSource, releaseRoot, setWorkspaceVersion } from "./release-workspace"
+import { assertReleaseSource, releaseRoot, resolveReleasePath, setWorkspaceVersion } from "./release-workspace"
 
 const source = await assertReleaseSource()
 const artifactSource = process.env.OPENSCIENCE_ARTIFACT_SOURCE
@@ -14,8 +14,9 @@ if (!artifactSource || !/^[0-9a-f]{40}$/i.test(artifactSource)) {
   throw new Error("OPENSCIENCE_ARTIFACT_SOURCE must be an immutable commit SHA")
 }
 const version = Script.version
-const output = process.env.OPENSCIENCE_NPM_ARTIFACT_DIR
-if (!output) throw new Error("OPENSCIENCE_NPM_ARTIFACT_DIR is required")
+const outputInput = process.env.OPENSCIENCE_NPM_ARTIFACT_DIR
+if (!outputInput) throw new Error("OPENSCIENCE_NPM_ARTIFACT_DIR is required")
+const output = resolveReleasePath(outputInput)
 
 await setWorkspaceVersion(version)
 await import("../sdk/js/script/build.ts")

--- a/tooling/repo/release-workspace.ts
+++ b/tooling/repo/release-workspace.ts
@@ -1,6 +1,11 @@
 import { $ } from "bun"
+import path from "path"
 
 export const releaseRoot = new URL("../..", import.meta.url).pathname
+
+export function resolveReleasePath(value: string) {
+  return path.isAbsolute(value) ? value : path.resolve(releaseRoot, value)
+}
 
 export async function assertReleaseSource(expected = process.env.OPENSCIENCE_RELEASE_SOURCE) {
   if (!expected || !/^[0-9a-f]{40}$/i.test(expected)) {


### PR DESCRIPTION
## Summary
- resolve npm release artifact directories against the repository root before nested SDK builds can change the process working directory
- cover relative and absolute artifact paths with a release regression

## Test Coverage
- 35 focused release tests passed (246 assertions)
- monorepo typecheck passed (7/7)

## Pre-Landing Review
No issues found.

## Design Review
No frontend files changed.

## Test plan
- [x] Bun 1.3.14 release-order and npm-release suites
- [x] Full monorepo typecheck
- [x] Prettier and git diff checks