### PR TITLE
fix(release): configure AppImage name during tag backfill

### DIFF
--- a/.github/workflows/desktop-backfill.yml
+++ b/.github/workflows/desktop-backfill.yml
@@ -220,6 +220,8 @@ jobs:
             args+=("-c.mac.identity=-" "-c.mac.notarize=false")
           elif [[ "${{ matrix.target }}" == "win" ]]; then
             args+=("-c.win.signExecutable=false")
+          else
+            args+=("-c.executableName=openscience")
           fi
           bun run --cwd frontend/desktop dist -- "${args[@]}"
 

--- a/backend/cli/test/installation/release-order.test.ts
+++ b/backend/cli/test/installation/release-order.test.ts
@@ -177,6 +177,7 @@ test("desktop backfill wraps the immutable public runtime without release or npm
   expect(workflow).toContain('CSC_IDENTITY_AUTO_DISCOVERY: "false"')
   expect(workflow).toContain('args+=("-c.mac.identity=-" "-c.mac.notarize=false")')
   expect(workflow).toContain('args+=("-c.win.signExecutable=false")')
+  expect(workflow).toContain('args+=("-c.executableName=openscience")')
   expect(workflow).toContain('bun run --cwd frontend/desktop dist -- "${args[@]}"')
   expect(workflow).toContain("Expand-Archive")
   expect(workflow).toContain('unzip -q "$OPENSCIENCE_ARCHIVE"')


### PR DESCRIPTION
The asset backfill correctly builds from the immutable v2.0.50 tag, so the new desktop config on main is intentionally unavailable there. Pass the safe Linux executable name as an electron-builder override in the backfill command. Existing macOS and Windows assets remain immutable and will be skipped.

Validated with actionlint, Prettier, and 21/21 focused release contract tests.