### PR TITLE
Streamline the Ace purchase handoff

### DIFF
--- a/frontend/landing/src/main.tsx
+++ b/frontend/landing/src/main.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react"
 import { createRoot } from "react-dom/client"
 import { Analytics } from "@vercel/analytics/react"
 import Download from "./pages/Download"
@@ -8,23 +7,12 @@ import "./index.css"
 const ANALYTICS_PREFERENCE = "openscience.websiteAnalytics"
 
 function App() {
-  const [analyticsEnabled, setAnalyticsEnabled] = useState(
-    () => window.localStorage.getItem(ANALYTICS_PREFERENCE) !== "off",
-  )
+  const analyticsEnabled = window.localStorage.getItem(ANALYTICS_PREFERENCE) !== "off"
   const path = window.location.pathname.replace(/\/+$/, "") || "/"
-  const toggle = () => {
-    const next = !analyticsEnabled
-    window.localStorage.setItem(ANALYTICS_PREFERENCE, next ? "on" : "off")
-    setAnalyticsEnabled(next)
-  }
 
   return (
     <>
-      {path === "/download" ? (
-        <Download analyticsEnabled={analyticsEnabled} onAnalyticsToggle={toggle} />
-      ) : (
-        <Landing analyticsEnabled={analyticsEnabled} onAnalyticsToggle={toggle} />
-      )}
+      {path === "/download" ? <Download /> : <Landing />}
       {analyticsEnabled ? <Analytics /> : null}
     </>
   )

--- a/frontend/landing/src/pages/Download.tsx
+++ b/frontend/landing/src/pages/Download.tsx
@@ -146,13 +146,7 @@ function Copy({ command }: { command: string }) {
   )
 }
 
-export default function Download({
-  analyticsEnabled = true,
-  onAnalyticsToggle,
-}: {
-  analyticsEnabled?: boolean
-  onAnalyticsToggle?: () => void
-} = {}) {
+export default function Download() {
   const [target, setTarget] = useState<Target>(detect)
 
   useEffect(() => {
@@ -385,17 +379,6 @@ export default function Download({
             >
               GitHub
             </a>
-            {onAnalyticsToggle ? (
-              <button
-                type="button"
-                onClick={onAnalyticsToggle}
-                aria-pressed={analyticsEnabled}
-                title="Website analytics records page activity, never research content"
-                className="min-h-11 hover:text-foreground"
-              >
-                Website analytics: {analyticsEnabled ? "on" : "off"}
-              </button>
-            ) : null}
           </div>
         </div>
       </footer>

--- a/frontend/landing/src/pages/Landing.test.ts
+++ b/frontend/landing/src/pages/Landing.test.ts
@@ -159,16 +159,15 @@ describe("OpenScience landing contract", () => {
     const faq = landing.indexOf('id="faq"')
     expect(ace).toBeGreaterThan(-1)
     expect(faq).toBeGreaterThan(ace)
-    expect(landing.slice(ace, faq)).toContain("${APP}/billing")
-    expect(landing.slice(ace, faq)).toContain("Add funds")
+    expect(landing.slice(ace, faq)).toContain("${APP}/billing?checkout=ace")
+    expect(landing.slice(ace, faq)).toContain("Add funds to get Ace")
   })
 
-  test("keeps Ace pricing concise and separates other access routes", () => {
+  test("keeps Ace pricing concise", () => {
     expect(landing).not.toContain("auto-reload")
     expect(landing).not.toContain("Set a monthly cap")
-    expect(landing).toContain("Unused balance stays in your account.")
-    expect(landing).toContain("Any processing fee is shown before payment")
-    expect(landing).toMatch(/Local models, your own keys, and eligible ChatGPT access remain\s+separate/)
+    expect(landing).not.toContain("Unused balance stays in your account.")
+    expect(landing).not.toContain("Any processing fee is shown before payment")
     expect(landing).not.toContain("Synthetic Scientists")
   })
 
@@ -213,8 +212,9 @@ describe("OpenScience landing contract", () => {
     expect(landing).not.toContain("Atlas")
   })
 
-  test("gives visitors an explicit website analytics control", () => {
+  test("keeps website analytics status out of public footer copy", () => {
     expect(main).toContain('window.localStorage.getItem(ANALYTICS_PREFERENCE) !== "off"')
-    expect(landing).toContain('Website analytics: {analyticsEnabled ? "on" : "off"}')
+    expect(landing).not.toMatch(/Website analytics:/i)
+    expect(download).not.toMatch(/Website analytics:/i)
   })
 })

--- a/frontend/landing/src/pages/Landing.tsx
+++ b/frontend/landing/src/pages/Landing.tsx
@@ -794,13 +794,7 @@ function FaqList({ items }: { items: Array<{ q: string; a: string }> }) {
 
 /* -------------------------------- Page ---------------------------------- */
 
-export default function Landing({
-  analyticsEnabled = true,
-  onAnalyticsToggle,
-}: {
-  analyticsEnabled?: boolean
-  onAnalyticsToggle?: () => void
-} = {}) {
+export default function Landing() {
   return (
     <div
       id="top"
@@ -974,7 +968,7 @@ export default function Landing({
               </p>
             </Reveal>
             <Reveal delay={240} className="mt-9">
-              <Cta href={`${APP}/billing`}>Add funds</Cta>
+              <Cta href={`${APP}/billing?checkout=ace`}>Add funds to get Ace</Cta>
             </Reveal>
           </div>
 
@@ -1001,13 +995,6 @@ export default function Landing({
               </div>
             ))}
           </div>
-        </Reveal>
-
-        <Reveal delay={360}>
-          <p className="mt-10 max-w-[78ch] text-[13px] leading-6 text-foreground/50">
-            Unused balance stays in your account. Local models, your own keys, and eligible ChatGPT access remain
-            separate. Any processing fee is shown before payment.
-          </p>
         </Reveal>
       </Section>
 
@@ -1197,17 +1184,6 @@ export default function Landing({
 
           <div className="mt-14 pt-6 border-t border-border/40 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 text-[12.5px] text-foreground/45">
             <div>&copy; {new Date().getFullYear()} Synthetic Sciences. Apache 2.0.</div>
-            {onAnalyticsToggle ? (
-              <button
-                type="button"
-                className="link-underline hover:text-foreground"
-                onClick={onAnalyticsToggle}
-                aria-pressed={analyticsEnabled}
-                title="Website analytics records page activity, never research content"
-              >
-                Website analytics: {analyticsEnabled ? "on" : "off"}
-              </button>
-            ) : null}
             <a href="#top" className="link-underline hover:text-foreground inline-flex items-center gap-2">
               Back to top
               <svg width="9" height="11" viewBox="0 0 9 11" aria-hidden>


### PR DESCRIPTION
## Summary

- remove the visible website-analytics status control from the landing and download footers
- change the Ace action to `Add funds to get Ace`
- deep-link the action to the authenticated dashboard checkout intent
- remove the final Ace balance and processing-fee footnote

## Verification

- `bun test src/pages/Landing.test.ts` (16 passing)
- `bunx tsc -b` in `frontend/landing`
- `bun run build` in `frontend/landing`
- root typecheck from the pre-push hook
- browser-verified the CTA destination and absence of the analytics label
