### PR TITLE
fix: ignore internal release archives

### DIFF
--- a/tooling/repo/release-assets.ts
+++ b/tooling/repo/release-assets.ts
@@ -15,7 +15,11 @@ async function sha256(file: string) {
 
 const directory = path.resolve(process.argv[2] ?? "backend/cli/dist")
 const files = (await readdir(directory))
-  .filter((file) => file === "checksums.txt" || file.endsWith(".zip") || file.endsWith(".tar.gz"))
+  .filter(
+    (file) =>
+      file === "checksums.txt" ||
+      (file.startsWith("openscience-") && (file.endsWith(".zip") || file.endsWith(".tar.gz"))),
+  )
   .sort()
 const expected = [
   "checksums.txt",


### PR DESCRIPTION
Production 2.0.32 stopped before npm because the release uploader treated internal skills.tar.gz as a public binary archive. Restrict release uploads to checksums.txt and openscience-* archives. No runtime/product code changed; npm remained untouched.