### PR TITLE
Fix packaged candidate rehearsal isolation

### DIFF
--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -60,7 +60,14 @@ jobs:
           if [ -n "$INPUT_VERSION" ]; then
             version="$INPUT_VERSION"
           else
-            current="$(node -p 'require("./backend/cli/package.json").version')"
+            # Match the production release script: workspace package versions
+            # intentionally stay static between releases, so the public stable
+            # tag is the only authoritative base for the next candidate.
+            current="$(npm view @synsci/openscience@latest version)"
+            if ! [[ "$current" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "::error::Could not resolve the current stable OpenScience version; received '$current'"
+              exit 1
+            fi
             core="${current%%-*}"
             IFS=. read -r major minor patch <<< "$core"
             version="${major}.${minor}.$((patch + 1))-test.${GITHUB_RUN_ID}"
@@ -318,6 +325,7 @@ jobs:
             printf '%s\n' "OPENSCIENCE_CONFIG_CONTENT=$CONFIG"
             printf '%s\n' "OPENSCIENCE_E2E_MODEL=e2e/echo"
             printf '%s\n' "OPENSCIENCE_E2E_FAKE_MODEL=1"
+            printf '%s\n' "SYNSC_API_BASE=http://127.0.0.1:4097"
           } >> "$GITHUB_ENV"
           bun frontend/workspace/script/e2e-fake-model.ts --port 4097 > "$RUNNER_TEMP/openscience-fake-model.log" 2>&1 &
           for _ in $(seq 1 30); do
@@ -360,19 +368,23 @@ jobs:
           OPENSCIENCE_CLIENT: "app"
       - name: Wait for published OpenScience server
         run: |
+          HEALTHY=0
           for _ in $(seq 1 120); do
             if curl -fsS "http://127.0.0.1:4096/global/health" > /dev/null; then
+              HEALTHY=1
               SESSION=$(curl -fsS -u "openscience:$OPENSCIENCE_SERVER_PASSWORD" \
-                "http://127.0.0.1:4096/account/session")
+                "http://127.0.0.1:4096/account/session" || true)
               if [[ "$SESSION" == '{"session":true}' ]]; then
                 exit 0
               fi
-              echo "::error::published OpenScience server did not load the isolated account session"
-              exit 1
             fi
             sleep 1
           done
-          echo "::error::published openscience server never became healthy on 127.0.0.1:4096"
+          if [[ "$HEALTHY" == "0" ]]; then
+            echo "::error::published OpenScience server never became healthy on 127.0.0.1:4096"
+          else
+            echo "::error::published OpenScience server became healthy but never loaded the isolated account session"
+          fi
           exit 1
       - name: Run packaged E2E
         working-directory: frontend/workspace

--- a/backend/cli/test/installation/release-order.test.ts
+++ b/backend/cli/test/installation/release-order.test.ts
@@ -207,13 +207,29 @@ test("packaged npm rehearsal imports every public SDK and plugin export", async 
   }
 })
 
-test("packaged npm rehearsal pins and verifies one account data root", async () => {
+test("packaged npm rehearsal pins one account data root and waits for the seeded session", async () => {
   const workflow = await Bun.file(path.join(import.meta.dir, "../../../../.github/workflows/npm-test.yml")).text()
+  const readiness = workflow.slice(
+    workflow.indexOf("      - name: Wait for published OpenScience server"),
+    workflow.indexOf("      - name: Run packaged E2E"),
+  )
 
   expect(workflow).toContain('echo "OPENSCIENCE_DATA_DIR=$RUNNER_TEMP/openscience-e2e/data"')
+  expect(workflow).toContain("printf '%s\\n' \"SYNSC_API_BASE=http://127.0.0.1:4097\"")
   expect(workflow).toContain('test -s "$OPENSCIENCE_DATA_DIR/openscience-session.json"')
-  expect(workflow).toContain('"http://127.0.0.1:4096/account/session"')
-  expect(workflow).toContain('[[ "$SESSION" == \'{"session":true}\' ]]')
+  expect(readiness).toContain('"http://127.0.0.1:4096/account/session" || true)')
+  expect(readiness).toContain('[[ "$SESSION" == \'{"session":true}\' ]]')
+  expect(readiness.match(/sleep 1/g)).toHaveLength(1)
+  expect(readiness.match(/exit 1/g)).toHaveLength(1)
+  expect(readiness.indexOf("sleep 1")).toBeLessThan(readiness.indexOf("never loaded the isolated account session"))
+})
+
+test("npm test candidates advance from the public stable version, not the static workspace manifest", async () => {
+  const workflow = await Bun.file(path.join(import.meta.dir, "../../../../.github/workflows/npm-test.yml")).text()
+  const versionJob = workflow.slice(workflow.indexOf("\n  version:"), workflow.indexOf("\n  build-cli:"))
+
+  expect(versionJob).toContain("npm view @synsci/openscience@latest version")
+  expect(versionJob).not.toContain('require("./backend/cli/package.json").version')
 })
 
 test("npm test rehearsal stages immutable exact artifacts and promotes only after every smoke gate", async () => {


### PR DESCRIPTION
## Summary
- derive candidate versions from the public stable npm tag
- keep packaged E2E account refreshes on the isolated fake control plane
- wait through transient startup state until both health and seeded session are ready

## Verification
- `bun run format:check`
- `actionlint .github/workflows/npm-test.yml`
- `git diff --check`
- `cd backend/cli && bun test test/installation/release-order.test.ts` (19 passed)
- exact published-candidate startup reproduced before/after locally