### PR TITLE
fix: share packaged e2e account state

### DIFF
--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -298,6 +298,8 @@ jobs:
             echo "VITE_OPENSCIENCE_SERVER_PASSWORD=$PASS"
             echo "OPENSCIENCE_E2E_ROOT=$RUNNER_TEMP/openscience-e2e"
             echo "OPENSCIENCE_TEST_HOME=$RUNNER_TEMP/openscience-e2e/home"
+            echo "OPENSCIENCE_CONFIG_DIR=$RUNNER_TEMP/openscience-e2e/config/openscience"
+            echo "OPENSCIENCE_DATA_DIR=$RUNNER_TEMP/openscience-e2e/data"
             echo "XDG_DATA_HOME=$RUNNER_TEMP/openscience-e2e/share"
             echo "XDG_CACHE_HOME=$RUNNER_TEMP/openscience-e2e/cache"
             echo "XDG_CONFIG_HOME=$RUNNER_TEMP/openscience-e2e/config"
@@ -326,7 +328,9 @@ jobs:
           exit 1
       - name: Seed OpenScience data
         working-directory: backend/cli
-        run: bun script/seed-e2e.ts
+        run: |
+          bun script/seed-e2e.ts
+          test -s "$OPENSCIENCE_DATA_DIR/openscience-session.json"
         env:
           OPENSCIENCE_DISABLE_SHARE: "true"
           OPENSCIENCE_DISABLE_LSP_DOWNLOAD: "true"
@@ -357,7 +361,15 @@ jobs:
       - name: Wait for published OpenScience server
         run: |
           for _ in $(seq 1 120); do
-            curl -fsS "http://127.0.0.1:4096/global/health" > /dev/null && exit 0
+            if curl -fsS "http://127.0.0.1:4096/global/health" > /dev/null; then
+              SESSION=$(curl -fsS -u "openscience:$OPENSCIENCE_SERVER_PASSWORD" \
+                "http://127.0.0.1:4096/account/session")
+              if [[ "$SESSION" == '{"session":true}' ]]; then
+                exit 0
+              fi
+              echo "::error::published OpenScience server did not load the isolated account session"
+              exit 1
+            fi
             sleep 1
           done
           echo "::error::published openscience server never became healthy on 127.0.0.1:4096"

--- a/backend/cli/test/installation/release-order.test.ts
+++ b/backend/cli/test/installation/release-order.test.ts
@@ -186,6 +186,15 @@ test("packaged npm rehearsal imports every public SDK and plugin export", async 
   }
 })
 
+test("packaged npm rehearsal pins and verifies one account data root", async () => {
+  const workflow = await Bun.file(path.join(import.meta.dir, "../../../../.github/workflows/npm-test.yml")).text()
+
+  expect(workflow).toContain('echo "OPENSCIENCE_DATA_DIR=$RUNNER_TEMP/openscience-e2e/data"')
+  expect(workflow).toContain('test -s "$OPENSCIENCE_DATA_DIR/openscience-session.json"')
+  expect(workflow).toContain('"http://127.0.0.1:4096/account/session"')
+  expect(workflow).toContain('[[ "$SESSION" == \'{"session":true}\' ]]')
+})
+
 test("npm test rehearsal stages immutable exact artifacts and promotes only after every smoke gate", async () => {
   const workflow = await Bun.file(path.join(import.meta.dir, "../../../../.github/workflows/npm-test.yml")).text()
   const helper = await Bun.file(path.join(import.meta.dir, "../../../../tooling/repo/npm-test-release.ts")).text()


### PR DESCRIPTION
## Summary
- pin the packaged E2E source seeder and compiled server to one explicit config/data root
- verify the seeded account file exists before launch
- verify the packaged server loads that account before Playwright starts

## Validation
- Bun 1.3.14 release contracts: 36 passed
- root typecheck: 7/7
- actionlint
- Prettier and git diff check

Root cause of rehearsal 32773798709: every UI test received openscience_account_required because source seeding and the compiled package did not share an explicit account data root. All 15 packages, SDK/plugin imports, and five native/OS smoke jobs passed; test promotion correctly remained skipped.