### PR TITLE
fix(cli): harden Modal release handoff

### DIFF
--- a/backend/cli/src/compute/jobs.ts
+++ b/backend/cli/src/compute/jobs.ts
@@ -372,6 +372,24 @@ export namespace ComputeJobs {
     provider?: ModalProvider
   }
 
+  type TestHooks = {
+    beforeModalDeactivate?: (id: string) => void | Promise<void>
+  }
+
+  const hooks = { value: undefined as TestHooks | undefined }
+
+  /** Deterministic lifecycle barriers for Modal lease handoff regressions. */
+  export function testing(input: TestHooks) {
+    if (!process.env.OPENSCIENCE_TEST_HOME) throw new Error("Compute job test hooks are disabled outside tests")
+    const prior = hooks.value
+    hooks.value = input
+    return {
+      [Symbol.dispose]() {
+        if (hooks.value === input) hooks.value = prior
+      },
+    }
+  }
+
   async function modalContext(options: Options, message: string): Promise<ModalAdapter.Context> {
     const context = options.credentials ?? (await options.resolveCredentials?.())
     if (!context) throw new Error(message)
@@ -3137,8 +3155,13 @@ export namespace ComputeJobs {
   export async function release(id: string, options: Options = {}): Promise<Job> {
     const scope = await scoped(options)
     const key = keyOf(scope.root, id)
-    if (active.has(key)) throw new Error(`Compute job ${id} still has an active recovery`)
     const stored = await get(id, { root: scope.root, workspace: scope.workspace })
+    if (stored?.target.kind !== "modal" && active.has(key)) {
+      throw new Error(`Compute job ${id} still has an active recovery`)
+    }
+    if (stored?.target.kind === "modal" && !terminal.has(stored.status)) {
+      throw new Error(`Cancel compute job ${id} before releasing its resources`)
+    }
     if (stored?.target.kind === "ssh") {
       if (!terminal.has(stored.status)) throw new Error(`Cancel compute job ${id} before releasing its resources`)
       if (stored.status === "cancelled" && stored.lifecycle?.resource !== "closed") return cancelSsh(stored, scope)
@@ -3163,6 +3186,7 @@ export namespace ComputeJobs {
     return await operation.during(async () => {
       await using lease = await FileLease.acquire(modalLeaseOf(scope.root, id))
       return await lease.during(async () => {
+        if (active.has(key)) throw new Error(`Compute job ${id} still has an active recovery`)
         const job = await get(id, { root: scope.root, workspace: scope.workspace })
         if (!job) throw new Error(`Compute job ${id} was not found`)
         if (job.target.kind !== "modal" || !job.modal || !job.cwd) {
@@ -3436,7 +3460,13 @@ export namespace ComputeJobs {
               throw error
             } finally {
               setup.resolve()
-              if (activated) await deactivate(key)
+              if (activated) {
+                try {
+                  await hooks.value?.beforeModalDeactivate?.(job.id)
+                } finally {
+                  await deactivate(key)
+                }
+              }
             }
           })
           .finally(() => releaseLease(lease))

--- a/backend/cli/src/compute/modal/volume.ts
+++ b/backend/cli/src/compute/modal/volume.ts
@@ -25,6 +25,25 @@ export namespace ModalVolume {
     uv?: string
   }
 
+  type TestHooks = {
+    probe?: { argv: string[]; timeout: number }
+    beforeUv?: () => void | Promise<void>
+  }
+
+  const hooks = { value: undefined as TestHooks | undefined }
+
+  /** Deterministic SDK-selection barriers for process-ownership regressions. */
+  export function testing(input: TestHooks) {
+    if (!process.env.OPENSCIENCE_TEST_HOME) throw new Error("Modal Volume test hooks are disabled outside tests")
+    const prior = hooks.value
+    hooks.value = input
+    return {
+      [Symbol.dispose]() {
+        if (hooks.value === input) hooks.value = prior
+      },
+    }
+  }
+
   export type Entry = {
     path: string
     type: string
@@ -98,6 +117,14 @@ export namespace ModalVolume {
   const MAX_STDOUT = 8 * 1024 * 1024
   const MAX_STDERR = 1024 * 1024
   const text = new TextDecoder()
+
+  class TimeoutError extends Error {
+    constructor(action: string, timeout: number) {
+      super(`Modal Volume ${action} timed out after ${timeout}ms`)
+      this.name = "ModalVolumeTimeoutError"
+    }
+  }
+
   const clean = (value: string) => value.replaceAll("\\", "/").replace(/^\/+/, "")
   const safe = (value: string) => {
     const result = clean(value)
@@ -178,22 +205,30 @@ export namespace ModalVolume {
     const python = context.python ?? Bun.which("python3") ?? Bun.which("python")
     if (python) {
       const probe = await execute(
-        [
+        hooks.value?.probe?.argv ?? [
           python,
           "-I",
           "-c",
           `import modal; assert modal.__version__ == '${VERSION}'; assert hasattr(modal.Volume, 'read_file')`,
         ],
         environment({ ...process.env, ...context.env }),
-        PROBE_TIMEOUT,
+        hooks.value?.probe?.timeout ?? PROBE_TIMEOUT,
         "SDK probe",
         undefined,
         signal,
-      )
-      if (probe.code === 0) return [python, "-I", file]
+      ).catch((error) => {
+        if (signal?.aborted) throw abortReason(signal)
+        if (error instanceof TimeoutError) return undefined
+        throw error
+      })
+      if (probe?.signal) throw new Error(`Modal Volume SDK probe was killed by ${probe.signal}`)
+      if (probe?.code === 0) return [python, "-I", file]
+      if (probe?.code === null) throw new Error("Modal Volume SDK probe ended without an exit code")
     }
+    if (signal?.aborted) throw abortReason(signal)
     const uv = context.uv ?? Bun.which("uv")
     if (uv) {
+      await hooks.value?.beforeUv?.()
       return [uv, "run", "--no-project", "--python", "3.12", "--with", `modal==${VERSION}`, "python", "-I", file]
     }
     throw new Error("Modal Volume access requires uv or a Python installation that can import the Modal SDK")
@@ -377,10 +412,7 @@ export namespace ModalVolume {
         timeout === undefined
           ? undefined
           : new Promise<never>((_, reject) => {
-              timer = setTimeout(
-                () => reject(new Error(`Modal Volume ${action} timed out after ${timeout}ms`)),
-                timeout,
-              )
+              timer = setTimeout(() => reject(new TimeoutError(action, timeout)), timeout)
             })
       const result = Promise.all([launched.stdout, launched.stderr, launched.completion] as const)
       const interrupted = signal ? Promise.withResolvers<never>() : undefined

--- a/backend/cli/test/compute/jobs.test.ts
+++ b/backend/cli/test/compute/jobs.test.ts
@@ -1439,6 +1439,7 @@ describe("ComputeJobs Modal governance", () => {
     await using tmp = await tmpdir()
     const root = path.join(tmp.path, "state")
     const gate = Promise.withResolvers<void>()
+    const releases = { count: 0 }
     const provider = modalProvider({
       run: async (_context, spec, hooks) => {
         await hooks.created(`sandbox-${spec.id}`)
@@ -1446,6 +1447,9 @@ describe("ComputeJobs Modal governance", () => {
         return { code: 0, outputs: [] }
       },
       close: async () => gate.resolve(),
+      release: async () => {
+        releases.count++
+      },
     })
     const request = {
       name: "held modal job",
@@ -1501,6 +1505,12 @@ describe("ComputeJobs Modal governance", () => {
     expect((refused[0] as PromiseRejectedResult).reason.message).toContain("Modal concurrency limit reached")
     const first = (started[0] as PromiseFulfilledResult<ComputeJobs.Job>).value
     expect(first.modal?.volume).toStartWith("test-")
+    const startedRelease = Date.now()
+    await expect(ComputeJobs.release(first.id, { root, workspace: tmp.path, credentials, provider })).rejects.toThrow(
+      `Cancel compute job ${first.id} before releasing its resources`,
+    )
+    expect(Date.now() - startedRelease).toBeLessThan(1_000)
+    expect(releases.count).toBe(0)
 
     await ComputeJobs.cancel(first.id, { root, workspace: tmp.path, credentials, provider })
   })
@@ -1696,6 +1706,72 @@ describe("ComputeJobs Modal governance", () => {
     expect(released.cleanup_error).toBeUndefined()
     expect(released.error).toBeUndefined()
   })
+
+  test("release waits for the exact Modal job lease before checking active recovery", async () => {
+    await using tmp = await tmpdir()
+    const root = path.join(tmp.path, "state")
+    const blocked = Promise.withResolvers<void>()
+    const deactivating = Promise.withResolvers<void>()
+    const calls = { release: 0 }
+    await using _testing = ComputeJobs.testing({
+      beforeModalDeactivate: async () => {
+        deactivating.resolve()
+        await blocked.promise
+      },
+    })
+    const provider = modalProvider({
+      run: async () => {
+        throw new Error("synthetic Modal launch failure")
+      },
+      release: async () => {
+        calls.release++
+      },
+    })
+    const request = {
+      name: "failed Modal handoff",
+      command: "true",
+      target: { kind: "modal" as const },
+      gpu: "none",
+    }
+    const prepared = await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await trustProject()
+        const session = await Session.create({})
+        const plan = await ComputeJobs.plan({ ...request, sessionID: session.id }, { root, workspace: tmp.path, modal })
+        return { session, plan }
+      },
+    })
+    const job = await Instance.provide({
+      directory: tmp.path,
+      fn: () =>
+        ComputeJobs.start(
+          { ...request, sessionID: prepared.session.id, approval: prepared.plan.digest },
+          { root, workspace: tmp.path, modal, credentials, provider },
+        ),
+    })
+    await deactivating.promise
+    expect((await ComputeJobs.get(job.id, { root, workspace: tmp.path }))?.status).toBe("failed")
+    const releasing = ComputeJobs.release(job.id, { root, workspace: tmp.path, credentials, provider }).then(
+      (value) => ({ ok: true as const, value }),
+      (error: unknown) => ({ ok: false as const, error }),
+    )
+
+    try {
+      const pending = await Promise.race([releasing.then(() => false), Bun.sleep(25).then(() => true)])
+      expect(pending).toBe(true)
+      expect(calls.release).toBe(0)
+    } finally {
+      blocked.resolve()
+    }
+
+    const result = await releasing
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw result.error
+    expect(result.value.status).toBe("failed")
+    expect(result.value.lifecycle?.resource).toBe("closed")
+    expect(calls.release).toBe(1)
+  }, 15_000)
 
   test("retries delivery from the durable Modal resource without rerunning the command", async () => {
     await using tmp = await tmpdir()

--- a/backend/cli/test/compute/modal-volume.test.ts
+++ b/backend/cli/test/compute/modal-volume.test.ts
@@ -184,6 +184,115 @@ describe("ModalVolume", () => {
     ])
   })
 
+  test("reaps a timed-out ambient SDK probe before selecting the pinned uv runtime", async () => {
+    const python = Bun.which("python3") ?? Bun.which("python")
+    if (!python) throw new Error("Python is required for the Modal Volume driver test")
+    const previous = new Set((await ledger()).map((entry) => entry.id))
+    let active: LedgerEntry | undefined
+    await using _testing = ModalVolume.testing({
+      probe: { argv: [python, "-I", "-c", "import time; time.sleep(600)"], timeout: 1_000 },
+      beforeUv: async () => {
+        expect(active).toBeDefined()
+        expect(await CredentialProcessLedger.owns(active!.pid, active!.identity)).toBe(false)
+        expect((await ledger()).some((entry) => entry.id === active!.id)).toBe(false)
+      },
+    })
+    const started = Date.now()
+    const running = ModalVolume.command({
+      tokenId: "ak-test",
+      tokenSecret: "as-test",
+      python,
+      uv: "/test/uv",
+    })
+    active = await waitEntry(previous)
+
+    const selected = await running
+
+    expect(Date.now() - started).toBeLessThan(4_000)
+    expect(selected).toEqual([
+      "/test/uv",
+      "run",
+      "--no-project",
+      "--python",
+      "3.12",
+      "--with",
+      `modal==${ModalVolume.VERSION}`,
+      "python",
+      "-I",
+      await ModalVolume.driverPath(),
+    ])
+  }, 30_000)
+
+  test("does not turn an in-flight caller abort into a uv fallback", async () => {
+    const python = Bun.which("python3") ?? Bun.which("python")
+    if (!python) throw new Error("Python is required for the Modal Volume driver test")
+    const previous = new Set((await ledger()).map((entry) => entry.id))
+    const controller = new AbortController()
+    const reason = new DOMException("release cancelled", "AbortError")
+    let selected = false
+    await using _testing = ModalVolume.testing({
+      probe: { argv: [python, "-I", "-c", "import time; time.sleep(600)"], timeout: 5_000 },
+      beforeUv: () => {
+        selected = true
+      },
+    })
+    const running = ModalVolume.command(
+      { tokenId: "ak-test", tokenSecret: "as-test", python, uv: "/test/uv" },
+      controller.signal,
+    ).then(
+      (value) => ({ ok: true as const, value }),
+      (error: unknown) => ({ ok: false as const, error }),
+    )
+    const active = await waitEntry(previous)
+
+    controller.abort(reason)
+    const result = await running
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error("The aborted SDK probe unexpectedly selected a runtime")
+    expect(result.error).toBe(reason)
+    expect(selected).toBe(false)
+    expect(await CredentialProcessLedger.owns(active.pid, active.identity)).toBe(false)
+    expect((await ledger()).some((entry) => entry.id === active.id)).toBe(false)
+  }, 30_000)
+
+  test("does not select uv when timed-out probe ownership cleanup fails", async () => {
+    const python = Bun.which("python3") ?? Bun.which("python")
+    if (!python) throw new Error("Python is required for the Modal Volume driver test")
+    const previous = new Set((await ledger()).map((entry) => entry.id))
+    let selected = false
+    await using _testing = ModalVolume.testing({
+      probe: { argv: [python, "-I", "-c", "import time; time.sleep(600)"], timeout: 1_000 },
+      beforeUv: () => {
+        selected = true
+      },
+    })
+    const running = ModalVolume.command({
+      tokenId: "ak-test",
+      tokenSecret: "as-test",
+      python,
+      uv: "/test/uv",
+    }).then(
+      (value) => ({ ok: true as const, value }),
+      (error: unknown) => ({ ok: false as const, error }),
+    )
+    const active = await waitEntry(previous)
+    const failure = new Error("synthetic ownership cleanup failure")
+    const revoke = spyOn(CredentialProcessLedger, "revoke").mockRejectedValue(failure)
+
+    try {
+      const result = await running
+      expect(result.ok).toBe(false)
+      if (result.ok) throw new Error("The unsafe SDK probe unexpectedly selected a runtime")
+      expect(result.error).toBeInstanceOf(AggregateError)
+      expect((result.error as AggregateError).errors).toContain(failure)
+      expect(selected).toBe(false)
+    } finally {
+      revoke.mockRestore()
+      await CredentialProcessLedger.revoke({ id: active.id, kind: "modal-volume" }).catch(() => undefined)
+    }
+  }, 30_000)
+
   // This is four independent control-plane calls. Each call deliberately
   // completes durable helper ownership and descendant reaping before the next
   // one starts, so their combined deadline must not inherit Bun's 5s default.


### PR DESCRIPTION
## Summary
- fall back from a timed-out/nonzero ambient Modal SDK probe to the pinned `uv` `modal==1.1.4` runtime only after durable child cleanup completes
- preserve caller aborts, killed probes, and ownership/cleanup failures as fail-closed errors
- serialize terminal Modal release behind the exact job lease, then re-check in-memory ownership and re-read durable state
- reject genuinely running jobs before operation locking so cancel remains unblocked

## Verification
- `bun test --timeout 15000 test/compute/modal-volume.test.ts test/compute/jobs.test.ts` — 67 pass, 0 fail
- `bun run typecheck` from `backend/cli` — pass
- Prettier check on all four changed files — pass
- `git diff --check` — pass

## Review
- No SQL/data, LLM trust-boundary, secret-logging, or distribution changes.
- Regressions use real governed helper processes and deterministic lease/deactivation barriers; no Modal provider workload is launched.