### PR TITLE
fix(desktop): add verified macOS self-updates

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -363,7 +363,9 @@ jobs:
           desktop_assets="$(jq -cS '
             [.assets[] | select(
               .name == "OpenScience-mac-arm64.dmg" or
+              .name == "OpenScience-mac-arm64.zip" or
               .name == "OpenScience-mac-x64.dmg" or
+              .name == "OpenScience-mac-x64.zip" or
               .name == "OpenScience-windows-x64.exe" or
               .name == "OpenScience-linux-x64.AppImage" or
               .name == "OpenScience-linux-arm64.AppImage"
@@ -417,77 +419,96 @@ jobs:
             arch: arm64
             sidecar: backend/cli/dist/@synsci/openscience-darwin-arm64/bin/openscience
             asset: OpenScience-mac-arm64.dmg
+            assets: OpenScience-mac-arm64.dmg OpenScience-mac-arm64.zip
             signing: mac
           - runner: macos-14
             target: mac
             arch: x64
             sidecar: backend/cli/dist/@synsci/openscience-darwin-x64/bin/openscience
             asset: OpenScience-mac-x64.dmg
+            assets: OpenScience-mac-x64.dmg OpenScience-mac-x64.zip
             signing: mac
           - runner: windows-2025
             target: win
             arch: x64
             sidecar: backend/cli/dist/@synsci/openscience-windows-x64/bin/openscience.exe
             asset: OpenScience-windows-x64.exe
+            assets: OpenScience-windows-x64.exe
             signing: windows
           - runner: ubuntu-24.04
             target: linux
             arch: x64
             sidecar: backend/cli/dist/@synsci/openscience-linux-x64/bin/openscience
             asset: OpenScience-linux-x64.AppImage
+            assets: OpenScience-linux-x64.AppImage
             signing: none
           - runner: ubuntu-24.04-arm
             target: linux
             arch: arm64
             sidecar: backend/cli/dist/@synsci/openscience-linux-arm64/bin/openscience
             asset: OpenScience-linux-arm64.AppImage
+            assets: OpenScience-linux-arm64.AppImage
             signing: none
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 45
     permissions:
       contents: write
     steps:
-      - name: Check for an existing immutable desktop installer
+      - name: Check for existing immutable desktop artifacts
         id: existing
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           OPENSCIENCE_TAG: ${{ needs.version.outputs.tag }}
-          DESKTOP_ASSET: ${{ matrix.asset }}
+          DESKTOP_ASSETS: ${{ matrix.assets }}
           TRUSTED_DESKTOP_ASSETS: ${{ needs.desktop-resume.outputs.trusted_assets }}
         run: |
           set -euo pipefail
-          existing="$(gh release view "$OPENSCIENCE_TAG" --json assets --jq '.assets[] | select(.name == env.DESKTOP_ASSET)')"
-          expected_digest="$(jq -r --arg name "$DESKTOP_ASSET" '.[$name] // empty' <<<"$TRUSTED_DESKTOP_ASSETS")"
-          if [[ -z "$existing" ]]; then
-            if [[ -n "$expected_digest" ]]; then
-              echo "::error::$DESKTOP_ASSET vanished after the desktop resume plan was frozen"
+          release="$(gh release view "$OPENSCIENCE_TAG" --json assets)"
+          found=0
+          total=0
+          for name in $DESKTOP_ASSETS; do
+            ((total += 1))
+            existing="$(jq -c --arg name "$name" '.assets[] | select(.name == $name)' <<<"$release")"
+            expected_digest="$(jq -r --arg name "$name" '.[$name] // empty' <<<"$TRUSTED_DESKTOP_ASSETS")"
+            if [[ -z "$existing" ]]; then
+              if [[ -n "$expected_digest" ]]; then
+                echo "::error::$name vanished after the desktop resume plan was frozen"
+                exit 1
+              fi
+              continue
+            fi
+            if [[ -z "$expected_digest" ]]; then
+              echo "::error::$name appeared after the desktop resume plan was frozen"
               exit 1
             fi
+            [[ "$(jq -r .state <<<"$existing")" == "uploaded" ]] || {
+              echo "::error::$name exists but is not fully uploaded"
+              exit 1
+            }
+            size="$(jq -r .size <<<"$existing")"
+            if [[ ! "$size" =~ ^[0-9]+$ ]] || (( size <= 0 )); then
+              echo "::error::$name exists but is empty"
+              exit 1
+            fi
+            digest="$(jq -r .digest <<<"$existing")"
+            if [[ ! "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+              echo "::error::$name exists without a valid sha256 digest"
+              exit 1
+            fi
+            if [[ ! "$expected_digest" =~ ^sha256:[0-9a-f]{64}$ ]] || [[ "$digest" != "$expected_digest" ]]; then
+              echo "::error::$name does not match its reviewed desktop resume manifest digest"
+              exit 1
+            fi
+            ((found += 1))
+          done
+          if (( found == 0 )); then
             echo "found=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if [[ -z "$expected_digest" ]]; then
-            echo "::error::$DESKTOP_ASSET appeared after the desktop resume plan was frozen"
-            exit 1
-          fi
-          if [[ "$(jq -r .state <<<"$existing")" != "uploaded" ]]; then
-            echo "::error::$DESKTOP_ASSET exists but is not fully uploaded"
-            exit 1
-          fi
-          size="$(jq -r .size <<<"$existing")"
-          if [[ ! "$size" =~ ^[0-9]+$ ]] || (( size <= 0 )); then
-            echo "::error::$DESKTOP_ASSET exists but is empty"
-            exit 1
-          fi
-          digest="$(jq -r .digest <<<"$existing")"
-          if [[ ! "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
-            echo "::error::$DESKTOP_ASSET exists without a valid sha256 digest"
-            exit 1
-          fi
-          if [[ ! "$expected_digest" =~ ^sha256:[0-9a-f]{64}$ ]] || [[ "$digest" != "$expected_digest" ]]; then
-            echo "::error::$DESKTOP_ASSET does not match its reviewed desktop resume manifest digest"
+          if (( found != total )); then
+            echo "::error::Desktop artifacts must be resumed or rebuilt as one complete architecture set"
             exit 1
           fi
           echo "found=true" >> "$GITHUB_OUTPUT"
@@ -572,13 +593,14 @@ jobs:
           unset APPLE_ID APPLE_APP_SPECIFIC_PASSWORD APPLE_TEAM_ID
           bun run --cwd frontend/desktop dist -- --${{ matrix.target }} --${{ matrix.arch }}
 
-      - name: Verify or upload immutable desktop installer
+      - name: Verify or upload immutable desktop artifacts
         if: steps.existing.outputs.found != 'true'
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
           OPENSCIENCE_TAG: ${{ needs.version.outputs.tag }}
           DESKTOP_ASSET: ${{ matrix.asset }}
+          DESKTOP_ASSETS: ${{ matrix.assets }}
         run: |
           set -euo pipefail
           installer="frontend/desktop/dist/$DESKTOP_ASSET"
@@ -586,20 +608,24 @@ jobs:
             produced="frontend/desktop/dist/OpenScience-linux-x86_64.AppImage"
             [[ -s "$produced" ]] && mv "$produced" "$installer"
           fi
-          [[ -s "$installer" ]] || {
-            echo "::error::electron-builder did not produce $DESKTOP_ASSET"
-            exit 1
-          }
-          existing="$(gh release view "$OPENSCIENCE_TAG" --json assets --jq '.assets[] | select(.name == env.DESKTOP_ASSET) | .digest' || true)"
-          if [[ -z "$existing" ]]; then
-            gh release upload "$OPENSCIENCE_TAG" "$installer"
-            exit 0
-          fi
-          actual="sha256:$(node -e 'const fs=require("fs"),c=require("crypto");const h=c.createHash("sha256");h.update(fs.readFileSync(process.argv[1]));process.stdout.write(h.digest("hex"))' "$installer")"
-          [[ "$actual" == "$existing" ]] || {
-            echo "::error::$DESKTOP_ASSET already exists with different bytes; refusing to clobber"
-            exit 1
-          }
+          release="$(gh release view "$OPENSCIENCE_TAG" --json assets)"
+          for name in $DESKTOP_ASSETS; do
+            artifact="frontend/desktop/dist/$name"
+            [[ -s "$artifact" ]] || {
+              echo "::error::electron-builder did not produce $name"
+              exit 1
+            }
+            existing="$(jq -r --arg name "$name" '.assets[] | select(.name == $name) | .digest' <<<"$release")"
+            if [[ -z "$existing" ]]; then
+              gh release upload "$OPENSCIENCE_TAG" "$artifact"
+              continue
+            fi
+            actual="sha256:$(node -e 'const fs=require("fs"),c=require("crypto");const h=c.createHash("sha256");h.update(fs.readFileSync(process.argv[1]));process.stdout.write(h.digest("hex"))' "$artifact")"
+            [[ "$actual" == "$existing" ]] || {
+              echo "::error::$name already exists with different bytes; refusing to clobber"
+              exit 1
+            }
+          done
 
   verify-native-cli:
     needs:
@@ -787,7 +813,9 @@ jobs:
           assets="$(gh release view "$OPENSCIENCE_TAG" --json assets)"
           expected=(
             OpenScience-mac-arm64.dmg
+            OpenScience-mac-arm64.zip
             OpenScience-mac-x64.dmg
+            OpenScience-mac-x64.zip
             OpenScience-windows-x64.exe
             OpenScience-linux-x64.AppImage
             OpenScience-linux-arm64.AppImage

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The command is `openscience`, and it opens the workspace in your browser. The fi
 npx synsci
 ```
 
-Platform binaries and desktop installers are also attached to [GitHub Releases](https://github.com/synthetic-sciences/OpenScience/releases); see the [changelog](CHANGELOG.md) for what's new in each version. Release notes identify unsigned builds. In unsigned mode, the macOS apps are ad-hoc signed but not notarized, so verify the published checksum before using macOS's explicit **Open Anyway** flow.
+Platform binaries and desktop installers are also attached to [GitHub Releases](https://github.com/synthetic-sciences/OpenScience/releases); see the [changelog](CHANGELOG.md) for what's new in each version. Release notes identify unsigned builds. In unsigned mode, the macOS apps are ad-hoc signed but not notarized, so verify the published checksum before using macOS's explicit **Open Anyway** flow once. Releases after the first self-update-capable install can update and restart from inside OpenScience without downloading another DMG.
 
 Linux installs require kernel 5.1 or newer. Glibc builds require glibc 2.17 or newer, and musl builds are published separately. CentOS 7's stock 3.10 kernel is not supported even though its glibc version meets the minimum; use a newer host kernel or VM.
 

--- a/backend/cli/src/installation/index.ts
+++ b/backend/cli/src/installation/index.ts
@@ -93,6 +93,8 @@ export namespace Installation {
   }
 
   export async function method() {
+    if (process.env.OPENSCIENCE_DESKTOP_UPDATE_URL && process.env.OPENSCIENCE_DESKTOP_UPDATE_TOKEN)
+      return "desktop" as const
     return methodFromPaths({ execPath: process.execPath, scriptPath: process.argv[1] })
   }
 
@@ -112,6 +114,26 @@ export namespace Installation {
   }
 
   export async function upgrade(method: Method, target: string) {
+    if (method === "desktop") {
+      const url = process.env.OPENSCIENCE_DESKTOP_UPDATE_URL
+      const token = process.env.OPENSCIENCE_DESKTOP_UPDATE_TOKEN
+      if (!url || !token) throw new Error("The desktop update service is unavailable")
+      const response = await fetch(url, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+        body: JSON.stringify({ version: target }),
+        signal: AbortSignal.timeout(30 * 60_000),
+      })
+      if (!response.ok) {
+        const message = await response
+          .json()
+          .then((value) => value.error)
+          .catch(() => undefined)
+        throw new UpgradeFailedError({ stderr: message ?? `Desktop update failed (${response.status})` })
+      }
+      log.info("desktop update staged", { target })
+      return
+    }
     const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "openscience-upgrade-"))
     const allowed = [
       "PATH",

--- a/backend/cli/src/server/routes/settings/updates.ts
+++ b/backend/cli/src/server/routes/settings/updates.ts
@@ -37,7 +37,7 @@ type UpdateResult = z.infer<typeof Result>
 type UpdateInstallResult = z.infer<typeof InstallResult>
 
 export function supportsAutomaticUpdate(method: string) {
-  return ["curl", "npm", "pnpm", "yarn", "bun", "brew", "choco", "scoop"].includes(method)
+  return ["curl", "npm", "pnpm", "yarn", "bun", "brew", "choco", "scoop", "desktop"].includes(method)
 }
 
 export function createUpdateInstaller(input: {
@@ -173,7 +173,7 @@ export const UpdatesSettingsRoutes = lazy(() =>
       }),
       async (c) => {
         const result = await install()
-        const restartScheduled = result.installed ? SelfRestart.schedule() : false
+        const restartScheduled = result.installed ? result.method === "desktop" || SelfRestart.schedule() : false
         return c.json(InstallResult.parse({ ...result, restartScheduled }))
       },
     )

--- a/backend/cli/test/installation/desktop-shell-contract.test.ts
+++ b/backend/cli/test/installation/desktop-shell-contract.test.ts
@@ -5,3 +5,17 @@ test("lists existing macOS windows before the New Window Dock action", async () 
   const dock = source.slice(source.indexOf("function dock()"), source.indexOf("function stop()"))
   expect(dock.indexOf("...entries")).toBeLessThan(dock.indexOf('label: "New Window"'))
 })
+
+test("wires the packaged macOS shell to the authenticated desktop updater", async () => {
+  const source = await Bun.file(new URL("../../../../frontend/desktop/src/main.mjs", import.meta.url)).text()
+  const config = await Bun.file(new URL("../../../../frontend/desktop/electron-builder.mjs", import.meta.url)).text()
+  const install = await Bun.file(new URL("../../src/installation/index.ts", import.meta.url)).text()
+
+  expect(config).toContain('target: ["dmg", "zip"]')
+  expect(source).toContain("OPENSCIENCE_DESKTOP_UPDATE_URL")
+  expect(source).toContain("OPENSCIENCE_DESKTOP_UPDATE_TOKEN")
+  expect(source).toContain("stageUpdate(input.version")
+  expect(source).toContain("await applyUpdate(update)")
+  expect(install).toContain('return "desktop" as const')
+  expect(install).toContain("Authorization: `Bearer ${token}`")
+})

--- a/backend/cli/test/installation/desktop-updater.test.ts
+++ b/backend/cli/test/installation/desktop-updater.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { chmod, mkdir, mkdtemp, rm } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { asset, checksum, release, stage } from "../../../../frontend/desktop/src/updater.mjs"
+
+const roots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe("desktop update release contract", () => {
+  test("selects the exact architecture payload and requires GitHub's digest", async () => {
+    const name = asset("arm64")
+    const server = Bun.serve({
+      port: 0,
+      routes: {
+        "/releases/tags/v3.2.1": Response.json({
+          tag_name: "v3.2.1",
+          draft: false,
+          prerelease: false,
+          assets: [
+            {
+              name,
+              digest: `sha256:${"a".repeat(64)}`,
+              browser_download_url:
+                "https://github.com/synthetic-sciences/openscience/releases/download/v3.2.1/update.zip",
+            },
+          ],
+        }),
+      },
+    })
+
+    expect(await release("3.2.1", { api: server.url, arch: "arm64" })).toEqual({
+      version: "3.2.1",
+      name,
+      url: "https://github.com/synthetic-sciences/openscience/releases/download/v3.2.1/update.zip",
+      digest: "a".repeat(64),
+    })
+    server.stop(true)
+  })
+})
+
+describe.skipIf(process.platform !== "darwin")("macOS desktop update integration", () => {
+  test("downloads, verifies, replaces, and validates an ad-hoc-signed app bundle", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "openscience-desktop-update-test-"))
+    roots.push(root)
+    const build = path.join(root, "build")
+    const bundle = path.join(build, "OpenScience.app")
+    const contents = path.join(bundle, "Contents")
+    const binary = path.join(contents, "MacOS", "openscience")
+    await mkdir(path.dirname(binary), { recursive: true })
+    await Bun.write(
+      path.join(contents, "Info.plist"),
+      `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>CFBundleExecutable</key><string>openscience</string>
+<key>CFBundleIdentifier</key><string>ai.syntheticsciences.openscience</string>
+<key>CFBundleName</key><string>OpenScience</string>
+<key>CFBundlePackageType</key><string>APPL</string>
+<key>CFBundleShortVersionString</key><string>9.8.7</string>
+<key>CFBundleVersion</key><string>9.8.7</string>
+</dict></plist>`,
+    )
+    await Bun.write(binary, "#!/bin/sh\nexit 0\n")
+    await chmod(binary, 0o755)
+    expect((await Bun.$`codesign --force --deep --sign - ${bundle}`.quiet()).exitCode).toBe(0)
+
+    const archive = path.join(root, asset(process.arch))
+    expect((await Bun.$`ditto -c -k --sequesterRsrc --keepParent ${bundle} ${archive}`.quiet()).exitCode).toBe(0)
+    const digest = await checksum(archive)
+    const server = Bun.serve({
+      port: 0,
+      routes: {
+        "/releases/tags/v9.8.7": (request) =>
+          Response.json({
+            tag_name: "v9.8.7",
+            draft: false,
+            prerelease: false,
+            assets: [
+              {
+                name: asset(process.arch),
+                digest: `sha256:${digest}`,
+                browser_download_url: new URL("/asset", request.url).toString(),
+              },
+            ],
+          }),
+        "/asset": new Response(Bun.file(archive)),
+      },
+    })
+
+    const update = await stage("9.8.7", {
+      api: server.url,
+      arch: process.arch,
+      cache: path.join(root, "cache"),
+    })
+    server.stop(true)
+
+    const current = path.join(root, "Installed.app")
+    await Bun.$`ditto ${bundle} ${current}`.quiet()
+    const helper = new URL("../../../../frontend/desktop/src/update-helper.mjs", import.meta.url)
+    const payload = Buffer.from(
+      JSON.stringify({
+        parent: 2_147_483_647,
+        current,
+        staged: update.bundle,
+        backup: path.join(root, "Installed.previous.app"),
+        root: update.root,
+      }),
+    ).toString("base64url")
+    const child = Bun.spawn([process.execPath, helper.pathname, payload], {
+      env: { ...process.env, OPENSCIENCE_UPDATE_SKIP_LAUNCH: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    expect(await child.exited).toBe(0)
+    expect(
+      (
+        await Bun.$`plutil -extract CFBundleShortVersionString raw ${path.join(current, "Contents", "Info.plist")}`.text()
+      ).trim(),
+    ).toBe("9.8.7")
+    expect((await Bun.$`codesign --verify --deep --strict ${current}`.quiet()).exitCode).toBe(0)
+  })
+})

--- a/backend/cli/test/installation/release-order.test.ts
+++ b/backend/cli/test/installation/release-order.test.ts
@@ -116,7 +116,7 @@ test("production release keeps signed publishing as the default and ships instal
   const preflight = workflow.slice(workflow.indexOf("\n  macos-signing-preflight:"), workflow.indexOf("\n  version:"))
   const sign = workflow.slice(workflow.indexOf("\n  sign-macos-cli:"), workflow.indexOf("\n  verify-native-cli:"))
   const desktop = workflow.slice(workflow.indexOf("\n  build-desktop:"), workflow.indexOf("\n  verify-native-cli:"))
-  const desktopUpload = desktop.slice(desktop.indexOf("Verify or upload immutable desktop installer"))
+  const desktopUpload = desktop.slice(desktop.indexOf("Verify or upload immutable desktop artifacts"))
   const prepare = workflow.slice(workflow.indexOf("\n  prepare-npm:"), workflow.indexOf("\n  publish:"))
   const publish = workflow.slice(workflow.indexOf("\n  publish:"), workflow.indexOf("\n  deployment:"))
 
@@ -163,8 +163,10 @@ test("production release keeps signed publishing as the default and ships instal
   expect(desktopUpload).toContain('produced="frontend/desktop/dist/OpenScience-linux-x86_64.AppImage"')
   expect(desktopUpload).toContain('mv "$produced" "$installer"')
   expect(desktopUpload.indexOf('mv "$produced" "$installer"')).toBeLessThan(
-    desktopUpload.indexOf('existing="$(gh release view "$OPENSCIENCE_TAG"'),
+    desktopUpload.indexOf('release="$(gh release view "$OPENSCIENCE_TAG"'),
   )
+  expect(desktop).toContain("OpenScience-mac-arm64.dmg OpenScience-mac-arm64.zip")
+  expect(desktop).toContain("OpenScience-mac-x64.dmg OpenScience-mac-x64.zip")
   expect(prepare).toContain("key: ${{ needs.sign-macos-cli.outputs.cache_key }}")
   expect(publish).toContain("key: ${{ needs.sign-macos-cli.outputs.cache_key }}")
   expect(publish).toContain("!cancelled() &&")
@@ -178,7 +180,7 @@ test("production desktop resume freezes an exact reviewed asset set before any r
   const desktop = workflow.slice(workflow.indexOf("\n  build-desktop:"), workflow.indexOf("\n  verify-native-cli:"))
   const steps = desktop.split("\n      - ").slice(1)
   const findStep = (marker: string) => steps.find((step) => step.includes(marker)) ?? ""
-  const check = findStep("Check for an existing immutable desktop installer")
+  const check = findStep("Check for existing immutable desktop artifacts")
 
   expect(plan).toContain("DESKTOP_RESUME_MANIFEST: ${{ inputs.desktop_resume_manifest }}")
   expect(plan).toContain(".version == $version")
@@ -190,7 +192,7 @@ test("production desktop resume freezes an exact reviewed asset set before any r
   expect(plan).toContain('all(.assets[]; type == "string"')
   expect(plan).toContain('echo "trusted_assets=$expected"')
   expect(desktop).toContain("- desktop-resume")
-  expect(desktop.indexOf("Check for an existing immutable desktop installer")).toBeLessThan(
+  expect(desktop.indexOf("Check for existing immutable desktop artifacts")).toBeLessThan(
     desktop.indexOf("uses: actions/checkout@"),
   )
   expect(check).toContain("GH_REPO: ${{ github.repository }}")
@@ -215,7 +217,7 @@ test("production desktop resume freezes an exact reviewed asset set before any r
     "name: Make sidecar executable",
     "name: Build signed desktop installer",
     "name: Build unsigned desktop installer",
-    "name: Verify or upload immutable desktop installer",
+    "name: Verify or upload immutable desktop artifacts",
   ]) {
     expect(findStep(marker)).toContain("steps.existing.outputs.found != 'true'")
   }
@@ -230,7 +232,9 @@ test("production publish finalizes a complete immutable desktop checksum manifes
   )
 
   expect(finalize).toContain("OpenScience-mac-arm64.dmg")
+  expect(finalize).toContain("OpenScience-mac-arm64.zip")
   expect(finalize).toContain("OpenScience-mac-x64.dmg")
+  expect(finalize).toContain("OpenScience-mac-x64.zip")
   expect(finalize).toContain("OpenScience-windows-x64.exe")
   expect(finalize).toContain("OpenScience-linux-x64.AppImage")
   expect(finalize).toContain("OpenScience-linux-arm64.AppImage")
@@ -250,6 +254,7 @@ test("desktop packaging explicitly separates signed and unsigned installers", as
 
   expect(config).toContain('process.env.OPENSCIENCE_DESKTOP_SIGNED === "true"')
   expect(config).toContain('executableName: "openscience"')
+  expect(config).toContain('target: ["dmg", "zip"]')
   expect(config).toContain('identity: signed ? undefined : "-"')
   expect(config).toContain("forceCodeSigning: signed")
   expect(config).toContain("hardenedRuntime: true")

--- a/backend/cli/test/server/settings-updates.test.ts
+++ b/backend/cli/test/server/settings-updates.test.ts
@@ -17,7 +17,9 @@ describe("update version ordering", () => {
 
 describe("automatic update support", () => {
   test("supports every installer implemented by the upgrader", () => {
-    expect(["curl", "npm", "pnpm", "yarn", "bun", "brew", "choco", "scoop"].every(supportsAutomaticUpdate)).toBe(true)
+    expect(
+      ["curl", "npm", "pnpm", "yarn", "bun", "brew", "choco", "scoop", "desktop"].every(supportsAutomaticUpdate),
+    ).toBe(true)
     expect(supportsAutomaticUpdate("unknown")).toBe(false)
   })
 

--- a/docs/notes/release-process.md
+++ b/docs/notes/release-process.md
@@ -20,7 +20,10 @@ branch.
    Use `release_mode=unsigned` only for a deliberately unsigned release. In
    that mode the macOS apps are ad-hoc signed but not notarized, the Windows
    installer is unsigned, and the workflow adds the required warning to the
-   release notes.
+   release notes. The first unsigned macOS install requires Apple's explicit
+   **Open Anyway** flow. Later desktop updates verify the architecture-specific
+   release ZIP's GitHub SHA-256 digest and app bundle identity, version, and
+   signature before replacing the installed bundle and restarting.
 
    The next version is derived from the current npm `latest`, so there is no
    manual version editing in `package.json` and no risk of a tag collision.

--- a/frontend/desktop/README.md
+++ b/frontend/desktop/README.md
@@ -4,8 +4,10 @@ The desktop shell starts the bundled OpenScience runtime on a random loopback po
 
 Release builds produce:
 
-- macOS `.dmg` (Apple Silicon and Intel)
+- macOS `.dmg` installers and `.zip` self-update payloads (Apple Silicon and Intel)
 - Windows NSIS `.exe`
 - Linux `.AppImage`
 
 Set `OPENSCIENCE_DESKTOP_SIDECAR` to the native runtime before running `bun run dist`. Electron Builder automatically signs when `CSC_LINK` and `CSC_KEY_PASSWORD` are present. macOS notarization additionally uses `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, and `APPLE_TEAM_ID`.
+
+The first launch of an unsigned macOS build still requires Apple's explicit **Open Anyway** flow. After that one-time approval, the desktop app can download the exact architecture-specific ZIP from a published GitHub release, verify GitHub's SHA-256 asset digest and the app bundle identity/version/signature, replace itself, and restart. A Developer ID certificate plus notarization credentials remain the only way to remove the first-launch Gatekeeper warning.

--- a/frontend/desktop/electron-builder.mjs
+++ b/frontend/desktop/electron-builder.mjs
@@ -24,7 +24,7 @@ export default {
   ],
   asar: true,
   mac: {
-    target: ["dmg"],
+    target: ["dmg", "zip"],
     icon: "build/icon.icns",
     category: "public.app-category.developer-tools",
     identity: signed ? undefined : "-",

--- a/frontend/desktop/src/main.mjs
+++ b/frontend/desktop/src/main.mjs
@@ -1,13 +1,24 @@
+import { randomBytes } from "node:crypto"
 import { spawn } from "node:child_process"
 import { appendFileSync, existsSync, mkdirSync, writeFileSync } from "node:fs"
+import { createServer } from "node:http"
 import net from "node:net"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
 import { app, BrowserWindow, Menu, shell } from "electron"
+import { apply as applyUpdate, stage as stageUpdate } from "./updater.mjs"
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..")
 const windows = new Set()
-const state = { service: undefined, address: undefined, exiting: false }
+const state = {
+  service: undefined,
+  address: undefined,
+  exiting: false,
+  updateServer: undefined,
+  updateAddress: undefined,
+  updateToken: undefined,
+  update: undefined,
+}
 
 function external(value) {
   if (!URL.canParse(value)) return
@@ -75,6 +86,15 @@ async function start() {
   state.address = `http://127.0.0.1:${selected}`
   state.service = spawn(executable, ["serve", "--port", String(selected), "--print-logs"], {
     cwd: workspace,
+    env: {
+      ...process.env,
+      ...(state.updateAddress && state.updateToken
+        ? {
+            OPENSCIENCE_DESKTOP_UPDATE_URL: `${state.updateAddress}/update`,
+            OPENSCIENCE_DESKTOP_UPDATE_TOKEN: state.updateToken,
+          }
+        : {}),
+    },
     stdio: ["ignore", "pipe", "pipe"],
     windowsHide: true,
   })
@@ -93,6 +113,61 @@ async function start() {
     }
   })
   await ready(state.address)
+}
+
+function respond(response, status, value) {
+  response.writeHead(status, { "Content-Type": "application/json", "Cache-Control": "no-store" })
+  response.end(JSON.stringify(value))
+}
+
+async function updateRequest(request, response) {
+  if (request.method !== "POST" || request.url !== "/update") {
+    respond(response, 404, { error: "Not found" })
+    return
+  }
+  if (request.headers.authorization !== `Bearer ${state.updateToken}`) {
+    respond(response, 401, { error: "Unauthorized" })
+    return
+  }
+  const chunks = []
+  for await (const chunk of request) {
+    chunks.push(chunk)
+    if (chunks.reduce((size, value) => size + value.length, 0) > 16_384) {
+      respond(response, 413, { error: "Update request is too large" })
+      return
+    }
+  }
+  const input = JSON.parse(Buffer.concat(chunks).toString("utf8"))
+  if (typeof input.version !== "string") throw new Error("The desktop update version is missing")
+  const pending = state.update ?? stageUpdate(input.version, { cache: path.join(app.getPath("userData"), "updates") })
+  state.update = pending
+  const update = await pending
+  if (update.version !== input.version) throw new Error("A different desktop update is already pending")
+  await applyUpdate(update)
+  respond(response, 200, { installed: true, version: update.version })
+  const timer = setTimeout(() => {
+    stop()
+  }, 500)
+  timer.unref?.()
+}
+
+async function updates() {
+  if (!app.isPackaged || process.platform !== "darwin") return
+  state.updateToken = randomBytes(32).toString("hex")
+  state.updateServer = createServer((request, response) => {
+    void updateRequest(request, response).catch((error) => {
+      respond(response, 500, { error: error instanceof Error ? error.message : String(error) })
+      state.update = undefined
+    })
+  })
+  state.updateServer.unref()
+  await new Promise((resolve, reject) => {
+    state.updateServer.once("error", reject)
+    state.updateServer.listen(0, "127.0.0.1", resolve)
+  })
+  const address = state.updateServer.address()
+  if (typeof address !== "object" || !address) throw new Error("The desktop update service did not start")
+  state.updateAddress = `http://127.0.0.1:${address.port}`
 }
 
 function dock() {
@@ -116,6 +191,7 @@ function dock() {
 function stop() {
   if (state.exiting) return
   state.exiting = true
+  state.updateServer?.close()
   state.service?.kill()
   for (const window of windows) window.destroy()
   setTimeout(() => app.exit(0), 0)
@@ -220,6 +296,7 @@ app.on("second-instance", () => {
 app.whenReady().then(async () => {
   app.name = "OpenScience"
   applicationMenu()
+  await updates()
   const splash = new BrowserWindow({
     width: 520,
     height: 300,

--- a/frontend/desktop/src/update-helper.mjs
+++ b/frontend/desktop/src/update-helper.mjs
@@ -1,0 +1,63 @@
+import { execFile } from "node:child_process"
+import { appendFile, rename, rm } from "node:fs/promises"
+import path from "node:path"
+import { setTimeout as sleep } from "node:timers/promises"
+import { promisify } from "node:util"
+
+const exec = promisify(execFile)
+
+function decode(value) {
+  const payload = JSON.parse(Buffer.from(value, "base64url").toString("utf8"))
+  if (!Number.isInteger(payload.parent) || payload.parent <= 0) throw new Error("Invalid update parent process")
+  for (const key of ["current", "staged", "backup", "root"]) {
+    if (typeof payload[key] !== "string" || !path.isAbsolute(payload[key])) throw new Error(`Invalid update ${key}`)
+  }
+  if (!payload.current.endsWith(".app") || !payload.staged.endsWith(".app") || !payload.backup.endsWith(".app")) {
+    throw new Error("Desktop update paths must be application bundles")
+  }
+  return payload
+}
+
+function alive(pid) {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function wait(pid, attempt = 0) {
+  if (!alive(pid)) return
+  if (attempt >= 600) throw new Error(`OpenScience ${pid} did not exit before the update`)
+  await sleep(100)
+  return wait(pid, attempt + 1)
+}
+
+async function install(payload) {
+  await wait(payload.parent)
+  await rename(payload.current, payload.backup)
+  try {
+    await exec("/usr/bin/ditto", [payload.staged, payload.current])
+    await exec("/usr/bin/codesign", ["--verify", "--deep", "--strict", payload.current])
+    await rm(payload.backup, { recursive: true, force: true })
+  } catch (error) {
+    await rm(payload.current, { recursive: true, force: true })
+    await rename(payload.backup, payload.current)
+    throw error
+  }
+  if (process.env.OPENSCIENCE_UPDATE_SKIP_LAUNCH !== "1") {
+    await exec("/usr/bin/open", ["-n", payload.current])
+  }
+  await rm(payload.root, { recursive: true, force: true })
+}
+
+const payload = decode(process.argv[2] ?? "")
+const log = path.join(path.dirname(payload.root), "update.log")
+
+await install(payload).catch(async (error) => {
+  await appendFile(log, `${new Date().toISOString()} ${error instanceof Error ? error.stack : String(error)}\n`, {
+    mode: 0o600,
+  })
+  process.exitCode = 1
+})

--- a/frontend/desktop/src/updater.mjs
+++ b/frontend/desktop/src/updater.mjs
@@ -1,0 +1,137 @@
+import { createHash, randomBytes } from "node:crypto"
+import { execFile, spawn } from "node:child_process"
+import { constants, createReadStream, createWriteStream } from "node:fs"
+import { access, chmod, copyFile, mkdir, mkdtemp, readdir, rm } from "node:fs/promises"
+import path from "node:path"
+import { Readable } from "node:stream"
+import { pipeline } from "node:stream/promises"
+import { promisify } from "node:util"
+
+const exec = promisify(execFile)
+const api = "https://api.github.com/repos/synthetic-sciences/openscience"
+const id = "ai.syntheticsciences.openscience"
+
+function valid(version) {
+  return /^\d+\.\d+\.\d+$/.test(version)
+}
+
+export function asset(arch = process.arch) {
+  if (arch !== "arm64" && arch !== "x64") throw new Error(`Unsupported macOS architecture: ${arch}`)
+  return `OpenScience-mac-${arch}.zip`
+}
+
+export async function checksum(file) {
+  const hash = createHash("sha256")
+  for await (const chunk of createReadStream(file)) hash.update(chunk)
+  return hash.digest("hex")
+}
+
+export async function release(version, options = {}) {
+  if (!valid(version)) throw new Error(`Invalid OpenScience update version: ${version}`)
+  const base = options.api ?? api
+  const response = await (options.fetch ?? fetch)(`${base}/releases/tags/v${version}`, {
+    headers: {
+      Accept: "application/vnd.github+json",
+      "User-Agent": `OpenScience/${version}`,
+    },
+    signal: AbortSignal.timeout(30_000),
+  })
+  if (!response.ok) throw new Error(`OpenScience ${version} release metadata is unavailable (${response.status})`)
+  const data = await response.json()
+  if (data.tag_name !== `v${version}` || data.draft || data.prerelease) {
+    throw new Error(`OpenScience ${version} is not a published stable release`)
+  }
+  const name = asset(options.arch)
+  const found = data.assets?.find((item) => item.name === name)
+  if (!found) throw new Error(`OpenScience ${version} is missing ${name}`)
+  if (!/^sha256:[0-9a-f]{64}$/.test(found.digest ?? "")) {
+    throw new Error(`${name} has no trusted GitHub SHA-256 digest`)
+  }
+  if (!URL.canParse(found.browser_download_url ?? "")) throw new Error(`${name} has no valid download URL`)
+  return {
+    version,
+    name,
+    url: found.browser_download_url,
+    digest: found.digest.slice("sha256:".length),
+  }
+}
+
+async function download(url, file, options = {}) {
+  const response = await (options.fetch ?? fetch)(url, {
+    headers: { "User-Agent": `OpenScience/${options.version}` },
+    redirect: "follow",
+    signal: AbortSignal.timeout(30 * 60_000),
+  })
+  if (!response.ok || !response.body) throw new Error(`OpenScience update download failed (${response.status})`)
+  await pipeline(Readable.fromWeb(response.body), createWriteStream(file, { mode: 0o600 }))
+}
+
+export async function verify(bundle, version) {
+  const plist = path.join(bundle, "Contents", "Info.plist")
+  const [identifier, current] = await Promise.all([
+    exec("/usr/bin/plutil", ["-extract", "CFBundleIdentifier", "raw", plist]),
+    exec("/usr/bin/plutil", ["-extract", "CFBundleShortVersionString", "raw", plist]),
+  ])
+  if (identifier.stdout.trim() !== id) throw new Error("The downloaded update has the wrong application identifier")
+  if (current.stdout.trim() !== version) throw new Error("The downloaded update has the wrong application version")
+  await exec("/usr/bin/codesign", ["--verify", "--deep", "--strict", bundle])
+}
+
+export async function stage(version, options = {}) {
+  if ((options.platform ?? process.platform) !== "darwin") throw new Error("Desktop self-updates require macOS")
+  const info = await release(version, options)
+  await mkdir(options.cache, { recursive: true, mode: 0o700 })
+  const root = await mkdtemp(path.join(options.cache, "pending-"))
+  const prepare = async () => {
+    const archive = path.join(root, info.name)
+    await download(info.url, archive, { fetch: options.fetch, version })
+    const digest = await checksum(archive)
+    if (digest !== info.digest) throw new Error(`OpenScience update digest mismatch for ${info.name}`)
+    const output = path.join(root, "app")
+    await mkdir(output, { mode: 0o700 })
+    await exec("/usr/bin/ditto", ["-x", "-k", archive, output])
+    const bundles = (await readdir(output, { withFileTypes: true })).filter(
+      (entry) => entry.isDirectory() && entry.name.endsWith(".app"),
+    )
+    if (bundles.length !== 1) throw new Error("The OpenScience update archive must contain exactly one app")
+    const bundle = path.join(output, bundles[0].name)
+    await verify(bundle, version)
+    return { root, bundle, version }
+  }
+  return prepare().catch(async (error) => {
+    await rm(root, { recursive: true, force: true })
+    throw error
+  })
+}
+
+export function current(executable = process.execPath) {
+  const bundle = path.resolve(path.dirname(executable), "../..")
+  if (!bundle.endsWith(".app")) throw new Error(`OpenScience is not running from an application bundle: ${bundle}`)
+  return bundle
+}
+
+export async function apply(update, options = {}) {
+  const active = options.current ?? current(options.executable)
+  if (active.startsWith("/Volumes/")) {
+    throw new Error("Move OpenScience to Applications before installing an update")
+  }
+  await access(path.dirname(active), constants.W_OK)
+  const helper = path.join(update.root, "update-helper.mjs")
+  await copyFile(new URL("./update-helper.mjs", import.meta.url), helper)
+  await chmod(helper, 0o700)
+  const payload = Buffer.from(
+    JSON.stringify({
+      parent: process.pid,
+      current: active,
+      staged: update.bundle,
+      backup: `${active.slice(0, -4)}.previous-${randomBytes(8).toString("hex")}.app`,
+      root: update.root,
+    }),
+  ).toString("base64url")
+  const child = spawn(options.executable ?? process.execPath, [helper, payload], {
+    detached: true,
+    env: { ...process.env, ELECTRON_RUN_AS_NODE: "1" },
+    stdio: "ignore",
+  })
+  child.unref()
+}


### PR DESCRIPTION
## Summary

- publish architecture-specific macOS ZIP payloads alongside each DMG
- route packaged desktop updates through a token-authenticated loopback service
- verify the exact stable GitHub release, SHA-256 asset digest, bundle identifier, version, and code signature before replacement
- replace the installed app through a detached helper with rollback and restart support
- document the unavoidable one-time Gatekeeper approval for ad-hoc-signed builds

## Why

The packaged sidecar was detected as an unknown installation, so the Settings update action could not update the desktop app. Releases also published only DMGs. Users therefore had to download and approve a new DMG for every release.

Apple still requires Developer ID signing plus notarization to remove the first-download Gatekeeper warning. This change does not pretend otherwise: an unsigned release needs Open Anyway once. After that, future updates use the verified ZIP path and no longer require another DMG download.

## Verification

- focused desktop/update/release tests: 33 passed
- actual macOS integration test creates an ad-hoc-signed app, downloads the update, validates its digest and bundle, replaces it, and verifies the installed signature
- root typecheck passed
- Prettier, JavaScript syntax checks, workflow YAML parsing, and git diff checks passed
- Electron Builder produced and verified both OpenScience-mac-arm64.dmg and OpenScience-mac-arm64.zip
- staged and verified the real 172 MB packaged ZIP and smoke-launched the packaged app with its bundled sidecar

The complete backend suite reported 2,951 passing and 23 skipped tests. Nine unrelated existing process/timing tests failed; isolated reruns passed for provider cache, filesystem event, and compute tool coverage, while Modal and two orphan-process tests continued to hit their own fixed timeouts.