### PR TITLE
fix: let release recovery inspect draft assets

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -341,7 +341,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
-      contents: read
+      # GitHub's release-by-tag API hides draft releases from read-only tokens.
+      contents: write
     outputs:
       trusted_assets: ${{ steps.plan.outputs.trusted_assets }}
     steps:

--- a/backend/cli/test/installation/release-order.test.ts
+++ b/backend/cli/test/installation/release-order.test.ts
@@ -43,6 +43,7 @@ test("production release preparation jobs can write their draft GitHub release",
   const jobs = [
     ["version", "build-cli"],
     ["sign-macos-cli", "verify-native-cli"],
+    ["desktop-resume", "build-desktop"],
   ]
 
   for (const item of jobs) {


### PR DESCRIPTION
## Summary
- grant the desktop recovery planner the GitHub release permission required to read draft assets by tag
- lock that permission into the release-order contract

The failed recovery run reached the correct pinned 2.0.51 source and then received a draft-release 404 under `contents: read`. No installer or npm publication occurred.

## Verification
- actionlint
- release-order contract: 23 passed, 239 assertions
- Prettier
- git diff --check

Failed recovery: https://github.com/synthetic-sciences/openscience/actions/runs/33142785132