### PR TITLE
fix(release): normalize x64 AppImage asset name

### DIFF
--- a/.github/workflows/desktop-backfill.yml
+++ b/.github/workflows/desktop-backfill.yml
@@ -235,6 +235,10 @@ jobs:
         run: |
           set -euo pipefail
           installer="frontend/desktop/dist/$DESKTOP_ASSET"
+          if [[ "${{ matrix.target }}" == "linux" && "${{ matrix.arch }}" == "x64" ]]; then
+            produced="frontend/desktop/dist/OpenScience-linux-x86_64.AppImage"
+            [[ -s "$produced" ]] && mv "$produced" "$installer"
+          fi
           [[ -s "$installer" ]] || {
             echo "::error::electron-builder did not produce $DESKTOP_ASSET"
             exit 1


### PR DESCRIPTION
Normalizes electron-builder’s x86_64 AppImage filename to the stable x64 release asset name during the resumable unsigned desktop backfill.\n\nVerified with actionlint, the 21-test release-order suite, and git diff-check.