### PR TITLE
test(e2e): align packaged UI contracts

### DIFF
--- a/frontend/workspace/e2e/settings-panels.spec.ts
+++ b/frontend/workspace/e2e/settings-panels.spec.ts
@@ -3,11 +3,13 @@ import { openSettings } from "./utils"
 
 const panels = [
   "Models",
+  "Local models",
   "Skills",
-  "Connectors",
+  "MCP & connectors",
+  "Research tools",
   "Compute",
+  "Security & access",
   "Network",
-  "Permissions",
   "Sandbox",
   "Credentials",
   "Storage",

--- a/frontend/workspace/e2e/setup-gate.spec.ts
+++ b/frontend/workspace/e2e/setup-gate.spec.ts
@@ -18,7 +18,7 @@ test("an unconfigured first run requires the one-time Synthetic Sciences connect
   await page.goto(`/${slug}/session/new`)
 
   await expect(page.getByRole("heading", { name: "Connect OpenScience", exact: true })).toBeVisible()
-  await expect(page.getByRole("button", { name: "Continue to sign in", exact: true })).toBeVisible()
+  await expect(page.getByRole("button", { name: "Sign in", exact: true })).toBeVisible()
   await expect(page.getByLabel("Synthetic Sciences API key", { exact: true })).toBeHidden()
   await page.getByText("Connect with a device key", { exact: true }).click()
   await expect(page.getByLabel("Synthetic Sciences API key", { exact: true })).toBeVisible()

--- a/frontend/workspace/e2e/workspace-consistency.spec.ts
+++ b/frontend/workspace/e2e/workspace-consistency.spec.ts
@@ -16,11 +16,13 @@ test("keeps Files and Customize labels visually consistent", async ({ page, goto
 
   const panels = [
     ["Models"],
+    ["Local models"],
     ["Skills", "Add skill"],
-    ["Connectors", "Add connector"],
+    ["MCP & connectors", "Add connector"],
+    ["Research tools"],
     ["Compute", "Add host"],
+    ["Security & access"],
     ["Network", "Add domain"],
-    ["Permissions"],
     ["Sandbox"],
     ["Credentials"],
     ["Storage"],


### PR DESCRIPTION
## Summary

- align packaged settings E2E selectors with the flattened settings navigation shipped in #419
- cover the newly first-class Local models and Research tools destinations and the current Security & access shell title
- assert the simplified Sign in CTA in the unconfigured-account gate

## Failure evidence

[Candidate run 33205869194](https://github.com/synthetic-sciences/openscience/actions/runs/33205869194) failed the packaged E2E job because these three specs still expected the pre-#419 labels: Connectors and Continue to sign in. The failure snapshots show the product correctly rendering MCP & connectors and Sign in, so this is a stale acceptance-contract fix rather than a product rollback.

## Validation

- targeted isolated Playwright run for `settings-panels.spec.ts`, `setup-gate.spec.ts`, and `workspace-consistency.spec.ts`: 4 passed in 52.9s
- `bun run typecheck` in `frontend/workspace`: passed
- pre-push `turbo typecheck`: 7/7 packages passed
- Prettier check on all three changed specs: passed
- `git diff --check`: passed
