### PR TITLE
Keep Ace telemetry independent of user-owned routes

### DIFF
--- a/backend/cli/src/server/routes/settings/research-tools.ts
+++ b/backend/cli/src/server/routes/settings/research-tools.ts
@@ -98,21 +98,10 @@ export const ResearchToolsSettingsRoutes = lazy(() =>
           },
         },
       }),
-      validator(
-        "json",
-        z
-          .object({
-            analyticsEnabled: z.boolean().optional(),
-            userOwnedContentEnabled: z.boolean().optional(),
-          })
-          .refine((value) => value.analyticsEnabled !== undefined || value.userOwnedContentEnabled !== undefined),
-      ),
+      validator("json", z.object({ userOwnedContentEnabled: z.boolean() })),
       async (c) => {
         const input = c.req.valid("json")
-        if (input.analyticsEnabled !== undefined) await OutboundTelemetry.setAnalytics(input.analyticsEnabled)
-        if (input.userOwnedContentEnabled !== undefined) {
-          await OutboundTelemetry.setUserOwned(input.userOwnedContentEnabled)
-        }
+        await OutboundTelemetry.setUserOwned(input.userOwnedContentEnabled)
         return c.json(await read())
       },
     )

--- a/backend/cli/test/server/settings-research-tools.test.ts
+++ b/backend/cli/test/server/settings-research-tools.test.ts
@@ -112,4 +112,39 @@ describe("research tools settings route", () => {
       search: { route: "credits", state: "basic", enabled: true, balanceUsd: -0.25 },
     })
   })
+
+  test("the settings switch changes only user-owned routes and cannot disable Ace", async () => {
+    restores.push(
+      spyOn(OpenScience, "getSession").mockResolvedValue({ api_key: "thk_fixture", user_id: "user_fixture" } as never),
+    )
+    restores.push(spyOn(OpenScience, "getBalance").mockResolvedValue(20))
+    restores.push(
+      spyOn(OutboundTelemetry, "status").mockResolvedValue({ ...telemetry, userOwnedContentEnabled: false }),
+    )
+    const userOwned = spyOn(OutboundTelemetry, "setUserOwned").mockResolvedValue({
+      ...telemetry,
+      userOwnedContentEnabled: false,
+    })
+    const analytics = spyOn(OutboundTelemetry, "setAnalytics")
+    restores.push(userOwned, analytics)
+
+    const response = await ResearchToolsSettingsRoutes().request("/telemetry", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ userOwnedContentEnabled: false }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(userOwned).toHaveBeenCalledWith(false)
+    expect(analytics).not.toHaveBeenCalled()
+  })
+
+  test("rejects the removed global telemetry switch", async () => {
+    const response = await ResearchToolsSettingsRoutes().request("/telemetry", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ analyticsEnabled: false }),
+    })
+    expect(response.status).toBe(400)
+  })
 })

--- a/backend/cli/test/telemetry/outbound-contract.test.ts
+++ b/backend/cli/test/telemetry/outbound-contract.test.ts
@@ -190,6 +190,137 @@ describe("outbound OpenScience trace contract", () => {
     })
   })
 
+  test("retains project context, prompts, exposed reasoning, outputs, and tools for every remote route", async () => {
+    await signIn("user_complete_remote_trajectories")
+    restores.push(spyOn(globalThis, "fetch").mockRejectedValue(new Error("offline")))
+    await OutboundTelemetry.initializeAccount()
+
+    const routes = [
+      { route: "managed", provider: "openrouter", model: "openai/gpt-5.6-sol" },
+      { route: "byok", provider: "google", model: "gemini-3.6-flash" },
+      { route: "chatgpt", provider: "openai", model: "gpt-5.6-codex" },
+    ] as const
+    for (const item of routes) {
+      const sessionID = `ses_complete_${item.route}`
+      const messageID = `msg_complete_${item.route}`
+      await OutboundTelemetry.sessionStarted({
+        sessionID,
+        session: {
+          id: sessionID,
+          projectID: `project_${item.route}`,
+          title: `Trajectory ${item.route}`,
+          directory: `/research/${item.route}`,
+        },
+      })
+      await OutboundTelemetry.userMessage({
+        sessionID,
+        messageID,
+        route: item.route,
+        provider: item.provider,
+        model: item.model,
+        message: { role: "user" },
+        parts: [{ type: "text", text: `prompt content ${item.route}` }],
+      })
+      await OutboundTelemetry.modelRequest({
+        sessionID,
+        messageID,
+        attempt: 1,
+        route: item.route,
+        provider: item.provider,
+        model: item.model,
+        system: [`Project: Trajectory ${item.route}`, `Project files: /research/${item.route}`],
+        messages: [{ role: "user", content: `prompt content ${item.route}` }],
+        tools: { research_search: { description: "Search research sources" } },
+        parameters: { reasoningEffort: "high" },
+      })
+      await OutboundTelemetry.modelResponse({
+        sessionID,
+        messageID,
+        attempt: 1,
+        route: item.route,
+        provider: item.provider,
+        model: item.model,
+        message: { role: "assistant", reasoningText: `exposed reasoning ${item.route}` },
+        parts: [
+          { type: "reasoning", text: `exposed reasoning ${item.route}` },
+          { type: "text", text: `model output ${item.route}` },
+        ],
+        tokens: { inputTokens: 100, outputTokens: 25, reasoningTokens: 10 },
+        finish: "stop",
+      })
+      await OutboundTelemetry.assistantMessage({
+        sessionID,
+        messageID,
+        attempt: 1,
+        route: item.route,
+        provider: item.provider,
+        model: item.model,
+        message: { role: "assistant" },
+        parts: [
+          { type: "reasoning", text: `exposed reasoning ${item.route}` },
+          { type: "text", text: `final output ${item.route}` },
+        ],
+      })
+      await OutboundTelemetry.tool({
+        id: `prt_complete_${item.route}`,
+        sessionID,
+        messageID,
+        type: "tool",
+        callID: `call_complete_${item.route}`,
+        tool: "research_search",
+        state: {
+          status: "completed",
+          input: { query: `research question ${item.route}` },
+          output: `source result ${item.route}`,
+          title: "Research search",
+          metadata: {},
+          time: { start: 1, end: 2 },
+        },
+      })
+    }
+
+    const events = (await Bun.file(queue).text())
+      .trim()
+      .split("\n")
+      .map((line) => Event.parse((JSON.parse(line) as { event: unknown }).event))
+    for (const item of routes) {
+      const session = events.find(
+        (event) =>
+          event.event_type === "session.started" &&
+          (event.payload.session as { title?: string } | undefined)?.title === `Trajectory ${item.route}`,
+      )
+      const routed = events.filter((event) => event.model_route === item.route)
+      expect(session?.payload).toMatchObject({
+        session: { projectID: `project_${item.route}`, directory: `/research/${item.route}` },
+      })
+      expect(routed.find((event) => event.event_type === "user.message")?.payload).toMatchObject({
+        parts: [{ type: "text", text: `prompt content ${item.route}` }],
+      })
+      expect(routed.find((event) => event.event_type === "model.request")?.payload).toMatchObject({
+        system: [`Project: Trajectory ${item.route}`, `Project files: /research/${item.route}`],
+        messages: [{ role: "user", content: `prompt content ${item.route}` }],
+      })
+      expect(routed.find((event) => event.event_type === "model.response")?.payload).toMatchObject({
+        parts: [
+          { type: "reasoning", text: `exposed reasoning ${item.route}` },
+          { type: "text", text: `model output ${item.route}` },
+        ],
+      })
+      expect(routed.find((event) => event.event_type === "assistant.message")?.payload).toMatchObject({
+        parts: [
+          { type: "reasoning", text: `exposed reasoning ${item.route}` },
+          { type: "text", text: `final output ${item.route}` },
+        ],
+      })
+      expect(routed.find((event) => event.event_type === "search.completed")?.payload).toMatchObject({
+        state: {
+          input: { query: `research question ${item.route}` },
+          output: `source result ${item.route}`,
+        },
+      })
+    }
+  })
+
   test("normalizes platform names and extracts only the non-secret key id", () => {
     expect(coarsePlatform("darwin")).toBe("macos")
     expect(coarsePlatform("win32")).toBe("windows")

--- a/frontend/workspace/src/components/settings/DataUse.tsx
+++ b/frontend/workspace/src/components/settings/DataUse.tsx
@@ -1,11 +1,11 @@
-import { Show, createMemo, createSignal, onMount } from "solid-js"
+import { Show, createSignal, onMount } from "solid-js"
 import { Icon } from "@synsci/ui/icon"
 import { Switch } from "@synsci/ui/switch"
 import { usePlatform } from "@/context/platform"
 import { useServer } from "@/context/server"
 import { Card, Row, RowCopy, Section } from "./_shared"
 import { settingsApi } from "./api"
-import { dataSharingDetail, dataSharingEnabled, type ResearchToolsStatus } from "./research-tools-state"
+import { type ResearchToolsStatus, userOwnedSharingDetail, userOwnedSharingEnabled } from "./research-tools-state"
 
 export function DataUse() {
   const platform = usePlatform()
@@ -14,20 +14,18 @@ export function DataUse() {
   const [error, setError] = createSignal<string>()
   const [saving, setSaving] = createSignal(false)
   const fetcher = () => platform.fetch ?? fetch
-  const enabled = createMemo(() => (state() ? dataSharingEnabled(state()!) : false))
-
   const load = async () => {
     setError(undefined)
     setState(await settingsApi<ResearchToolsStatus>(server.url, fetcher(), "/settings/research-tools"))
   }
 
-  const update = async (body: { analyticsEnabled?: boolean; userOwnedContentEnabled?: boolean }) => {
+  const update = async (userOwnedContentEnabled: boolean) => {
     if (saving()) return
     setSaving(true)
     setError(undefined)
     const result = await settingsApi<ResearchToolsStatus>(server.url, fetcher(), "/settings/research-tools/telemetry", {
       method: "PUT",
-      body: JSON.stringify(body),
+      body: JSON.stringify({ userOwnedContentEnabled }),
     }).catch((cause) => {
       setError(cause instanceof Error ? cause.message : String(cause))
       return undefined
@@ -39,7 +37,10 @@ export function DataUse() {
   onMount(() => void load().catch((cause) => setError(cause instanceof Error ? cause.message : String(cause))))
 
   return (
-    <Section title="Data & privacy" description="Control exactly which OpenScience traces leave this device.">
+    <Section
+      title="Data & privacy"
+      description="Ace records its managed service activity. You control sharing from routes that use your own credentials."
+    >
       <Show when={error()}>
         <div class="settings-alert" data-tone="critical" role="alert">
           <span>{error()}</span>
@@ -50,37 +51,32 @@ export function DataUse() {
       </Show>
       <Card>
         <Row>
-          <span class="settings-preference-icon" data-tone={enabled() ? "success" : undefined} aria-hidden="true">
+          <span class="settings-preference-icon" data-tone="success" aria-hidden="true">
             <Icon name="activity" size="small" />
           </span>
           <RowCopy
-            title="Improve OpenScience with my activity"
-            description={state() ? dataSharingDetail(state()!) : "Loading your preference…"}
+            title="OpenScience Ace traces"
+            description="Managed prompts, provider-visible reasoning, tool results, outputs, tokens, and spend are recorded as part of the Ace service."
           />
-          <Switch
-            hideLabel
-            checked={enabled()}
-            disabled={!state() || saving()}
-            onChange={(value) => void update({ analyticsEnabled: value })}
-          >
-            Improve OpenScience with my activity
-          </Switch>
+          <span class="settings-preference-status" data-tone="success">
+            Always on
+          </span>
         </Row>
         <Row>
           <span class="settings-preference-icon" aria-hidden="true">
             <Icon name="shield" size="small" />
           </span>
           <RowCopy
-            title="Include user-owned routes"
-            description="Include prompts, traces, tool results, and final answers from API keys, ChatGPT/Codex or provider subscriptions, and local models. Ace is covered by the main switch."
+            title="Share user-owned routes"
+            description={state() ? userOwnedSharingDetail(state()!) : "Loading your preference…"}
           />
           <Switch
             hideLabel
-            checked={state()?.telemetry.userOwnedContentEnabled ?? false}
-            disabled={!state() || saving() || !enabled()}
-            onChange={(value) => void update({ userOwnedContentEnabled: value })}
+            checked={state() ? userOwnedSharingEnabled(state()!) : false}
+            disabled={!state() || saving()}
+            onChange={(value) => void update(value)}
           >
-            Include user-owned routes
+            Share user-owned routes
           </Switch>
         </Row>
         <Row>

--- a/frontend/workspace/src/components/settings/ResearchTools.test.ts
+++ b/frontend/workspace/src/components/settings/ResearchTools.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test"
-import { dataSharingDetail, dataSharingEnabled, searchStatus, type ResearchToolsStatus } from "./research-tools-state"
+import {
+  searchStatus,
+  type ResearchToolsStatus,
+  userOwnedSharingDetail,
+  userOwnedSharingEnabled,
+} from "./research-tools-state"
 
 const status = (patch?: Partial<ResearchToolsStatus>): ResearchToolsStatus => ({
   signedIn: true,
@@ -73,33 +78,34 @@ describe("Research Tools settings", () => {
     ).toMatchObject({ label: "Basic", tone: "neutral" })
   })
 
-  test("discloses default-on sharing and corrupt-record fail-closed behavior", () => {
-    expect(dataSharingEnabled(status())).toBe(true)
-    expect(dataSharingDetail(status())).toContain("On by default")
+  test("discloses default-on user-owned sharing without presenting Ace as optional", () => {
+    expect(userOwnedSharingEnabled(status())).toBe(true)
+    expect(userOwnedSharingDetail(status())).toContain("On by default")
     const migrated = status({
-      telemetry: { ...status().telemetry, analyticsEnabled: true, researchContentEnabled: false, source: "account" },
+      telemetry: { ...status().telemetry, userOwnedContentEnabled: false, source: "account" },
     })
-    expect(dataSharingEnabled(migrated)).toBe(false)
-    expect(dataSharingDetail(migrated)).toBe("Off. New activity is not shared.")
+    expect(userOwnedSharingEnabled(migrated)).toBe(false)
+    expect(userOwnedSharingDetail(migrated)).toContain("Ace remains on")
     expect(
-      dataSharingEnabled(
+      userOwnedSharingEnabled(
         status({
-          telemetry: { ...status().telemetry, analyticsEnabled: true, researchContentEnabled: true, corrupt: true },
+          telemetry: { ...status().telemetry, corrupt: true },
         }),
       ),
     ).toBe(false)
     expect(
-      dataSharingDetail(
-        status({ telemetry: { ...status().telemetry, analyticsEnabled: false, corrupt: true, source: "account" } }),
+      userOwnedSharingDetail(
+        status({
+          telemetry: { ...status().telemetry, userOwnedContentEnabled: false, corrupt: true, source: "account" },
+        }),
       ),
-    ).toContain("Off until")
+    ).toContain("Ace managed traces remain on")
     expect(
-      dataSharingDetail(
+      userOwnedSharingDetail(
         status({
           telemetry: {
             ...status().telemetry,
-            analyticsEnabled: false,
-            researchContentEnabled: false,
+            userOwnedContentEnabled: false,
             pending: true,
             source: "account",
           },
@@ -129,11 +135,15 @@ describe("Research Tools settings", () => {
 
   test("places route-aware data controls at the end of General settings", async () => {
     const source = await Bun.file(new URL("./DataUse.tsx", import.meta.url)).text()
+    const stateSource = await Bun.file(new URL("./research-tools-state.ts", import.meta.url)).text()
     const general = await Bun.file(new URL("./General.tsx", import.meta.url)).text()
     const copy = source.replace(/\s+/g, " ")
-    expect(copy).toContain("Improve OpenScience with my activity")
-    expect(copy).toContain("Include user-owned routes")
-    expect(copy).toContain("ChatGPT/Codex or provider subscriptions")
+    expect(copy).toContain("OpenScience Ace traces")
+    expect(copy).toContain("Always on")
+    expect(copy).toContain("Share user-owned routes")
+    expect(stateSource).toContain("ChatGPT/Codex, provider subscriptions")
+    expect(stateSource).toContain("Ace remains on")
+    expect(copy).not.toContain("analyticsEnabled")
     expect(copy).toContain("queued")
     expect(general.lastIndexOf("<DataUse />")).toBeGreaterThan(general.lastIndexOf("settings-disclosure-group"))
     expect(copy).not.toContain("complete research trajectory")

--- a/frontend/workspace/src/components/settings/research-tools-state.ts
+++ b/frontend/workspace/src/components/settings/research-tools-state.ts
@@ -53,17 +53,18 @@ export function searchStatus(status: ResearchToolsStatus) {
   }
 }
 
-export function dataSharingDetail(status: ResearchToolsStatus) {
-  if (status.telemetry.corrupt) return "Off until you choose this setting again."
-  if (status.telemetry.pending && (!status.telemetry.analyticsEnabled || !status.telemetry.researchContentEnabled))
-    return "Off on this device. The setting will sync when OpenScience reconnects."
-  if (!status.telemetry.analyticsEnabled || !status.telemetry.researchContentEnabled)
-    return "Off. New activity is not shared."
+export function userOwnedSharingDetail(status: ResearchToolsStatus) {
+  if (status.telemetry.corrupt) return "Unavailable until you choose this setting again. Ace managed traces remain on."
+  if (status.telemetry.pending && !status.telemetry.userOwnedContentEnabled)
+    return "Off on this device. The setting will sync when OpenScience reconnects. Ace remains on."
+  if (!status.telemetry.userOwnedContentEnabled)
+    return "Off for API keys, ChatGPT/Codex, provider subscriptions, and local models. Ace remains on."
   if (status.telemetry.pending) return "Saved on this device. It will sync when OpenScience reconnects."
-  if (status.telemetry.source === "default") return "On by default for this account."
-  return "On. New research activity helps improve OpenScience."
+  if (status.telemetry.source === "default")
+    return "On by default for API keys, ChatGPT/Codex, provider subscriptions, and local models."
+  return "On for API keys, ChatGPT/Codex, provider subscriptions, and local models."
 }
 
-export function dataSharingEnabled(status: ResearchToolsStatus) {
-  return !status.telemetry.corrupt && status.telemetry.analyticsEnabled && status.telemetry.researchContentEnabled
+export function userOwnedSharingEnabled(status: ResearchToolsStatus) {
+  return !status.telemetry.corrupt && status.telemetry.userOwnedContentEnabled
 }


### PR DESCRIPTION
## Summary
- make the Settings control apply only to BYOK, ChatGPT/Codex, subscriptions, and local routes
- keep OpenScience Ace managed traces on as part of the service record
- verify project context, prompts, provider-visible reasoning, output, search, tools, tokens, and cost across Ace, BYOK, and ChatGPT

## Verification
- focused telemetry and settings tests: 46 passed
- settings UI tests: 6 passed
- repository typecheck and workspace production build pass