### PR TITLE
fix: recover research tool contract failures

### DIFF
--- a/backend/cli/src/session/processor.ts
+++ b/backend/cli/src/session/processor.ts
@@ -81,6 +81,27 @@ export namespace SessionProcessor {
     return last.every((part) => InvalidCall.signature(part.state.input) === signature)
   }
 
+  function toolErrorSignature(error: string) {
+    return error
+      .toLowerCase()
+      .replace(/\b(?:artifact-path|artifact|tool-call|tool):[^\s,;]+/g, "$ref")
+      .replace(/\b(?:ses|msg|prt|call|job|lesson)[_-][a-z0-9_-]+\b/g, "$id")
+      .replace(/\b\d+(?:\.\d+)?\b/g, "#")
+      .replace(/\s+/g, " ")
+      .trim()
+  }
+
+  export function isToolErrorLoop(parts: MessageV2.Part[], toolName: string, threshold = 2) {
+    const calls = parts.filter(
+      (part): part is MessageV2.ToolPart & { state: MessageV2.ToolStateError } =>
+        part.type === "tool" && part.tool === toolName && part.state.status === "error",
+    )
+    const last = calls.slice(-threshold)
+    if (last.length < threshold) return false
+    const signature = toolErrorSignature(last.at(-1)!.state.error)
+    return last.every((part) => toolErrorSignature(part.state.error) === signature)
+  }
+
   /** Collect all assistant parts produced for one user request. The prompt loop
    * creates a new assistant message after every tool step, so checking only the
    * current message misses the most common repeated-call failure mode. */
@@ -705,7 +726,22 @@ export namespace SessionProcessor {
                 }
 
                 case "tool-error": {
+                  const part = toolOutcomes.part(value.toolCallId)
                   await result.toolError(value.toolCallId, value.input, value.error)
+                  if (!part) break
+                  const history = await Array.fromAsync(MessageV2.stream(input.sessionID))
+                  const parts = turnParts(history, input.assistantMessage.parentID)
+                  if (!isToolErrorLoop(parts, part.tool)) break
+                  blocked = true
+                  await Session.updatePart({
+                    id: Identifier.ascending("part"),
+                    messageID: input.assistantMessage.id,
+                    sessionID: input.sessionID,
+                    type: "text",
+                    synthetic: true,
+                    text: `OpenScience stopped after the same ${part.tool} failure occurred twice. No further retry was attempted; continue with another available step or correct the tool input.`,
+                    time: { start: Date.now(), end: Date.now() },
+                  } satisfies MessageV2.TextPart)
                   break
                 }
                 case "error":

--- a/backend/cli/src/tool/research-contract.ts
+++ b/backend/cli/src/tool/research-contract.ts
@@ -222,20 +222,25 @@ function authorized(text: string, value: number, unit: RegExp) {
   return limit.test(window) && !denied.test(window)
 }
 
-function assertLimits(input: z.infer<typeof Define>, ctx: Tool.Context) {
+function limits(input: z.infer<typeof Define>, ctx: Tool.Context) {
   const text = authority(ctx)
-  const limits = [
-    ["max_model_calls", input.max_model_calls, /(?:model|inference)[\s-]*calls?/i],
-    ["max_tool_calls", input.max_tool_calls, /tool[\s-]*calls?/i],
-    ["max_tokens", input.max_tokens, /tokens?/i],
-    ["max_minutes", input.max_minutes, /minutes?|mins?/i],
-    ["max_cost_usd", input.max_cost_usd, /(?:usd|dollars?|\$)/i],
-  ] as const
-  for (const [field, value, unit] of limits) {
-    if (value === undefined || authorized(text, value, unit)) continue
-    throw new Error(
-      `${field}=${value} is not an exact hard ceiling authorized by the current user request. Omit ${field} and use the runtime default.`,
-    )
+  return {
+    ...(input.max_model_calls !== undefined &&
+    authorized(text, input.max_model_calls, /(?:model|inference)[\s-]*calls?/i)
+      ? { modelCalls: input.max_model_calls }
+      : {}),
+    ...(input.max_tool_calls !== undefined && authorized(text, input.max_tool_calls, /tool[\s-]*calls?/i)
+      ? { toolCalls: input.max_tool_calls }
+      : {}),
+    ...(input.max_tokens !== undefined && authorized(text, input.max_tokens, /tokens?/i)
+      ? { tokens: input.max_tokens }
+      : {}),
+    ...(input.max_minutes !== undefined && authorized(text, input.max_minutes, /minutes?|mins?/i)
+      ? { wallClockMs: input.max_minutes * 60_000 }
+      : {}),
+    ...(input.max_cost_usd !== undefined && authorized(text, input.max_cost_usd, /(?:usd|dollars?|\$)/i)
+      ? { costUsd: input.max_cost_usd }
+      : {}),
   }
 }
 
@@ -327,7 +332,14 @@ async function evidence(
           (!("tool" in parsed) || part.tool === parsed.tool),
       )
       if (!found) {
-        throw new Error(`No terminal tool call matches ${request}`)
+        if (request.startsWith("tool-call:")) {
+          throw new Error(
+            `Evidence reference ${request} must use the exact call ID returned by an earlier completed tool call. No prior call with that ID exists in this session tree.`,
+          )
+        }
+        throw new Error(
+          `Evidence reference ${request} looks backward for an earlier completed ${parsed.tool} call; it does not run that tool. Run ${parsed.tool} first, then cite its returned call ID.`,
+        )
       }
       const output = found.state.status === "completed" ? found.state.output : found.state.error
       return SessionResearch.EvidenceReference.parse({
@@ -341,6 +353,26 @@ async function evidence(
       })
     }),
   )
+}
+
+const Schemas = {
+  define: Define,
+  preregister: Preregister,
+  stage: Stage,
+  check: Check,
+  trial: Trial,
+  failure: Failure,
+  learn: Learn,
+  unlearn: Unlearn,
+  status: Status,
+} as const
+
+function normalize(input: unknown) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) return input
+  const action = "action" in input && typeof input.action === "string" ? input.action : undefined
+  if (!action || !(action in Schemas)) return input
+  const parsed = Schemas[action as keyof typeof Schemas].safeParse(input)
+  return parsed.success ? parsed.data : input
 }
 
 const Params = z
@@ -377,17 +409,7 @@ const Params = z
     reason: Unlearn.shape.reason.optional(),
   })
   .superRefine((value, ctx) => {
-    const schema = {
-      define: Define,
-      preregister: Preregister,
-      stage: Stage,
-      check: Check,
-      trial: Trial,
-      failure: Failure,
-      learn: Learn,
-      unlearn: Unlearn,
-      status: Status,
-    }[value.action]
+    const schema = Schemas[value.action]
     const parsed = schema.safeParse(value)
     if (parsed.success) return
     parsed.error.issues.forEach((issue) => ctx.addIssue({ code: "custom", path: issue.path, message: issue.message }))
@@ -400,14 +422,17 @@ export const ResearchContractTool = Tool.define("research_contract", {
     "Add metric plus baseline when quantitative; contradictory outcomes fail.",
     "Learn methods only from verified trials; unlearn with verified counterevidence.",
     "Preregister freezes an empirical plan Result before trials and verifies hash and chronology.",
-    "Never infer max_* fields: set only exact numeric ceilings from the user. Omitted limits are generous. Status inspects state.",
+    "Set max_* only for exact user ceilings; other limits are ignored. Status inspects state.",
   ].join(" "),
   parameters: Params,
+  normalizeInput: normalize,
   formatValidationError(error) {
     return error.issues[0]?.message ?? "Invalid research contract input"
   },
   async execute(params, ctx) {
-    const refs = await evidence(params.evidence_refs, ctx.sessionID)
+    const refs = ["preregister", "check", "trial", "learn", "unlearn"].includes(params.action)
+      ? await evidence(params.evidence_refs, ctx.sessionID)
+      : []
     const lesson = await (async () => {
       if (params.action === "learn") {
         const input = Learn.parse(params)
@@ -433,23 +458,14 @@ export const ResearchContractTool = Tool.define("research_contract", {
     const contract = await (async () => {
       if (params.action === "define") {
         const input = Define.parse(params)
-        assertLimits(input, ctx)
+        const ceiling = limits(input, ctx)
         return SessionResearch.define(ctx.sessionID, {
           objective: input.objective,
           domain: input.domain,
           template: input.template,
           deliverables: input.deliverables,
-          reserveUsd: input.reserve_usd,
-          limits:
-            input.max_model_calls || input.max_tool_calls || input.max_tokens || input.max_minutes || input.max_cost_usd
-              ? {
-                  ...(input.max_model_calls ? { modelCalls: input.max_model_calls } : {}),
-                  ...(input.max_tool_calls ? { toolCalls: input.max_tool_calls } : {}),
-                  ...(input.max_tokens ? { tokens: input.max_tokens } : {}),
-                  ...(input.max_minutes ? { wallClockMs: input.max_minutes * 60_000 } : {}),
-                  ...(input.max_cost_usd ? { costUsd: input.max_cost_usd } : {}),
-                }
-              : undefined,
+          reserveUsd: input.reserve_usd || undefined,
+          limits: Object.keys(ceiling).length ? ceiling : undefined,
         })
       }
       if (params.action === "preregister") {

--- a/backend/cli/src/tool/task.ts
+++ b/backend/cli/src/tool/task.ts
@@ -46,7 +46,13 @@ const parameters = z.object({
     .enum(DELEGATION_SPECIALISTS)
     .optional()
     .describe("Optional user-selected biology, physics, or ML specialist for an execute phase"),
-  session_id: z.string().describe("Existing Task session to continue").optional(),
+  session_id: z
+    .string()
+    .startsWith("ses_")
+    .describe(
+      "Exact sessionId returned by an earlier successful Task call from this parent session. Never use the current or parent session ID.",
+    )
+    .optional(),
   command: z.string().describe("The command that triggered this task").optional(),
 })
 
@@ -62,7 +68,7 @@ export function childPermissionRules(primaryTools: string[] = []): PermissionNex
 export function assertTaskContinuation(input: { session: Session.Info; parentSessionID: string; projectID: string }) {
   if (input.session.projectID !== input.projectID || input.session.parentID !== input.parentSessionID) {
     throw new Error(
-      `Task continuation session ${input.session.id} is not a direct child of the calling session ${input.parentSessionID}`,
+      `Task continuation session ${input.session.id} is not a direct child of the calling session ${input.parentSessionID}. Use only the exact sessionId returned by an earlier successful Task call from this session.`,
     )
   }
   return input.session
@@ -254,7 +260,10 @@ export function taskDispatchBudget(
     })
     .flatMap((message) =>
       message.parts
-        .filter((part): part is MessageV2.ToolPart => part.type === "tool" && part.tool === "task")
+        .filter(
+          (part): part is MessageV2.ToolPart =>
+            part.type === "tool" && part.tool === "task" && part.state.status !== "error",
+        )
         .map((part) => ({ created: message.info.time.created, part })),
     )
     .sort((a, b) => a.created - b.created || a.part.id.localeCompare(b.part.id))
@@ -318,6 +327,13 @@ export const TaskTool = Tool.define("task", async (ctx) => {
       const effort = MessageV2.resolveResearchEffort(ctx.extra?.effort)
       const maxConcurrentChildren = MessageV2.childAgentLimit(effort)
       const budgetMs = TASK_WALL_CLOCK_MS[effort]
+      const continuation = params.session_id
+        ? assertTaskContinuation({
+            session: await Session.get(params.session_id),
+            parentSessionID: ctx.sessionID,
+            projectID: Instance.project.id,
+          })
+        : undefined
 
       // Skip permission check when user explicitly invoked via @ or command subtask
       if (!ctx.extra?.bypassAgentCheck) {
@@ -368,10 +384,12 @@ export const TaskTool = Tool.define("task", async (ctx) => {
         if (!current) throw new Error(`Durable Task attempt ${ctx.callID} disappeared after reservation`)
         if (current.status === "completed" && current.result) return current.result
 
-        const existing = await Session.get(reserved.childSessionID).catch((error) => {
-          if (Storage.NotFoundError.isInstance(error)) return
-          throw error
-        })
+        const existing =
+          continuation ??
+          (await Session.get(reserved.childSessionID).catch((error) => {
+            if (Storage.NotFoundError.isInstance(error)) return
+            throw error
+          }))
         const session = existing
           ? assertTaskContinuation({
               session: existing,

--- a/backend/cli/test/tool/research-contract.test.ts
+++ b/backend/cli/test/tool/research-contract.test.ts
@@ -3,6 +3,7 @@ import { ArtifactStore } from "../../src/artifact/store"
 import { Instance } from "../../src/project/instance"
 import type { MessageV2 } from "../../src/session/message-v2"
 import { SessionResearch } from "../../src/session/research"
+import { SessionProcessor } from "../../src/session/processor"
 import { ResearchContractTool } from "../../src/tool/research-contract"
 import { executionSession, tmpdir } from "../fixture/fixture"
 
@@ -36,7 +37,7 @@ function request(sessionID: string, text: string): MessageV2.WithParts {
   }
 }
 
-test("hard runtime ceilings require exact authority from the current user request", async () => {
+test("hard runtime ceilings use only exact authority from the current user request", async () => {
   await using tmp = await tmpdir({ git: true })
   await Instance.provide({
     directory: tmp.path,
@@ -44,17 +45,19 @@ test("hard runtime ceilings require exact authority from the current user reques
       const session = await executionSession()
       const tool = await ResearchContractTool.init()
       try {
-        await expect(
-          tool.execute(
-            {
-              action: "define",
-              objective: "Run an extensive study",
-              max_tokens: 500_000,
-            },
-            context(session.id, [request(session.id, "Keep going for hours; do not set a token budget.")]),
-          ),
-        ).rejects.toThrow("max_tokens=500000 is not an exact hard ceiling authorized by the current user request")
-        expect(await SessionResearch.read(session.id)).toBeUndefined()
+        await tool.execute(
+          {
+            action: "define",
+            objective: "Run an extensive study",
+            max_tokens: 500_000,
+          },
+          context(session.id, [request(session.id, "Keep going for hours; do not set a token budget.")]),
+        )
+        expect((await SessionResearch.read(session.id))?.budget).toMatchObject({
+          reserveUsd: 1,
+          limits: { modelCalls: 128, toolCalls: 1_024, tokens: 20_000_000, wallClockMs: 86_400_000, costUsd: 200 },
+        })
+        await SessionResearch.remove(session.id)
 
         await tool.execute(
           {
@@ -92,6 +95,115 @@ test("hard runtime ceilings require exact authority from the current user reques
       }
     },
   })
+})
+
+test("define ignores unrelated autofilled action fields and unrequested sentinel limits", async () => {
+  await using tmp = await tmpdir({ git: true })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const session = await executionSession()
+      const tool = await ResearchContractTool.init()
+      try {
+        await tool.execute(
+          {
+            action: "define",
+            objective: "Run the approved empirical workflow",
+            domain: "ml",
+            template: "empirical",
+            deliverables: [{ path: "paper/main.pdf", label: "Paper", required: true }],
+            reserve_usd: 0,
+            max_model_calls: 1,
+            max_tool_calls: 1,
+            max_tokens: 1,
+            max_minutes: 1,
+            max_cost_usd: 1,
+            stage: "setup",
+            check: "initialized",
+            label: "Initialize workflow",
+            status: "running",
+            evidence: "Implementation has not begun.",
+            evidence_refs: ["tool:compute_job"],
+            detail: "Start locally before paid dispatch.",
+            candidate: "benchmark",
+            message: "Begin.",
+            disposition: "none",
+            branch: "main",
+            outcome: "neutral",
+            summary: "Initialized.",
+            metric: { name: "placeholder", value: 0, direction: "maximize", baseline: 0, target: 0, unit: "none" },
+            source_trial: "none",
+            situation: "setup",
+            guidance: "Proceed.",
+            lesson: "lesson-00000000000000000000",
+            reason: "Authorized.",
+          },
+          context(session.id, [request(session.id, "Start the workflow. Modal is enabled.")]),
+        )
+        expect(await SessionResearch.read(session.id)).toMatchObject({
+          objective: "Run the approved empirical workflow",
+          domain: "ml",
+          budget: {
+            reserveUsd: 1,
+            limits: { modelCalls: 128, toolCalls: 1_024, tokens: 20_000_000, wallClockMs: 86_400_000, costUsd: 200 },
+          },
+        })
+      } finally {
+        await SessionResearch.remove(session.id)
+      }
+    },
+  })
+})
+
+test("tool evidence errors explain that references point to prior calls", async () => {
+  await using tmp = await tmpdir({ git: true })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const session = await executionSession()
+      const tool = await ResearchContractTool.init()
+      try {
+        await tool.execute({ action: "define", objective: "Verify a compute result" }, context(session.id))
+        await expect(
+          tool.execute(
+            {
+              action: "check",
+              check: "compute",
+              status: "passed",
+              evidence_refs: ["tool:compute_job"],
+            },
+            context(session.id),
+          ),
+        ).rejects.toThrow("looks backward for an earlier completed compute_job call; it does not run that tool")
+      } finally {
+        await SessionResearch.remove(session.id)
+      }
+    },
+  })
+})
+
+test("semantic tool-error loops normalize dynamic evidence selectors", () => {
+  const failure = (id: string, error: string): MessageV2.ToolPart => ({
+    id: `prt_${id}`,
+    sessionID: "ses_loop",
+    messageID: "msg_loop",
+    type: "tool",
+    callID: `call_${id}`,
+    tool: "research_contract",
+    state: { status: "error", input: {}, error, time: { start: 1, end: 2 } },
+  })
+  const parts = [
+    failure("one", "Evidence reference tool:compute_job looks backward for an earlier completed call"),
+    failure("two", "Evidence reference tool:research_search looks backward for an earlier completed call"),
+  ]
+
+  expect(SessionProcessor.isToolErrorLoop(parts, "research_contract")).toBe(true)
+  expect(
+    SessionProcessor.isToolErrorLoop(
+      [...parts.slice(0, 1), failure("three", "max_model_calls=1 is not an exact hard ceiling")],
+      "research_contract",
+    ),
+  ).toBe(false)
 })
 
 test("research checks settle only from a runtime-verified immutable Result", async () => {

--- a/backend/cli/test/tool/task-profiles.test.ts
+++ b/backend/cli/test/tool/task-profiles.test.ts
@@ -49,7 +49,14 @@ test("Task advertises generic phases and accepts an explicit domain specialist l
           subagent_type: "biology",
         }).success,
       ).toBe(false)
-
+      expect(
+        task.parameters.safeParse({
+          description: "Invalid continuation",
+          prompt: "Continue the earlier inspection.",
+          subagent_type: "explore",
+          session_id: "current-session",
+        }).success,
+      ).toBe(false)
       expect(await Agent.get("biology")).toBeDefined()
       expect(await Agent.get("reviewer")).toBeUndefined()
       expect(await Agent.get("plan")).toBeDefined()
@@ -254,7 +261,7 @@ test("Task dispatch budget counts continuations across one parent user turn", ()
     id: string
     parent: string
     created: number
-    calls: Array<{ id: string; callID: string; sessionID?: string }>
+    calls: Array<{ id: string; callID: string; sessionID?: string; failed?: boolean }>
   }): MessageV2.WithParts => ({
     info: {
       id: input.id,
@@ -277,11 +284,18 @@ test("Task dispatch budget counts continuations across one parent user turn", ()
       type: "tool" as const,
       callID: call.callID,
       tool: "task",
-      state: {
-        status: "running" as const,
-        input: call.sessionID ? { session_id: call.sessionID } : {},
-        time: { start: input.created },
-      },
+      state: call.failed
+        ? {
+            status: "error" as const,
+            input: call.sessionID ? { session_id: call.sessionID } : {},
+            error: "Invalid Task continuation handle",
+            time: { start: input.created, end: input.created + 1 },
+          }
+        : {
+            status: "running" as const,
+            input: call.sessionID ? { session_id: call.sessionID } : {},
+            time: { start: input.created },
+          },
     })),
   })
   const user = (input: { id: string; created: number; carrier?: boolean }): MessageV2.WithParts => ({
@@ -321,6 +335,8 @@ test("Task dispatch budget counts continuations across one parent user turn", ()
       parent: "msg_user",
       created: 1,
       calls: [
+        { id: "prt_failed_001", callID: "call_failed_1", sessionID: "ses_parent", failed: true },
+        { id: "prt_failed_002", callID: "call_failed_2", sessionID: "ses_parent", failed: true },
         { id: "prt_001", callID: "call_1" },
         { id: "prt_002", callID: "call_2", sessionID: "ses_child" },
       ],


### PR DESCRIPTION
Fixes the v2.0.41 research-contract failure loop observed with GPT-5.6 Sol through OpenRouter.

- normalize action-specific contract input and discard irrelevant autofilled fields
- ignore unrequested synthetic max_* ceilings while preserving authorized limits
- explain backward-looking evidence references clearly
- stop after two semantically identical tool failures
- validate Task continuation handles before reservation and exclude failed calls from delegation budgets

Validation:
- `bun test test/tool/research-contract.test.ts test/tool/task-profiles.test.ts test/session/doom-loop.test.ts` (29 pass)
- `bun run typecheck`
- `git diff --check`