### PR TITLE
fix(desktop): give AppImage a safe executable name

### DIFF
--- a/backend/cli/test/installation/release-order.test.ts
+++ b/backend/cli/test/installation/release-order.test.ts
@@ -158,6 +158,7 @@ test("desktop packaging explicitly separates signed and unsigned installers", as
   const config = await Bun.file(path.join(import.meta.dir, "../../../../frontend/desktop/electron-builder.mjs")).text()
 
   expect(config).toContain('process.env.OPENSCIENCE_DESKTOP_SIGNED === "true"')
+  expect(config).toContain('executableName: "openscience"')
   expect(config).toContain('identity: signed ? undefined : "-"')
   expect(config).toContain("forceCodeSigning: signed")
   expect(config).toContain("hardenedRuntime: true")

--- a/frontend/desktop/electron-builder.mjs
+++ b/frontend/desktop/electron-builder.mjs
@@ -9,6 +9,7 @@ const signed = process.env.OPENSCIENCE_DESKTOP_SIGNED === "true"
 export default {
   appId: "ai.syntheticsciences.openscience",
   productName: "OpenScience",
+  executableName: "openscience",
   artifactName: `OpenScience-${name}-\${arch}.\${ext}`,
   extraMetadata: {
     version: process.env.OPENSCIENCE_VERSION || "2.0.47",


### PR DESCRIPTION
AppImage creation rejects the scoped package name as an executable path. Set the packaged executable name explicitly to `openscience`; macOS and Windows product/artifact names remain unchanged.

Validated with Prettier and 21/21 focused release contract tests.