### PR TITLE
Make telemetry and updates observable

### DIFF
--- a/backend/cli/src/agent/agent.ts
+++ b/backend/cli/src/agent/agent.ts
@@ -667,6 +667,20 @@ export namespace Agent {
           tokens,
           finish,
         }).catch(() => false)
+        if (tokens) {
+          const usage = await import("@/session").then((module) => module.Session.getUsage({ model, usage: tokens }))
+          await OutboundTelemetry.modelUsage({
+            sessionID,
+            messageID,
+            operationID: "agent-config-generation",
+            attempt: 1,
+            route,
+            provider: model.providerID,
+            model: model.id,
+            tokens: usage.tokens,
+            cost: usage.cost,
+          }).catch(() => false)
+        }
         outcome = "completed"
         return object
       }
@@ -683,6 +697,18 @@ export namespace Agent {
         parts: [{ type: "json", value: result.object }],
         tokens: result.usage,
         finish: result.finishReason,
+      }).catch(() => false)
+      const usage = await import("@/session").then((module) => module.Session.getUsage({ model, usage: result.usage }))
+      await OutboundTelemetry.modelUsage({
+        sessionID,
+        messageID,
+        operationID: "agent-config-generation",
+        attempt: 1,
+        route,
+        provider: model.providerID,
+        model: model.id,
+        tokens: usage.tokens,
+        cost: usage.cost,
       }).catch(() => false)
       outcome = "completed"
       return result.object

--- a/backend/cli/src/credentials/lifecycle.ts
+++ b/backend/cli/src/credentials/lifecycle.ts
@@ -53,6 +53,11 @@ export namespace CredentialLifecycle {
   let checking: Promise<boolean> | undefined
   let reconciliation: Promise<void> = Promise.resolve()
   let timer: ReturnType<typeof setInterval> | undefined
+  const retry: {
+    progress?: { token: string; refreshers: Set<Handler>; revokers: Set<Handler> }
+    retryAt: number
+    retryDelay: number
+  } = { retryAt: 0, retryDelay: 250 }
 
   function parse(value: unknown): Revision {
     if (!value || typeof value !== "object") throw new Error("credential revision is not an object")
@@ -120,9 +125,14 @@ export namespace CredentialLifecycle {
     return current
   }
 
-  async function run(handlers: Set<Handler>, event: Event): Promise<void> {
-    const results = await Promise.allSettled([...handlers].map((handler) => handler(event)))
-    const failures = results.flatMap((result) => (result.status === "rejected" ? [result.reason] : []))
+  async function run(handlers: Set<Handler>, complete: Set<Handler>, event: Event): Promise<void> {
+    const pending = [...handlers].filter((handler) => !complete.has(handler))
+    const results = await Promise.allSettled(pending.map((handler) => handler(event)))
+    const failures = results.flatMap((result, index) => {
+      if (result.status === "rejected") return [result.reason]
+      complete.add(pending[index]!)
+      return []
+    })
     if (failures.length) throw new AggregateError(failures, "Credential invalidation did not complete")
   }
 
@@ -130,9 +140,15 @@ export namespace CredentialLifecycle {
     const task = reconciliation.then(async () => {
       if (!local && seen === revision.token) return false
       const event = { token: revision.token, reason: revision.reason, pid: revision.pid }
-      await run(refreshers, event)
-      await run(revokers, event)
+      const current =
+        retry.progress?.token === revision.token
+          ? retry.progress
+          : { token: revision.token, refreshers: new Set<Handler>(), revokers: new Set<Handler>() }
+      retry.progress = current
+      await run(refreshers, current.refreshers, event)
+      await run(revokers, current.revokers, event)
       seen = revision.token
+      retry.progress = undefined
       return true
     })
     reconciliation = task.then(
@@ -273,7 +289,18 @@ export namespace CredentialLifecycle {
       void ensureFresh().catch((error) => log.warn("credential revision baseline failed", { error }))
       timer = setInterval(
         () => {
-          void ensureFresh().catch((error) => log.error("credential revision reconciliation failed", { error }))
+          if (Date.now() < retry.retryAt) return
+          void ensureFresh().then(
+            () => {
+              retry.retryAt = 0
+              retry.retryDelay = 250
+            },
+            (error) => {
+              retry.retryAt = Date.now() + retry.retryDelay
+              retry.retryDelay = Math.min(5_000, retry.retryDelay * 2)
+              log.error("credential revision reconciliation failed", { error })
+            },
+          )
         },
         Math.max(25, interval),
       )
@@ -285,6 +312,8 @@ export namespace CredentialLifecycle {
   export function stopWatching(): void {
     if (timer) clearInterval(timer)
     timer = undefined
+    retry.retryAt = 0
+    retry.retryDelay = 250
   }
 
   /** Exposed for narrow integration tests and sandbox deny-list construction. */

--- a/backend/cli/src/installation/index.ts
+++ b/backend/cli/src/installation/index.ts
@@ -149,6 +149,9 @@ export namespace Installation {
       case "pnpm":
         cmd = $`pnpm install -g @synsci/openscience@${target}`
         break
+      case "yarn":
+        cmd = $`yarn global add @synsci/openscience@${target}`
+        break
       case "bun":
         cmd = $`bun install -g @synsci/openscience@${target}`
         break

--- a/backend/cli/src/server/routes/settings/updates.ts
+++ b/backend/cli/src/server/routes/settings/updates.ts
@@ -26,6 +26,48 @@ const Result = z.object({
   releaseNotes: z.string().url(),
 })
 
+const InstallResult = Result.extend({
+  installed: z.boolean(),
+  restartRequired: z.boolean(),
+})
+
+type UpdateResult = z.infer<typeof Result>
+type UpdateInstallResult = z.infer<typeof InstallResult>
+
+export function supportsAutomaticUpdate(method: string) {
+  return ["curl", "npm", "pnpm", "yarn", "bun", "brew", "choco", "scoop"].includes(method)
+}
+
+export function createUpdateInstaller(input: {
+  resolve: () => Promise<UpdateResult>
+  upgrade: (method: Installation.Method, target: string) => Promise<void>
+}) {
+  const state: { pending?: Promise<UpdateInstallResult> } = {}
+  return () => {
+    if (state.pending) return state.pending
+    const pending = input.resolve().then(async (result) => {
+      if (!result.updateAvailable) {
+        return InstallResult.parse({ ...result, installed: false, restartRequired: false })
+      }
+      if (!supportsAutomaticUpdate(result.method)) {
+        throw new Error("Automatic updates are unavailable for this installation.")
+      }
+      await input.upgrade(result.method as Installation.Method, result.latest)
+      return InstallResult.parse({ ...result, installed: true, restartRequired: true })
+    })
+    state.pending = pending
+    void pending.then(
+      () => {
+        if (state.pending === pending) state.pending = undefined
+      },
+      () => {
+        if (state.pending === pending) state.pending = undefined
+      },
+    )
+    return pending
+  }
+}
+
 /**
  * Deduplicates startup/background update probes without making an explicit
  * manual check stale. Failed probes are never retained, so a transient package
@@ -82,6 +124,11 @@ const update = createUpdateCache({
   },
 })
 
+const install = createUpdateInstaller({
+  resolve: () => update(true),
+  upgrade: Installation.upgrade,
+})
+
 export const UpdatesSettingsRoutes = lazy(() =>
   new Hono()
     .get(
@@ -98,6 +145,22 @@ export const UpdatesSettingsRoutes = lazy(() =>
       }),
       async (c) => {
         return c.json(await update(c.req.query("refresh") === "1"))
+      },
+    )
+    .post(
+      "/",
+      describeRoute({
+        summary: "Install the latest OpenScience release",
+        operationId: "settings.updates.install",
+        responses: {
+          200: {
+            description: "Installation result",
+            content: { "application/json": { schema: resolver(InstallResult) } },
+          },
+        },
+      }),
+      async (c) => {
+        return c.json(await install())
       },
     )
     .get("/releases", async (c) => {

--- a/backend/cli/test/agent/agent.test.ts
+++ b/backend/cli/test/agent/agent.test.ts
@@ -52,10 +52,11 @@ function generationTelemetrySpies() {
   const userMessage = spyOn(OutboundTelemetry, "userMessage").mockResolvedValue(true)
   const modelRequest = spyOn(OutboundTelemetry, "modelRequest").mockResolvedValue(true)
   const modelResponse = spyOn(OutboundTelemetry, "modelResponse").mockResolvedValue(true)
+  const modelUsage = spyOn(OutboundTelemetry, "modelUsage").mockResolvedValue(true)
   const error = spyOn(OutboundTelemetry, "error").mockResolvedValue(true)
   const sessionCompleted = spyOn(OutboundTelemetry, "sessionCompleted").mockResolvedValue(true)
-  restores.push(sessionStarted, userMessage, modelRequest, modelResponse, error, sessionCompleted)
-  return { sessionStarted, userMessage, modelRequest, modelResponse, error, sessionCompleted }
+  restores.push(sessionStarted, userMessage, modelRequest, modelResponse, modelUsage, error, sessionCompleted)
+  return { sessionStarted, userMessage, modelRequest, modelResponse, modelUsage, error, sessionCompleted }
 }
 
 test("returns default native agents when no config", async () => {
@@ -965,6 +966,17 @@ test("agent configuration generation emits one canonical ephemeral model trace a
         model: "anthropic/claude-test",
         parts: [{ type: "json", value: output }],
       })
+      expect(telemetry.modelUsage).toHaveBeenCalledWith({
+        sessionID: started?.sessionID,
+        messageID: user?.messageID,
+        operationID: "agent-config-generation",
+        attempt: 1,
+        route: "byok",
+        provider: "openrouter",
+        model: "anthropic/claude-test",
+        tokens: { input: 20, output: 10, reasoning: 0, cache: { read: 0, write: 0 } },
+        cost: 0,
+      })
       expect(telemetry.error).not.toHaveBeenCalled()
       expect(telemetry.sessionCompleted).toHaveBeenCalledWith({
         sessionID: started?.sessionID,
@@ -1028,6 +1040,12 @@ test("OAuth configuration generation traces the streamObject response without pr
         model: "gpt-test",
         parts: [{ type: "json", value: output }],
       })
+      expect(telemetry.modelUsage.mock.calls[0]?.[0]).toMatchObject({
+        route: "subscription",
+        provider: "openai",
+        model: "gpt-test",
+        tokens: { input: 20, output: 10, reasoning: 0, cache: { read: 0, write: 0 } },
+      })
       expect(telemetry.error).not.toHaveBeenCalled()
     },
   })
@@ -1057,6 +1075,7 @@ test("agent configuration generation records provider errors under the model req
 
       const request = telemetry.modelRequest.mock.calls[0]?.[0]
       expect(telemetry.modelResponse).not.toHaveBeenCalled()
+      expect(telemetry.modelUsage).not.toHaveBeenCalled()
       expect(telemetry.error).toHaveBeenCalledTimes(1)
       expect(telemetry.error.mock.calls[0]?.[0]).toMatchObject({
         sessionID: request?.sessionID,

--- a/backend/cli/test/credentials/lifecycle-retry.test.ts
+++ b/backend/cli/test/credentials/lifecycle-retry.test.ts
@@ -1,0 +1,65 @@
+import { expect, test } from "bun:test"
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+
+test("a failed credential handler retries without replaying handlers that already succeeded", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openscience-credential-retry-"))
+  const mutate = path.join(root, "mutate.ts")
+  const worker = path.join(root, "worker.ts")
+  const ready = path.join(root, "ready")
+  const result = path.join(root, "result.json")
+  const lifecycle = new URL("../../src/credentials/lifecycle.ts", import.meta.url).href
+  await Bun.write(
+    mutate,
+    [
+      `import { CredentialLifecycle } from ${JSON.stringify(lifecycle)}`,
+      `await CredentialLifecycle.mutate("retry-test", async () => undefined)`,
+    ].join("\n"),
+  )
+  await Bun.write(
+    worker,
+    [
+      `import fs from "node:fs/promises"`,
+      `import { CredentialLifecycle } from ${JSON.stringify(lifecycle)}`,
+      `await CredentialLifecycle.ensureFresh()`,
+      `const counts = { refreshed: 0, revoked: 0 }`,
+      `CredentialLifecycle.onRefresh(() => { counts.refreshed++ })`,
+      `CredentialLifecycle.onRevoke(() => { counts.revoked++; if (counts.revoked === 1) throw new Error("retry once") })`,
+      `CredentialLifecycle.watch(25)`,
+      `await fs.writeFile(${JSON.stringify(ready)}, "ready")`,
+      `for (const _ of Array.from({ length: 500 })) { if (counts.revoked >= 2) break; await Bun.sleep(10) }`,
+      `await CredentialLifecycle.ensureFresh()`,
+      `CredentialLifecycle.stopWatching()`,
+      `await fs.writeFile(${JSON.stringify(result)}, JSON.stringify(counts))`,
+    ].join("\n"),
+  )
+  const env = {
+    ...process.env,
+    OPENSCIENCE_DATA_DIR: root,
+    OPENSCIENCE_CONFIG_DIR: path.join(root, "config"),
+    OPENSCIENCE_TEST_HOME: path.join(root, "home"),
+    XDG_STATE_HOME: path.join(root, "state"),
+    XDG_CACHE_HOME: path.join(root, "cache"),
+  }
+  const run = async (args: string[]) => {
+    const proc = Bun.spawn(args, { env, stdout: "pipe", stderr: "pipe" })
+    const [exit, error] = await Promise.all([proc.exited, new Response(proc.stderr).text()])
+    if (exit !== 0) throw new Error(error)
+  }
+
+  try {
+    const live = Bun.spawn([process.execPath, worker], { env, stdout: "pipe", stderr: "pipe" })
+    for (const _ of Array.from({ length: 400 })) {
+      if (await Bun.file(ready).exists()) break
+      await Bun.sleep(10)
+    }
+    expect(await Bun.file(ready).exists()).toBe(true)
+    await run([process.execPath, mutate])
+    const [exit, error] = await Promise.all([live.exited, new Response(live.stderr).text()])
+    if (exit !== 0) throw new Error(error)
+    expect(await Bun.file(result).json()).toEqual({ refreshed: 1, revoked: 2 })
+  } finally {
+    await fs.rm(root, { recursive: true, force: true })
+  }
+})

--- a/backend/cli/test/server/settings-updates.test.ts
+++ b/backend/cli/test/server/settings-updates.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test"
-import { createUpdateCache, isNewerVersion } from "../../src/server/routes/settings/updates"
+import {
+  createUpdateCache,
+  createUpdateInstaller,
+  isNewerVersion,
+  supportsAutomaticUpdate,
+} from "../../src/server/routes/settings/updates"
 
 describe("update version ordering", () => {
   test("only reports a genuinely newer release", () => {
@@ -7,6 +12,42 @@ describe("update version ordering", () => {
     expect(isNewerVersion("2.0.2", "2.0.2")).toBe(false)
     expect(isNewerVersion("2.0.2-test.58.1", "2.0.1")).toBe(false)
     expect(isNewerVersion("local", "2.0.2")).toBe(false)
+  })
+})
+
+describe("automatic update support", () => {
+  test("supports every installer implemented by the upgrader", () => {
+    expect(["curl", "npm", "pnpm", "yarn", "bun", "brew", "choco", "scoop"].every(supportsAutomaticUpdate)).toBe(true)
+    expect(supportsAutomaticUpdate("unknown")).toBe(false)
+  })
+
+  test("deduplicates concurrent install requests", async () => {
+    const gate = Promise.withResolvers<void>()
+    const calls: string[] = []
+    const install = createUpdateInstaller({
+      resolve: async () => ({
+        current: "2.0.47",
+        latest: "2.0.49",
+        channel: "latest",
+        method: "npm",
+        updateAvailable: true,
+        releaseNotes: "https://example.com/releases",
+      }),
+      upgrade: async (_method, version) => {
+        calls.push(version)
+        await gate.promise
+      },
+    })
+
+    const first = install()
+    const second = install()
+    await Promise.resolve()
+    expect(calls).toEqual(["2.0.49"])
+    gate.resolve()
+    expect(await Promise.all([first, second])).toEqual([
+      expect.objectContaining({ installed: true, restartRequired: true }),
+      expect.objectContaining({ installed: true, restartRequired: true }),
+    ])
   })
 })
 

--- a/frontend/workspace/src/components/settings-general.tsx
+++ b/frontend/workspace/src/components/settings-general.tsx
@@ -58,11 +58,22 @@ export const AppearanceSections: Component = () => {
   })
 
   const install = () => {
-    if (!platform.update || !platform.restart || store.installing) return
+    if (!platform.update || store.installing) return
     setStore("installing", true)
     void platform
       .update()
-      .then(() => platform.restart!())
+      .then((result) => {
+        setStore("installing", false)
+        setStore("available", undefined)
+        showToast({
+          variant: "success",
+          icon: "circle-check",
+          title: result.installed ? `OpenScience ${result.version ?? ""} installed` : "OpenScience is up to date",
+          description: result.restartRequired
+            ? "Restart the OpenScience command to finish the update."
+            : "You're running the latest version of OpenScience.",
+        })
+      })
       .catch((error: unknown) => {
         const message = error instanceof Error ? error.message : String(error)
         showToast({ title: language.t("common.requestFailed"), description: message })
@@ -90,27 +101,23 @@ export const AppearanceSections: Component = () => {
 
         setStore("available", result.version ?? "Update available")
 
-        const actions =
-          platform.update && platform.restart
-            ? [
-                {
-                  label: language.t("toast.update.action.installRestart"),
-                  onClick: async () => {
-                    await platform.update!()
-                    await platform.restart!()
-                  },
-                },
-                {
-                  label: language.t("toast.update.action.notYet"),
-                  onClick: "dismiss" as const,
-                },
-              ]
-            : [
-                {
-                  label: language.t("toast.update.action.notYet"),
-                  onClick: "dismiss" as const,
-                },
-              ]
+        const actions = platform.update
+          ? [
+              {
+                label: "Install update",
+                onClick: install,
+              },
+              {
+                label: language.t("toast.update.action.notYet"),
+                onClick: "dismiss" as const,
+              },
+            ]
+          : [
+              {
+                label: language.t("toast.update.action.notYet"),
+                onClick: "dismiss" as const,
+              },
+            ]
 
         showToast({
           persistent: true,
@@ -411,7 +418,7 @@ export const AppearanceSections: Component = () => {
             description={language.t("settings.updates.row.check.description")}
           >
             <div class="flex max-w-full flex-wrap items-center justify-end gap-2">
-              <Show when={store.available && platform.update && platform.restart}>
+              <Show when={store.available && platform.update}>
                 <Button size="small" variant="primary" disabled={store.installing} onClick={install}>
                   {store.installing ? "Installing…" : `Install ${store.available}`}
                 </Button>

--- a/frontend/workspace/src/components/settings/startup-update.css
+++ b/frontend/workspace/src/components/settings/startup-update.css
@@ -1,0 +1,84 @@
+.startup-update {
+  position: fixed;
+  inset-block-start: 10px;
+  inset-inline-start: 50%;
+  z-index: 90;
+  display: flex;
+  width: min(680px, calc(100vw - 24px));
+  min-height: 52px;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 8px 8px 10px;
+  border: 1px solid var(--border-base);
+  border-radius: 15px;
+  background: color-mix(in srgb, var(--surface-raised-stronger-non-alpha) 94%, transparent);
+  box-shadow: var(--atlas-shadow-md, var(--shadow-lg));
+  color: var(--text-base);
+  translate: -50% 0;
+  backdrop-filter: blur(20px) saturate(1.08);
+  -webkit-backdrop-filter: blur(20px) saturate(1.08);
+}
+
+.startup-update__icon {
+  display: grid;
+  width: 32px;
+  height: 32px;
+  flex: 0 0 auto;
+  place-items: center;
+  border-radius: 10px;
+  background: var(--surface-interactive-weak);
+  color: var(--text-interactive-base);
+}
+
+.startup-update__copy {
+  display: grid;
+  min-width: 0;
+  flex: 1;
+  line-height: 1.25;
+}
+
+.startup-update__copy strong {
+  overflow: hidden;
+  color: var(--text-strong);
+  font-size: 13px;
+  font-weight: var(--font-weight-semibold);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.startup-update__copy small {
+  overflow: hidden;
+  color: var(--text-weak);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.startup-update__dismiss {
+  display: grid;
+  width: 30px;
+  height: 30px;
+  flex: 0 0 auto;
+  place-items: center;
+  border: 0;
+  border-radius: 9px;
+  background: transparent;
+  color: var(--text-weak);
+}
+
+.startup-update__dismiss:hover,
+.startup-update__dismiss:focus-visible {
+  background: var(--surface-base-hover);
+  color: var(--text-base);
+}
+
+@media (max-width: 640px) {
+  .startup-update {
+    align-items: center;
+    flex-wrap: wrap;
+  }
+
+  .startup-update__copy {
+    flex-basis: calc(100% - 84px);
+  }
+}

--- a/frontend/workspace/src/components/settings/startup-update.tsx
+++ b/frontend/workspace/src/components/settings/startup-update.tsx
@@ -1,9 +1,13 @@
-import { createEffect, onCleanup, type Component } from "solid-js"
+import { Show, createEffect, onCleanup, type Component } from "solid-js"
+import { createStore } from "solid-js/store"
+import { Button } from "@synsci/ui/button"
+import { Icon } from "@synsci/ui/icon"
+import { useDialog } from "@synsci/ui/context/dialog"
 import { showToast } from "@synsci/ui/toast"
-import { useLanguage } from "@/context/language"
 import { usePlatform } from "@/context/platform"
 import { useSettings } from "@/context/settings"
-import { URLS } from "@/config/urls"
+import { DialogSettings } from "@/components/dialog-settings"
+import "./startup-update.css"
 
 type UpdateResult = { updateAvailable: boolean; version?: string }
 
@@ -45,9 +49,49 @@ export function queueStartupUpdateCheck(input: {
 export const StartupUpdateCheck: Component = () => {
   const platform = usePlatform()
   const settings = useSettings()
-  const language = useLanguage()
+  const dialog = useDialog()
+  const [store, setStore] = createStore({
+    available: undefined as string | undefined,
+    dismissed: false,
+    installing: false,
+    installed: false,
+  })
   let queued = false
   let cancel = () => {}
+
+  const install = async () => {
+    if (!platform.update || store.installing) return
+    setStore("installing", true)
+    await platform
+      .update()
+      .then((result) => {
+        if (!result.installed) {
+          setStore({ dismissed: true, installing: false })
+          showToast({
+            variant: "success",
+            icon: "circle-check",
+            title: "OpenScience is up to date",
+            description: "You're running the latest version of OpenScience.",
+          })
+          return
+        }
+        setStore({ installed: true, installing: false })
+        showToast({
+          variant: "success",
+          icon: "circle-check",
+          title: `OpenScience ${result.version ?? store.available ?? ""} installed`,
+          description: "Restart the OpenScience command to finish the update.",
+        })
+      })
+      .catch((error: unknown) => {
+        setStore("installing", false)
+        showToast({
+          variant: "error",
+          title: "Update failed",
+          description: error instanceof Error ? error.message : String(error),
+        })
+      })
+  }
 
   createEffect(() => {
     if (queued || !settings.ready()) return
@@ -56,28 +100,47 @@ export const StartupUpdateCheck: Component = () => {
       enabled: settings.updates.startup(),
       check: platform.checkUpdate,
       notify: (result) => {
-        showToast({
-          persistent: true,
-          icon: "download",
-          title: language.t("toast.update.title"),
-          description: language.t("toast.update.description", { version: result.version ?? "" }),
-          actions: [
-            {
-              label: language.t("settings.general.row.releaseNotes.title"),
-              onClick: () => platform.openLink(URLS.releases),
-            },
-            {
-              label: language.t("toast.update.action.notYet"),
-              onClick: "dismiss",
-            },
-          ],
-        })
+        setStore({ available: result.version ?? "latest", dismissed: false })
       },
     })
   })
 
   onCleanup(() => cancel())
-  return null
+  return (
+    <Show when={store.available && !store.dismissed}>
+      <aside class="startup-update" aria-label="OpenScience update available" aria-live="polite">
+        <span class="startup-update__icon" aria-hidden="true">
+          <Icon name={store.installed ? "circle-check" : "download"} size="small" />
+        </span>
+        <span class="startup-update__copy">
+          <strong>{store.installed ? "Update installed" : `OpenScience ${store.available} is ready`}</strong>
+          <small>
+            {store.installed ? "Restart OpenScience to finish." : "Install it now or manage updates in Customize."}
+          </small>
+        </span>
+        <Show when={!store.installed && platform.update}>
+          <Button size="small" variant="primary" disabled={store.installing} onClick={() => void install()}>
+            {store.installing ? "Installing…" : "Update"}
+          </Button>
+        </Show>
+        <Button
+          size="small"
+          variant="secondary"
+          onClick={() => dialog.show(() => <DialogSettings initial="general" />)}
+        >
+          Customize
+        </Button>
+        <button
+          type="button"
+          class="startup-update__dismiss"
+          aria-label="Dismiss update notice"
+          onClick={() => setStore("dismissed", true)}
+        >
+          <Icon name="close" size="small" />
+        </button>
+      </aside>
+    </Show>
+  )
 }
 
 export default StartupUpdateCheck

--- a/frontend/workspace/src/context/platform.tsx
+++ b/frontend/workspace/src/context/platform.tsx
@@ -45,8 +45,8 @@ export type Platform = {
   /** Check for updates (Tauri only) */
   checkUpdate?(options?: { refresh?: boolean }): Promise<{ updateAvailable: boolean; version?: string }>
 
-  /** Install updates (Tauri only) */
-  update?(): Promise<void>
+  /** Install the latest update through the local OpenScience server */
+  update?(): Promise<{ installed: boolean; restartRequired: boolean; version?: string }>
 
   /** Fetch override */
   fetch?: typeof fetch

--- a/frontend/workspace/src/entry.tsx
+++ b/frontend/workspace/src/entry.tsx
@@ -110,6 +110,19 @@ const platform: Platform = {
     const result = (await response.json()) as { updateAvailable: boolean; latest?: string }
     return { updateAvailable: result.updateAvailable, version: result.latest }
   },
+  update: async () => {
+    const url = resolveServerRoute("/settings/updates", server(), window.location.origin)
+    const response = await openscienceFetch(url, {
+      method: "POST",
+      headers: { Accept: "application/json" },
+    })
+    if (!response.ok) {
+      const detail = (await response.json().catch(() => undefined)) as { error?: string } | undefined
+      throw new Error(detail?.error ?? `Update install failed (${response.status})`)
+    }
+    const result = (await response.json()) as { installed: boolean; restartRequired: boolean; latest?: string }
+    return { installed: result.installed, restartRequired: result.restartRequired, version: result.latest }
+  },
   getDefaultServerUrl: () => stored() ?? null,
   setDefaultServerUrl: (url) => {
     if (desktopUrl) return

--- a/tooling/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/tooling/sdk/js/src/v2/gen/sdk.gen.ts
@@ -9,6 +9,7 @@ import type {
   AccountDeviceRevokeResponses,
   AccountDevicesResponses,
   AccountGetResponses,
+  AccountLoginBrowserResponses,
   AccountLoginKeyResponses,
   AccountLogoutResponses,
   AccountSessionResponses,
@@ -342,6 +343,7 @@ import type {
   SettingsStorageResetLocationResponses,
   SettingsStorageUsageResponses,
   SettingsUpdatesCheckResponses,
+  SettingsUpdatesInstallResponses,
   SettingsUsageGetResponses,
   SettingsWalletGetResponses,
   SubtaskPartInput,
@@ -701,6 +703,16 @@ export class Account extends HeyApiClient {
   public devices<ThrowOnError extends boolean = false>(options?: Options<never, ThrowOnError>) {
     return (options?.client ?? this.client).get<AccountDevicesResponses, unknown, ThrowOnError>({
       url: "/account/devices",
+      ...options,
+    })
+  }
+
+  /**
+   * Sign in through the system browser
+   */
+  public loginBrowser<ThrowOnError extends boolean = false>(options?: Options<never, ThrowOnError>) {
+    return (options?.client ?? this.client).post<AccountLoginBrowserResponses, unknown, ThrowOnError>({
+      url: "/account/login-browser",
       ...options,
     })
   }
@@ -1679,6 +1691,7 @@ export class Preferences extends HeyApiClient {
       extra_budget_usd?: number
       show_trace?: boolean
       show_local_models?: boolean
+      desktop_onboarding_version?: number
       atlas_enabled?: boolean
       delegation_enabled?: boolean
       delegation_specialist?: string | null
@@ -1702,6 +1715,7 @@ export class Preferences extends HeyApiClient {
             { in: "body", key: "extra_budget_usd" },
             { in: "body", key: "show_trace" },
             { in: "body", key: "show_local_models" },
+            { in: "body", key: "desktop_onboarding_version" },
             { in: "body", key: "atlas_enabled" },
             { in: "body", key: "delegation_enabled" },
             { in: "body", key: "delegation_specialist" },
@@ -1793,6 +1807,16 @@ export class Updates extends HeyApiClient {
       ...options,
     })
   }
+
+  /**
+   * Install the latest OpenScience release
+   */
+  public install<ThrowOnError extends boolean = false>(options?: Options<never, ThrowOnError>) {
+    return (options?.client ?? this.client).post<SettingsUpdatesInstallResponses, unknown, ThrowOnError>({
+      url: "/settings/updates",
+      ...options,
+    })
+  }
 }
 
 export class Telemetry extends HeyApiClient {
@@ -1800,12 +1824,23 @@ export class Telemetry extends HeyApiClient {
    * Update OpenScience data-use consent
    */
   public update<ThrowOnError extends boolean = false>(
-    parameters: {
-      analyticsEnabled: boolean
+    parameters?: {
+      analyticsEnabled?: boolean
+      userOwnedContentEnabled?: boolean
     },
     options?: Options<never, ThrowOnError>,
   ) {
-    const params = buildClientParams([parameters], [{ args: [{ in: "body", key: "analyticsEnabled" }] }])
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "body", key: "analyticsEnabled" },
+            { in: "body", key: "userOwnedContentEnabled" },
+          ],
+        },
+      ],
+    )
     return (options?.client ?? this.client).put<SettingsResearchToolsTelemetryUpdateResponses, unknown, ThrowOnError>({
       url: "/settings/research-tools/telemetry",
       ...options,
@@ -3495,7 +3530,6 @@ export class Session extends HeyApiClient {
           modelID: string
         }
         autonomy?: "interactive" | "balanced" | "autonomous"
-        diversity?: "focused" | "balanced" | "exploratory"
       }
       system?: string
       variant?: string
@@ -3599,7 +3633,6 @@ export class Session extends HeyApiClient {
           modelID: string
         }
         autonomy?: "interactive" | "balanced" | "autonomous"
-        diversity?: "focused" | "balanced" | "exploratory"
       }
       system?: string
       variant?: string
@@ -3666,7 +3699,6 @@ export class Session extends HeyApiClient {
           modelID: string
         }
         autonomy?: "interactive" | "balanced" | "autonomous"
-        diversity?: "focused" | "balanced" | "exploratory"
       }
       variant?: string
       tier?: string

--- a/tooling/sdk/js/src/v2/gen/types.gen.ts
+++ b/tooling/sdk/js/src/v2/gen/types.gen.ts
@@ -233,6 +233,8 @@ export type UserMessage = {
         text: string
         epoch: string
         transaction: string
+        progress?: string
+        repair?: boolean
       }
     | {
         type: "compaction"
@@ -255,7 +257,6 @@ export type UserMessage = {
       modelID: string
     }
     autonomy?: "interactive" | "balanced" | "autonomous"
-    diversity?: "focused" | "balanced" | "exploratory"
   }
   variant?: string
   tier?: string
@@ -2881,6 +2882,25 @@ export type AccountBillingModeSetResponses = {
 
 export type AccountBillingModeSetResponse = AccountBillingModeSetResponses[keyof AccountBillingModeSetResponses]
 
+export type AccountLoginBrowserData = {
+  body?: never
+  path?: never
+  query?: never
+  url: "/account/login-browser"
+}
+
+export type AccountLoginBrowserResponses = {
+  /**
+   * Login result
+   */
+  200: {
+    ok: boolean
+    error?: string
+  }
+}
+
+export type AccountLoginBrowserResponse = AccountLoginBrowserResponses[keyof AccountLoginBrowserResponses]
+
 export type AccountLoginKeyData = {
   body?: {
     key: string
@@ -4803,6 +4823,7 @@ export type SettingsComputeJobsListResponses = {
       approval: string
       sdk: string
       volume?: string
+      retained_volume?: boolean
     }
     ssh?: {
       protocol: 1
@@ -5561,6 +5582,7 @@ export type SettingsComputeJobsStartResponses = {
       approval: string
       sdk: string
       volume?: string
+      retained_volume?: boolean
     }
     ssh?: {
       protocol: 1
@@ -6519,6 +6541,7 @@ export type SettingsComputeJobsRetryResponses = {
       approval: string
       sdk: string
       volume?: string
+      retained_volume?: boolean
     }
     ssh?: {
       protocol: 1
@@ -7247,6 +7270,7 @@ export type SettingsComputeJobsReleaseResponses = {
       approval: string
       sdk: string
       volume?: string
+      retained_volume?: boolean
     }
     ssh?: {
       protocol: 1
@@ -7971,6 +7995,7 @@ export type SettingsComputeJobsCancelResponses = {
       approval: string
       sdk: string
       volume?: string
+      retained_volume?: boolean
     }
     ssh?: {
       protocol: 1
@@ -8027,6 +8052,7 @@ export type SettingsPreferencesGetResponses = {
     extra_budget_usd?: number
     show_trace?: boolean
     show_local_models?: boolean
+    desktop_onboarding_version?: number
     atlas_enabled?: boolean
     delegation_enabled?: boolean
     delegation_specialist?: string | null
@@ -8046,12 +8072,10 @@ export type SettingsPreferencesUpdateData = {
   body?: {
     reasoning_effort?: "minimal" | "low" | "medium" | "high"
     intent?: "commercial" | "non-commercial"
-    /**
-     * @deprecated No billing effect. OpenScience compute is user-owned.
-     */
     extra_budget_usd?: number
     show_trace?: boolean
     show_local_models?: boolean
+    desktop_onboarding_version?: number
     atlas_enabled?: boolean
     delegation_enabled?: boolean
     delegation_specialist?: string | null
@@ -8081,6 +8105,7 @@ export type SettingsPreferencesUpdateResponses = {
     extra_budget_usd?: number
     show_trace?: boolean
     show_local_models?: boolean
+    desktop_onboarding_version?: number
     atlas_enabled?: boolean
     delegation_enabled?: boolean
     delegation_specialist?: string | null
@@ -8323,6 +8348,31 @@ export type SettingsUpdatesCheckResponses = {
 
 export type SettingsUpdatesCheckResponse = SettingsUpdatesCheckResponses[keyof SettingsUpdatesCheckResponses]
 
+export type SettingsUpdatesInstallData = {
+  body?: never
+  path?: never
+  query?: never
+  url: "/settings/updates"
+}
+
+export type SettingsUpdatesInstallResponses = {
+  /**
+   * Installation result
+   */
+  200: {
+    current: string
+    latest: string
+    channel: string
+    method: string
+    updateAvailable: boolean
+    releaseNotes: string
+    installed: boolean
+    restartRequired: boolean
+  }
+}
+
+export type SettingsUpdatesInstallResponse = SettingsUpdatesInstallResponses[keyof SettingsUpdatesInstallResponses]
+
 export type SettingsResearchToolsGetData = {
   body?: never
   path?: never
@@ -8370,12 +8420,15 @@ export type SettingsResearchToolsGetResponses = {
     telemetry: {
       analyticsEnabled: boolean
       researchContentEnabled: boolean
+      userOwnedContentEnabled: boolean
       source: "default" | "local" | "account"
       signedIn: boolean
       consentVersion: string
       pending: boolean
       corrupt: boolean
       deletionAvailable: boolean
+      queuedEvents: number
+      quarantinedEvents: number
     }
   }
 }
@@ -8385,7 +8438,8 @@ export type SettingsResearchToolsGetResponse =
 
 export type SettingsResearchToolsTelemetryUpdateData = {
   body?: {
-    analyticsEnabled: boolean
+    analyticsEnabled?: boolean
+    userOwnedContentEnabled?: boolean
   }
   path?: never
   query?: never
@@ -8432,12 +8486,15 @@ export type SettingsResearchToolsTelemetryUpdateResponses = {
     telemetry: {
       analyticsEnabled: boolean
       researchContentEnabled: boolean
+      userOwnedContentEnabled: boolean
       source: "default" | "local" | "account"
       signedIn: boolean
       consentVersion: string
       pending: boolean
       corrupt: boolean
       deletionAvailable: boolean
+      queuedEvents: number
+      quarantinedEvents: number
     }
   }
 }
@@ -10502,7 +10559,6 @@ export type SessionPromptData = {
         modelID: string
       }
       autonomy?: "interactive" | "balanced" | "autonomous"
-      diversity?: "focused" | "balanced" | "exploratory"
     }
     system?: string
     variant?: string
@@ -10701,7 +10757,6 @@ export type SessionPromptAsyncData = {
         modelID: string
       }
       autonomy?: "interactive" | "balanced" | "autonomous"
-      diversity?: "focused" | "balanced" | "exploratory"
     }
     system?: string
     variant?: string
@@ -10758,7 +10813,6 @@ export type SessionCommandData = {
         modelID: string
       }
       autonomy?: "interactive" | "balanced" | "autonomous"
-      diversity?: "focused" | "balanced" | "exploratory"
     }
     variant?: string
     tier?: string
@@ -16464,6 +16518,7 @@ export type AppSkillsResponses = {
     tags?: Array<string>
     role?: "workflow" | "support"
     capability?: string
+    allowed_tools?: Array<string>
     requirements?: {
       all?: Array<string>
       any?: Array<string>
@@ -16528,6 +16583,7 @@ export type AppSkillWriteResponses = {
     tags?: Array<string>
     role?: "workflow" | "support"
     capability?: string
+    allowed_tools?: Array<string>
     requirements?: {
       all?: Array<string>
       any?: Array<string>

--- a/tooling/sdk/openapi.json
+++ b/tooling/sdk/openapi.json
@@ -842,6 +842,41 @@
         ]
       }
     },
+    "/account/login-browser": {
+      "post": {
+        "operationId": "account.loginBrowser",
+        "summary": "Sign in through the system browser",
+        "responses": {
+          "200": {
+            "description": "Login result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpenScienceClient } from \"@synsci/sdk\"\n\nconst client = createOpenScienceClient()\nawait client.account.loginBrowser({\n  ...\n})"
+          }
+        ]
+      }
+    },
     "/account/login-key": {
       "post": {
         "operationId": "account.loginKey",
@@ -7733,6 +7768,9 @@
                           },
                           "volume": {
                             "type": "string"
+                          },
+                          "retained_volume": {
+                            "type": "boolean"
                           }
                         },
                         "required": [
@@ -10168,6 +10206,9 @@
                         },
                         "volume": {
                           "type": "string"
+                        },
+                        "retained_volume": {
+                          "type": "boolean"
                         }
                       },
                       "required": [
@@ -13569,6 +13610,9 @@
                         },
                         "volume": {
                           "type": "string"
+                        },
+                        "retained_volume": {
+                          "type": "boolean"
                         }
                       },
                       "required": [
@@ -16033,6 +16077,9 @@
                         },
                         "volume": {
                           "type": "string"
+                        },
+                        "retained_volume": {
+                          "type": "boolean"
                         }
                       },
                       "required": [
@@ -18497,6 +18544,9 @@
                         },
                         "volume": {
                           "type": "string"
+                        },
+                        "retained_volume": {
+                          "type": "boolean"
                         }
                       },
                       "required": [
@@ -18739,6 +18789,12 @@
                       "default": true,
                       "type": "boolean"
                     },
+                    "desktop_onboarding_version": {
+                      "default": 0,
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
+                    },
                     "atlas_enabled": {
                       "default": false,
                       "type": "boolean"
@@ -18865,6 +18921,12 @@
                       "default": true,
                       "type": "boolean"
                     },
+                    "desktop_onboarding_version": {
+                      "default": 0,
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
+                    },
                     "atlas_enabled": {
                       "default": false,
                       "type": "boolean"
@@ -18948,7 +19010,6 @@
                 "type": "object",
                 "properties": {
                   "reasoning_effort": {
-                    "default": "medium",
                     "type": "string",
                     "enum": [
                       "minimal",
@@ -18958,7 +19019,6 @@
                     ]
                   },
                   "intent": {
-                    "default": "non-commercial",
                     "type": "string",
                     "enum": [
                       "commercial",
@@ -18966,29 +19026,27 @@
                     ]
                   },
                   "extra_budget_usd": {
-                    "description": "@deprecated No billing effect. OpenScience compute is user-owned.",
-                    "default": 0,
                     "type": "number",
                     "minimum": 0
                   },
                   "show_trace": {
-                    "default": false,
                     "type": "boolean"
                   },
                   "show_local_models": {
-                    "default": true,
                     "type": "boolean"
                   },
+                  "desktop_onboarding_version": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
                   "atlas_enabled": {
-                    "default": false,
                     "type": "boolean"
                   },
                   "delegation_enabled": {
-                    "default": true,
                     "type": "boolean"
                   },
                   "delegation_specialist": {
-                    "default": null,
                     "anyOf": [
                       {
                         "type": "string"
@@ -18999,7 +19057,6 @@
                     ]
                   },
                   "delegation_level": {
-                    "default": "standard",
                     "type": "string",
                     "enum": [
                       "off",
@@ -19009,7 +19066,6 @@
                     ]
                   },
                   "delegation_worker_model": {
-                    "default": null,
                     "anyOf": [
                       {
                         "type": "object",
@@ -19032,7 +19088,6 @@
                     ]
                   },
                   "delegation_autonomy": {
-                    "default": "balanced",
                     "type": "string",
                     "enum": [
                       "interactive",
@@ -19041,7 +19096,6 @@
                     ]
                   },
                   "delegation_diversity": {
-                    "default": "balanced",
                     "type": "string",
                     "enum": [
                       "focused",
@@ -19696,6 +19750,65 @@
             "source": "import { createOpenScienceClient } from \"@synsci/sdk\"\n\nconst client = createOpenScienceClient()\nawait client.settings.updates.check({\n  ...\n})"
           }
         ]
+      },
+      "post": {
+        "operationId": "settings.updates.install",
+        "summary": "Install the latest OpenScience release",
+        "responses": {
+          "200": {
+            "description": "Installation result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "current": {
+                      "type": "string"
+                    },
+                    "latest": {
+                      "type": "string"
+                    },
+                    "channel": {
+                      "type": "string"
+                    },
+                    "method": {
+                      "type": "string"
+                    },
+                    "updateAvailable": {
+                      "type": "boolean"
+                    },
+                    "releaseNotes": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "installed": {
+                      "type": "boolean"
+                    },
+                    "restartRequired": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "current",
+                    "latest",
+                    "channel",
+                    "method",
+                    "updateAvailable",
+                    "releaseNotes",
+                    "installed",
+                    "restartRequired"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpenScienceClient } from \"@synsci/sdk\"\n\nconst client = createOpenScienceClient()\nawait client.settings.updates.install({\n  ...\n})"
+          }
+        ]
       }
     },
     "/settings/research-tools": {
@@ -19851,6 +19964,9 @@
                         "researchContentEnabled": {
                           "type": "boolean"
                         },
+                        "userOwnedContentEnabled": {
+                          "type": "boolean"
+                        },
                         "source": {
                           "type": "string",
                           "enum": [
@@ -19873,17 +19989,30 @@
                         },
                         "deletionAvailable": {
                           "type": "boolean"
+                        },
+                        "queuedEvents": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "maximum": 9007199254740991
+                        },
+                        "quarantinedEvents": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "maximum": 9007199254740991
                         }
                       },
                       "required": [
                         "analyticsEnabled",
                         "researchContentEnabled",
+                        "userOwnedContentEnabled",
                         "source",
                         "signedIn",
                         "consentVersion",
                         "pending",
                         "corrupt",
-                        "deletionAvailable"
+                        "deletionAvailable",
+                        "queuedEvents",
+                        "quarantinedEvents"
                       ]
                     }
                   },
@@ -20059,6 +20188,9 @@
                         "researchContentEnabled": {
                           "type": "boolean"
                         },
+                        "userOwnedContentEnabled": {
+                          "type": "boolean"
+                        },
                         "source": {
                           "type": "string",
                           "enum": [
@@ -20081,17 +20213,30 @@
                         },
                         "deletionAvailable": {
                           "type": "boolean"
+                        },
+                        "queuedEvents": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "maximum": 9007199254740991
+                        },
+                        "quarantinedEvents": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "maximum": 9007199254740991
                         }
                       },
                       "required": [
                         "analyticsEnabled",
                         "researchContentEnabled",
+                        "userOwnedContentEnabled",
                         "source",
                         "signedIn",
                         "consentVersion",
                         "pending",
                         "corrupt",
-                        "deletionAvailable"
+                        "deletionAvailable",
+                        "queuedEvents",
+                        "quarantinedEvents"
                       ]
                     }
                   },
@@ -20114,11 +20259,11 @@
                 "properties": {
                   "analyticsEnabled": {
                     "type": "boolean"
+                  },
+                  "userOwnedContentEnabled": {
+                    "type": "boolean"
                   }
-                },
-                "required": [
-                  "analyticsEnabled"
-                ]
+                }
               }
             }
           }
@@ -26254,15 +26399,6 @@
                           "balanced",
                           "autonomous"
                         ]
-                      },
-                      "diversity": {
-                        "default": "balanced",
-                        "type": "string",
-                        "enum": [
-                          "focused",
-                          "balanced",
-                          "exploratory"
-                        ]
                       }
                     }
                   },
@@ -26698,15 +26834,6 @@
                           "balanced",
                           "autonomous"
                         ]
-                      },
-                      "diversity": {
-                        "default": "balanced",
-                        "type": "string",
-                        "enum": [
-                          "focused",
-                          "balanced",
-                          "exploratory"
-                        ]
                       }
                     }
                   },
@@ -26890,15 +27017,6 @@
                           "interactive",
                           "balanced",
                           "autonomous"
-                        ]
-                      },
-                      "diversity": {
-                        "default": "balanced",
-                        "type": "string",
-                        "enum": [
-                          "focused",
-                          "balanced",
-                          "exploratory"
                         ]
                       }
                     }
@@ -47862,6 +47980,12 @@
                       "capability": {
                         "type": "string"
                       },
+                      "allowed_tools": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
                       "requirements": {
                         "type": "object",
                         "properties": {
@@ -48007,6 +48131,12 @@
                     },
                     "capability": {
                       "type": "string"
+                    },
+                    "allowed_tools": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
                     },
                     "requirements": {
                       "type": "object",
@@ -49126,6 +49256,13 @@
                   },
                   "transaction": {
                     "type": "string"
+                  },
+                  "progress": {
+                    "type": "string",
+                    "pattern": "^[a-f0-9]{64}$"
+                  },
+                  "repair": {
+                    "type": "boolean"
                   }
                 },
                 "required": [
@@ -49229,15 +49366,6 @@
                   "interactive",
                   "balanced",
                   "autonomous"
-                ]
-              },
-              "diversity": {
-                "default": "balanced",
-                "type": "string",
-                "enum": [
-                  "focused",
-                  "balanced",
-                  "exploratory"
                 ]
               }
             }


### PR DESCRIPTION
## Summary
- emit normalized model usage for ephemeral agent configuration across managed, subscription, and BYOK routes
- make credential reconciliation retry only failed handlers with bounded backoff
- surface new releases in a persistent top banner and install updates from Customize
- add the update-install API and regenerate the JavaScript SDK

## Live validation
- connected a Google Gemini BYOK credential through the installed OpenScience UI
- completed a real research task with powered search
- confirmed the resulting Gemini call, token usage, and route appeared in the authenticated Atlas admin dashboard as Own API keys
- confirmed current production data also contains Ace, ChatGPT subscription, and local route usage

## Tests
- 93 focused backend telemetry, agent, lifecycle, update, and installation tests
- workspace and repository typechecks
- 10 generated SDK runtime tests
- update UI tests
- compute job isolation file: 47/47 passing

The process-supervision LSP and command orphan tests still hit their existing 60s timeout on this macOS host; no touched file participates in those paths.