### PR TITLE
Restore reasoning trajectories and model options UI

### DIFF
--- a/frontend/ui/src/components/research-trace.test.ts
+++ b/frontend/ui/src/components/research-trace.test.ts
@@ -31,18 +31,43 @@ const lifecycle = (id: string, type: "step-start" | "step-finish", message: stri
   }) as ResearchTraceEntry
 
 describe("research trace presentation", () => {
-  test("keeps concrete tool operations chronological without semantic summaries", () => {
+  test("keeps provider-visible reasoning and tool operations chronological", () => {
     const trace = groupResearchTrace([
       lifecycle("start", "step-start", "msg"),
-      narrative("reason", "reasoning", "private provider reasoning", "msg"),
+      narrative("reason", "reasoning", "provider-visible reasoning bytes", "msg"),
       entry("read", "read", "Read paper.tex"),
       narrative("progress", "text", "intermediate assistant text", "msg"),
       entry("search", "websearch", "Find source"),
       lifecycle("finish", "step-finish", "msg"),
     ])
 
-    expect(trace.map((item) => item.kind)).toEqual(["part", "part"])
-    expect(trace.map((item) => (item.kind === "part" ? item.entry.part.id : "group"))).toEqual(["read", "search"])
+    expect(trace.map((item) => item.kind)).toEqual(["part", "part", "part", "part"])
+    expect(trace.map((item) => (item.kind === "part" ? item.entry.part.id : "group"))).toEqual([
+      "reason",
+      "read",
+      "progress",
+      "search",
+    ])
+    expect(trace[0]?.kind === "part" && trace[0].entry.part.type === "reasoning" && trace[0].entry.part.text).toBe(
+      "provider-visible reasoning bytes",
+    )
+  })
+
+  test("compacts repeated tool families without dropping interleaved reasoning", () => {
+    const trace = groupResearchTrace([
+      narrative("reason-1", "reasoning", "First thought", "msg-1"),
+      entry("read", "read", "Read paper.tex", "completed", "msg-1"),
+      lifecycle("finish", "step-finish", "msg-1"),
+      lifecycle("start", "step-start", "msg-2"),
+      narrative("reason-2", "reasoning", "Second thought", "msg-2"),
+      entry("grep", "grep", "Find citations", "completed", "msg-2"),
+    ])
+
+    expect(trace).toHaveLength(1)
+    expect(trace[0]?.kind).toBe("group")
+    if (trace[0]?.kind !== "group") throw new Error("expected grouped context phase")
+    expect(trace[0].entries.map((item) => item.part.id)).toEqual(["reason-1", "read", "reason-2", "grep"])
+    expect(trace[0].label).toBe("Reviewed 2 files and code searches")
   })
 
   test("omits hidden promoted tools from the inline activity list", () => {

--- a/frontend/ui/src/components/research-trace.ts
+++ b/frontend/ui/src/components/research-trace.ts
@@ -1,4 +1,4 @@
-import type { AssistantMessage, Part } from "@synsci/sdk/v2/client"
+import type { AssistantMessage, Part, ToolPart } from "@synsci/sdk/v2/client"
 
 export type ResearchTraceEntry = {
   message: AssistantMessage
@@ -69,11 +69,29 @@ export function traceLabel(family: TraceFamily, count: number) {
   return `Completed ${count} research ${count === 1 ? "operation" : "operations"}`
 }
 
+function toolTitle(part: ToolPart) {
+  const state = part.state
+  if ("title" in state && typeof state.title === "string" && state.title.trim()) return state.title.trim()
+  const input = state.input ?? {}
+  const value = input.filePath ?? input.path ?? input.pattern ?? input.query ?? input.url ?? input.description
+  if (typeof value === "string" && value.trim()) return value.trim()
+  return part.tool
+}
+
 function compact(values: string[], limit = 3) {
   const unique = [...new Set(values)]
   const visible = unique.slice(0, limit)
   const hidden = unique.length - visible.length
   return [visible.join(" · "), hidden > 0 ? `+${hidden} more` : undefined].filter(Boolean).join(" · ")
+}
+
+function grouped(part: Part): part is ToolPart {
+  if (part.type !== "tool") return false
+  if (part.state.status !== "completed") return false
+  if (part.tool === "task" || part.tool === "todowrite" || part.tool === "todoread" || part.tool === "planwrite") {
+    return false
+  }
+  return traceFamily(part.tool) !== "other"
 }
 
 function narrative(part: Part) {
@@ -84,13 +102,108 @@ function lifecycle(part: Part) {
   return part.type === "step-start" || part.type === "step-finish" || part.type === "snapshot" || part.type === "patch"
 }
 
-/** Keep the visible execution record chronological and literal. The previous
- * semantic grouping replaced concrete operations with generated phase labels,
- * which made ordinary turns read like a verbose audit report. */
+/**
+ * Keep provider-visible reasoning and intermediate text byte-for-byte in their
+ * chronological position. Only repeated completed tools are compacted; opening
+ * a group always reveals the literal operations and surrounding reasoning.
+ */
 export function groupResearchTrace(entries: ResearchTraceEntry[]): ResearchTraceItem[] {
-  return entries
-    .filter((entry) => !entry.hidden && !lifecycle(entry.part) && !narrative(entry.part))
-    .map((entry) => ({ kind: "part" as const, entry }))
+  const output: ResearchTraceItem[] = []
+  const state = {
+    phase: undefined as
+      | {
+          family: TraceFamily
+          entries: ResearchTraceEntry[]
+          tools: ResearchTraceEntry[]
+        }
+      | undefined,
+    bridge: [] as ResearchTraceEntry[],
+  }
+
+  const parts = (items: ResearchTraceEntry[]) => {
+    for (const entry of items) output.push({ kind: "part", entry })
+  }
+
+  const flush = () => {
+    const phase = state.phase
+    if (!phase) return
+    if (phase.tools.length === 1) {
+      parts(phase.entries)
+      state.phase = undefined
+      return
+    }
+
+    output.push({
+      kind: "group",
+      id: `trace-${phase.tools[0].part.id}-${phase.tools.at(-1)!.part.id}`,
+      family: phase.family,
+      label: traceLabel(phase.family, phase.tools.length),
+      detail: compact(phase.tools.map((entry) => toolTitle(entry.part as ToolPart))),
+      entries: phase.entries,
+    })
+    state.phase = undefined
+  }
+
+  for (const entry of entries) {
+    if (lifecycle(entry.part)) continue
+
+    if (entry.hidden) {
+      if (state.phase) {
+        state.phase.entries.push(...state.bridge)
+        state.bridge = []
+        flush()
+      } else {
+        parts(state.bridge)
+        state.bridge = []
+      }
+      continue
+    }
+
+    if (narrative(entry.part)) {
+      state.bridge.push(entry)
+      continue
+    }
+
+    if (!grouped(entry.part)) {
+      if (state.phase) {
+        state.phase.entries.push(...state.bridge)
+        state.bridge = []
+        flush()
+      } else {
+        parts(state.bridge)
+        state.bridge = []
+      }
+      output.push({ kind: "part", entry })
+      continue
+    }
+
+    const family = traceFamily(entry.part.tool)
+    if (!state.phase) {
+      state.phase = { family, entries: [...state.bridge, entry], tools: [entry] }
+      state.bridge = []
+      continue
+    }
+
+    if (state.phase.family === family) {
+      state.phase.entries.push(...state.bridge, entry)
+      state.phase.tools.push(entry)
+      state.bridge = []
+      continue
+    }
+
+    flush()
+    state.phase = { family, entries: [...state.bridge, entry], tools: [entry] }
+    state.bridge = []
+  }
+
+  if (state.phase) {
+    state.phase.entries.push(...state.bridge)
+    state.bridge = []
+    flush()
+  } else {
+    parts(state.bridge)
+  }
+  return output
 }
 
 export function summarizeTaskActivity(items: TaskActivity[]): TaskActivityGroup[] {

--- a/frontend/ui/src/components/session-turn-science-results.test.ts
+++ b/frontend/ui/src/components/session-turn-science-results.test.ts
@@ -69,13 +69,14 @@ test("expanded steps render literal tool activity and first-class delegation res
   expect(css).toContain('[data-component="delegation-card"]')
 })
 
-test("activity hides provider reasoning and removes the execution-trace legend", () => {
+test("activity shows raw provider reasoning without the repetitive execution-trace legend", () => {
   const parts = readFileSync(fileURLToPath(new URL("./message-part.tsx", import.meta.url)), "utf8")
   const english = readFileSync(fileURLToPath(new URL("../i18n/en.ts", import.meta.url)), "utf8")
 
   expect(source).not.toContain('data-slot="session-turn-trace-legend"')
-  expect(source).toContain("hideReasoning")
+  expect(source).toContain("hideReasoning={false}")
+  expect(source).toContain("stripRedactedReasoning")
   expect(parts).toContain('data-origin="provider-reasoning"')
-  expect(english).toContain('"ui.sessionTurn.steps.show": "Show activity"')
+  expect(english).toContain('"ui.sessionTurn.steps.show": "Show reasoning and activity"')
   expect(english).not.toContain("model summaries are provider-generated")
 })

--- a/frontend/ui/src/components/session-turn.tsx
+++ b/frontend/ui/src/components/session-turn.tsx
@@ -19,7 +19,14 @@ import { Binary } from "@synsci/util/binary"
 import { createEffect, createMemo, createSignal, For, Match, on, onCleanup, ParentProps, Show, Switch } from "solid-js"
 import { DiffChanges } from "./diff-changes"
 import { Message, Part } from "./message-part"
-import { artifactTypeLabel, artifactActions, generatedArtifacts, sessionErrorText, writtenFiles } from "./tool-display"
+import {
+  artifactTypeLabel,
+  artifactActions,
+  generatedArtifacts,
+  sessionErrorText,
+  stripRedactedReasoning,
+  writtenFiles,
+} from "./tool-display"
 import { Markdown } from "./markdown"
 import { Accordion } from "./accordion"
 import { StickyAccordionHeader } from "./sticky-accordion-header"
@@ -326,6 +333,8 @@ export function SessionTurn(
       if (!msgParts) continue
       for (const p of msgParts) {
         if (p?.type === "tool") return true
+        // Encrypted placeholders are continuation state, not readable UI.
+        if (p?.type === "reasoning" && stripRedactedReasoning(p.text ?? "").length > 0) return true
       }
     }
     return false
@@ -735,7 +744,7 @@ export function SessionTurn(
                           messages={assistantMessages()}
                           responsePartId={responsePartId()}
                           hideResponsePart={hideResponsePart()}
-                          hideReasoning
+                          hideReasoning={false}
                           hidePromotedTools
                         />
                         <Show when={error()}>

--- a/frontend/ui/src/i18n/en.ts
+++ b/frontend/ui/src/i18n/en.ts
@@ -14,10 +14,10 @@ export const dict = {
   "ui.lineComment.placeholder": "Add comment",
   "ui.lineComment.submit": "Comment",
 
-  "ui.sessionTurn.steps.show": "Show activity",
-  "ui.sessionTurn.steps.hide": "Hide activity",
-  "ui.sessionTurn.trace.title": "Activity",
-  "ui.sessionTurn.trace.detail": "Tool activity from this response.",
+  "ui.sessionTurn.steps.show": "Show reasoning and activity",
+  "ui.sessionTurn.steps.hide": "Hide reasoning and activity",
+  "ui.sessionTurn.trace.title": "Reasoning and activity",
+  "ui.sessionTurn.trace.detail": "Provider-visible reasoning and recorded tool activity.",
   "ui.sessionTurn.summary.response": "Response",
   "ui.sessionTurn.diff.showMore": "Show more changes ({{count}})",
 

--- a/frontend/workspace/src/components/model-settings-popover.css
+++ b/frontend/workspace/src/components/model-settings-popover.css
@@ -539,16 +539,17 @@
 }
 
 [data-model-effort-panel] {
-  padding: 0;
+  padding: 2px;
 }
 
 [data-model-popover-kind="effort"] {
-  width: min(272px, calc(100vw - 24px));
-  max-height: min(72dvh, 320px);
+  width: min(344px, calc(100vw - 24px));
+  max-height: min(72dvh, 440px);
 }
 
 [data-model-popover-kind="effort"] .model-settings-popover__body {
-  overflow: visible;
+  overflow-y: auto;
+  overscroll-behavior: contain;
   padding: 5px;
 }
 
@@ -559,8 +560,8 @@
 }
 
 [data-model-settings-popover][data-model-popover-kind="effort"] [data-model-option="effort"].model-settings-row {
-  min-height: 36px;
-  padding: 0 9px;
+  min-height: 44px;
+  padding: 5px 9px;
   border: 1px solid transparent;
   background: transparent;
 }
@@ -577,21 +578,38 @@
 [data-model-popover-kind="effort"] [data-model-menu-label] {
   display: block;
   overflow: visible;
-  padding-block: 1px;
-  line-height: 20px;
+  line-height: 18px;
+}
+
+.model-settings-speed-section {
+  margin-top: 6px;
+  padding-top: 6px;
+  border-top: 1px solid var(--model-control-border);
 }
 
 [data-model-fast-toggle] {
-  margin-top: 5px;
-  padding: 7px 8px 1px;
-  border-top: 1px solid var(--model-control-border);
+  border-radius: var(--radius-sm);
+  transition:
+    background-color 150ms ease,
+    color 150ms ease,
+    transform 150ms ease;
+}
+
+[data-model-fast-toggle]:hover,
+[data-model-fast-toggle]:focus-within {
+  background: var(--model-control-hover);
 }
 
 [data-model-fast-toggle] [data-component="switch"] {
   width: 100%;
-  min-height: 36px;
+  min-height: 48px;
   justify-content: space-between;
+  padding: 5px 9px;
   cursor: pointer;
+}
+
+[data-model-fast-toggle]:active {
+  transform: scale(0.99);
 }
 
 .model-settings-fast-label {
@@ -609,7 +627,7 @@
   }
 
   [data-model-settings-popover][data-model-popover-kind="effort"] {
-    width: min(272px, calc(100vw - 24px));
+    width: min(344px, calc(100vw - 24px));
   }
 
   [data-model-settings-popover]:not([data-model-settings-view="root"]) [data-model-settings-layout] {
@@ -747,10 +765,6 @@
     font-size: 14px;
   }
 
-  [data-model-popover-kind="effort"] {
-    max-height: min(336px, calc(100dvh - 16px)) !important;
-  }
-
   [data-model-popover-kind="effort"] .model-settings-popover__body {
     padding: 8px 14px calc(10px + env(safe-area-inset-bottom));
   }
@@ -767,13 +781,8 @@
     line-height: 18px;
   }
 
-  [data-model-fast-toggle] {
-    margin-top: 8px;
-    padding-inline: 4px;
-  }
-
   [data-model-fast-toggle] [data-component="switch"] {
-    min-height: 44px;
+    min-height: 52px;
   }
 
   [data-model-settings-popover] [data-model-menu-label],

--- a/frontend/workspace/src/components/model-settings-popover.test.ts
+++ b/frontend/workspace/src/components/model-settings-popover.test.ts
@@ -268,7 +268,8 @@ describe("reasoning effort and Fast mode", () => {
     expect(supported.querySelectorAll('[data-component="switch"]')).toHaveLength(1)
     expect(supported.querySelector("[data-model-fast-toggle]")).not.toBeNull()
     expect(supported.textContent).toContain("Fast mode")
-    expect(supported.textContent).not.toContain("Response speed")
+    expect(supported.textContent).toContain("Response speed")
+    expect(supported.textContent).toContain("Prefer faster responses")
 
     const fastOnly = mount(() =>
       web.createComponent(subject.ModelEffortPanel, {

--- a/frontend/workspace/src/components/model-settings-popover.tsx
+++ b/frontend/workspace/src/components/model-settings-popover.tsx
@@ -260,6 +260,7 @@ export const ModelEffortPanel: Component<ModelEffortPanelProps> = (props) => (
   <div data-model-effort-panel>
     <Show when={props.options.length > 0}>
       <section class="model-settings-option-section" aria-label="Reasoning effort">
+        <div class="model-settings-heading">Reasoning effort</div>
         <ModelOptionList
           id="model-effort-options"
           kind="effort"
@@ -272,11 +273,17 @@ export const ModelEffortPanel: Component<ModelEffortPanelProps> = (props) => (
     </Show>
     <Show when={props.fast}>
       {(fast) => (
-        <div data-model-fast-toggle>
-          <Switch checked={fast().active} onChange={(checked) => props.onTierSelect(checked ? "fast" : "standard")}>
-            <span class="model-settings-fast-label">Fast mode</span>
-          </Switch>
-        </div>
+        <section class="model-settings-option-section model-settings-speed-section" aria-label="Response speed">
+          <div class="model-settings-heading">Response speed</div>
+          <div data-model-fast-toggle>
+            <Switch checked={fast().active} onChange={(checked) => props.onTierSelect(checked ? "fast" : "standard")}>
+              <span class="model-settings-setting">
+                <span class="model-settings-fast-label">Fast mode</span>
+                <small>Prefer faster responses when this route supports them</small>
+              </span>
+            </Switch>
+          </div>
+        </section>
       )}
     </Show>
   </div>
@@ -328,7 +335,7 @@ export const ModelEffortPopover: Component<ModelEffortPopoverProps> = (props) =>
       <ModelPopoverSurface
         kind="effort"
         view="effort"
-        title={props.options.length > 0 ? "Reasoning" : "Fast mode"}
+        title="Model options"
         close={() => setOpen(false)}
         initialFocus={
           props.options.length > 0

--- a/frontend/workspace/src/components/model-surface.test.ts
+++ b/frontend/workspace/src/components/model-surface.test.ts
@@ -104,6 +104,12 @@ describe("model control surface", () => {
     expect(styles).toContain("[data-model-settings-layout] {\n    display: block")
     expect(styles).not.toContain("grid-template-columns: minmax(0, 272px) minmax(0, 304px)")
     expect(styles).toContain("overflow-y: auto")
+    expect(styles).toMatch(
+      /\[data-model-popover-kind="effort"\] \.model-settings-popover__body\s*\{[^}]*overflow-y: auto;[^}]*overscroll-behavior: contain;/s,
+    )
+    expect(styles).not.toMatch(
+      /\[data-model-popover-kind="effort"\] \.model-settings-popover__body\s*\{[^}]*overflow: visible;/s,
+    )
     expect(styles).toContain("[data-model-effort-chip] strong")
     expect(styles).toContain("line-height: 20px")
     expect(styles).toContain(


### PR DESCRIPTION
## Summary

- restore provider-visible reasoning and intermediate text to the chronological trajectory while compacting only repeated tool operations
- keep encrypted reasoning placeholders hidden and remove repetitive Model summary / execution-trace banners
- make the reasoning and Fast mode dialog match the model selector width, interaction states, and scroll containment
- add clear Reasoning effort and Response speed sections with a full-row Fast mode control

This restores the trace contract from #325 and #333 without restoring their repetitive per-reasoning labels.

## Verification

- UI trace tests: 11 passed
- workspace model UI tests: 16 passed
- workspace typecheck passed
- full pre-push monorepo typecheck: 7/7 passed
- formatting and diff check passed