### PR TITLE
Fix multi-tab workspace recovery

### DIFF
--- a/backend/cli/src/cli/cmd/web.ts
+++ b/backend/cli/src/cli/cmd/web.ts
@@ -5,6 +5,7 @@ import { cmd } from "./cmd"
 import { withNetworkOptions, resolveNetworkOptions } from "../network"
 import { openUrl } from "../../util/open-url"
 import { probeProtectedFolderAccess } from "../../file/protected-folder-access"
+import { DEFAULT_LOCAL_PORT, localServerBase, localWorkspaceUrl, probeLocalServer } from "../local-server"
 
 async function announceFdaIfNeeded() {
   const result = await probeProtectedFolderAccess()
@@ -46,9 +47,21 @@ export const WebCommand = cmd({
       }
     }
     const opts = await resolveNetworkOptions(args)
+    const directory = args.project ? process.cwd() : undefined
+    const preferred = localServerBase(opts.port || DEFAULT_LOCAL_PORT)
     UI.empty()
     UI.println(UI.logo("  "))
     UI.empty()
+
+    if (await probeLocalServer(preferred)) {
+      const target = localWorkspaceUrl(preferred, directory)
+      UI.println(UI.Style.TEXT_INFO_BOLD + "  Web interface:    ", UI.Style.TEXT_NORMAL, target)
+      UI.empty()
+      UI.println(UI.Style.TEXT_DIM, "  Using the OpenScience server that is already running.")
+      openUrl(target)
+      await announceFdaIfNeeded()
+      return
+    }
 
     // Run the dashboard sync BEFORE starting the server — and without
     // the 5s race timeout the global middleware uses. The model picker
@@ -95,11 +108,23 @@ export const WebCommand = cmd({
     const server = Server.listen(opts)
 
     const base = `http://localhost:${server.port}`
-    UI.println(UI.Style.TEXT_INFO_BOLD + "  Web interface:    ", UI.Style.TEXT_NORMAL, base)
+    if (opts.port === 0 && server.port !== DEFAULT_LOCAL_PORT && (await probeLocalServer(localServerBase()))) {
+      await server.stop(true)
+      const target = localWorkspaceUrl(localServerBase(), directory)
+      UI.println(UI.Style.TEXT_INFO_BOLD + "  Web interface:    ", UI.Style.TEXT_NORMAL, target)
+      UI.empty()
+      UI.println(UI.Style.TEXT_DIM, "  Using the OpenScience server started by the other launch.")
+      openUrl(target)
+      await announceFdaIfNeeded()
+      return
+    }
+
+    const target = localWorkspaceUrl(base, directory)
+    UI.println(UI.Style.TEXT_INFO_BOLD + "  Web interface:    ", UI.Style.TEXT_NORMAL, target)
     UI.empty()
     UI.println(UI.Style.TEXT_DIM, "  Opening your browser… if it doesn't open, visit the URL above.")
 
-    openUrl(base)
+    openUrl(target)
 
     // macOS-only: warn when the host explicitly denies protected-folder
     // access. System Settings opens only after a deliberate UI action.

--- a/backend/cli/src/cli/local-server.ts
+++ b/backend/cli/src/cli/local-server.ts
@@ -1,0 +1,26 @@
+import { base64Encode } from "@synsci/util/encode"
+
+export const DEFAULT_LOCAL_PORT = 4096
+
+export function localServerBase(port = DEFAULT_LOCAL_PORT) {
+  return `http://localhost:${port}`
+}
+
+export function localWorkspaceUrl(base: string, directory?: string) {
+  if (!directory) return base
+  return `${base}/${base64Encode(directory)}/session`
+}
+
+export function probeLocalServer(base: string, timeout = 1200) {
+  return fetch(`${base}/global/health`, {
+    headers: { accept: "application/json" },
+    signal: AbortSignal.timeout(timeout),
+  })
+    .then(async (response) => {
+      if (!response.ok) return false
+      const body = await response.json().catch(() => undefined)
+      if (!body || typeof body !== "object" || Array.isArray(body)) return false
+      return "healthy" in body && body.healthy === true && "version" in body && typeof body.version === "string"
+    })
+    .catch(() => false)
+}

--- a/backend/cli/test/cli/local-server.test.ts
+++ b/backend/cli/test/cli/local-server.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { localServerBase, localWorkspaceUrl, probeLocalServer } from "../../src/cli/local-server"
+
+const servers: Bun.Server<unknown>[] = []
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((server) => server.stop(true)))
+})
+
+describe("local OpenScience server reuse", () => {
+  test("recognizes only a healthy OpenScience endpoint", async () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch(request) {
+        if (new URL(request.url).pathname === "/global/health") {
+          return Response.json({ healthy: true, version: "2.0.40" })
+        }
+        return new Response("not found", { status: 404 })
+      },
+    })
+    servers.push(server)
+
+    expect(await probeLocalServer(localServerBase(server.port))).toBe(true)
+  })
+
+  test("does not reuse an unrelated listener", async () => {
+    const server = Bun.serve({ port: 0, fetch: () => new Response("hello") })
+    servers.push(server)
+
+    expect(await probeLocalServer(localServerBase(server.port))).toBe(false)
+  })
+
+  test("opens a project through the compatible directory route", () => {
+    const target = localWorkspaceUrl("http://localhost:4096", "/Users/research/Titanic study")
+    expect(target).toMatch(/^http:\/\/localhost:4096\/[A-Za-z0-9_-]+\/session$/)
+    expect(target).not.toContain("Titanic study")
+  })
+})

--- a/frontend/ui/src/components/message-part.tsx
+++ b/frontend/ui/src/components/message-part.tsx
@@ -2181,7 +2181,7 @@ ToolRegistry.register({
 
 // --- End Colab Plugin Tool Renderers ---
 
-function QuestionPrompt(props: { request: QuestionRequest }) {
+export function QuestionPrompt(props: { request: QuestionRequest }) {
   const data = useData()
   const i18n = useI18n()
   const questions = createMemo(() => props.request.questions)

--- a/frontend/ui/src/components/session-turn-question.test.ts
+++ b/frontend/ui/src/components/session-turn-question.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test"
+
+const source = Bun.file(new URL("./session-turn.tsx", import.meta.url)).text()
+
+describe("pending questions", () => {
+  test("stay actionable while the execution trace is expanded", async () => {
+    const component = await source
+
+    expect(component).not.toContain("if (props.stepsExpanded) return emptyRequestParts")
+    expect(component).toContain("requestMessage() && nextQuestion()")
+    expect(component).toContain("<QuestionPrompt request={question()} />")
+  })
+
+  test("renders a pending request once, outside the trace", async () => {
+    const component = await source
+
+    expect(component).toContain("pendingRequestCallID={pendingRequestCallID()}")
+    expect(component).toContain("part.callID === props.pendingRequestCallID")
+    expect(component).not.toContain('data-slot="session-turn-collapsible-content-inner" aria-hidden={working()}')
+  })
+})

--- a/frontend/ui/src/components/session-turn.tsx
+++ b/frontend/ui/src/components/session-turn.tsx
@@ -30,7 +30,7 @@ import {
   Switch,
 } from "solid-js"
 import { DiffChanges } from "./diff-changes"
-import { Message, Part } from "./message-part"
+import { Message, Part, QuestionPrompt } from "./message-part"
 import {
   artifactTypeLabel,
   artifactActions,
@@ -154,6 +154,7 @@ function AssistantTrace(props: {
   hideResponsePart: boolean
   hideReasoning: boolean
   hidePromotedTools?: boolean
+  pendingRequestCallID?: string
 }) {
   const data = useData()
   const emptyParts: PartType[] = []
@@ -164,6 +165,7 @@ function AssistantTrace(props: {
         return parts.flatMap((part) => {
           if (props.hideReasoning && part?.type === "reasoning") return []
           if (props.hideResponsePart && props.responsePartId === part?.id) return []
+          if (part?.type === "tool" && part.callID === props.pendingRequestCallID) return []
           if (props.hidePromotedTools && isHiddenTool(part)) return [{ message, part, hidden: true }]
           if (part?.type === "tool" && part.tool === "todoread") return [{ message, part, hidden: true }]
           return [{ message, part }]
@@ -369,13 +371,18 @@ export function SessionTurn(
   const nextPermission = createMemo(() => permissions()[0])
   const questions = createMemo(() => data.store.question?.[props.sessionID] ?? emptyQuestions)
   const nextQuestion = createMemo(() => questions()[0])
+  const requestTool = createMemo(() => nextPermission()?.tool ?? nextQuestion()?.tool)
+  const requestMessage = createMemo(() => {
+    const tool = requestTool()
+    if (!tool) return
+    return findLast(assistantMessages(), (message) => message.id === tool.messageID)
+  })
+  const pendingRequestCallID = createMemo(() => (requestMessage() ? requestTool()?.callID : undefined))
   const requestParts = createMemo(() => {
-    if (props.stepsExpanded) return emptyRequestParts
-
-    const tool = nextPermission()?.tool ?? nextQuestion()?.tool
+    const tool = requestTool()
     if (!tool) return emptyRequestParts
 
-    const message = findLast(assistantMessages(), (m) => m.id === tool.messageID)
+    const message = requestMessage()
     if (!message) return emptyRequestParts
 
     const parts = data.store.part[message.id] ?? emptyParts
@@ -753,13 +760,14 @@ export function SessionTurn(
                     </div>
                     {/* Response */}
                     <Show when={props.stepsExpanded && assistantMessages().length > 0}>
-                      <div data-slot="session-turn-collapsible-content-inner" aria-hidden={working()}>
+                      <div data-slot="session-turn-collapsible-content-inner">
                         <AssistantTrace
                           messages={assistantMessages()}
                           responsePartId={responsePartId()}
                           hideResponsePart={hideResponsePart()}
                           hideReasoning={false}
                           hidePromotedTools
+                          pendingRequestCallID={pendingRequestCallID()}
                         />
                         <Show when={error()}>
                           <Card variant="error" class="error-card">
@@ -781,9 +789,16 @@ export function SessionTurn(
                         </section>
                       </details>
                     </Show>
-                    <Show when={!props.stepsExpanded && requestParts().length > 0}>
+                    <Show when={requestParts().length > 0 || (requestMessage() && nextQuestion())}>
                       <div data-slot="session-turn-permission-parts">
                         <For each={requestParts()}>{({ part, message }) => <Part part={part} message={message} />}</For>
+                        <Show when={requestParts().length === 0 && requestMessage() && nextQuestion()}>
+                          {(question) => (
+                            <div data-component="tool-part-wrapper" data-question="true">
+                              <QuestionPrompt request={question()} />
+                            </div>
+                          )}
+                        </Show>
                       </div>
                     </Show>
                     <Show when={response() || hasDiffs()}>

--- a/frontend/workspace/src/context/global-sdk.tsx
+++ b/frontend/workspace/src/context/global-sdk.tsx
@@ -4,6 +4,7 @@ import { createGlobalEmitter } from "@solid-primitives/event-bus"
 import { batch, onCleanup } from "solid-js"
 import { usePlatform } from "./platform"
 import { useServer } from "./server"
+import { consumeReconnectingStream } from "./reconnecting-event-stream"
 
 export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleContext({
   name: "GlobalSDK",
@@ -67,10 +68,11 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
       timer = setTimeout(flush, Math.max(0, 16 - elapsed))
     }
 
-    void (async () => {
-      const events = await eventSdk.global.event()
-      let yielded = Date.now()
-      for await (const event of events.stream) {
+    let yielded = Date.now()
+    void consumeReconnectingStream({
+      connect: () => eventSdk.global.event(),
+      signal: abort.signal,
+      onEvent: async (event) => {
         const directory = event.directory ?? "global"
         const payload = event.payload
         const k = key(directory, payload)
@@ -84,13 +86,11 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
         queue.push({ directory, payload })
         schedule()
 
-        if (Date.now() - yielded < 8) continue
+        if (Date.now() - yielded < 8) return
         yielded = Date.now()
         await new Promise<void>((resolve) => setTimeout(resolve, 0))
-      }
-    })()
-      .finally(flush)
-      .catch(() => undefined)
+      },
+    }).finally(flush)
 
     onCleanup(() => {
       abort.abort()

--- a/frontend/workspace/src/context/global-sync-error.test.ts
+++ b/frontend/workspace/src/context/global-sync-error.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test"
 import { handleInstanceDisposed, syncErrorMessage } from "./global-sync"
 
+const source = Bun.file(new URL("./global-sync.tsx", import.meta.url)).text()
+
 describe("global sync errors", () => {
   test("unwraps structured SDK errors instead of rendering object coercions", () => {
     expect(syncErrorMessage({ data: { message: "Project is unavailable" } })).toBe("Project is unavailable")
@@ -21,5 +23,19 @@ describe("instance disposal", () => {
     )
 
     expect(calls).toEqual(["clear", "sync"])
+  })
+})
+
+describe("event stream recovery", () => {
+  test("rebuilds root and project state when a replacement stream connects", async () => {
+    const component = await source
+    const connected = component.slice(
+      component.indexOf('case "server.connected"'),
+      component.indexOf('case "global.disposed"'),
+    )
+
+    expect(connected).toContain("refresh()")
+    expect(connected).toContain("Object.keys(children)")
+    expect(connected).toContain("push(directory)")
   })
 })

--- a/frontend/workspace/src/context/global-sync.tsx
+++ b/frontend/workspace/src/context/global-sync.tsx
@@ -754,6 +754,12 @@ function createGlobalSync() {
 
     if (directory === "global") {
       switch (event?.type) {
+        case "server.connected": {
+          if (!globalStore.ready) return
+          refresh()
+          for (const directory of Object.keys(children)) push(directory)
+          return
+        }
         case "global.disposed": {
           // Nobody is waiting on this one, so it has no error UI to surface
           // into — unlike the settings panels, which await their own call and

--- a/frontend/workspace/src/context/reconnecting-event-stream.test.ts
+++ b/frontend/workspace/src/context/reconnecting-event-stream.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test"
+import { consumeReconnectingStream, reconnectDelay } from "./reconnecting-event-stream"
+
+describe("global event reconnection", () => {
+  test("reconnects after a failed stream and consumes the replacement", async () => {
+    const abort = new AbortController()
+    const received: string[] = []
+    const delays: number[] = []
+    let connections = 0
+
+    await consumeReconnectingStream({
+      signal: abort.signal,
+      connect: async () => {
+        connections += 1
+        if (connections === 1) throw new Error("connection reset")
+        return {
+          stream: (async function* () {
+            yield "server.connected"
+          })(),
+        }
+      },
+      onEvent(event) {
+        received.push(event)
+        abort.abort()
+      },
+      sleep(ms) {
+        delays.push(ms)
+        return Promise.resolve()
+      },
+    })
+
+    expect(connections).toBe(2)
+    expect(delays).toEqual([250])
+    expect(received).toEqual(["server.connected"])
+  })
+
+  test("backs off failed connection attempts without exceeding five seconds", () => {
+    expect([1, 2, 3, 4, 5, 6, 20].map(reconnectDelay)).toEqual([250, 500, 1000, 2000, 4000, 5000, 5000])
+  })
+})

--- a/frontend/workspace/src/context/reconnecting-event-stream.ts
+++ b/frontend/workspace/src/context/reconnecting-event-stream.ts
@@ -1,0 +1,43 @@
+export function reconnectDelay(failures: number) {
+  return Math.min(250 * 2 ** Math.max(0, failures - 1), 5000)
+}
+
+function pause(ms: number, signal: AbortSignal) {
+  if (signal.aborted) return Promise.resolve()
+  return new Promise<void>((resolve) => {
+    const done = () => {
+      clearTimeout(timer)
+      signal.removeEventListener("abort", done)
+      resolve()
+    }
+    const timer = setTimeout(done, ms)
+    signal.addEventListener("abort", done, { once: true })
+  })
+}
+
+export async function consumeReconnectingStream<T>(options: {
+  connect: () => Promise<{ stream: AsyncIterable<T> }>
+  onEvent: (event: T) => void | Promise<void>
+  signal: AbortSignal
+  sleep?: (ms: number, signal: AbortSignal) => Promise<void>
+}) {
+  let failures = 0
+  while (!options.signal.aborted) {
+    const connected = await options
+      .connect()
+      .then(async (events) => {
+        let received = false
+        for await (const event of events.stream) {
+          if (options.signal.aborted) return received
+          received = true
+          await options.onEvent(event)
+        }
+        return received
+      })
+      .catch(() => false)
+
+    if (options.signal.aborted) return
+    failures = connected ? 0 : failures + 1
+    await (options.sleep ?? pause)(reconnectDelay(failures), options.signal)
+  }
+}

--- a/frontend/workspace/src/context/server-health.test.ts
+++ b/frontend/workspace/src/context/server-health.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test"
+import { nextServerHealth, SERVER_FAILURE_THRESHOLD } from "./server"
+
+describe("server health hysteresis", () => {
+  test("keeps a usable server through transient probe failures", () => {
+    const first = nextServerHealth(true, 0, false)
+    const second = nextServerHealth(first.healthy, first.failures, false)
+
+    expect(first).toEqual({ healthy: true, failures: 1 })
+    expect(second).toEqual({ healthy: true, failures: 2 })
+  })
+
+  test("disconnects after the bounded threshold and recovers immediately", () => {
+    const failed = nextServerHealth(true, SERVER_FAILURE_THRESHOLD - 1, false)
+    expect(failed).toEqual({ healthy: false, failures: SERVER_FAILURE_THRESHOLD })
+    expect(nextServerHealth(failed.healthy, failed.failures, true)).toEqual({ healthy: true, failures: 0 })
+  })
+})

--- a/frontend/workspace/src/context/server.tsx
+++ b/frontend/workspace/src/context/server.tsx
@@ -151,6 +151,17 @@ export function serverDisplayName(url: string) {
   return trimSlashes(withoutProtocol(url))
 }
 
+export const SERVER_FAILURE_THRESHOLD = 3
+
+export function nextServerHealth(healthy: boolean | undefined, failures: number, succeeded: boolean) {
+  if (succeeded) return { healthy: true, failures: 0 }
+  const count = Math.min(failures + 1, SERVER_FAILURE_THRESHOLD)
+  return {
+    healthy: count >= SERVER_FAILURE_THRESHOLD ? false : healthy,
+    failures: count,
+  }
+}
+
 function withoutProtocol(value: string) {
   if (value.startsWith("http://")) return value.slice("http://".length)
   if (value.startsWith("https://")) return value.slice("https://".length)
@@ -309,10 +320,11 @@ export const { use: useServer, provider: ServerProvider } = createSimpleContext(
       setState("checking", true)
       const next = await check(target)
       if (state.active !== target) return next
+      const result = nextServerHealth(state.healthy, state.failures, next)
       batch(() => {
-        setState("healthy", next)
+        setState("healthy", result.healthy)
         setState("checking", false)
-        setState("failures", next ? 0 : state.failures + 1)
+        setState("failures", result.failures)
       })
       if (next) void loadProjects(target).catch(() => undefined)
       return next


### PR DESCRIPTION
## Summary
- reuse the existing local OpenScience server when opening more projects or tabs
- reconnect the global event stream and rehydrate missed root/project state
- tolerate transient health-probe failures without freezing the workspace
- keep pending agent questions pinned and actionable while execution steps are expanded

## Verification
- focused backend/UI/workspace regressions: 29 passed
- monorepo typecheck: 7/7 packages
- production workspace build
- git diff --check