### PR TITLE
Fix Linux scientific capability archive attestation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup-bun

--- a/backend/cli/src/science/kernel/environment-manager.ts
+++ b/backend/cli/src/science/kernel/environment-manager.ts
@@ -893,6 +893,16 @@ async function fixtureOwnership() {
     z.null(),
     z
       .object({
+        kind: z.literal("symlink"),
+        digest: z
+          .string()
+          .regex(/^[a-f0-9]{64}$/)
+          .optional(),
+        linkTarget: z.string().min(1),
+      })
+      .strict(),
+    z
+      .object({
         digest: z.string().regex(/^[a-f0-9]{64}$/),
         size: z.number().int().nonnegative(),
         canonical: z.literal("macho_unsigned"),
@@ -923,9 +933,11 @@ async function fixtureOwnership() {
     const owned =
       typeof value === "string"
         ? { kind: "file" as const, digest: value }
-        : value
-          ? { kind: "file" as const, ...value }
-          : { kind: "file" as const }
+        : value && "kind" in value
+          ? value
+          : value
+            ? { kind: "file" as const, ...value }
+            : { kind: "file" as const }
     if (!safe || !own(ownership, safe, owned)) return undefined
   }
   for (const relative of parsed.data.scripts) {
@@ -1050,10 +1062,11 @@ async function verifyOwnership(prefix: string, ownership: Ownership, options: { 
         // directory symlinks is package-specific and is not a link-byte hash.
         continue
       }
+      // A Conda softlink's paths.json digest can describe the target present
+      // in the source package's build environment. Authenticate the exact
+      // link text and the currently locked, in-prefix target independently.
       const record = entry.isSymbolicLink() ? ownership.files.get(resolvedRelative ?? "") : expected
       if (!record || record.kind !== "file") return reject("resolved target is not archive-owned", relative)
-      if (entry.isSymbolicLink() && expected.digest && expected.digest !== (record.archiveDigest ?? record.digest))
-        return reject("symlink and target archive identity differ", relative)
       const bytes = await openedBytes(resolved)
       if (!bytes) return reject("owned bytes changed while reading", relative)
       if (!record.digest) continue

--- a/backend/cli/test/installation/release-order.test.ts
+++ b/backend/cli/test/installation/release-order.test.ts
@@ -579,3 +579,13 @@ test("native Windows file tests keep the repository test timeout", async () => {
     "bun test --timeout 15000 test/file/safe-io.test.ts test/file/rename.test.ts test/file/trash.test.ts",
   )
 })
+
+test("the full CI test job budgets for preflights and the exhaustive suite", async () => {
+  const workflow = await Bun.file(path.join(import.meta.dir, "../../../../.github/workflows/ci.yml")).text()
+  const job = workflow.slice(workflow.indexOf("\n  test:"), workflow.indexOf("\n  build:"))
+
+  expect(job).toContain("timeout-minutes: 30")
+  expect(job).toContain("Exercise real OpenSSH dispatch and recovery")
+  expect(job).toContain("Build embedded web assets for server tests")
+  expect(job).toContain("bun run --cwd backend/cli test")
+})

--- a/backend/cli/test/science/kernel/environment-manager.test.ts
+++ b/backend/cli/test/science/kernel/environment-manager.test.ts
@@ -149,6 +149,26 @@ fs.chmodSync(binary, 0o755)
 	    size: canonical.length,
 	    canonical: "macho_unsigned",
 	  }
+	  if (process.env.OPENSCIENCE_TEST_CROSS_PACKAGE_SOFTLINK === "1") {
+	    const targetRelative = path.join("bin", "locked-link-target")
+	    fs.writeFileSync(path.join(prefix, targetRelative), "locked target\\n")
+	    files[targetRelative.split(path.sep).join("/")] = crypto
+	      .createHash("sha256")
+	      .update(fs.readFileSync(path.join(prefix, targetRelative)))
+	      .digest("hex")
+	    const linkRelative = path.join("compiler_compat", "ld")
+	    fs.mkdirSync(path.dirname(path.join(prefix, linkRelative)), { recursive: true })
+	    const linkTarget = "../bin/locked-link-target"
+	    fs.symlinkSync(linkTarget, path.join(prefix, linkRelative))
+	    files[linkRelative.split(path.sep).join("/")] = {
+	      kind: "symlink",
+	      // Conda softlink metadata can describe the target used when the
+	      // source package was built rather than the target selected by this
+	      // exact multi-package lock.
+	      digest: "0".repeat(64),
+	      linkTarget,
+	    }
+	  }
 	  fs.writeFileSync(process.env.OPENSCIENCE_TEST_TRUSTED_OWNERSHIP, JSON.stringify({ version: 1, files, scripts: [] }))
 	}
 `,
@@ -353,6 +373,20 @@ test.skipIf(!capabilityPlatform())("attests the Conda prefix before isolated pip
     await current.dispose()
   }
 })
+
+test.skipIf(!capabilityPlatform())(
+  "accepts an exact cross-package softlink when its build-time target digest differs",
+  async () => {
+    const current = await profile()
+    try {
+      current.env.OPENSCIENCE_TEST_CROSS_PACKAGE_SOFTLINK = "1"
+      const inspected = JSON.parse((await run("task", current.env)).trim()) as { ready: boolean }
+      expect(inspected.ready).toBe(true)
+    } finally {
+      await current.dispose()
+    }
+  },
+)
 
 test.skipIf(!capabilityPlatform())("rejects an unowned .pth planted before the first Python invocation", async () => {
   const current = await profile()


### PR DESCRIPTION
## Outcome

Unblocks both Linux scientific-capability candidate canaries without weakening the archive trust boundary.

The Conda paths.json digest for a softlink can describe the target present in the source package build environment. The exact multi-package lock can select a different, independently authenticated target. The previous verifier incorrectly required those two payload digests to match, rejecting legitimate locked links such as compiler_compat/ld and lib/libgomp.so.1.

The verifier still requires:

- the exact archive-authenticated link text;
- an in-prefix resolved target;
- a target owned by the exact locked archives; and
- normalized target bytes matching the locked digest and size.

## Regression

Adds a cross-package softlink fixture whose build-time digest intentionally differs from its exact locked target.

## Verification

- Focused environment-manager test: 18 passed
- Backend CLI typecheck: passed
- Prettier and diff check: passed
- Exact Linux lock forensic: 1,171 symlinks checked; two legitimate build-time/current-target digest differences; zero escaping, unowned, or target-integrity violations
