### PR TITLE
Keep funded Managed access inside OpenScience

### DIFF
--- a/backend/cli/src/server/routes/settings/wallet.ts
+++ b/backend/cli/src/server/routes/settings/wallet.ts
@@ -14,6 +14,7 @@ export const WalletState = z.object({
   balanceUsd: z.number().nullable().describe("Wallet balance in USD; null when signed out or unavailable"),
   billingMode: z.enum(["managed", "byok"]).nullable(),
   managedSupported: z.boolean(),
+  managedUnlocked: z.boolean(),
   aceEnabled: z.boolean(),
   lifetimeSpentUsd: z.number().nullable(),
   transactions: z.array(
@@ -33,6 +34,7 @@ const SIGNED_OUT: WalletState = {
   balanceUsd: null,
   billingMode: null,
   managedSupported: false,
+  managedUnlocked: false,
   aceEnabled: false,
   lifetimeSpentUsd: null,
   transactions: [],
@@ -46,16 +48,18 @@ async function readWallet(): Promise<WalletState> {
     OpenScience.getBillingMode().catch(() => null),
     OpenScience.getTransactions(20).catch(() => null),
   ])
+  const balance = credits?.balanceUsd ?? null
   return {
     signedIn: true,
     // Financial display comes only from the authoritative Wallet response.
     // Compatibility mode metadata may synthesize zero when that read failed;
     // never turn an unavailable balance into "$0.00".
-    balanceUsd: credits?.balanceUsd ?? null,
+    balanceUsd: balance,
     billingMode: mode?.mode ?? null,
-    // The control is account-aware: infrastructure support alone must not
-    // make Managed selectable before Ace is enabled or funded.
-    managedSupported: mode?.managed_unlocked ?? false,
+    managedSupported: mode?.managed_supported ?? false,
+    // Keep funded accounts usable during a rolling Atlas deploy where the
+    // older access response still tied managed_unlocked to Ace consent.
+    managedUnlocked: Boolean(mode?.managed_unlocked || mode?.ace_enabled || (balance !== null && balance > 0)),
     aceEnabled: mode?.ace_enabled ?? false,
     lifetimeSpentUsd:
       credits?.lifetimeSpentCents === null || credits?.lifetimeSpentCents === undefined

--- a/backend/cli/test/server/settings-wallet.test.ts
+++ b/backend/cli/test/server/settings-wallet.test.ts
@@ -32,7 +32,14 @@ test("uses current Atlas access plus purchased Wallet truth without calling the 
     const path = new URL(String(input)).pathname
     const method = init?.method ?? "GET"
     calls.push({ path, method })
-    if (path === "/api/cli/access") return Response.json({ managed_supported: true, cli_balance_cents: 2500 })
+    if (path === "/api/cli/access") {
+      return Response.json({
+        managed_supported: true,
+        managed_unlocked: false,
+        ace_enabled: false,
+        cli_balance_cents: 2500,
+      })
+    }
     if (path === "/api/cli/billing-mode") return new Response("retired", { status: 404 })
     if (path === "/api/v1/wallet") {
       return Response.json({ balance_cents: 2500, purchased_cents: 2000, promotional_cents: 500 })
@@ -44,7 +51,14 @@ test("uses current Atlas access plus purchased Wallet truth without calling the 
   }) as typeof fetch
 
   const wallet = await (await WalletSettingsRoutes().request("/")).json()
-  expect(wallet).toMatchObject({ signedIn: true, balanceUsd: 20, lifetimeSpentUsd: 7.5, managedSupported: true })
+  expect(wallet).toMatchObject({
+    signedIn: true,
+    balanceUsd: 20,
+    lifetimeSpentUsd: 7.5,
+    managedSupported: true,
+    managedUnlocked: true,
+    aceEnabled: false,
+  })
   expect(await OpenScience.getBalance()).toBe(25)
 
   const update = await BillingSettingsRoutes().request("/", {

--- a/frontend/workspace/src/atlas/DesktopOnboarding.test.ts
+++ b/frontend/workspace/src/atlas/DesktopOnboarding.test.ts
@@ -46,11 +46,60 @@ describe("desktop onboarding", () => {
 
   test("uses the server's Wallet-or-reload managed-access decision", () => {
     expect(canUseManaged(undefined)).toBe(false)
-    expect(canUseManaged({ signedIn: true, managedSupported: false, aceEnabled: true, balanceUsd: 20 })).toBe(false)
-    expect(canUseManaged({ signedIn: true, managedSupported: true, aceEnabled: false, balanceUsd: 20 })).toBe(true)
-    expect(canUseManaged({ signedIn: true, managedSupported: true, aceEnabled: false, balanceUsd: null })).toBe(true)
-    expect(canUseManaged({ signedIn: false, managedSupported: true, aceEnabled: true, balanceUsd: 20 })).toBe(false)
-    expect(canUseManaged({ signedIn: true, managedSupported: true, aceEnabled: true, balanceUsd: 20 })).toBe(true)
+    expect(
+      canUseManaged({
+        signedIn: true,
+        managedSupported: false,
+        managedUnlocked: true,
+        aceEnabled: true,
+        balanceUsd: 20,
+      }),
+    ).toBe(false)
+    expect(
+      canUseManaged({
+        signedIn: true,
+        managedSupported: true,
+        managedUnlocked: true,
+        aceEnabled: false,
+        balanceUsd: 20,
+      }),
+    ).toBe(true)
+    expect(
+      canUseManaged({
+        signedIn: true,
+        managedSupported: true,
+        managedUnlocked: true,
+        aceEnabled: false,
+        balanceUsd: null,
+      }),
+    ).toBe(true)
+    expect(
+      canUseManaged({
+        signedIn: false,
+        managedSupported: true,
+        managedUnlocked: true,
+        aceEnabled: true,
+        balanceUsd: 20,
+      }),
+    ).toBe(false)
+    expect(
+      canUseManaged({
+        signedIn: true,
+        managedSupported: true,
+        managedUnlocked: true,
+        aceEnabled: true,
+        balanceUsd: 0,
+      }),
+    ).toBe(true)
+    expect(
+      canUseManaged({
+        signedIn: true,
+        managedSupported: true,
+        managedUnlocked: false,
+        aceEnabled: false,
+        balanceUsd: 0,
+      }),
+    ).toBe(false)
   })
 
   test("keeps interactions compact, responsive, and motion restrained", async () => {

--- a/frontend/workspace/src/atlas/desktop-onboarding-access.ts
+++ b/frontend/workspace/src/atlas/desktop-onboarding-access.ts
@@ -2,7 +2,9 @@ export type ManagedWallet = {
   signedIn: boolean
   balanceUsd: number | null
   managedSupported: boolean
+  managedUnlocked: boolean
   aceEnabled: boolean
 }
 
-export const canUseManaged = (wallet: ManagedWallet | undefined) => Boolean(wallet?.signedIn && wallet.managedSupported)
+export const canUseManaged = (wallet: ManagedWallet | undefined) =>
+  Boolean(wallet?.signedIn && wallet.managedSupported && wallet.managedUnlocked)

--- a/frontend/workspace/src/components/settings/ManagedInference.test.ts
+++ b/frontend/workspace/src/components/settings/ManagedInference.test.ts
@@ -30,17 +30,65 @@ test("formats the purchased-credit balance to exact cents", () => {
 test("allows Managed whenever the server authorizes Wallet or reload access", () => {
   expect(canSelectManaged(undefined)).toBe(false)
   expect(
-    canSelectManaged({ signedIn: false, managedSupported: true, aceEnabled: true, balanceUsd: 20, billingMode: null }),
+    canSelectManaged({
+      signedIn: false,
+      managedSupported: true,
+      managedUnlocked: true,
+      aceEnabled: true,
+      balanceUsd: 20,
+      billingMode: null,
+    }),
   ).toBe(false)
   expect(
-    canSelectManaged({ signedIn: true, managedSupported: false, aceEnabled: true, balanceUsd: 20, billingMode: null }),
+    canSelectManaged({
+      signedIn: true,
+      managedSupported: false,
+      managedUnlocked: true,
+      aceEnabled: true,
+      balanceUsd: 20,
+      billingMode: null,
+    }),
   ).toBe(false)
   expect(
-    canSelectManaged({ signedIn: true, managedSupported: true, aceEnabled: false, balanceUsd: 20, billingMode: null }),
+    canSelectManaged({
+      signedIn: true,
+      managedSupported: true,
+      managedUnlocked: true,
+      aceEnabled: false,
+      balanceUsd: 20,
+      billingMode: null,
+    }),
   ).toBe(true)
   expect(
-    canSelectManaged({ signedIn: true, managedSupported: true, aceEnabled: true, balanceUsd: 0, billingMode: null }),
+    canSelectManaged({
+      signedIn: true,
+      managedSupported: true,
+      managedUnlocked: true,
+      aceEnabled: true,
+      balanceUsd: 0,
+      billingMode: null,
+    }),
   ).toBe(true)
+  expect(
+    canSelectManaged({
+      signedIn: true,
+      managedSupported: true,
+      managedUnlocked: false,
+      aceEnabled: false,
+      balanceUsd: 0,
+      billingMode: "byok",
+    }),
+  ).toBe(false)
+})
+
+test("does not redirect the Managed choice and gives an explicit zero-balance action", () => {
+  const update = source.slice(source.indexOf("const update ="), source.indexOf("// The mode can change"))
+
+  expect(update).not.toContain("openLink")
+  expect(source).toContain('return "No Wallet balance"')
+  expect(source).toContain('return "Turn on Ace"')
+  expect(source).toContain('option.value === "managed" && !canSelectManaged(wallet())')
+  expect(source).toContain("Add Wallet funds or turn on Ace to use Managed models")
 })
 
 // The provider catalog is intentionally not part of this helper. It is a

--- a/frontend/workspace/src/components/settings/ManagedInference.tsx
+++ b/frontend/workspace/src/components/settings/ManagedInference.tsx
@@ -16,10 +16,12 @@ type Wallet = {
   balanceUsd: number | null
   billingMode: "managed" | "byok" | null
   managedSupported: boolean
+  managedUnlocked: boolean
   aceEnabled: boolean
 }
 
-export const canSelectManaged = (wallet: Wallet | undefined) => Boolean(wallet?.signedIn && wallet.managedSupported)
+export const canSelectManaged = (wallet: Wallet | undefined) =>
+  Boolean(wallet?.signedIn && wallet.managedSupported && wallet.managedUnlocked)
 
 const MODES: { value: Mode; title: string; body: string }[] = [
   {
@@ -30,7 +32,7 @@ const MODES: { value: Mode; title: string; body: string }[] = [
   {
     value: "managed",
     title: "Managed",
-    body: "Use your Ace balance for supported models without configuring a provider key.",
+    body: "Use your Wallet balance for supported models without configuring a provider key.",
   },
 ]
 
@@ -85,10 +87,6 @@ export function ManagedInference(props: { onError?: (error: string | undefined) 
   }
   const update = (value: Mode) => {
     if (busy()) return
-    if (value === "managed" && wallet() && !canSelectManaged(wallet())) {
-      platform.openLink(URLS.dashboardBilling)
-      return
-    }
     const previous = mode()
     // Immediate visual acknowledgement: the network write may include account
     // synchronization, but the pressed state should never wait on that work.
@@ -157,19 +155,20 @@ export function ManagedInference(props: { onError?: (error: string | undefined) 
     unsubscribe()
   })
 
-  const needsAce = () => wallet() !== undefined && !canSelectManaged(wallet())
+  const managedUnavailable = () => wallet() !== undefined && !canSelectManaged(wallet())
   const aceLabel = () => {
     if (!wallet()) return "Checking account"
     if (!wallet()!.signedIn) return "Account required"
     if (!wallet()!.managedSupported) return "Managed unavailable"
+    if (!wallet()!.managedUnlocked) return "No Wallet balance"
     if (wallet()!.aceEnabled) return "Ace on"
     return "Wallet funded"
   }
   const aceAction = () => {
     if (!wallet()?.signedIn) return "Sign in"
-    if (!wallet()?.managedSupported) return "Add funds"
-    if (!wallet()?.aceEnabled) return "Manage Wallet"
-    return "Manage Ace"
+    if (!wallet()?.managedSupported) return "Manage Wallet"
+    if (!wallet()?.managedUnlocked) return "Turn on Ace"
+    return wallet()?.aceEnabled ? "Manage Ace" : "Manage Wallet"
   }
 
   return (
@@ -187,9 +186,13 @@ export function ManagedInference(props: { onError?: (error: string | undefined) 
                 type="button"
                 aria-pressed={mode() === option.value}
                 aria-busy={busy()}
-                disabled={busy() || (option.value === "managed" && wallet() === undefined)}
+                disabled={busy() || (option.value === "managed" && !canSelectManaged(wallet()))}
                 class="models-routing__option"
-                title={option.value === "managed" && needsAce() ? "Enable Ace to use Managed models" : undefined}
+                title={
+                  option.value === "managed" && managedUnavailable()
+                    ? "Add Wallet funds or turn on Ace to use Managed models"
+                    : undefined
+                }
                 onClick={() => update(option.value)}
               >
                 <span class="models-routing__option-label">
@@ -206,7 +209,7 @@ export function ManagedInference(props: { onError?: (error: string | undefined) 
               <span class="models-routing__sync"> Updating model availability…</span>
             </Show>
           </p>
-          <Show when={mode() === "managed"}>
+          <Show when={mode() === "managed" || managedUnavailable()}>
             <div class="models-routing__account">
               <span class="models-routing__account-state">{aceLabel()}</span>
               <span aria-live="polite" class="models-account-summary__balance">


### PR DESCRIPTION
## Summary
- consume the Wallet-or-Ace access decision separately from deployment support
- stop redirecting funded users to Billing when they select Managed
- disable Managed only at zero balance with Ace off while keeping BYOK available and showing Turn on Ace

## Validation
- focused wallet and UI tests: 23 passed
- backend and workspace typechecks
- production build
- local signed-in BYOK to Managed browser flow stayed inside OpenScience
- full suite: 2951 passed, 23 skipped; 11 process-heavy timeout/listener cases passed on isolated rerun, with two unrelated macOS orphan-process tests still timing out locally