### PR TITLE
test: align overflow stress contract

### DIFF
--- a/backend/cli/test/eval/harness-provider-stress.test.ts
+++ b/backend/cli/test/eval/harness-provider-stress.test.ts
@@ -80,10 +80,9 @@ const CAMPAIGN_IDS = [
   "provider_failures.model-missing",
 ] as const
 
-const TRANSIENT_IDS = new Set([
+const RETRY_IDS = new Set([
   "retries.rate-limit",
   "retries.server-overload",
-  "retries.openrouter-502",
   "retries.stream-disconnect",
 ])
 
@@ -337,13 +336,12 @@ describe("provider-driven harness stress campaign", () => {
             }
           }
 
-          expect(Object.fromEntries([...TRANSIENT_IDS].map((id) => [id, provider.count(id)]))).toEqual({
+          expect(Object.fromEntries([...RETRY_IDS].map((id) => [id, provider.count(id)]))).toEqual({
             "retries.rate-limit": 2,
             "retries.server-overload": 2,
-            "retries.openrouter-502": 2,
             "retries.stream-disconnect": 2,
           })
-          for (const id of TRANSIENT_IDS) {
+          for (const id of RETRY_IDS) {
             const outcome = outcomes.find((item) => item.scenario.id === id)!
             expect(outcome.result.info.role).toBe("assistant")
             if (outcome.result.info.role !== "assistant") throw new Error("Expected assistant result")
@@ -481,7 +479,12 @@ describe("provider-driven harness stress campaign", () => {
             expect.objectContaining({ permission: "task", action: "deny" }),
           )
 
-          for (const id of ["compaction.proactive", "compaction.reactive-overflow", "compaction.handoff-objective"]) {
+          for (const id of [
+            "retries.openrouter-502",
+            "compaction.proactive",
+            "compaction.reactive-overflow",
+            "compaction.handoff-objective",
+          ]) {
             const outcome = outcomes.find((item) => item.scenario.id === id)!
             const carriers = outcome.messages.filter(
               (message) => message.info.role === "user" && message.info.internal?.type === "compaction",

--- a/evals/cadence-harness/stress-matrix.ts
+++ b/evals/cadence-harness/stress-matrix.ts
@@ -406,11 +406,11 @@ export const STRESS_MATRIX: readonly StressScenario[] = [
   }),
   clean({
     id: "retries.openrouter-502",
-    category: "retries",
-    title: "Provider unavailable is not compaction",
+    category: "compaction",
+    title: "OpenRouter-wrapped context overflow compacts",
     prompt: "Exercise the provider-unavailable context wording fixture.",
     stimulus: { kind: "error", status: 502, body: "provider_unavailable: exceeds the context window" },
-    expect: { terminal: "completed", tools: 0, retries: 1, artifacts: "none", excludes: ["handoff"] },
+    expect: { terminal: "completed", tools: 0, retries: 0, artifacts: "none" },
   }),
   clean({
     id: "retries.stream-disconnect",


### PR DESCRIPTION
Align the provider stress campaign with the shipped context-recovery contract: OpenRouter-wrapped explicit context-window rejections compact instead of consuming a transient retry.

Verified:
- provider stress campaign: 1 pass, 3003 assertions
- monorepo typecheck: 7/7
- diff check and gitleaks clean