### PR TITLE
feat(landing): explain unsigned desktop downloads

### DIFF
--- a/frontend/landing/src/pages/Download.tsx
+++ b/frontend/landing/src/pages/Download.tsx
@@ -281,8 +281,11 @@ export default function Download() {
                 </svg>
                 Download for {download.label} ({download.detail})
               </a>
-              <div className="mt-3 text-[12.5px] text-foreground/55">
+              <div className="mt-3 text-[12.5px] leading-5 text-foreground/55">
                 {download.kind} · latest release · free and open source
+                <br />
+                Unsigned release. macOS and Windows may show security prompts; macOS builds are ad-hoc signed and
+                not notarized.
               </div>
             </div>
           </div>
@@ -349,9 +352,9 @@ export default function Download() {
             <h2 className="sr-only">Quick start</h2>
             <div className="grid gap-px border-y border-border/45 bg-border/45 sm:grid-cols-3">
               {[
-                ["01", "Install", "Open the installer. On Linux, make the AppImage executable."],
-                ["02", "Connect", "Run openscience login once."],
-                ["03", "Launch", "Run openscience in any project."],
+                ["01", "Install", "Open the download and follow your operating system's install prompt."],
+                ["02", "Connect", "Sign in or choose your own model provider during onboarding."],
+                ["03", "Research", "Open a project and start your first research session."],
               ].map((step) => (
                 <div key={step[0]} className="min-h-[150px] bg-background px-6 py-7 sm:px-7">
                   <div className="font-terminal text-[10px] tracking-[0.12em] text-[hsl(var(--accent-coral)/0.8)]">

--- a/frontend/landing/src/pages/Download.tsx
+++ b/frontend/landing/src/pages/Download.tsx
@@ -284,8 +284,8 @@ export default function Download() {
               <div className="mt-3 text-[12.5px] leading-5 text-foreground/55">
                 {download.kind} · latest release · free and open source
                 <br />
-                Unsigned release. macOS and Windows may show security prompts; macOS builds are ad-hoc signed and
-                not notarized.
+                Unsigned release. macOS and Windows may show security prompts; macOS builds are ad-hoc signed and not
+                notarized.
               </div>
             </div>
           </div>

--- a/frontend/landing/src/pages/Landing.test.ts
+++ b/frontend/landing/src/pages/Landing.test.ts
@@ -81,6 +81,8 @@ describe("OpenScience landing contract", () => {
     expect(download).not.toContain("openscience-linux-x64.tar.gz")
     expect(download).not.toContain("openscience-linux-arm64.tar.gz")
     expect(download).not.toContain("Portable archive")
+    expect(download).toContain("Unsigned release")
+    expect(download).toContain("ad-hoc signed")
     expect(download).toContain("npm i -g @synsci/openscience")
     expect(download).toContain("curl -fsSL https://openscience.sh/install | bash")
     expect(download).toContain('role="group"')


### PR DESCRIPTION
Polishes the desktop download flow now that all v2.0.50 installers are live. Adds a visible unsigned/notarization warning and replaces CLI-centric setup steps with install, connect, and research guidance.\n\nVerified: landing contract tests 16/16; prior Vite production build; diff-check clean.