### PR TITLE
feat: report usage across model routes

### DIFF
--- a/backend/cli/src/session/processor.ts
+++ b/backend/cli/src/session/processor.ts
@@ -798,6 +798,17 @@ export namespace SessionProcessor {
                     tokens: usage.tokens,
                     cost: usage.cost,
                   })
+                  await OutboundTelemetry.modelUsage({
+                    sessionID: input.sessionID,
+                    messageID: input.assistantMessage.id,
+                    operationID: stepPartID,
+                    attempt: attempt + 1,
+                    route: traceRoute,
+                    provider: input.model.providerID,
+                    model: input.model.id,
+                    tokens: usage.tokens,
+                    cost: usage.cost,
+                  }).catch(() => undefined)
                   await Session.updateMessage(input.assistantMessage)
                   // Report usage ONLY for managed-proxy credentials. BYOK keys
                   // and first-party OAuth subscriptions are billed to the user's

--- a/backend/cli/src/telemetry/outbound.ts
+++ b/backend/cli/src/telemetry/outbound.ts
@@ -89,6 +89,7 @@ export const EVENT_TYPES = [
   "user.message",
   "model.request",
   "model.response",
+  "model.usage",
   "assistant.message",
   "tool.started",
   "tool.completed",
@@ -1495,6 +1496,42 @@ export namespace OutboundTelemetry {
         parts: input.parts,
         tokens: input.tokens,
         finish: input.finish,
+      },
+    })
+  }
+
+  export function modelUsage(input: {
+    sessionID: string
+    messageID: string
+    operationID: string
+    attempt: number
+    route: string
+    provider: string
+    model: string
+    tokens: {
+      input: number
+      output: number
+      reasoning: number
+      cache: { read: number; write: number }
+    }
+    cost: number
+  }) {
+    return append("model.usage", {
+      sessionID: input.sessionID,
+      runID: input.messageID,
+      spanKey: `${input.messageID}:usage:${input.operationID}`,
+      parentSpanID: `${input.messageID}:model:${input.attempt}:response`,
+      route: input.route,
+      provider: input.provider,
+      model: input.model,
+      payload: {
+        input_tokens: input.tokens.input,
+        output_tokens: input.tokens.output,
+        reasoning_tokens: input.tokens.reasoning,
+        cache_read_tokens: input.tokens.cache.read,
+        cache_write_tokens: input.tokens.cache.write,
+        estimated_cost_microusd: Math.max(0, Math.round(input.cost * 1_000_000)),
+        cost_source: "model_catalog",
       },
     })
   }

--- a/backend/cli/test/telemetry/outbound-contract.test.ts
+++ b/backend/cli/test/telemetry/outbound-contract.test.ts
@@ -74,6 +74,48 @@ describe("outbound OpenScience trace contract", () => {
     )
   })
 
+  test("records normalized usage for Ace and user-owned credential routes", async () => {
+    await signIn("user_usage_routes")
+    restores.push(spyOn(globalThis, "fetch").mockRejectedValue(new Error("offline")))
+    await OutboundTelemetry.initializeAccount()
+    for (const route of ["managed", "byok", "chatgpt", "subscription", "local"] as const) {
+      expect(
+        await OutboundTelemetry.modelUsage({
+          sessionID: `ses_${route}`,
+          messageID: `msg_${route}`,
+          operationID: `step_${route}`,
+          attempt: 1,
+          route,
+          provider: route === "managed" ? "openrouter" : "anthropic",
+          model: "claude-sonnet-4-5",
+          tokens: {
+            input: 120,
+            output: 30,
+            reasoning: 8,
+            cache: { read: 40, write: 5 },
+          },
+          cost: 0.001234,
+        }),
+      ).toBe(true)
+    }
+    const rows = (await Bun.file(queue).text())
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { event: unknown })
+    const events = rows.map((row) => Event.parse(row.event)).filter((event) => event.event_type === "model.usage")
+    expect(events).toHaveLength(5)
+    expect(events.map((event) => event.model_route)).toEqual(["managed", "byok", "chatgpt", "subscription", "local"])
+    expect(events[0]?.payload).toEqual({
+      input_tokens: 120,
+      output_tokens: 30,
+      reasoning_tokens: 8,
+      cache_read_tokens: 40,
+      cache_write_tokens: 5,
+      estimated_cost_microusd: 1234,
+      cost_source: "model_catalog",
+    })
+  })
+
   test("normalizes platform names and extracts only the non-secret key id", () => {
     expect(coarsePlatform("darwin")).toBe("macos")
     expect(coarsePlatform("win32")).toBe("windows")


### PR DESCRIPTION
## Summary

- emits one normalized `model.usage` telemetry event for every completed OpenScience model step
- covers Ace-managed, BYOK, ChatGPT OAuth, provider subscription, local, and custom credential routes
- records input, output, reasoning, cache read/write tokens, model-catalog cost, provider, model, and route
- preserves the existing rule that only managed requests are reported to the financial billing endpoint
- uses the existing consent, redaction, offline queue, and account isolation path

## Verification

- `bun run format:check`: passed
- root `bun run typecheck`: 7 packages passed
- `bun test test/telemetry/outbound-contract.test.ts`: 35 passed
- contract test verifies normalized events for managed and user-owned credential routes
- gitleaks pre-push scan: no leaks found