### PR TITLE
Align Ace copy with fixed auto-reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ openscience login          # connect this device once
 openscience wallet         # check the Ace wallet and auto-reload
 ```
 
-Ace has no subscription. Add **20 credits** for $20 plus the processing fee shown before payment. One credit is $1 of purchased wallet value shared by credit-backed model calls and enhanced search. Usage is debited at the underlying provider cost plus a 2% service margin. By default, Ace adds 20 credits when the balance falls below 5; change the amount, set a monthly limit, or turn it off anytime in Billing. BYOK, local-model, and eligible ChatGPT/Codex usage remain separate and never debit the wallet.
+Ace has no subscription. Add **20 credits** for $20 plus the processing fee shown before payment. One credit is $1 of purchased wallet value shared by credit-backed model calls and enhanced search. Usage is debited at the underlying provider cost plus a 2% service margin. Auto-reload is one on/off setting: when enabled, Ace adds 20 credits whenever the purchased balance falls below 2. Turning it off stops future automatic payments and leaves the remaining balance available. BYOK, local-model, and eligible ChatGPT/Codex usage remain separate and never debit the wallet.
 
 ## How it works
 

--- a/backend/cli/src/cli/cmd/billing.ts
+++ b/backend/cli/src/cli/cmd/billing.ts
@@ -52,7 +52,9 @@ const BillingTopupCommand = cmd({
     prompts.intro("openscience billing")
     prompts.log.info(`Open: ${BILLING_URL}`)
     prompts.log.info("20 credits add $20 to your wallet; the processing fee is shown separately at checkout.")
-    prompts.log.info("Auto-reload adds 20 credits below a 2-credit purchased balance; turn it on or off anytime in Billing.")
+    prompts.log.info(
+      "Auto-reload adds 20 credits below a 2-credit purchased balance; turn it on or off anytime in Billing.",
+    )
     prompts.log.info("Provider accounts and local models remain available and never draw down your wallet.")
     // Open the URL using execFile (no shell) so BILLING_URL can't be
     // interpreted as a shell expression. BILLING_URL itself is either an

--- a/backend/cli/src/cli/cmd/billing.ts
+++ b/backend/cli/src/cli/cmd/billing.ts
@@ -52,7 +52,7 @@ const BillingTopupCommand = cmd({
     prompts.intro("openscience billing")
     prompts.log.info(`Open: ${BILLING_URL}`)
     prompts.log.info("20 credits add $20 to your wallet; the processing fee is shown separately at checkout.")
-    prompts.log.info("Auto-reload adds 20 credits below a 5-credit balance; change or disable it anytime in Billing.")
+    prompts.log.info("Auto-reload adds 20 credits below a 2-credit purchased balance; turn it on or off anytime in Billing.")
     prompts.log.info("Provider accounts and local models remain available and never draw down your wallet.")
     // Open the URL using execFile (no shell) so BILLING_URL can't be
     // interpreted as a shell expression. BILLING_URL itself is either an

--- a/frontend/docs/src/content/openscience/gateway.mdx
+++ b/frontend/docs/src/content/openscience/gateway.mdx
@@ -40,7 +40,7 @@ OpenScience requires a free **Synthetic Sciences account** for installation iden
 
 **20 credits add $20 to your wallet.** One credit is $1 of wallet value shared by managed model calls and enhanced research search. Usage is debited at the underlying provider cost plus a 2% service margin. The payment-processing fee is shown separately before checkout.
 
-Auto-reload adds 20 credits when your balance falls below 5. You can change the reload amount or disable auto-reload anytime in Billing. There is no subscription and no scheduled monthly top-up.
+Auto-reload is one on/off setting. When enabled, it adds 20 credits whenever your purchased balance falls below 2. Turning it off stops future automatic payments and leaves the remaining balance available. There is no subscription and no scheduled monthly top-up.
 
 ## Routing and billing
 

--- a/frontend/landing/public/docs/assets/index-CTmABf3F.js
+++ b/frontend/landing/public/docs/assets/index-CTmABf3F.js
@@ -180,7 +180,7 @@ OpenScience requires a free **Synthetic Sciences account** for installation iden
 
 **20 credits add $20 to your wallet.** One credit is $1 of wallet value shared by managed model calls and enhanced research search. Usage is debited at the underlying provider cost plus a 2% service margin. The payment-processing fee is shown separately before checkout.
 
-Auto-reload adds 20 credits when your balance falls below 5. You can change the reload amount or disable auto-reload anytime in Billing. There is no subscription and no scheduled monthly top-up.
+Auto-reload is one on/off setting. When enabled, it adds 20 credits whenever your purchased balance falls below 2. Turning it off stops future automatic payments and leaves the remaining balance available. There is no subscription and no scheduled monthly top-up.
 
 ## Routing and billing
 

--- a/frontend/landing/public/docs/index.html
+++ b/frontend/landing/public/docs/index.html
@@ -14,7 +14,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
-    <script type="module" crossorigin src="/docs/assets/index-Csnw2bb1.js"></script>
+    <script type="module" crossorigin src="/docs/assets/index-CTmABf3F.js"></script>
     <link rel="stylesheet" crossorigin href="/docs/assets/index-BZ3vGriT.css">
   </head>
   <body>

--- a/frontend/landing/src/pages/Landing.test.ts
+++ b/frontend/landing/src/pages/Landing.test.ts
@@ -40,8 +40,10 @@ describe("OpenScience landing contract", () => {
   })
 
   test("explains Zen-style reload and separates the processing fee from credits", () => {
-    expect(landing).toContain("Reloads 20 credits below 5")
-    expect(landing).toContain("Change or disable it anytime")
+    expect(landing).toContain("Reloads 20 credits below 2")
+    expect(landing).toContain("Turn auto-reload off any time")
+    expect(landing).not.toContain("Set a monthly cap")
+    expect(landing).toContain("One on/off setting. Your remaining balance stays available.")
     expect(landing).toContain("Processing fee shown before payment")
     expect(landing).toContain("never added to your credit balance")
     expect(landing).not.toContain("Synthetic Scientists")
@@ -52,7 +54,7 @@ describe("OpenScience landing contract", () => {
       expect(source).toContain("20 credits")
       expect(source).toMatch(/pay[- ]as[- ]you[- ]go/i)
       expect(source).toMatch(/OpenRouter/i)
-      expect(source).toMatch(/below 5/i)
+      expect(source).toMatch(/below 2/i)
       expect(source).not.toMatch(/Ace\+/i)
       expect(source).not.toMatch(/Synthetic Scientists/i)
       expect(source).not.toMatch(/research quota/i)

--- a/frontend/landing/src/pages/Landing.tsx
+++ b/frontend/landing/src/pages/Landing.tsx
@@ -886,8 +886,8 @@ export default function Landing({
                 {[
                   ["Credit-backed models through OpenRouter", "A curated route without provider setup."],
                   ["One balance for models and enhanced search", "Free basic search still works without Ace."],
-                  ["Reloads 20 credits below 5", "On after card setup. Change or disable it anytime."],
-                  ["Stay in control", "Set a monthly cap and review every charge in Billing."],
+                  ["Reloads 20 credits below 2", "One on/off setting. Your remaining balance stays available."],
+                  ["Stay in control", "Turn auto-reload off any time and review every charge in Billing."],
                 ].map(([title, copy]) => (
                   <div key={title} className="bg-background/90 p-5">
                     <h3 className="text-[15px] leading-6 text-foreground/90">{title}</h3>


### PR DESCRIPTION
## Summary
- describe Ace as a fixed $20 reload below a $2 purchased Wallet balance
- remove the stale monthly-cap promise from public copy
- regenerate the shipped docs bundle

## Validation
- landing contract: 9 passed
- docs + landing production builds passed
- monorepo typecheck: 7/7 passed
- diff check passed