### PR TITLE
Swap the landing feature themes

### DIFF
--- a/frontend/landing/src/pages/Landing.test.ts
+++ b/frontend/landing/src/pages/Landing.test.ts
@@ -141,8 +141,8 @@ describe("OpenScience landing contract", () => {
     expect(sources.indexOf("<ProjectContextVisual")).toBeLessThan(sources.indexOf("dither-red"))
 
     expect(models).toContain("Model agnostic.")
-    expect(models).toContain("dither-purple flex min-h-[470px]")
-    expect(models.indexOf("dither-purple")).toBeLessThan(models.indexOf("<ModelRouteVisual"))
+    expect(models).toContain("dither-ace flex min-h-[470px]")
+    expect(models.indexOf("dither-ace")).toBeLessThan(models.indexOf("<ModelRouteVisual"))
     expect(modelIndex).toBeGreaterThan(-1)
     expect(modelIndex).toBeLessThan(workflowIndex)
     expect(workflowIndex).toBeLessThan(sourceIndex)
@@ -165,8 +165,8 @@ describe("OpenScience landing contract", () => {
     expect(ace).toBeGreaterThan(-1)
     expect(faq).toBeGreaterThan(ace)
     expect(landing.slice(ace, faq)).toContain("${APP}/billing?checkout=ace")
-    expect(landing.slice(ace, faq)).toContain("Add funds")
-    expect(landing.slice(ace, faq)).toContain("dither-ace")
+    expect(landing.slice(ace, faq)).toContain("Get Ace")
+    expect(landing.slice(ace, faq)).toContain("dither-purple")
   })
 
   test("keeps Ace pricing concise", () => {

--- a/frontend/landing/src/pages/Landing.tsx
+++ b/frontend/landing/src/pages/Landing.tsx
@@ -747,7 +747,7 @@ export default function Landing() {
       <section id="models" className="relative w-full overflow-hidden border-t border-border/40">
         <div className="relative z-10 mx-auto w-full max-w-[1400px] px-6 py-24 sm:px-10 sm:py-32">
           <div className="grid gap-8 lg:grid-cols-2 lg:items-stretch lg:gap-12">
-            <Reveal className="dither-purple flex min-h-[470px] items-center border border-border/40 p-8 sm:min-h-[520px] sm:p-12 lg:p-14">
+            <Reveal className="dither-ace flex min-h-[470px] items-center border border-border/40 p-8 sm:min-h-[520px] sm:p-12 lg:p-14">
               <div className="dither-content max-w-[520px]">
                 <h2 className={`text-balance ${H_HUGE} text-foreground`}>Model agnostic.</h2>
                 <p className={`mt-7 max-w-[38ch] ${P_BIG} text-foreground/85`}>
@@ -868,14 +868,14 @@ export default function Landing() {
       <section id="ace" className="relative w-full overflow-hidden border-t border-border/40">
         <div className="mx-auto w-full max-w-[1400px] px-6 py-24 sm:px-10 sm:py-32">
           <div className="grid gap-8 lg:grid-cols-[1.15fr_0.85fr] lg:items-stretch lg:gap-12">
-            <Reveal className="dither-ace relative flex min-h-[430px] items-center overflow-hidden border border-border/40 p-8 sm:p-12 lg:p-14">
+            <Reveal className="dither-purple relative flex min-h-[430px] items-center overflow-hidden border border-border/40 p-8 sm:p-12 lg:p-14">
               <div className="dither-content max-w-[580px]">
                 <h2 className={`text-balance ${H_HUGE} text-foreground`}>OpenScience Ace.</h2>
                 <p className={`mt-7 max-w-[42ch] ${P_BIG} text-foreground/85`}>
                   Add funds for Ace models and research search. You pay only when you use it. OpenScience remains free.
                 </p>
                 <div className="mt-9">
-                  <Cta href={`${APP}/billing?checkout=ace`}>Add funds</Cta>
+                  <Cta href={`${APP}/billing?checkout=ace`}>Get Ace</Cta>
                 </div>
               </div>
             </Reveal>


### PR DESCRIPTION
## Summary
- move the mixed purple/red treatment to Model Agnostic
- give OpenScience Ace the quieter purple treatment
- rename the Ace action to Get Ace

## Verification
- bun test src/pages/Landing.test.ts
- bun run build
- turbo typecheck
- verified the live desktop layout at http://127.0.0.1:4178/