### PR TITLE
fix: polish runtime tools and sign macOS releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,10 +73,37 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+  macos-signing-preflight:
+    needs: release-source
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Require Developer ID and notarization credentials
+        shell: bash
+        env:
+          APPLE_DEVELOPER_ID_P12_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_P12_BASE64 }}
+          APPLE_DEVELOPER_ID_P12_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_P12_PASSWORD }}
+          APPLE_NOTARY_APPLE_ID: ${{ secrets.APPLE_NOTARY_APPLE_ID }}
+          APPLE_NOTARY_PASSWORD: ${{ secrets.APPLE_NOTARY_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          missing=()
+          for name in APPLE_DEVELOPER_ID_P12_BASE64 APPLE_DEVELOPER_ID_P12_PASSWORD APPLE_NOTARY_APPLE_ID APPLE_NOTARY_PASSWORD APPLE_TEAM_ID; do
+            if [[ -z "${!name:-}" ]]; then missing+=("$name"); fi
+          done
+          if (( ${#missing[@]} )); then
+            echo "::error::macOS release signing is not configured. Missing repository secrets: ${missing[*]}"
+            exit 1
+          fi
+
   version:
     needs:
       - release-source
       - npm-preflight
+      - macos-signing-preflight
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -107,8 +134,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     permissions:
-      # The job verifies/uploads native archives and checksums to the draft release.
-      contents: write
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -143,8 +169,124 @@ jobs:
             frontend/workspace/dist/version.json
           key: cli-build-${{ needs.version.outputs.version }}
 
-      # Persist the nondeterministic binary build before the first draft-asset
-      # mutation. A retry can then verify/upload these exact bytes.
+    outputs:
+      version: ${{ needs.version.outputs.version }}
+
+  sign-macos-cli:
+    needs:
+      - version
+      - build-cli
+    runs-on: macos-15
+    timeout-minutes: 45
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.version.outputs.source }}
+
+      - uses: ./.github/actions/setup-bun
+
+      - name: Restore signed CLI build
+        id: signed-cli-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            backend/cli/dist
+            frontend/workspace/dist/version.json
+          key: cli-build-signed-${{ needs.version.outputs.version }}
+
+      - name: Restore unsigned CLI build
+        if: steps.signed-cli-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            backend/cli/dist
+            frontend/workspace/dist/version.json
+          key: cli-build-${{ needs.version.outputs.version }}
+          fail-on-cache-miss: true
+
+      - name: Developer ID sign and notarize macOS binaries
+        if: steps.signed-cli-cache.outputs.cache-hit != 'true'
+        shell: bash
+        env:
+          APPLE_DEVELOPER_ID_P12_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_P12_BASE64 }}
+          APPLE_DEVELOPER_ID_P12_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_P12_PASSWORD }}
+          APPLE_NOTARY_APPLE_ID: ${{ secrets.APPLE_NOTARY_APPLE_ID }}
+          APPLE_NOTARY_PASSWORD: ${{ secrets.APPLE_NOTARY_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          certificate="$RUNNER_TEMP/openscience-developer-id.p12"
+          keychain="$RUNNER_TEMP/openscience-signing.keychain-db"
+          keychain_password="$(openssl rand -hex 24)"
+          trap 'security delete-keychain "$keychain" >/dev/null 2>&1 || true; rm -f "$certificate"' EXIT
+
+          printf '%s' "$APPLE_DEVELOPER_ID_P12_BASE64" | openssl base64 -d -A -out "$certificate"
+          security create-keychain -p "$keychain_password" "$keychain"
+          security set-keychain-settings -lut 21600 "$keychain"
+          security unlock-keychain -p "$keychain_password" "$keychain"
+          security import "$certificate" -k "$keychain" -P "$APPLE_DEVELOPER_ID_P12_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$keychain_password" "$keychain"
+
+          identity="$(security find-identity -v -p codesigning "$keychain" | sed -n 's/.*"\(Developer ID Application:.*\)"/\1/p' | head -n 1)"
+          if [[ -z "$identity" ]]; then
+            echo "::error::The imported certificate does not contain a Developer ID Application identity."
+            exit 1
+          fi
+
+          shopt -s nullglob
+          binaries=(backend/cli/dist/@synsci/openscience-darwin-*/bin/openscience)
+          if [[ ${#binaries[@]} -ne 3 ]]; then
+            echo "::error::Expected exactly 3 macOS native binaries; found ${#binaries[@]}."
+            exit 1
+          fi
+          for binary in "${binaries[@]}"; do
+            codesign --force --options runtime --timestamp \
+              --identifier ai.syntheticsciences.openscience \
+              --keychain "$keychain" --sign "$identity" "$binary"
+            codesign --verify --strict --verbose=2 "$binary"
+            details="$(codesign -dv --verbose=4 "$binary" 2>&1)"
+            grep -Fxq 'Identifier=ai.syntheticsciences.openscience' <<<"$details"
+            grep -Fxq "TeamIdentifier=$APPLE_TEAM_ID" <<<"$details"
+
+            package_dir="$(dirname "$(dirname "$binary")")"
+            package_name="$(basename "$package_dir")"
+            archive="backend/cli/dist/${package_name}.zip"
+            rm -f "$archive"
+            (cd "$package_dir/bin" && /usr/bin/zip -q -r "$GITHUB_WORKSPACE/$archive" openscience)
+          done
+
+          archives=(backend/cli/dist/openscience-darwin-*.zip)
+          if [[ ${#archives[@]} -ne 3 ]]; then
+            echo "::error::Expected exactly 3 macOS release archives; found ${#archives[@]}."
+            exit 1
+          fi
+          for archive in "${archives[@]}"; do
+            xcrun notarytool submit "$archive" \
+              --apple-id "$APPLE_NOTARY_APPLE_ID" \
+              --team-id "$APPLE_TEAM_ID" \
+              --password "$APPLE_NOTARY_PASSWORD" \
+              --wait
+          done
+
+          : > backend/cli/dist/checksums.txt
+          while IFS= read -r archive; do
+            printf '%s  %s\n' "$(shasum -a 256 "$archive" | awk '{print $1}')" "$(basename "$archive")" \
+              >> backend/cli/dist/checksums.txt
+          done < <(find backend/cli/dist -maxdepth 1 -type f \( -name 'openscience-*.zip' -o -name 'openscience-*.tar.gz' \) | sort)
+
+      - name: Cache immutable signed CLI build
+        if: steps.signed-cli-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            backend/cli/dist
+            frontend/workspace/dist/version.json
+          key: cli-build-signed-${{ needs.version.outputs.version }}
+
+      # Remote assets must be derived from the signed, notarization-accepted
+      # bytes. Uploading in build-cli would permanently expose unsigned assets.
       - name: Verify or upload immutable draft assets
         run: ./tooling/repo/release-assets.ts backend/cli/dist
         env:
@@ -152,13 +294,10 @@ jobs:
           OPENSCIENCE_RELEASE: ${{ needs.version.outputs.release }}
           GH_TOKEN: ${{ github.token }}
 
-    outputs:
-      version: ${{ needs.version.outputs.version }}
-
   verify-native-cli:
     needs:
       - version
-      - build-cli
+      - sign-macos-cli
     strategy:
       fail-fast: false
       matrix:
@@ -188,7 +327,7 @@ jobs:
           path: |
             backend/cli/dist
             frontend/workspace/dist/version.json
-          key: cli-build-${{ needs.version.outputs.version }}
+          key: cli-build-signed-${{ needs.version.outputs.version }}
           fail-on-cache-miss: true
 
       - name: Install the native npm distribution
@@ -220,7 +359,7 @@ jobs:
   prepare-npm:
     needs:
       - version
-      - build-cli
+      - sign-macos-cli
       - verify-native-cli
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -244,7 +383,7 @@ jobs:
           path: |
             backend/cli/dist
             frontend/workspace/dist/version.json
-          key: cli-build-${{ needs.version.outputs.version }}
+          key: cli-build-signed-${{ needs.version.outputs.version }}
           fail-on-cache-miss: true
 
       - name: Restore immutable npm artifacts
@@ -320,7 +459,7 @@ jobs:
           path: |
             backend/cli/dist
             frontend/workspace/dist/version.json
-          key: cli-build-${{ needs.version.outputs.version }}
+          key: cli-build-signed-${{ needs.version.outputs.version }}
           fail-on-cache-miss: true
 
       - name: Publish

--- a/backend/cli/src/agent/prompt/research.txt
+++ b/backend/cli/src/agent/prompt/research.txt
@@ -26,9 +26,9 @@ You are the lead Research agent. Own the request through a verified result.
   citation-management for audits, scientific-schematics for technical figures, and generate-image
   for illustrations. Preserve existing content during format-only work.
 - Default to zero children. Delegate independent Explore or Execute work when parallelism materially
-  improves the result; delegation posture is guidance, not a quota. Children may delegate genuinely
-  independent work within the same permission boundary. Carry forward decisive evidence instead of
-  dumping tool calls or redoing the phase.
+  improves the result; delegation posture is guidance, not a quota. Only the lead dispatches workers,
+  asks questions, and synthesizes. Children recommend follow-ups; they cannot dispatch children. Carry
+  forward decisive evidence instead of dumping tool calls or redoing the phase.
 
 ## Compute, evidence, and trust
 

--- a/backend/cli/src/provider/transform.ts
+++ b/backend/cli/src/provider/transform.ts
@@ -480,7 +480,7 @@ export namespace ProviderTransform {
   // release date or inheriting API-only `none`/`minimal` values.
   function codexOAuthEfforts(id: string): string[] | undefined {
     if (/^gpt-5[.-]6-(?:sol|terra)$/.test(id)) {
-      return [...WIDELY_SUPPORTED_EFFORTS, "xhigh", "max", "ultra"]
+      return [...WIDELY_SUPPORTED_EFFORTS, "xhigh", "max"]
     }
     if (/^gpt-5[.-]6-luna$/.test(id)) {
       return [...WIDELY_SUPPORTED_EFFORTS, "xhigh", "max"]

--- a/backend/cli/src/session/prompt.ts
+++ b/backend/cli/src/session/prompt.ts
@@ -1753,7 +1753,7 @@ export namespace SessionPrompt {
       { modelID: input.model.api.id, providerID: input.model.providerID },
       input.agent,
       (id) =>
-        (id !== TaskTool.id || input.delegation) &&
+        (id !== TaskTool.id || (input.delegation && !input.session.parentID)) &&
         ToolSelection.enabled(id, { permission, tools: input.tools }) &&
         ToolSelection.relevant(id, {
           agent: input.agent.name,

--- a/backend/cli/src/session/prompt/core.txt
+++ b/backend/cli/src/session/prompt/core.txt
@@ -41,8 +41,8 @@ verify, and return the smallest sufficient result.
 
 - Default to no children. Delegate independent Explore or Execute work only when parallelism materially
   improves the result; posture is guidance, never a quota.
-- The lead verifies and synthesizes. Children may delegate independent work within the same
-  permission boundary. An optional child failure cannot block a usable result.
+- Only the lead dispatches workers, asks questions, verifies, and synthesizes. Children recommend
+  follow-ups; they cannot delegate. A child failure cannot block a usable result.
 
 ## Trust, spend, and downloads
 

--- a/backend/cli/src/tool/task.ts
+++ b/backend/cli/src/tool/task.ts
@@ -65,9 +65,20 @@ const parameters = z.object({
 export function childPermissionRules(primaryTools: string[] = []): PermissionNext.Ruleset {
   return [
     ...primaryTools.map((permission) => ({ permission, pattern: "*", action: "allow" as const })),
+    { permission: "task", pattern: "*", action: "deny" },
+    { permission: "question", pattern: "*", action: "deny" },
     { permission: "todowrite", pattern: "*", action: "deny" },
     { permission: "todoread", pattern: "*", action: "deny" },
   ]
+}
+
+export function assertLeadDelegationSession(session: Session.Info) {
+  if (session.parentID) {
+    throw new Error(
+      `Only the lead Research session may dispatch Task workers. Child session ${session.id} must return follow-up recommendations to its lead.`,
+    )
+  }
+  return session
 }
 
 export function assertTaskContinuation(input: { session: Session.Info; parentSessionID: string; projectID: string }) {
@@ -258,6 +269,7 @@ export const TaskTool = Tool.define("task", async (ctx) => {
     description,
     parameters,
     async execute(params: z.infer<typeof parameters>, ctx) {
+      assertLeadDelegationSession(await Session.get(ctx.sessionID))
       const config = await Config.get()
       const effort = MessageV2.resolveResearchEffort(ctx.extra?.effort)
       const configured = MessageV2.resolveDelegationSettings(ctx.extra?.delegationSettings, { effort })
@@ -481,7 +493,7 @@ export const TaskTool = Tool.define("task", async (ctx) => {
                 )
                 const childGuidance = [
                   `You own one ${params.subagent_type} phase${params.specialist ? ` with the ${params.specialist} specialist` : ""} for the lead Research agent. The assignment in the user message is authoritative.`,
-                  "Work independently on that phase. Delegate genuinely independent work when it materially improves the result; runtime capacity may queue it. Load a domain skill only when useful.",
+                  "Work independently on that phase and load a domain skill only when useful. You cannot dispatch workers; recommend any worthwhile follow-up to the lead in your handoff.",
                   "Do not return a diary of searches, reads, or commands. Your final response is a decision-ready handoff to the lead, not a second user-facing report.",
                   "Use only the Markdown sections that carry substance: Outcome; Findings; Evidence; Changes / outputs; Limitations; Next action.",
                   "Preserve exact paths, identifiers, numeric results, commands, and error strings when they matter. Distinguish observed evidence from inference. If blocked or partial, say exactly what remains.",
@@ -505,13 +517,14 @@ export const TaskTool = Tool.define("task", async (ctx) => {
                     model,
                     agent: agent.name,
                     effort,
-                    delegation: true,
-                    delegationSettings: settings,
+                    delegation: false,
+                    delegationSettings: { ...settings, level: "off" },
                     system: childGuidance,
                     tools: {
                       todowrite: false,
                       todoread: false,
-                      task: true,
+                      question: false,
+                      task: false,
                       ...Object.fromEntries((config.experimental?.primary_tools ?? []).map((tool) => [tool, false])),
                     },
                     parts: await SessionPrompt.resolvePromptParts(transfer.prompt),

--- a/backend/cli/src/tool/task.txt
+++ b/backend/cli/src/tool/task.txt
@@ -7,7 +7,8 @@ Use `explore` for evidence and `execute` for implementation or compute.
 
 - Use as many independent workers as useful. Delegation posture is guidance, not a quota; capacity
   may queue work.
-- Children may delegate within the same permission boundary; the lead owns synthesis and verification.
+- Only the lead dispatches workers and owns questions, synthesis, and verification. Children cannot
+  dispatch children; they return worthwhile follow-up recommendations to the lead.
 - Do not delegate sequential work, small edits, ceremonial review, or duplicate retrieval.
 - Task returns with the child's handoff. Issue independent calls together.
 - Continue a `session_id` only for missing work. Otherwise include objective, inputs, references,

--- a/backend/cli/src/tool/webfetch.ts
+++ b/backend/cli/src/tool/webfetch.ts
@@ -160,7 +160,7 @@ const parameters = z
     timeout: z
       .number()
       .positive()
-      .describe("Optional timeout in seconds (max 120 for text, 1800 when output_path is set)")
+      .describe("Optional timeout in seconds (max 120 for text, 1800 for explicit or automatically detected downloads)")
       .optional(),
     output_path: z
       .string()
@@ -258,9 +258,16 @@ export const WebFetchTool = Tool.define("webfetch", {
       : undefined
     const defaultTimeout = download ? DEFAULT_DOWNLOAD_TIMEOUT : DEFAULT_TIMEOUT
     const maxTimeout = download ? MAX_DOWNLOAD_TIMEOUT : MAX_TIMEOUT
-    const timeout = Math.min((params.timeout ?? defaultTimeout / 1000) * 1000, maxTimeout)
+    let timeout = Math.min((params.timeout ?? defaultTimeout / 1000) * 1000, maxTimeout)
     const controller = new AbortController()
-    const timeoutId = setTimeout(() => controller.abort(), timeout)
+    let timeoutId = setTimeout(() => controller.abort(), timeout)
+    const useDownloadTimeout = () => {
+      const next = Math.min((params.timeout ?? DEFAULT_DOWNLOAD_TIMEOUT / 1000) * 1000, MAX_DOWNLOAD_TIMEOUT)
+      if (next <= timeout) return
+      timeout = next
+      clearTimeout(timeoutId)
+      timeoutId = setTimeout(() => controller.abort(), timeout)
+    }
 
     // Build Accept header based on requested format with q parameters for fallbacks
     let acceptHeader = "*/*"
@@ -294,7 +301,7 @@ export const WebFetchTool = Tool.define("webfetch", {
           { signal, headers },
           download
             ? { authorize, streamResponse: true, maxResponseBytes: downloadCapacity! }
-            : { authorize, maxResponseBytes: MAX_RESPONSE_SIZE },
+            : { authorize, streamResponse: true },
         ),
       )
 
@@ -308,7 +315,7 @@ export const WebFetchTool = Tool.define("webfetch", {
             { signal, headers: { ...headers, "User-Agent": "openscience" } },
             download
               ? { authorize, streamResponse: true, maxResponseBytes: downloadCapacity! }
-              : { authorize, maxResponseBytes: MAX_RESPONSE_SIZE },
+              : { authorize, streamResponse: true },
           ),
         )
       }
@@ -371,12 +378,40 @@ export const WebFetchTool = Tool.define("webfetch", {
       const contentType = response.headers.get("content-type") || ""
       const mime = contentType.split(";", 1)[0]?.trim().toLowerCase() ?? ""
       if (!isTextualMime(mime)) {
-        await response.body?.cancel().catch(() => {})
-        throw unsupportedFileError({
-          contentType,
-          contentDisposition: response.headers.get("content-disposition") ?? undefined,
-          declaredBytes: parseContentLength(response.headers.get("content-length")),
+        useDownloadTimeout()
+        using automatic = await resolveAutomaticDownloadTarget(ctx.sessionID, response, params.url, mime)
+        const capacity = await safeDownloadCapacity(automatic).catch((error) => {
+          if (error instanceof DownloadCapacityError) {
+            throw ToolRetryGuard.annotateWebFetch(ctx, params, error, {
+              safeCapacityBytes: error.safeCapacityBytes,
+              declaredSizeBytes: error.responseBytes,
+            })
+          }
+          throw error
         })
+        const result = await streamDownload(response, automatic, capacity)
+        return {
+          title: `Downloaded ${result.filename}`,
+          output: [
+            "Downloaded the binary response through the authorized network broker into this session's workspace.",
+            `Path: ${result.path}`,
+            `Filename: ${result.filename}`,
+            ...(result.sourceFilename && result.sourceFilename !== result.filename
+              ? [`Source filename: ${result.sourceFilename}`]
+              : []),
+            `Bytes: ${result.bytes}`,
+            `SHA-256: ${result.sha256}`,
+            `Content type: ${result.contentType || "unknown"}`,
+          ].join("\n"),
+          metadata: {
+            download: {
+              url: Network.finalURL(response) || params.url,
+              ...result,
+              automatic: true,
+              autoOpen: mime === "application/pdf",
+            },
+          } as Record<string, unknown>,
+        }
       }
 
       const contentLength = response.headers.get("content-length")
@@ -525,14 +560,6 @@ function responseTooLargeError(input: {
   return new Error(
     `Response is too large for Web fetch${details.length ? ` (${details.join(", ")})` : ""}; ` +
       `the text-response limit is ${formatBytes(input.limitBytes)}. ${downloadGuidance()}`,
-  )
-}
-
-function unsupportedFileError(input: { contentType: string; contentDisposition?: string; declaredBytes?: number }) {
-  const details = [input.contentType, formatBytes(input.declaredBytes), input.contentDisposition].filter(Boolean)
-  return new Error(
-    `Web fetch is text-only; the response is a file${details.length ? ` (${details.join(", ")})` : ""}. ` +
-      downloadGuidance(),
   )
 }
 
@@ -710,6 +737,74 @@ function sourceFilename(response: Response) {
   const ordinary = /filename\s*=\s*(?:"([^"]+)"|([^;]+))/i.exec(disposition)
   const value = ordinary?.[1] ?? ordinary?.[2]?.trim()
   return value ? path.basename(value) : undefined
+}
+
+const MIME_EXTENSIONS: Record<string, string> = {
+  "application/pdf": ".pdf",
+  "application/zip": ".zip",
+  "application/gzip": ".gz",
+  "application/x-gzip": ".gz",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document": ".docx",
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": ".xlsx",
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation": ".pptx",
+  "image/png": ".png",
+  "image/jpeg": ".jpg",
+  "image/svg+xml": ".svg",
+  "image/webp": ".webp",
+}
+
+const MIME_EXTENSION_ALIASES: Record<string, readonly string[]> = {
+  "application/pdf": [".pdf"],
+  "application/zip": [".zip", ".whl", ".jar"],
+  "application/gzip": [".gz", ".tgz"],
+  "application/x-gzip": [".gz", ".tgz"],
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document": [".docx"],
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": [".xlsx"],
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation": [".pptx"],
+  "image/png": [".png"],
+  "image/jpeg": [".jpg", ".jpeg"],
+  "image/svg+xml": [".svg"],
+  "image/webp": [".webp"],
+}
+
+export function automaticDownloadName(response: Response, requestURL: string, mime: string) {
+  const finalURL = Network.finalURL(response) || requestURL
+  const urlName = (() => {
+    try {
+      return path.basename(decodeURIComponent(new URL(finalURL).pathname))
+    } catch {
+      return ""
+    }
+  })()
+  const fallback = `download-${crypto.createHash("sha256").update(finalURL).digest("hex").slice(0, 12)}`
+  const raw = sourceFilename(response) || urlName || fallback
+  const sanitized = raw
+    .replace(/[\u0000-\u001f\u007f/\\:]/g, "-")
+    .replace(/^\.+$/, "")
+    .trim()
+    .slice(0, 180)
+  const base = sanitized || fallback
+  const expected = MIME_EXTENSIONS[mime]
+  const extension = path.extname(base).toLowerCase()
+  if (expected && !MIME_EXTENSION_ALIASES[mime]?.includes(extension)) {
+    return `${extension ? base.slice(0, -extension.length) : base}${expected}`
+  }
+  return extension ? base : `${base}${expected ?? ".bin"}`
+}
+
+async function resolveAutomaticDownloadTarget(sessionID: string, response: Response, requestURL: string, mime: string) {
+  const filename = automaticDownloadName(response, requestURL, mime)
+  const parsed = path.parse(filename)
+  for (let index = 0; index < 1_000; index++) {
+    const candidate = index === 0 ? filename : `${parsed.name}-${index + 1}${parsed.ext}`
+    try {
+      return await resolveDownloadTarget(sessionID, candidate)
+    } catch (error) {
+      if (!(error instanceof Error) || !error.message.startsWith("Refusing to overwrite an unapproved file:"))
+        throw error
+    }
+  }
+  throw new Error(`Could not choose a new workspace filename for ${filename}`)
 }
 
 async function writeChunk(handle: fs.FileHandle, chunk: Uint8Array) {

--- a/backend/cli/src/tool/webfetch.txt
+++ b/backend/cli/src/tool/webfetch.txt
@@ -1,7 +1,7 @@
 Fetch a fully formed HTTP(S) URL as markdown (default), text, HTML, or a workspace download. Prefer a more targeted available tool.
 
 - Text mode is read-only and capped at 5 MiB; use it for bounded pages and API responses. Full bounded text may be retained in managed output when only a preview is shown.
-- For large or binary scientific data, archives, compressed datasets, or larger text, set `output_path`. Absolute and nested paths become a new root filename and never overwrite.
+- Binary responses (including PDFs) are detected and streamed into session scratch under a safe non-overwriting filename automatically. Set `output_path` only when you need a specific root filename or when a large text response should bypass model context.
 - For `papers/foo.pdf`, use `output_path:"foo.pdf"`; only after success run sandboxed Bash `mkdir -p -- 'papers' && test ! -e 'papers/foo.pdf' && mv -- 'foo.pdf' 'papers/foo.pdf'`.
 - Downloads stream through the network broker to disk, never model context, and return filename, bytes, SHA-256, and content type.
 - Capacity is live free disk minus a 512 MiB reserve; never send cap or claimed-size override fields. After a capacity failure, paginate, free space, or use an approved transfer instead of retrying unchanged.

--- a/backend/cli/test/agent/harness-contract.test.ts
+++ b/backend/cli/test/agent/harness-contract.test.ts
@@ -135,7 +135,7 @@ test("ordinary literature reviews stay conversational instead of becoming report
   expect(specialist).not.toContain("Before ANY literature search")
 })
 
-test("delegation is model-directed, capacity-bound, nested, and observable", async () => {
+test("delegation is lead-owned, capacity-bound, flat, and observable", async () => {
   const [prompt, source, core, research, processor] = await Promise.all([
     read("tool/task.txt"),
     read("tool/task.ts"),
@@ -150,7 +150,8 @@ test("delegation is model-directed, capacity-bound, nested, and observable", asy
   expect(prompt).toContain("Use as many independent workers as useful")
   expect(prompt).toContain("Delegation posture is guidance, not a quota")
   expect(prompt).toContain("Issue independent calls together")
-  expect(prompt).toContain("Children may delegate")
+  expect(prompt).toContain("Only the lead dispatches workers")
+  expect(prompt).toContain("Children cannot")
   expect(prompt).toContain("decision-ready handoff")
   expect(core).not.toMatch(/Normal .*(?:two|2).*Task/i)
   expect(research).not.toMatch(/Ultra .*(?:four|4).*Task/i)
@@ -161,7 +162,9 @@ test("delegation is model-directed, capacity-bound, nested, and observable", asy
   expect(source).not.toContain("taskDispatchBudget")
   expect(source).not.toContain("TASK_WALL_CLOCK_MS")
   expect(source).toContain("system: childGuidance")
-  expect(source).toContain("task: true")
+  expect(source).toContain("task: false")
+  expect(source).toContain("delegation: false")
+  expect(source).toContain("assertLeadDelegationSession")
   expect(source).not.toContain("Delegation is unavailable")
   expect(source).not.toContain("under 1,200 words")
   expect(source).toContain("Your final response is a decision-ready handoff")

--- a/backend/cli/test/eval/harness-provider-stress.test.ts
+++ b/backend/cli/test/eval/harness-provider-stress.test.ts
@@ -468,7 +468,7 @@ describe("provider-driven harness stress campaign", () => {
             expect(childGrants.some((grant) => grant.path === outcome.workspace)).toBe(false)
           }
           expect((await Session.get(grantChild.id)).permission).toContainEqual(
-            expect.objectContaining({ permission: "task", action: "allow" }),
+            expect.objectContaining({ permission: "task", action: "deny" }),
           )
 
           for (const id of [

--- a/backend/cli/test/installation/release-order.test.ts
+++ b/backend/cli/test/installation/release-order.test.ts
@@ -42,7 +42,7 @@ test("production release preparation jobs can write their draft GitHub release",
   const source = await Bun.file(path.join(import.meta.dir, "../../../../.github/workflows/publish.yml")).text()
   const jobs = [
     ["version", "build-cli"],
-    ["build-cli", "verify-native-cli"],
+    ["sign-macos-cli", "verify-native-cli"],
   ]
 
   for (const item of jobs) {
@@ -84,6 +84,7 @@ test("production release caches exact builds and packed npm artifacts by version
   const workflow = await Bun.file(path.join(import.meta.dir, "../../../../.github/workflows/publish.yml")).text()
 
   expect(workflow).toContain("key: cli-build-${{ needs.version.outputs.version }}")
+  expect(workflow).toContain("key: cli-build-signed-${{ needs.version.outputs.version }}")
   expect(workflow).toContain("key: npm-release-${{ needs.version.outputs.version }}")
   expect(workflow).toContain("run: ./tooling/repo/prepare-npm.ts")
   expect(workflow).toContain("OPENSCIENCE_NPM_ARTIFACT_DIR: .release/npm/${{ needs.version.outputs.version }}")
@@ -99,6 +100,26 @@ test("production release caches exact builds and packed npm artifacts by version
   expect(prepare.indexOf("Verify packed SDK and plugin exports before publication")).toBeLessThan(
     prepare.indexOf("Cache immutable npm artifacts"),
   )
+})
+
+test("production release signs and notarizes every macOS binary before artifacts or npm packages are created", async () => {
+  const workflow = await Bun.file(path.join(import.meta.dir, "../../../../.github/workflows/publish.yml")).text()
+  const sign = workflow.slice(workflow.indexOf("\n  sign-macos-cli:"), workflow.indexOf("\n  verify-native-cli:"))
+  const prepare = workflow.slice(workflow.indexOf("\n  prepare-npm:"), workflow.indexOf("\n  publish:"))
+  const publish = workflow.slice(workflow.indexOf("\n  publish:"), workflow.indexOf("\n  deployment:"))
+
+  expect(workflow.indexOf("macos-signing-preflight:")).toBeLessThan(workflow.indexOf("\n  version:"))
+  expect(sign).toContain("Developer ID sign and notarize macOS binaries")
+  expect(sign).toContain("--identifier ai.syntheticsciences.openscience")
+  expect(sign).toContain("codesign --verify --strict")
+  expect(sign).toContain("xcrun notarytool submit")
+  expect(sign).toContain("TeamIdentifier=$APPLE_TEAM_ID")
+  expect(sign.indexOf("xcrun notarytool submit")).toBeLessThan(sign.indexOf("Cache immutable signed CLI build"))
+  expect(sign.indexOf("Cache immutable signed CLI build")).toBeLessThan(
+    sign.indexOf("Verify or upload immutable draft assets"),
+  )
+  expect(prepare).toContain("key: cli-build-signed-${{ needs.version.outputs.version }}")
+  expect(publish).toContain("key: cli-build-signed-${{ needs.version.outputs.version }}")
 })
 
 test("production npm writes stage the complete set before latest promotion and release publication", async () => {

--- a/backend/cli/test/provider/provider.test.ts
+++ b/backend/cli/test/provider/provider.test.ts
@@ -125,7 +125,7 @@ test("synthesized Codex OAuth models use Codex variants and preserve model-speci
         expect(sol.providerID).toBe("openai-codex")
         expect(sol.limit.context).toBe(1_050_000)
         expect(sol.cost).toEqual({ input: 0, output: 0, cache: { read: 0, write: 0 } })
-        expect(Object.keys(sol.variants ?? {})).toEqual(["low", "medium", "high", "xhigh", "max", "ultra"])
+        expect(Object.keys(sol.variants ?? {})).toEqual(["low", "medium", "high", "xhigh", "max"])
         expect(Object.keys(sol.modes ?? {})).toEqual(["fast"])
         expect(sol.modes?.fast.provider?.body).toEqual({ service_tier: "priority" })
 

--- a/backend/cli/test/provider/transform-reasoning-wire.test.ts
+++ b/backend/cli/test/provider/transform-reasoning-wire.test.ts
@@ -46,13 +46,13 @@ async function send(language: any, providerOptions: Record<string, any>) {
 }
 
 describe("reasoning options serialize onto provider request bodies", () => {
-  test("Codex OAuth ultra reaches the OpenAI Responses wire shape", async () => {
+  test("Codex OAuth max reaches the OpenAI Responses wire shape", async () => {
     const target = model({
       id: "gpt-5.6-sol",
       providerID: "openai-codex",
       api: { id: "gpt-5.6-sol", url: "https://chatgpt.com/backend-api/codex", npm: "@ai-sdk/openai" },
     })
-    const selected = ProviderTransform.variants(target).ultra
+    const selected = ProviderTransform.variants(target).max
     const options = mergeDeep(ProviderTransform.options({ model: target, sessionID, providerOptions: {} }), selected)
     const wire = recorder()
     const sdk = createOpenAI({ apiKey: "test", baseURL: "https://codex.test/v1", fetch: wire.fetch })
@@ -63,7 +63,7 @@ describe("reasoning options serialize onto provider request bodies", () => {
     expect(wire.bodies[0]).toMatchObject({
       store: false,
       include: ["reasoning.encrypted_content"],
-      reasoning: { effort: "ultra", summary: "auto" },
+      reasoning: { effort: "max", summary: "auto" },
     })
   })
 

--- a/backend/cli/test/provider/transform-reasoning.test.ts
+++ b/backend/cli/test/provider/transform-reasoning.test.ts
@@ -212,7 +212,6 @@ describe("new model reasoning effort contracts", () => {
       "high",
       "xhigh",
       "max",
-      "ultra",
     ])
     expect(Object.keys(ProviderTransform.variants(codex("gpt-5.6-terra")))).toEqual([
       "low",
@@ -220,7 +219,6 @@ describe("new model reasoning effort contracts", () => {
       "high",
       "xhigh",
       "max",
-      "ultra",
     ])
     expect(Object.keys(ProviderTransform.variants(codex("gpt-5.6-luna")))).toEqual([
       "low",
@@ -231,11 +229,7 @@ describe("new model reasoning effort contracts", () => {
     ])
     expect(Object.keys(ProviderTransform.variants(codex("gpt-5.5")))).toEqual(["low", "medium", "high", "xhigh"])
     expect(ProviderTransform.variants(codex("gpt-5.6-sol")).none).toBeUndefined()
-    expect(ProviderTransform.variants(codex("gpt-5.6-sol")).ultra).toEqual({
-      reasoningEffort: "ultra",
-      reasoningSummary: "auto",
-      include: ["reasoning.encrypted_content"],
-    })
+    expect(ProviderTransform.variants(codex("gpt-5.6-sol")).ultra).toBeUndefined()
 
     expect(ProviderTransform.options({ model: codex("gpt-5.6-sol"), sessionID, providerOptions: {} })).toMatchObject({
       reasoningEffort: "low",

--- a/backend/cli/test/session/delegation-provider.test.ts
+++ b/backend/cli/test/session/delegation-provider.test.ts
@@ -44,6 +44,16 @@ const scenarios: StressScenario[] = [
   },
 ]
 
+const childScenario: StressScenario = {
+  id: "delegation-schema-child",
+  category: "delegation",
+  title: "Child delegation provider schema",
+  prompt: "Ask the explicitly attached execution agent to inspect another independent branch.",
+  config: { delegation: true, explicitAgent: "execute" },
+  stimulus: { kind: "inspect", target: "tools" },
+  expect: { terminal: "completed", children: 0, artifacts: "none" },
+}
+
 function text(value: unknown): string {
   if (typeof value === "string") return value
   if (Array.isArray(value)) return value.map(text).join("\n")
@@ -64,7 +74,7 @@ function role(body: { messages?: unknown }, name: string) {
 
 describe("delegation at the provider boundary", () => {
   test("keeps internal reminders in system messages and applies explicit delegation to the actual tool schema", async () => {
-    const local = startStressProvider(scenarios)
+    const local = startStressProvider([...scenarios, childScenario])
     try {
       await using tmp = await tmpdir({
         git: true,
@@ -123,13 +133,30 @@ describe("delegation at the provider boundary", () => {
             expect(JSON.stringify(user)).not.toContain("Research effort:")
           }
 
+          const lead = await Session.create({ title: "Delegation lead" })
+          const child = await Session.create({ parentID: lead.id, title: childScenario.title })
+          await SessionPrompt.prompt({
+            sessionID: child.id,
+            model: { providerID: STRESS_PROVIDER_ID, modelID: STRESS_PROVIDER_MODEL },
+            agent: "research",
+            effort: "normal",
+            delegation: true,
+            system: `${STRESS_SCENARIO_MARKER}${childScenario.id}`,
+            parts: [
+              { type: "text", text: childScenario.prompt },
+              { type: "agent", name: "execute" },
+            ],
+          })
+
           await local.quiet()
           const disabled = local.main("delegation-schema-disabled")[0]
           const explicit = local.main("delegation-schema-explicit")[0]
-          if (!disabled || !explicit) throw new Error("Missing provider request")
+          const childRequest = local.main(childScenario.id)[0]
+          if (!disabled || !explicit || !childRequest) throw new Error("Missing provider request")
 
           expect(disabled.tools).not.toContain("task")
           expect(explicit.tools).toContain("task")
+          expect(childRequest.tools).not.toContain("task")
           expect(disabled.tools).toContain("read")
           expect(explicit.tools).toContain("read")
 
@@ -138,7 +165,7 @@ describe("delegation at the provider boundary", () => {
           expect(role(legacy.body, "user")).not.toContain("LEGACY_INTERNAL_GUIDANCE")
           expect(role(legacy.body, "system")).toContain("LEGACY_INTERNAL_GUIDANCE")
 
-          for (const request of [disabled, explicit, legacy]) {
+          for (const request of [disabled, explicit, childRequest, legacy]) {
             const user = role(request.body, "user")
             const system = role(request.body, "system")
             expect(user).not.toContain("<system-reminder>")

--- a/backend/cli/test/tool/task-profiles.test.ts
+++ b/backend/cli/test/tool/task-profiles.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "bun:test"
 import { Agent } from "../../src/agent/agent"
 import { Instance } from "../../src/project/instance"
 import {
+  assertLeadDelegationSession,
   assertTaskContinuation,
   childPermissionRules,
   classifyTaskOutcome,
@@ -61,12 +62,27 @@ test("Task advertises generic phases and accepts an explicit domain specialist l
   })
 })
 
-test("child sessions preserve the active Task permission for nested independent work", () => {
+test("child sessions deny nested delegation and user questions", () => {
   const configuredProfile = [{ permission: "task", pattern: "*", action: "allow" as const }]
   const child = childPermissionRules()
 
-  expect(PermissionNext.evaluate("task", "explore", configuredProfile, child).action).toBe("allow")
-  expect(PermissionNext.disabled(["task"], child)).not.toContain("task")
+  expect(PermissionNext.evaluate("task", "explore", configuredProfile, child).action).toBe("deny")
+  expect(PermissionNext.evaluate("question", "*", child).action).toBe("deny")
+  expect(PermissionNext.disabled(["task", "question"], child)).toEqual(new Set(["task", "question"]))
+})
+
+test("only a lead session may dispatch Task workers", async () => {
+  await using tmp = await tmpdir()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const lead = await Session.create({})
+      const child = await Session.create({ parentID: lead.id })
+
+      expect(assertLeadDelegationSession(lead)).toBe(lead)
+      expect(() => assertLeadDelegationSession(child)).toThrow("Only the lead Research session")
+    },
+  })
 })
 
 test("Task treats provider placeholder session IDs as a new child", () => {
@@ -266,8 +282,9 @@ test("Task runtime has no per-turn dispatch quota or default deadline", async ()
   expect(source).not.toContain("taskDispatchBudget")
   expect(source).not.toContain("TASK_WALL_CLOCK_MS")
   expect(source).not.toContain("withTaskDeadline")
-  expect(source).not.toContain("delegation: false")
-  expect(source).toContain("task: true")
+  expect(source).toContain("delegation: false")
+  expect(source).toContain("task: false")
+  expect(source).toContain("assertLeadDelegationSession")
   expect(source).toContain('TaskCapacity.acquire("child", MAX_CHILD_AGENTS')
 })
 

--- a/backend/cli/test/tool/webfetch-network.test.ts
+++ b/backend/cli/test/tool/webfetch-network.test.ts
@@ -4,6 +4,7 @@ import {
   DOWNLOAD_DISK_RESERVE_BYTES,
   MAX_RESPONSE_SIZE,
   WebFetchTool,
+  automaticDownloadName,
   normalizeDownloadOutputPath,
   webFetchRetryAfterMs,
 } from "../../src/tool/webfetch"
@@ -98,8 +99,10 @@ test("webfetch serializes same-host requests and honors Retry-After after a 429"
   let active = 0
   let maxActive = 0
   let calls = 0
+  const started = Promise.withResolvers<void>()
   globalThis.fetch = (async () => {
     const call = ++calls
+    if (call === 1) started.resolve()
     active++
     maxActive = Math.max(maxActive, active)
     await Bun.sleep(10)
@@ -117,6 +120,7 @@ test("webfetch serializes same-host requests and honors Retry-After after a 429"
       context(async () => {}),
     ),
   )
+  await started.promise
   const second = webfetch.execute(
     { url: "https://example.com/crossref-b", format: "text" },
     context(async () => {}),
@@ -354,7 +358,9 @@ test("webfetch bounds a chunked response while it is being read", async () => {
   expect(cancelled).toBe(true)
 })
 
-test("webfetch refuses binary attachments instead of decoding them as UTF-8", async () => {
+test("webfetch automatically saves binary attachments instead of decoding them as UTF-8", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "webfetch-auto-binary-"))
+  const workspace = spyOn(SessionFilesystem, "workspace").mockResolvedValue(root)
   await Network.set({ allowlistEnabled: false, enabled: [], custom: [] })
   globalThis.fetch = (async () =>
     new Response(new Uint8Array([0x1f, 0x8b, 0x08, 0x00]), {
@@ -366,14 +372,75 @@ test("webfetch refuses binary attachments instead of decoding them as UTF-8", as
     })) as unknown as typeof fetch
 
   const webfetch = await WebFetchTool.init()
-  await expect(
-    webfetch.execute(
+  try {
+    const result = await webfetch.execute(
       { url: "https://example.com/masked-maf", format: "text" },
       context(async () => {}),
-    ),
-  ).rejects.toThrow(
-    'Web fetch is text-only; the response is a file (application/octet-stream, 4 bytes, attachment; filename="masked.maf.gz").',
+    )
+    expect(await fs.readFile(path.join(root, "masked.maf.gz"))).toEqual(Buffer.from([0x1f, 0x8b, 0x08, 0x00]))
+    expect(result.metadata).toMatchObject({
+      download: {
+        path: "masked.maf.gz",
+        filename: "masked.maf.gz",
+        bytes: 4,
+        contentType: "application/octet-stream",
+        automatic: true,
+        autoOpen: false,
+      },
+    })
+  } finally {
+    workspace.mockRestore()
+    await fs.rm(root, { recursive: true, force: true })
+  }
+})
+
+test("automatic binary downloads use the response MIME type instead of a misleading URL extension", () => {
+  expect(automaticDownloadName(new Response(), "https://publisher.example/article.html", "application/pdf")).toBe(
+    "article.pdf",
   )
+  expect(automaticDownloadName(new Response(), "https://packages.example/model.whl", "application/zip")).toBe(
+    "model.whl",
+  )
+})
+
+test("webfetch saves a PDF under a non-overwriting name and marks it for preview", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "webfetch-auto-pdf-"))
+  await fs.writeFile(path.join(root, "paper.pdf"), "existing")
+  const workspace = spyOn(SessionFilesystem, "workspace").mockResolvedValue(root)
+  const payload = new TextEncoder().encode("%PDF-1.7\n%%EOF\n")
+  await Network.set({ allowlistEnabled: false, enabled: [], custom: [] })
+  globalThis.fetch = (async () =>
+    new Response(payload, {
+      headers: {
+        "content-type": "application/pdf",
+        "content-length": String(payload.byteLength),
+        "content-disposition": 'inline; filename="paper.pdf"',
+      },
+    })) as unknown as typeof fetch
+
+  const webfetch = await WebFetchTool.init()
+  try {
+    const result = await webfetch.execute(
+      { url: "https://example.com/paper", format: "markdown" },
+      context(async () => {}),
+    )
+    expect(await fs.readFile(path.join(root, "paper.pdf"), "utf8")).toBe("existing")
+    expect(await fs.readFile(path.join(root, "paper-2.pdf"))).toEqual(Buffer.from(payload))
+    expect(result.metadata).toMatchObject({
+      download: {
+        path: "paper-2.pdf",
+        filename: "paper-2.pdf",
+        sourceFilename: "paper.pdf",
+        bytes: payload.byteLength,
+        contentType: "application/pdf",
+        automatic: true,
+        autoOpen: true,
+      },
+    })
+  } finally {
+    workspace.mockRestore()
+    await fs.rm(root, { recursive: true, force: true })
+  }
 })
 
 test("webfetch marks a 404 as terminal instead of inviting a blind retry", async () => {

--- a/frontend/ui/src/components/message-part.css
+++ b/frontend/ui/src/components/message-part.css
@@ -1171,6 +1171,15 @@
   background-color: var(--surface-raised-strong);
   border-radius: 0 0 var(--radius-xs) var(--radius-xs);
 
+  [data-slot="permission-origin"] {
+    color: var(--text-weaker);
+    font-size: 10px;
+    font-weight: var(--font-weight-medium);
+    letter-spacing: 0.04em;
+    line-height: 1.2;
+    text-transform: uppercase;
+  }
+
   [data-slot="permission-summary"] {
     font-size: 12px;
     color: var(--text-weak);

--- a/frontend/ui/src/components/message-part.tsx
+++ b/frontend/ui/src/components/message-part.tsx
@@ -56,7 +56,7 @@ import {
   savedArtifact,
   scienceTaskLabel,
   sentenceCaseLabel,
-  skillName,
+  skillActivity,
   toolErrorDisplay,
 } from "./tool-display"
 import { ToolRegistry, type ToolProps } from "./tool-registry"
@@ -166,6 +166,7 @@ function PermissionActions(props: { respond: (response: PermissionReply) => void
       )}
       fallback={
         <div data-component="permission-prompt">
+          <span data-slot="permission-origin">OpenScience approval</span>
           <Show when={summary()}>
             <div data-slot="permission-summary">{summary()}</div>
           </Show>
@@ -204,6 +205,7 @@ function PermissionActions(props: { respond: (response: PermissionReply) => void
       }
     >
       <div data-component="permission-prompt" data-kind={mutation() ? "environment-mutation" : "remote-compute"}>
+        <span data-slot="permission-origin">OpenScience approval</span>
         <div data-slot="permission-summary" data-kind={mutation() ? "environment-mutation" : "remote-compute"}>
           <strong data-slot="permission-compute-title">
             {mutation()
@@ -1185,10 +1187,10 @@ ToolRegistry.register({
 ToolRegistry.register({
   name: "skill",
   render(props) {
-    const i18n = useI18n()
-    const name = skillName({ metadata: props.metadata, input: props.input, title: props.title })
+    const activity = () =>
+      skillActivity({ metadata: props.metadata, input: props.input, title: props.title, status: props.status })
     return (
-      <BasicTool {...props} icon="mcp" trigger={{ title: i18n.t("ui.tool.skill", { name }) }}>
+      <BasicTool {...props} icon="mcp" trigger={{ title: activity().title, subtitle: activity().subtitle }}>
         <Show when={props.output}>
           {(output) => (
             <div data-component="tool-output" data-scrollable>
@@ -1315,13 +1317,29 @@ ToolRegistry.register({
   name: "webfetch",
   render(props) {
     const i18n = useI18n()
+    const data = useData()
+    const downloaded = () => {
+      const value = props.metadata.download
+      return value && typeof value === "object" ? (value as { path?: unknown; autoOpen?: unknown }) : undefined
+    }
+    // Do not reopen persisted downloads on reload, but keep listening if the
+    // completed metadata arrives one event after the terminal status.
+    let opened = props.status === "completed"
+    createEffect(() => {
+      const status = props.status
+      const download = downloaded()
+      if (!opened && status === "completed" && download?.autoOpen === true && typeof download.path === "string") {
+        opened = true
+        data.openFile?.(download.path)
+      }
+    })
     return (
       <BasicTool
         {...props}
         icon="window-cursor"
         trigger={{
-          title: i18n.t("ui.tool.webfetch"),
-          subtitle: props.input.url || "",
+          title: downloaded() ? "Downloaded file" : i18n.t("ui.tool.webfetch"),
+          subtitle: typeof downloaded()?.path === "string" ? (downloaded()!.path as string) : props.input.url || "",
           args: props.input.format ? ["format=" + props.input.format] : [],
           action: (
             <div data-component="tool-action">
@@ -1329,6 +1347,9 @@ ToolRegistry.register({
             </div>
           ),
         }}
+        onSubtitleClick={
+          typeof downloaded()?.path === "string" ? () => data.openFile?.(downloaded()!.path as string) : undefined
+        }
       >
         <Show when={props.output}>
           {(output) => (

--- a/frontend/ui/src/components/research-trace.test.ts
+++ b/frontend/ui/src/components/research-trace.test.ts
@@ -68,6 +68,64 @@ describe("research trace presentation", () => {
     expect(trace.map((item) => item.part.id)).toEqual(["read", "grep", "list"])
   })
 
+  test("collapses adjacent completed skill loads into one truthful disclosure", () => {
+    const trace = visibleResearchTrace([
+      {
+        ...entry("skill-1", "skill", "Loaded skill: scientific-schematics"),
+        part: {
+          ...entry("skill-1", "skill", "Loaded skill: scientific-schematics").part,
+          state: {
+            status: "completed",
+            input: { name: "scientific-schematics" },
+            metadata: { name: "scientific-schematics" },
+            output: "instructions",
+          },
+        },
+      } as unknown as ResearchTraceEntry,
+      {
+        ...entry("skill-2", "skill", "Loaded skill: ml-paper-writing"),
+        part: {
+          ...entry("skill-2", "skill", "Loaded skill: ml-paper-writing").part,
+          state: {
+            status: "completed",
+            input: { name: "ml-paper-writing" },
+            metadata: { name: "ml-paper-writing" },
+            output: "instructions",
+          },
+        },
+      } as unknown as ResearchTraceEntry,
+    ])
+
+    expect(trace).toHaveLength(1)
+    const aggregated = trace[0]?.part
+    expect(aggregated?.type === "tool" && aggregated.state.status === "completed" && aggregated.state.metadata).toEqual(
+      {
+        names: ["scientific-schematics", "ml-paper-writing"],
+      },
+    )
+  })
+
+  test("does not group skill search results as skills that were used", () => {
+    const searched = entry("skill-search", "skill", "Skill matches: figures")
+    const trace = visibleResearchTrace([
+      {
+        ...searched,
+        part: {
+          ...searched.part,
+          state: {
+            status: "completed",
+            input: { query: "figures" },
+            metadata: { matches: ["scientific-schematics"] },
+            output: "matches",
+          },
+        },
+      } as unknown as ResearchTraceEntry,
+      entry("read", "read", "Read paper.tex"),
+    ])
+
+    expect(trace.map((item) => item.part.id)).toEqual(["skill-search", "read"])
+  })
+
   test("keeps repeated failed source attempts individually inspectable", () => {
     const trace = visibleResearchTrace([
       entry("fetch-1", "webfetch", "Download returned HTML", "error"),
@@ -108,6 +166,17 @@ describe("delegation summaries", () => {
     expect(groups).toHaveLength(2)
     expect(groups[0]).toMatchObject({ family: "sources", count: 2, failed: 1 })
     expect(groups[1]).toMatchObject({ family: "context", count: 1, failed: 0 })
+  })
+
+  test("counts only loaded skills as used", () => {
+    const groups = summarizeTaskActivity([
+      { id: "1", tool: "skill", state: { status: "completed", title: "Loaded skill: scientific-schematics" } },
+      { id: "2", tool: "skill", state: { status: "completed", title: "Skill matches: figures" } },
+    ])
+
+    expect(groups).toEqual([
+      { family: "skills", count: 1, failed: 0, label: "Using 1 skill", detail: "scientific-schematics" },
+    ])
   })
 
   test("removes the internal task metadata envelope from user-visible findings", () => {

--- a/frontend/ui/src/components/research-trace.ts
+++ b/frontend/ui/src/components/research-trace.ts
@@ -1,5 +1,5 @@
-import type { AssistantMessage, Part } from "@synsci/sdk/v2/client"
-import { reasoningDisplayText } from "./tool-display"
+import type { AssistantMessage, Part, ToolPart, ToolStateCompleted } from "@synsci/sdk/v2/client"
+import { reasoningDisplayText, skillName } from "./tool-display"
 
 export type ResearchTraceEntry = {
   message: AssistantMessage
@@ -31,7 +31,7 @@ const sources = new Set(["webfetch", "websearch", "science_fetch", "science_sear
 const commands = new Set(["bash", "python", "r", "notebook", "rkernel", "modal", "compute_job"])
 const changes = new Set(["edit", "write", "multiedit", "apply_patch"])
 const images = new Set(["generate_image"])
-const skills = new Set(["skill", "learn"])
+const skills = new Set(["skill"])
 
 export function traceFamily(tool: string): TraceFamily {
   if (context.has(tool)) return "context"
@@ -50,7 +50,7 @@ export function traceLabel(family: TraceFamily, count: number) {
   if (family === "commands") return `Ran ${count} build or verification ${count === 1 ? "step" : "steps"}`
   if (family === "changes") return `Updated ${count} ${count === 1 ? "file" : "files"}`
   if (family === "images") return `Generated ${count} ${count === 1 ? "image" : "images"}`
-  if (family === "skills") return `Loaded ${count} research ${count === 1 ? "skill" : "skills"}`
+  if (family === "skills") return `Using ${count} ${count === 1 ? "skill" : "skills"}`
   return `Completed ${count} research ${count === 1 ? "operation" : "operations"}`
 }
 
@@ -65,27 +65,87 @@ function lifecycle(part: Part) {
   return part.type === "step-start" || part.type === "step-finish" || part.type === "snapshot" || part.type === "patch"
 }
 
+type CompletedSkillEntry = ResearchTraceEntry & {
+  part: ToolPart & { state: ToolStateCompleted }
+}
+
+function completedSkillLoad(entry: ResearchTraceEntry): entry is CompletedSkillEntry {
+  if (entry.part.type !== "tool" || entry.part.tool !== "skill" || entry.part.state.status !== "completed") return false
+  return !!skillName({
+    input: (entry.part.state.input ?? {}) as Record<string, unknown>,
+    metadata: (entry.part.state.metadata ?? {}) as Record<string, unknown>,
+    title: entry.part.state.title,
+  })
+}
+
 /**
  * Keep the primary activity transcript literal and chronological. Streaming
  * state changes must not replace already-visible rows with aggregate summaries;
  * compact grouping is reserved for secondary child-agent summaries below.
  */
 export function visibleResearchTrace(entries: ResearchTraceEntry[]): ResearchTraceEntry[] {
-  return entries.filter((entry) => {
+  const visible = entries.filter((entry) => {
     if (entry.hidden || lifecycle(entry.part)) return false
     if (entry.part.type === "reasoning" && !reasoningDisplayText(entry.part.text ?? "")) return false
     return true
   })
+  const result: ResearchTraceEntry[] = []
+  for (let index = 0; index < visible.length; index++) {
+    const first = visible[index]!
+    if (!completedSkillLoad(first)) {
+      result.push(first)
+      continue
+    }
+    const group: CompletedSkillEntry[] = [first]
+    while (index + 1 < visible.length) {
+      const next = visible[index + 1]!
+      if (!completedSkillLoad(next)) break
+      group.push(next)
+      index++
+    }
+    if (group.length === 1) {
+      result.push(first)
+      continue
+    }
+    const names = [
+      ...new Set(
+        group
+          .map((entry) =>
+            skillName({
+              input: (entry.part.state.input ?? {}) as Record<string, unknown>,
+              metadata: (entry.part.state.metadata ?? {}) as Record<string, unknown>,
+              title: entry.part.state.title,
+            }),
+          )
+          .filter((name): name is string => !!name),
+      ),
+    ]
+    result.push({
+      message: first.message,
+      part: {
+        ...first.part,
+        state: {
+          ...first.part.state,
+          title: `Using ${names.length} ${names.length === 1 ? "skill" : "skills"}`,
+          input: {},
+          output: names.map((name) => `- ${name}`).join("\n"),
+          metadata: { names },
+        },
+      },
+    })
+  }
+  return result
 }
 
 export function summarizeTaskActivity(items: TaskActivity[]): TaskActivityGroup[] {
   const groups = new Map<TraceFamily, TaskActivityGroup & { titles: string[] }>()
   for (const item of items) {
+    const directSkill = item.tool === "skill" && item.state.title?.startsWith("Loaded skill: ")
+    if (item.tool === "skill" && !directSkill) continue
     const family = traceFamily(item.tool)
     const previous = groups.get(family)
-    const titles = item.state.title?.trim()
-      ? [...(previous?.titles ?? []), item.state.title.trim()]
-      : (previous?.titles ?? [])
+    const title = directSkill ? item.state.title?.replace(/^Loaded skill:\s*/, "") : item.state.title
+    const titles = title?.trim() ? [...(previous?.titles ?? []), title.trim()] : (previous?.titles ?? [])
     groups.set(family, {
       family,
       count: (previous?.count ?? 0) + 1,

--- a/frontend/ui/src/components/tool-display.test.ts
+++ b/frontend/ui/src/components/tool-display.test.ts
@@ -11,6 +11,7 @@ import {
   scienceTaskLabel,
   sessionErrorDisplay,
   sessionErrorText,
+  skillActivity,
   skillName,
   stripRedactedReasoning,
   toolErrorDisplay,
@@ -92,8 +93,26 @@ describe("skillName", () => {
   test("strips the title prefix", () => {
     expect(skillName({ title: "Loaded skill: qa" })).toBe("qa")
   })
-  test("defaults to 'skill'", () => {
-    expect(skillName({})).toBe("skill")
+  test("does not invent a literal skill name while streaming", () => {
+    expect(skillName({})).toBeUndefined()
+    expect(skillActivity({ status: "running" })).toEqual({ title: "Finding relevant skills" })
+  })
+  test("distinguishes using a skill from merely finding candidates", () => {
+    expect(skillActivity({ input: { name: "scientific-schematics" }, status: "running" })).toEqual({
+      title: "Using scientific-schematics",
+    })
+    expect(
+      skillActivity({
+        input: { query: "scientific figures" },
+        metadata: { matches: ["scientific-schematics", "matplotlib"] },
+        title: "Skill matches: scientific figures",
+        status: "completed",
+      }),
+    ).toEqual({ title: "Found 2 relevant skills" })
+    expect(skillActivity({ metadata: { names: ["scientific-schematics", "ml-paper-writing"] } })).toEqual({
+      title: "Using 2 skills",
+      subtitle: "scientific-schematics · ml-paper-writing",
+    })
   })
 })
 
@@ -156,6 +175,14 @@ describe("writtenFiles", () => {
         completed("generate_image", {}, { filepath: "diagram.png" }),
       ]),
     ).toEqual(["results.csv", "figure.png", "model.rds", "diagram.png"])
+  })
+
+  test("offers brokered web downloads as session outputs", () => {
+    expect(
+      writtenFiles([
+        completed("webfetch", { url: "https://example.com/paper.pdf" }, { download: { path: "paper.pdf" } }),
+      ]),
+    ).toEqual(["paper.pdf"])
   })
 })
 

--- a/frontend/ui/src/components/tool-display.ts
+++ b/frontend/ui/src/components/tool-display.ts
@@ -259,6 +259,9 @@ export function writtenFiles(
       for (const file of Array.isArray(metadata.files) ? metadata.files : []) push(file)
     }
     if (part.tool === "generate_image") push(metadata.filepath)
+    if (part.tool === "webfetch" && metadata.download && typeof metadata.download === "object") {
+      push((metadata.download as Record<string, unknown>).path)
+    }
     if (part.tool !== "apply_patch") continue
     const changes = Array.isArray(metadata.files) ? metadata.files : []
     for (const change of changes) {
@@ -287,12 +290,40 @@ export function skillName(source: {
   metadata?: Record<string, unknown>
   input?: Record<string, unknown>
   title?: string
-}): string {
+}): string | undefined {
   const meta = source.metadata?.name
   if (typeof meta === "string" && meta) return meta
   const input = source.input?.name
   if (typeof input === "string" && input) return input
   const title = source.title
   if (typeof title === "string" && title.startsWith("Loaded skill: ")) return title.slice("Loaded skill: ".length)
-  return "skill"
+  return undefined
+}
+
+export function skillActivity(source: {
+  metadata?: Record<string, unknown>
+  input?: Record<string, unknown>
+  title?: string
+  status?: string
+}): { title: string; subtitle?: string } {
+  const used = Array.isArray(source.metadata?.names)
+    ? source.metadata.names.filter((name): name is string => typeof name === "string" && !!name)
+    : []
+  if (used.length > 1) {
+    return { title: `Using ${used.length} skills`, subtitle: used.join(" · ") }
+  }
+  const search =
+    typeof source.input?.query === "string" ||
+    typeof source.input?.category === "string" ||
+    source.title?.startsWith("Skill matches:") ||
+    source.title?.startsWith("Skills in category:")
+  if (search) {
+    const matches = Array.isArray(source.metadata?.matches) ? source.metadata.matches.length : 0
+    return source.status === "completed" && matches > 0
+      ? { title: `Found ${matches} relevant ${matches === 1 ? "skill" : "skills"}` }
+      : { title: "Finding relevant skills" }
+  }
+
+  const name = skillName(source)
+  return name ? { title: `Using ${name}` } : { title: "Finding relevant skills" }
 }


### PR DESCRIPTION
## Summary
- stream binary WebFetch responses into authorized session scratch, preserve non-overwrite semantics, and auto-open downloaded PDFs
- keep skill discovery distinct from actual skill use, collapse adjacent completed loads into one stable disclosure, and label OpenScience approval cards explicitly
- remove unsupported `ultra` provider effort from GPT-5.6 Sol/Terra while preserving OpenScience Research Ultra separately
- enforce a flat delegation graph: only the lead can dispatch Task workers; children cannot receive or execute Task, cannot question the user directly, and return follow-up recommendations to the lead
- retain unlimited useful top-level delegation with machine-capacity queuing, durable child sessions, exact continuation IDs, and no default wall-clock cutoff
- Developer ID-sign and notarize all three macOS binaries before draft assets or npm artifacts can be created
- fail production publishing before any release mutation when Apple credentials are absent

## Verification
- backend runtime and release contracts: 92 passed, 0 failed, including a provider-boundary child delegation regression
- frontend focused regressions: 59 passed, 0 failed
- backend and frontend TypeScript checks: passed
- full monorepo typecheck: passed before the final type-narrowing-only fixture correction; both affected packages passed afterward
- actionlint: passed
- git diff --check: passed

## Release prerequisite
Production publishing now requires these repository secrets: `APPLE_DEVELOPER_ID_P12_BASE64`, `APPLE_DEVELOPER_ID_P12_PASSWORD`, `APPLE_NOTARY_APPLE_ID`, `APPLE_NOTARY_PASSWORD`, and `APPLE_TEAM_ID`. They are intentionally not present in the repository today, so an unsigned npm release cannot proceed.