### PR TITLE
fix: restore conversational traces and context recovery

### DIFF
--- a/backend/cli/skills/writing/literature-review/SKILL.md
+++ b/backend/cli/skills/writing/literature-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: literature-review
-description: Conduct comprehensive, systematic literature reviews using multiple academic databases (PubMed, arXiv, bioRxiv, Semantic Scholar, etc.). This skill should be used when conducting systematic literature reviews, meta-analyses, research synthesis, or comprehensive literature searches across biomedical, scientific, and technical domains. Creates professionally formatted markdown documents and PDFs with verified citations in multiple citation styles (APA, Nature, Vancouver, etc.).
+description: Answer literature-review requests with a concise, source-grounded narrative by default. Escalate to PRISMA screening, evidence tables, figures, files, or PDFs only when the user explicitly asks for a systematic, scoping, or publication-formatted review.
 category: writing
 allowed-tools: [Read, Write, Edit, Bash]
 ---
@@ -9,13 +9,14 @@ allowed-tools: [Read, Write, Edit, Bash]
 
 ## Overview
 
-Conduct systematic, comprehensive literature reviews following rigorous academic methodology. Search multiple literature databases, synthesize findings thematically, verify all citations for accuracy, and generate professional output documents in markdown and PDF formats.
+Give the user a clear, conversational synthesis of the relevant literature. Verify citations, explain the field's consensus and disagreements, and scale the method and deliverables to the request.
 
 This skill integrates with multiple scientific skills for database access (gget, bioservices, datacommons-client) and provides specialized tools for citation verification, result aggregation, and document generation.
 
 ## When to Use This Skill
 
 Use this skill when:
+- Asking for an ordinary narrative literature review or research synthesis
 - Conducting a systematic literature review for research or publication
 - Synthesizing current knowledge on a specific topic across multiple sources
 - Performing meta-analysis or scoping reviews
@@ -24,46 +25,27 @@ Use this skill when:
 - Identifying research gaps and future directions
 - Requiring verified citations and professional formatting
 
-## Visual Enhancement with Scientific Schematics
+## Default: narrative review
 
-**⚠️ MANDATORY: Every literature review MUST include at least 1-2 AI-generated figures using the scientific-schematics skill.**
+Unless the user explicitly asks for a systematic/scoping review, meta-analysis, paper, report, PDF, or figure:
 
-This is not optional. Literature reviews without visual elements are incomplete. Before finalizing any document:
-1. Generate at minimum ONE schematic or diagram (e.g., PRISMA flow diagram for systematic reviews)
-2. Prefer 2-3 figures for comprehensive reviews (search strategy flowchart, thematic synthesis diagram, conceptual framework)
+- Answer in the conversation; do not create files.
+- Use a focused search that is broad enough to support the answer, not a fixed database or paper quota.
+- Synthesize by idea and evidence, not by narrating the workflow.
+- Include links or citations for the sources that materially support the answer.
+- Do not create PRISMA diagrams, screening logs, evidence matrices, schematics, or BibTeX appendices.
+- Do not generate images. A figure is an optional deliverable, never a completion requirement.
+- Stop when the question is answered. Do not turn a normal review into a publication pipeline.
 
-**How to generate figures:**
-- Use the **scientific-schematics** skill to generate AI-powered publication-quality diagrams
-- Simply describe your desired diagram in natural language
-- Nano Banana Pro will automatically generate, review, and refine the schematic
+## Explicit systematic-review mode
 
-**How to generate schematics:**
-```bash
-python scripts/generate_schematic.py "your diagram description" -o figures/output.png
-```
-
-The AI will automatically:
-- Create publication-quality images with proper formatting
-- Review and refine through multiple iterations
-- Ensure accessibility (colorblind-friendly, high contrast)
-- Save outputs in the figures/ directory
-
-**When to add schematics:**
-- PRISMA flow diagrams for systematic reviews
-- Literature search strategy flowcharts
-- Thematic synthesis diagrams
-- Research gap visualization maps
-- Citation network diagrams
-- Conceptual framework illustrations
-- Any complex concept that benefits from visualization
-
-For detailed guidance on creating schematics, refer to the scientific-schematics skill documentation.
+Use the structured workflow below only when the user clearly requests systematic, scoping, meta-analytic, comprehensive publication-grade, or PRISMA-style work. Confirm material scope or spend only when it is genuinely ambiguous.
 
 ---
 
 ## Core Workflow
 
-Literature reviews follow a structured, multi-phase workflow:
+Explicit systematic reviews follow a structured, multi-phase workflow:
 
 ### Phase 1: Planning and Scoping
 

--- a/backend/cli/src/agent/prompt/literature-review.txt
+++ b/backend/cli/src/agent/prompt/literature-review.txt
@@ -1,25 +1,23 @@
 <system-reminder>
-You are a literature review sub-agent — a specialist in PRISMA-style systematic literature
-search, evidence screening, citation verification, and research synthesis.
+You are a literature review sub-agent. Produce a focused, source-grounded narrative by
+default; use PRISMA-style screening only when the delegated request explicitly asks for a
+systematic, scoping, or publication-grade review.
 
 ## Mission
-You perform rigorous, systematic literature reviews following an adapted PRISMA workflow.
-You search multiple databases, screen results with explicit inclusion/exclusion criteria,
-verify every citation, assess evidence quality, detect contradictions, and return a
-structured synthesis with a PRISMA flow diagram. You are typically spawned in parallel with
-other literature-review agents, each covering a different facet of a broader review.
+Answer the assigned question directly, verify material citations, assess evidence quality,
+and explain consensus, contradictions, and gaps. Do not manufacture a report pipeline,
+figure, file, screening log, or fixed paper quota unless the request needs it.
 
 ## Depth: scale to the request
 Match your effort to the scope you are asked for:
-- **Focused facet** (a narrow question — one method, algorithm, or topic; "find papers on X"):
-  return 5-15 verified papers with BibTeX via targeted search and citation verification, and
-  skip the formal screening tables and PRISMA flow diagram. This is the fast path; primary
-  agents spawn many of these in parallel, one per facet.
+- **Narrative/focused review** (the default): return a concise thematic synthesis with the
+  sources needed to support it. Do not force BibTeX, a paper count, files, figures, or formal
+  screening artifacts unless requested.
 - **Broad survey** (an explicit systematic review, or a deliberately wide topic): run the full
   PRISMA workflow below — multi-database search, explicit inclusion/exclusion screening, 15-25
   papers, and a flow diagram.
-Default to the focused path unless the request clearly calls for a systematic review. Either
-way, every citation must be real and verified (see below).
+Default to the narrative path unless the request clearly calls for a systematic review.
+Either way, every citation must be real and verified (see below).
 
 Your approach is inspired by state-of-the-art AI research agents (PaperQA2's iterative
 refinement, Edison/Kosmos's structured synthesis, InsightAgent's provenance tracking, and
@@ -32,20 +30,22 @@ ASReview's systematic screening methodology).
 - If you cannot find a real paper for a claim, mark it [CITATION NEEDED] — never invent one
 - Return BibTeX entries for every paper you cite
 
-## CRITICAL: Skill-First
-Before ANY literature search, load the relevant skills:
-1. ALWAYS load: `research-lookup` (Perplexity-powered search), `citation-management` (BibTeX, DOI verification)
-2. ALWAYS load: `literature-review` (PRISMA methodology, search strategies)
-3. For domain-specific databases: load the appropriate database skill (see Database Skills below)
+## Skill use
+Load only the skills needed for the assigned question. For a normal narrative review, a
+search/retrieval skill is usually enough; load citation-management when exact bibliographic
+verification is material. Do not load PRISMA or database machinery just to satisfy a checklist.
+For an explicitly systematic review, load literature-review, citation-management, and the
+relevant domain databases before the systematic search.
 
 Use the `skill` tool to load each skill. Follow the workflows and search patterns from the loaded skills.
 
 ---
 
-## PRISMA-Adapted Systematic Review Workflow
+## PRISMA-Adapted Systematic Review Workflow (explicit systematic reviews only)
 
-Follow these 6 phases sequentially. This is a rigorous, PRISMA-compliant workflow adapted
-for AI agent execution.
+Follow these 6 phases sequentially only when the user explicitly requested systematic,
+scoping, meta-analytic, comprehensive publication-grade, or PRISMA-style work. For a normal
+literature review, do not enter this workflow; return the concise narrative synthesis.
 
 ### Phase 1: IDENTIFICATION — Multi-Source Search
 Cast a wide net across multiple sources. The goal is comprehensive recall.
@@ -149,9 +149,9 @@ Compile your findings into the output format below.
 
 ---
 
-## Output Format
+## Systematic-review output format
 
-Return your review as a structured report with ALL of the following sections:
+Only in explicit systematic-review mode, return a structured report with the following sections:
 
 ### PRISMA Flow Diagram
 ```

--- a/backend/cli/src/session/compaction.ts
+++ b/backend/cli/src/session/compaction.ts
@@ -49,7 +49,7 @@ export namespace SessionCompaction {
   // How many of the most-recent images to keep in full in the model request. Older
   // images are replaced with a text placeholder (they stay on disk, re-readable) so a
   // session that reads many figures can't bloat the window with re-shipped base64.
-  export const KEEP_RECENT_IMAGES = 5
+  export const KEEP_RECENT_IMAGES = 1
 
   // Flat per-image token cost for pruning decisions. A tool output's TEXT is tiny but
   // its image attachments are ~1-2k tokens each; counting only text made image-heavy
@@ -411,7 +411,7 @@ Output exactly this Markdown structure, keeping every section (write "(none)" wh
       if (part.type === "file") {
         // text/plain + directory files are folded into text upstream, not shipped as files.
         if (part.mime === "text/plain" || part.mime === "application/x-directory") continue
-        total += part.mime.startsWith("image/") ? IMAGE_TOKEN_ESTIMATE : Token.estimate(part.url)
+        total += part.mime.startsWith("image/") ? MessageV2.imageTokens(part.url) : Token.estimate(part.url)
         continue
       }
       if (part.type === "tool") {
@@ -423,7 +423,7 @@ Output exactly this Markdown structure, keeping every section (write "(none)" wh
           total += Token.estimate(compacted ? MessageV2.toolSummary(part.tool, part.state) : part.state.output)
           if (!compacted)
             for (const a of part.state.attachments ?? [])
-              total += a.mime.startsWith("image/") ? IMAGE_TOKEN_ESTIMATE : Token.estimate(a.url)
+              total += a.mime.startsWith("image/") ? MessageV2.imageTokens(a.url) : Token.estimate(a.url)
         }
         if (part.state.status === "error") total += Token.estimate(part.state.error)
       }
@@ -532,12 +532,9 @@ Output exactly this Markdown structure, keeping every section (write "(none)" wh
     let total = 0
     let pruned = 0
     const toPrune = []
-    let turns = 0
 
     loop: for (let msgIndex = msgs.length - 1; msgIndex >= 0; msgIndex--) {
       const msg = msgs[msgIndex]
-      if (msg.info.role === "user") turns++
-      if (turns < 2) continue
       if (msg.info.role === "assistant" && msg.info.summary) break loop
       for (let partIndex = msg.parts.length - 1; partIndex >= 0; partIndex--) {
         const part = msg.parts[partIndex]
@@ -546,8 +543,10 @@ Output exactly this Markdown structure, keeping every section (write "(none)" wh
             if (PRUNE_PROTECTED_TOOLS.includes(part.tool)) continue
 
             if (part.state.time.compacted) break loop
-            const images = (part.state.attachments ?? []).filter((a) => a.mime.startsWith("image/")).length
-            const estimate = Token.estimate(part.state.output) + images * IMAGE_TOKEN_ESTIMATE
+            const images = (part.state.attachments ?? [])
+              .filter((attachment) => attachment.mime.startsWith("image/"))
+              .reduce((sum, attachment) => sum + MessageV2.imageTokens(attachment.url), 0)
+            const estimate = Token.estimate(part.state.output) + images
             total += estimate
             if (total > PRUNE_PROTECT) {
               pruned += estimate

--- a/backend/cli/src/session/message-v2.ts
+++ b/backend/cli/src/session/message-v2.ts
@@ -568,22 +568,28 @@ export namespace MessageV2 {
     // P2.1: older tool outputs identical to a more recent call collapse to a back-ref.
     const superseded = supersededOutputs(input)
 
-    // Media budgeting. `stripMedia` (used for the compaction summary) drops ALL images;
-    // otherwise `keepRecentImages` keeps only the last N images in full and replaces
-    // older ones with a text placeholder — so re-shipping many figures every turn can't
-    // bloat the window. The image stays on disk and can be re-read on demand. Count up
-    // front so "last N" is well-defined; both passes visit images in input→part order.
+    // Media budgeting. `stripMedia` drops all images; otherwise keep only the last N
+    // unique images. A generated image followed by `read` commonly attaches the same
+    // bytes twice, so dedupe by payload rather than MIME or filename.
     const isImage = (mime: string) => mime.startsWith("image/")
-    let totalImages = 0
-    if (!options?.stripMedia && options?.keepRecentImages !== undefined) {
-      for (const msg of input)
-        for (const part of msg.parts) {
-          if (part.type === "file" && isImage(part.mime)) totalImages++
-          if (part.type === "tool" && part.state.status === "completed" && !part.state.time.compacted)
-            for (const a of part.state.attachments ?? []) if (isImage(a.mime)) totalImages++
-        }
+    const order: string[] = []
+    const add = (mime: string, url: string) => {
+      if (!isImage(mime)) return
+      const id = mediaIdentity(url)
+      const found = order.indexOf(id)
+      if (found >= 0) order.splice(found, 1)
+      order.push(id)
     }
-    let imagesSeen = 0
+    for (const msg of input)
+      for (const part of msg.parts) {
+        if (part.type === "file") add(part.mime, part.url)
+        if (part.type === "tool" && part.state.status === "completed" && !part.state.time.compacted)
+          for (const attachment of part.state.attachments ?? []) add(attachment.mime, attachment.url)
+      }
+    const retained = new Set(
+      options?.keepRecentImages === undefined ? order : order.slice(-Math.max(0, options.keepRecentImages)),
+    )
+    const emitted = new Set<string>()
     // Returns a placeholder string when this image occurrence should be dropped, else undefined.
     const dropImage = (mime: string, url: string, filename?: string): string | undefined => {
       if (!isImage(mime)) return undefined
@@ -592,11 +598,11 @@ export namespace MessageV2 {
       // nudge even when it is a recent image we would otherwise keep — shipping it would
       // 400 the request. Independent of the recency budget below.
       const oversized = oversizedImageNudge(url, filename)
-      if (options?.keepRecentImages === undefined) return oversized
-      const drop = imagesSeen < totalImages - options.keepRecentImages
-      imagesSeen++
       if (oversized) return oversized
-      return drop
+      const id = mediaIdentity(url)
+      if (emitted.has(id)) return DUPLICATE_IMAGE
+      emitted.add(id)
+      return !retained.has(id)
         ? `[older image omitted to save context${filename ? `: ${filename}` : ""} — read it again if you need it]`
         : undefined
     }
@@ -609,7 +615,7 @@ export namespace MessageV2 {
       if (typeof output === "object") {
         const outputObject = output as {
           text: string
-          attachments?: Array<{ mime: string; url: string }>
+          attachments?: Array<{ mime: string; url: string; filename?: string }>
         }
         const attachments = (outputObject.attachments ?? []).filter((attachment) => {
           return attachment.url.startsWith("data:") && attachment.url.includes(",")
@@ -627,7 +633,7 @@ export namespace MessageV2 {
               const mime = attachment.mime.startsWith("image/")
                 ? correctImageMimeFromBase64(attachment.mime, base64)
                 : attachment.mime
-              return { type: "media", mediaType: mime, data: base64 }
+              return { type: "media" as const, mediaType: mime, data: base64 }
             }),
           ],
         }
@@ -858,11 +864,23 @@ export namespace MessageV2 {
     )
   }
 
-  // Flat per-image token cost. An image's model cost bears no relation to its base64
-  // byte length, so a fixed estimate is what the reference tools use (claude-code /
-  // opencode 2000, hermes 1500). Single source of truth — SessionCompaction re-exports
-  // it as IMAGE_TOKEN_ESTIMATE (it can't import here without a cycle).
+  // Native multimodal endpoints usually charge a small pixel-based image budget, while
+  // OpenAI-compatible relays can tokenize inline base64 much more heavily. Use a flat
+  // floor for small images and a conservative inline estimate for preflight safety.
   export const IMAGE_TOKENS = 1600
+  export const INLINE_IMAGE_TOKEN_RATIO = 0.75
+  export const DUPLICATE_IMAGE =
+    "[Duplicate image omitted — byte-for-byte identical image content was already provided in this request.]"
+
+  export function mediaIdentity(url: string) {
+    const comma = url.indexOf(",")
+    return comma === -1 ? url : url.slice(comma + 1)
+  }
+
+  export function imageTokens(url: string) {
+    if (!url.startsWith("data:")) return IMAGE_TOKENS
+    return Math.max(IMAGE_TOKENS, Math.ceil(mediaIdentity(url).length * INLINE_IMAGE_TOKEN_RATIO))
+  }
 
   // Anthropic (and most providers) reject a single image over 5 MB with an HTTP 400.
   // P1's flat token estimate neither counts an oversized image accurately nor prevents
@@ -1008,9 +1026,14 @@ export namespace MessageV2 {
     for (const s of options?.system ?? []) out.system += Token.estimate(s)
     const superseded = supersededOutputs(input)
 
-    const addImages = (count: number) => {
-      out.image += count * IMAGE_TOKENS
-      out.images += count
+    const images = new Set<string>()
+    const addImage = (url: string) => {
+      const id = mediaIdentity(url)
+      if (images.has(id)) return false
+      images.add(id)
+      out.image += imageTokens(url)
+      out.images++
+      return true
     }
 
     for (const msg of input)
@@ -1028,7 +1051,7 @@ export namespace MessageV2 {
           if (part.mime.startsWith("image/")) {
             const nudge = oversizedImageNudge(part.url, part.filename)
             if (nudge) out.text += Token.estimate(nudge)
-            else addImages(1)
+            else if (!addImage(part.url)) out.text += Token.estimate(DUPLICATE_IMAGE)
           }
           continue
         }
@@ -1053,7 +1076,7 @@ export namespace MessageV2 {
                 if (a.mime.startsWith("image/")) {
                   const nudge = oversizedImageNudge(a.url, a.filename)
                   if (nudge) out[bucket] += Token.estimate(nudge)
-                  else addImages(1)
+                  else if (!addImage(a.url)) out[bucket] += Token.estimate(DUPLICATE_IMAGE)
                 }
           }
           if (part.state.status === "error") out[bucket] += Token.estimate(part.state.error)

--- a/backend/cli/src/session/retry.ts
+++ b/backend/cli/src/session/retry.ts
@@ -160,19 +160,22 @@ export namespace SessionRetry {
   // should compact + resume rather than retry.
   export function isContextOverflow(error: ReturnType<NamedError["toObject"]>): boolean {
     const { statusCode, code, type, message } = normalizeProviderError(error)
-    // A context-window rejection is always a client error (400/413). A 5xx is a
-    // genuine server fault, and 429 is a rate limit — both retryable, not overflow.
-    if (statusCode && statusCode >= 500) return false
     if (statusCode === 429) return false
     if (OVERFLOW_CODES.has(code) || OVERFLOW_CODES.has(type)) return true
     const lower = message.toLowerCase()
     // Catches transient failures with no statusCode (streamed error chunks) whose
     // text would otherwise match an overflow pattern — keep them retryable.
     if (RATELIMIT_PATTERNS.some((pattern) => lower.includes(pattern))) return false
-    return OVERFLOW_PATTERNS.some((pattern) => lower.includes(pattern))
+    // OpenRouter can wrap an upstream context rejection in a 502 with
+    // metadata.error_type=provider_unavailable. The explicit rejection remains
+    // deterministic; retrying the identical request cannot recover.
+    if (OVERFLOW_PATTERNS.some((pattern) => lower.includes(pattern))) return true
+    if (statusCode && statusCode >= 500) return false
+    return false
   }
 
   export function retryable(error: ReturnType<NamedError["toObject"]>) {
+    if (isContextOverflow(error)) return undefined
     if (MessageV2.APIError.isInstance(error)) {
       if (!error.data.isRetryable) return undefined
       return error.data.message.includes("Overloaded") ? "Provider is overloaded" : error.data.message

--- a/backend/cli/test/agent/harness-contract.test.ts
+++ b/backend/cli/test/agent/harness-contract.test.ts
@@ -127,6 +127,20 @@ test("the primary, domain, and specialist prompts stay adaptive instead of proce
   expect(explore).not.toContain("copying, moving")
 })
 
+test("ordinary literature reviews stay conversational instead of becoming report pipelines", async () => {
+  const [skill, specialist] = await Promise.all([
+    Bun.file(new URL("../../skills/writing/literature-review/SKILL.md", import.meta.url)).text(),
+    read("agent/prompt/literature-review.txt"),
+  ])
+  expect(skill).toContain("Default: narrative review")
+  expect(skill).toContain("do not create files")
+  expect(skill).toContain("Do not generate images")
+  expect(skill).not.toContain("Every literature review MUST")
+  expect(specialist).toContain("Default to the narrative path")
+  expect(specialist).toContain("do not enter this workflow")
+  expect(specialist).not.toContain("Before ANY literature search")
+})
+
 test("delegation is rare, bounded, and observable", async () => {
   const [prompt, source] = await Promise.all([read("tool/task.txt"), read("tool/task.ts")])
   expect(DELEGATION_PROFILES).toEqual(["explore", "execute"])

--- a/backend/cli/test/session/composition.test.ts
+++ b/backend/cli/test/session/composition.test.ts
@@ -114,6 +114,27 @@ describe("session.message-v2.composition", () => {
     expect(c.total).toBe(IMG)
   })
 
+  test("counts duplicate inline images once and reports the omitted copy", () => {
+    const input: MessageV2.WithParts[] = [
+      {
+        info: userInfo("u1"),
+        parts: [imageFilePart("u1", "i1", "a.png"), imageFilePart("u1", "i2", "copy.png")],
+      },
+    ]
+    const c = MessageV2.composition(input)
+    expect(c.image).toBe(IMG)
+    expect(c.images).toBe(1)
+    expect(c.text).toBeGreaterThan(0)
+  })
+
+  test("conservatively accounts for large inline image payloads", () => {
+    const part = imageFilePart("u1", "i1", "large.png") as MessageV2.FilePart
+    part.url = `data:image/png;base64,${"A".repeat(400_000)}`
+    const c = MessageV2.composition([{ info: userInfo("u1"), parts: [part] }])
+    expect(c.image).toBe(300_000)
+    expect(c.total).toBe(300_000)
+  })
+
   test("counts tool args + output under `tool`, attachment images under `image`", () => {
     const input: MessageV2.WithParts[] = [
       {

--- a/backend/cli/test/session/message-v2.test.ts
+++ b/backend/cli/test/session/message-v2.test.ts
@@ -126,7 +126,7 @@ describe("session.message-v2.toModelMessage — media budgeting", () => {
     type: "file" as const,
     mime: "image/png",
     filename: name,
-    url: "data:image/png;base64,Zm9v",
+    url: `data:image/png;base64,${Buffer.from(name).toString("base64")}`,
   })
   const imagesInput = (): MessageV2.WithParts[] => [
     {
@@ -154,6 +154,20 @@ describe("session.message-v2.toModelMessage — media budgeting", () => {
     const s = JSON.stringify(MessageV2.toModelMessages(imagesInput(), model))
     expect((s.match(/"type":"file"/g) ?? []).length).toBe(3)
     expect(s).not.toContain("image omitted")
+  })
+
+  test("ships byte-identical image content once even when it is attached twice", () => {
+    const duplicate = imagePart("i2", "a.png")
+    duplicate.url = imagePart("i1", "a.png").url
+    const input: MessageV2.WithParts[] = [
+      {
+        info: userInfo("m-imgs"),
+        parts: [imagePart("i1", "a.png"), duplicate] as MessageV2.Part[],
+      },
+    ]
+    const serialized = JSON.stringify(MessageV2.toModelMessages(input, model, { keepRecentImages: 1 }))
+    expect((serialized.match(/"type":"file"/g) ?? []).length).toBe(1)
+    expect(serialized).toContain(MessageV2.DUPLICATE_IMAGE)
   })
 })
 

--- a/backend/cli/test/session/retry.test.ts
+++ b/backend/cli/test/session/retry.test.ts
@@ -307,7 +307,7 @@ describe("SessionRetry.isContextOverflow", () => {
     expect(SessionRetry.isContextOverflow(err)).toBe(false)
   })
 
-  test("retries OpenRouter streamed provider-unavailable 502 instead of compacting it", () => {
+  test("compacts an explicit OpenRouter context overflow wrapped in provider-unavailable 502", () => {
     const err = wrap(
       JSON.stringify({
         error: {
@@ -317,8 +317,8 @@ describe("SessionRetry.isContextOverflow", () => {
         },
       }),
     )
-    expect(SessionRetry.isContextOverflow(err)).toBe(false)
-    expect(SessionRetry.retryable(err)).toBe("Provider is overloaded")
+    expect(SessionRetry.isContextOverflow(err)).toBe(true)
+    expect(SessionRetry.retryable(err)).toBeUndefined()
   })
 
   test("false for a plain rate limit", () => {

--- a/frontend/ui/src/components/research-trace.test.ts
+++ b/frontend/ui/src/components/research-trace.test.ts
@@ -53,7 +53,7 @@ describe("research trace presentation", () => {
     )
   })
 
-  test("compacts repeated tool families without dropping interleaved reasoning", () => {
+  test("keeps repeated tool families literal without dropping interleaved reasoning", () => {
     const trace = groupResearchTrace([
       narrative("reason-1", "reasoning", "First thought", "msg-1"),
       entry("read", "read", "Read paper.tex", "completed", "msg-1"),
@@ -63,11 +63,7 @@ describe("research trace presentation", () => {
       entry("grep", "grep", "Find citations", "completed", "msg-2"),
     ])
 
-    expect(trace).toHaveLength(1)
-    expect(trace[0]?.kind).toBe("group")
-    if (trace[0]?.kind !== "group") throw new Error("expected grouped context phase")
-    expect(trace[0].entries.map((item) => item.part.id)).toEqual(["reason-1", "read", "reason-2", "grep"])
-    expect(trace[0].label).toBe("Reviewed 2 files and code searches")
+    expect(trace.map((item) => item.entry.part.id)).toEqual(["reason-1", "read", "reason-2", "grep"])
   })
 
   test("omits hidden promoted tools from the inline activity list", () => {

--- a/frontend/ui/src/components/research-trace.ts
+++ b/frontend/ui/src/components/research-trace.ts
@@ -6,21 +6,10 @@ export type ResearchTraceEntry = {
   hidden?: boolean
 }
 
-export type ResearchTraceGroup = {
-  kind: "group"
-  id: string
-  family: TraceFamily
-  label: string
-  detail: string
-  entries: ResearchTraceEntry[]
+export type ResearchTraceItem = {
+  kind: "part"
+  entry: ResearchTraceEntry
 }
-
-export type ResearchTraceItem =
-  | {
-      kind: "part"
-      entry: ResearchTraceEntry
-    }
-  | ResearchTraceGroup
 
 export type TaskActivity = {
   id: string
@@ -69,15 +58,6 @@ export function traceLabel(family: TraceFamily, count: number) {
   return `Completed ${count} research ${count === 1 ? "operation" : "operations"}`
 }
 
-function toolTitle(part: ToolPart) {
-  const state = part.state
-  if ("title" in state && typeof state.title === "string" && state.title.trim()) return state.title.trim()
-  const input = state.input ?? {}
-  const value = input.filePath ?? input.path ?? input.pattern ?? input.query ?? input.url ?? input.description
-  if (typeof value === "string" && value.trim()) return value.trim()
-  return part.tool
-}
-
 function compact(values: string[], limit = 3) {
   const unique = [...new Set(values)]
   const visible = unique.slice(0, limit)
@@ -85,125 +65,18 @@ function compact(values: string[], limit = 3) {
   return [visible.join(" · "), hidden > 0 ? `+${hidden} more` : undefined].filter(Boolean).join(" · ")
 }
 
-function grouped(part: Part): part is ToolPart {
-  if (part.type !== "tool") return false
-  if (part.state.status !== "completed") return false
-  if (part.tool === "task" || part.tool === "todowrite" || part.tool === "todoread" || part.tool === "planwrite") {
-    return false
-  }
-  return traceFamily(part.tool) !== "other"
-}
-
-function narrative(part: Part) {
-  return part.type === "reasoning" || part.type === "text"
-}
-
 function lifecycle(part: Part) {
   return part.type === "step-start" || part.type === "step-finish" || part.type === "snapshot" || part.type === "patch"
 }
 
 /**
- * Keep provider-visible reasoning and intermediate text byte-for-byte in their
- * chronological position. Only repeated completed tools are compacted; opening
- * a group always reveals the literal operations and surrounding reasoning.
+ * Keep provider-visible reasoning, intermediate text, and every tool operation
+ * byte-for-byte in chronological order. Do not replace live activity with
+ * semantic summaries: those groups changed identity as each tool completed,
+ * remounted the trace, and made both the transcript and scroll position jump.
  */
 export function groupResearchTrace(entries: ResearchTraceEntry[]): ResearchTraceItem[] {
-  const output: ResearchTraceItem[] = []
-  const state = {
-    phase: undefined as
-      | {
-          family: TraceFamily
-          entries: ResearchTraceEntry[]
-          tools: ResearchTraceEntry[]
-        }
-      | undefined,
-    bridge: [] as ResearchTraceEntry[],
-  }
-
-  const parts = (items: ResearchTraceEntry[]) => {
-    for (const entry of items) output.push({ kind: "part", entry })
-  }
-
-  const flush = () => {
-    const phase = state.phase
-    if (!phase) return
-    if (phase.tools.length === 1) {
-      parts(phase.entries)
-      state.phase = undefined
-      return
-    }
-
-    output.push({
-      kind: "group",
-      id: `trace-${phase.tools[0].part.id}-${phase.tools.at(-1)!.part.id}`,
-      family: phase.family,
-      label: traceLabel(phase.family, phase.tools.length),
-      detail: compact(phase.tools.map((entry) => toolTitle(entry.part as ToolPart))),
-      entries: phase.entries,
-    })
-    state.phase = undefined
-  }
-
-  for (const entry of entries) {
-    if (lifecycle(entry.part)) continue
-
-    if (entry.hidden) {
-      if (state.phase) {
-        state.phase.entries.push(...state.bridge)
-        state.bridge = []
-        flush()
-      } else {
-        parts(state.bridge)
-        state.bridge = []
-      }
-      continue
-    }
-
-    if (narrative(entry.part)) {
-      state.bridge.push(entry)
-      continue
-    }
-
-    if (!grouped(entry.part)) {
-      if (state.phase) {
-        state.phase.entries.push(...state.bridge)
-        state.bridge = []
-        flush()
-      } else {
-        parts(state.bridge)
-        state.bridge = []
-      }
-      output.push({ kind: "part", entry })
-      continue
-    }
-
-    const family = traceFamily(entry.part.tool)
-    if (!state.phase) {
-      state.phase = { family, entries: [...state.bridge, entry], tools: [entry] }
-      state.bridge = []
-      continue
-    }
-
-    if (state.phase.family === family) {
-      state.phase.entries.push(...state.bridge, entry)
-      state.phase.tools.push(entry)
-      state.bridge = []
-      continue
-    }
-
-    flush()
-    state.phase = { family, entries: [...state.bridge, entry], tools: [entry] }
-    state.bridge = []
-  }
-
-  if (state.phase) {
-    state.phase.entries.push(...state.bridge)
-    state.bridge = []
-    flush()
-  } else {
-    parts(state.bridge)
-  }
-  return output
+  return entries.flatMap((entry) => (entry.hidden || lifecycle(entry.part) ? [] : [{ kind: "part", entry }]))
 }
 
 export function summarizeTaskActivity(items: TaskActivity[]): TaskActivityGroup[] {

--- a/frontend/ui/src/components/session-turn.tsx
+++ b/frontend/ui/src/components/session-turn.tsx
@@ -43,7 +43,7 @@ import { DateTime, DurationUnit, Interval } from "luxon"
 import { createAutoScroll } from "../hooks"
 import { createResizeObserver } from "@solid-primitives/resize-observer"
 import { lastResponseTextPart } from "./session-turn-response"
-import { groupResearchTrace, type ResearchTraceGroup } from "./research-trace"
+import { groupResearchTrace } from "./research-trace"
 
 type Translator = (key: UiI18nKey, params?: UiI18nParams) => string
 
@@ -160,49 +160,7 @@ function AssistantTrace(props: {
     ),
   )
 
-  return (
-    <For each={trace()}>
-      {(item) => (
-        <Show
-          when={item.kind === "group" ? (item as ResearchTraceGroup) : undefined}
-          fallback={
-            <Part
-              part={(item as { kind: "part"; entry: { part: PartType } }).entry.part}
-              message={(item as { kind: "part"; entry: { message: AssistantMessage } }).entry.message}
-            />
-          }
-        >
-          {(group) => <ResearchTraceGroupDisplay group={group()} />}
-        </Show>
-      )}
-    </For>
-  )
-}
-
-function ResearchTraceGroupDisplay(props: { group: ResearchTraceGroup }) {
-  const icon = () => {
-    if (props.group.family === "context") return "glasses" as const
-    if (props.group.family === "sources") return "window-cursor" as const
-    if (props.group.family === "commands") return "console" as const
-    if (props.group.family === "changes") return "code-lines" as const
-    if (props.group.family === "images") return "photo" as const
-    if (props.group.family === "skills") return "sparkles" as const
-    return "activity" as const
-  }
-
-  return (
-    <details data-component="research-trace-group" data-family={props.group.family}>
-      <summary>
-        <Icon name={icon()} size="small" />
-        <span data-slot="research-trace-group-label">{props.group.label}</span>
-        <span data-slot="research-trace-group-detail">{props.group.detail}</span>
-        <Icon name="chevron-down" size="small" />
-      </summary>
-      <div data-slot="research-trace-group-operations">
-        <For each={props.group.entries}>{(entry) => <Part part={entry.part} message={entry.message} />}</For>
-      </div>
-    </details>
-  )
+  return <For each={trace()}>{(item) => <Part part={item.entry.part} message={item.entry.message} />}</For>
 }
 
 export function SessionTurn(
@@ -469,7 +427,7 @@ export function SessionTurn(
   const responsePartId = createMemo(() => lastTextPart()?.id)
   const messageDiffs = createMemo(() => message()?.summary?.diffs ?? emptyDiffs)
   const hasDiffs = createMemo(() => messageDiffs().length > 0)
-  const hideResponsePart = createMemo(() => !working() && !!responsePartId())
+  const hideResponsePart = createMemo(() => !!responsePartId())
 
   const [copied, setCopied] = createSignal(false)
 
@@ -772,7 +730,7 @@ export function SessionTurn(
                         <For each={requestParts()}>{({ part, message }) => <Part part={part} message={message} />}</For>
                       </div>
                     </Show>
-                    <Show when={!working() && (response() || hasDiffs())}>
+                    <Show when={response() || hasDiffs()}>
                       <div data-slot="session-turn-summary-section">
                         <div data-slot="session-turn-summary-header">
                           <h2 data-slot="session-turn-summary-title">{i18n.t("ui.sessionTurn.summary.response")}</h2>

--- a/frontend/ui/src/hooks/create-auto-scroll.tsx
+++ b/frontend/ui/src/hooks/create-auto-scroll.tsx
@@ -16,6 +16,7 @@ export function createAutoScroll(options: AutoScrollOptions) {
   let autoTimer: ReturnType<typeof setTimeout> | undefined
   let cleanup: (() => void) | undefined
   let auto: { top: number; time: number } | undefined
+  let height = 0
 
   const threshold = () => options.bottomThreshold ?? 10
 
@@ -96,7 +97,6 @@ export function createAutoScroll(options: AutoScrollOptions) {
     const el = scroll
     if (!el) return
     if (!canScroll(el)) {
-      if (store.userScrolled) setStore("userScrolled", false)
       return
     }
     if (store.userScrolled) return
@@ -122,7 +122,6 @@ export function createAutoScroll(options: AutoScrollOptions) {
     if (!el) return
 
     if (!canScroll(el)) {
-      if (store.userScrolled) setStore("userScrolled", false)
       return
     }
 
@@ -163,14 +162,17 @@ export function createAutoScroll(options: AutoScrollOptions) {
 
   createResizeObserver(
     () => store.contentRef,
-    () => {
+    ({ height: next }) => {
       const el = scroll
-      if (el && !canScroll(el)) {
-        if (store.userScrolled) setStore("userScrolled", false)
-        return
-      }
+      const grew = next > height
+      height = next
+      if (el && !canScroll(el)) return
       if (!active()) return
       if (store.userScrolled) return
+      // A live trace can contract when a spinner or transient row disappears.
+      // Never interpret that contraction as new content worth following: doing
+      // so recaptures readers who are inspecting earlier activity.
+      if (!grew) return
       // ResizeObserver fires after layout, before paint.
       // Keep the bottom locked in the same frame to avoid visible
       // "jump up then catch up" artifacts while streaming content.
@@ -221,6 +223,8 @@ export function createAutoScroll(options: AutoScrollOptions) {
       scroll = el
 
       if (!el) return
+
+      height = store.contentRef?.getBoundingClientRect().height ?? 0
 
       updateOverflowAnchor(el)
       el.addEventListener("wheel", handleWheel, { passive: true })

--- a/frontend/workspace/src/pages/session.tsx
+++ b/frontend/workspace/src/pages/session.tsx
@@ -1115,7 +1115,9 @@ export default function Page(): JSX.Element {
                                   sessionID={params.id!}
                                   messageID={message.id}
                                   lastUserMessageID={lastUserMessage()?.id}
-                                  stepsExpanded={stepsExpanded()[message.id] ?? false}
+                                  stepsExpanded={
+                                    stepsExpanded()[message.id] ?? (working() && message.id === lastUserMessage()?.id)
+                                  }
                                   onStepsExpandedToggle={() => toggleSteps(message.id)}
                                   classes={{
                                     root: "min-w-0 w-full relative",


### PR DESCRIPTION
## What changed
- render provider-visible reasoning and tool calls literally in chronological order; remove unstable semantic trace grouping
- keep the active trace visible, keep the response in a stable container, and preserve user-detached scroll position
- dedupe byte-identical inline images, retain one recent image, conservatively account inline base64, and prune completed activity inside long active turns
- classify explicit OpenRouter context-overflow 502s as compaction instead of retrying ten times
- make ordinary literature reviews conversational; PRISMA, figures, files, and PDFs are opt-in

## Verification
- 79 focused session/media/retry tests
- 11 focused trace UI tests
- 11 harness contract tests
- monorepo typecheck (7/7)
- exact broken RLVR session replay: 49 messages, 1 unique image, 681,292 estimated tokens
- git diff --check and gitleaks clean