### PR TITLE
fix: prewarm Modal volume SDK offline

### DIFF
--- a/backend/cli/src/compute/modal/volume.ts
+++ b/backend/cli/src/compute/modal/volume.ts
@@ -27,7 +27,10 @@ export namespace ModalVolume {
 
   type TestHooks = {
     probe?: { argv: string[]; timeout: number }
+    bootstrap?: { argv: string[]; timeout: number }
     beforeUv?: () => void | Promise<void>
+    beforeBootstrapListener?: () => void
+    afterBootstrapSettled?: () => void
   }
 
   const hooks = { value: undefined as TestHooks | undefined }
@@ -114,6 +117,7 @@ export namespace ModalVolume {
 
   const LIST_TIMEOUT = 60_000
   const PROBE_TIMEOUT = 15_000
+  const BOOTSTRAP_TIMEOUT = 180_000
   const MAX_STDOUT = 8 * 1024 * 1024
   const MAX_STDERR = 1024 * 1024
   const text = new TextDecoder()
@@ -173,6 +177,19 @@ export namespace ModalVolume {
 
   const cache: { path?: Promise<string> } = {}
 
+  type Prewarm = {
+    controller: AbortController
+    promise: Promise<void>
+    waiters: number
+    settled: boolean
+    failure?: unknown
+  }
+
+  // Share only an identical in-flight token-free bootstrap. Successful
+  // checks are deliberately not retained: every later credential-bearing
+  // operation must re-attest its exact uv path, pin, and isolated runtime.
+  const prewarms = new Map<string, Prewarm>()
+
   export async function driverPath() {
     if (cache.path) return cache.path
     const pending = Promise.resolve().then(async () => {
@@ -196,6 +213,97 @@ export namespace ModalVolume {
       throw error
     })
     return cache.path
+  }
+
+  async function bootstrap(argv: string[], env: Record<string, string>, timeout: number, signal: AbortSignal) {
+    const result = await execute(argv, env, timeout, "SDK bootstrap", undefined, signal)
+    if (result.signal) throw new Error(`Modal Volume SDK bootstrap was killed by ${result.signal}`)
+    if (result.code === null) throw new Error("Modal Volume SDK bootstrap ended without an exit code")
+    if (result.code !== 0) {
+      const detail = result.stderr.byteLength ? result.stderr : result.stdout
+      const message = text.decode(detail).trim()
+      throw new Error(`Modal Volume SDK bootstrap failed (exit ${result.code})${message ? `: ${message}` : ""}`)
+    }
+  }
+
+  async function prewarm(argv: string[], env: Record<string, string>, timeout: number, signal?: AbortSignal) {
+    if (signal?.aborted) throw abortReason(signal)
+    const key = JSON.stringify([
+      argv,
+      Object.entries(env).toSorted(([left], [right]) => left.localeCompare(right)),
+      timeout,
+    ])
+    let entry = prewarms.get(key)
+    if (!entry) {
+      const controller = new AbortController()
+      entry = {
+        controller,
+        promise: Promise.resolve(),
+        waiters: 0,
+        settled: false,
+      }
+      const current = entry
+      current.promise = bootstrap(argv, env, timeout, controller.signal)
+        .catch((error) => {
+          current.failure = error
+          throw error
+        })
+        .finally(() => {
+          current.settled = true
+          hooks.value?.afterBootstrapSettled?.()
+          if (prewarms.get(key) === current) prewarms.delete(key)
+        })
+      prewarms.set(key, current)
+    }
+
+    entry.waiters++
+    let released = false
+    const release = async (reason?: unknown) => {
+      if (released) return
+      released = true
+      entry!.waiters--
+      if (reason === undefined || entry!.waiters > 0 || entry!.settled) return
+      entry!.controller.abort(reason)
+      try {
+        await entry!.promise
+      } catch (error) {
+        // The caller's own abort is expected. Ownership or process cleanup
+        // failures are not: they must replace it and fail closed.
+        if (error !== reason) throw error
+      }
+    }
+
+    if (!signal) {
+      try {
+        await entry.promise
+      } finally {
+        await release()
+      }
+      return
+    }
+
+    const interrupted = Promise.withResolvers<never>()
+    const abort = () => interrupted.reject(abortReason(signal))
+    hooks.value?.beforeBootstrapListener?.()
+    signal.addEventListener("abort", abort, { once: true })
+    if (signal.aborted) abort()
+    try {
+      await Promise.race([entry.promise, interrupted.promise])
+    } catch (error) {
+      if (!signal.aborted) {
+        await release()
+        throw error
+      }
+      const reason = abortReason(signal)
+      await release(reason)
+      if (entry.failure instanceof AggregateError) throw entry.failure
+      if (error instanceof AggregateError) throw error
+      throw reason
+    } finally {
+      signal.removeEventListener("abort", abort)
+    }
+    await release()
+    if (signal.aborted) throw abortReason(signal)
   }
 
   export async function command(context: Context, signal?: AbortSignal) {
@@ -229,7 +337,38 @@ export namespace ModalVolume {
     const uv = context.uv ?? Bun.which("uv")
     if (uv) {
       await hooks.value?.beforeUv?.()
-      return [uv, "run", "--no-project", "--python", "3.12", "--with", `modal==${VERSION}`, "python", "-I", file]
+      const env = environment({ ...process.env, ...context.env })
+      const setup = hooks.value?.bootstrap ?? {
+        argv: [
+          uv,
+          "run",
+          "--no-project",
+          "--python",
+          "3.12",
+          "--with",
+          `modal==${VERSION}`,
+          "python",
+          "-I",
+          "-c",
+          `import modal; assert modal.__version__ == '${VERSION}'; assert hasattr(modal.Volume, 'read_file')`,
+        ],
+        timeout: BOOTSTRAP_TIMEOUT,
+      }
+      await prewarm(setup.argv, env, setup.timeout, signal)
+      if (signal?.aborted) throw abortReason(signal)
+      return [
+        uv,
+        "run",
+        "--offline",
+        "--no-project",
+        "--python",
+        "3.12",
+        "--with",
+        `modal==${VERSION}`,
+        "python",
+        "-I",
+        file,
+      ]
     }
     throw new Error("Modal Volume access requires uv or a Python installation that can import the Modal SDK")
   }

--- a/backend/cli/test/compute/modal-volume.test.ts
+++ b/backend/cli/test/compute/modal-volume.test.ts
@@ -44,7 +44,9 @@ async function waitEntry(previous: Set<string>) {
 }
 
 function passingBootstrap(python: string) {
-  return { argv: [python, "-I", "-c", "pass"], timeout: 1_000 }
+  // The full CI suite can delay governed child registration by several
+  // seconds under load. This is a success fixture, not a timeout test.
+  return { argv: [python, "-I", "-c", "pass"], timeout: 10_000 }
 }
 
 async function fixture() {
@@ -213,7 +215,7 @@ describe("ModalVolume", () => {
           ].join("; "),
           marker,
         ],
-        timeout: 1_000,
+        timeout: 10_000,
       },
     })
 
@@ -307,7 +309,7 @@ describe("ModalVolume", () => {
       probe: { argv: [python, "-I", "-c", "raise SystemExit(1)"], timeout: 1_000 },
       bootstrap: {
         argv: [python, "-I", "-c", "import sys; sys.stderr.write('bootstrap-only'); raise SystemExit(7)"],
-        timeout: 1_000,
+        timeout: 10_000,
       },
     })
     const nonzero = await ModalVolume.command({
@@ -328,7 +330,7 @@ describe("ModalVolume", () => {
       probe: { argv: [python, "-I", "-c", "raise SystemExit(1)"], timeout: 1_000 },
       bootstrap: {
         argv: [python, "-I", "-c", "import os, signal; os.kill(os.getpid(), signal.SIGTERM)"],
-        timeout: 1_000,
+        timeout: 10_000,
       },
     })
     const signalled = await ModalVolume.command({
@@ -396,7 +398,7 @@ describe("ModalVolume", () => {
     const previous = new Set((await ledger()).map((entry) => entry.id))
     await using _testing = ModalVolume.testing({
       probe: { argv: [python, "-I", "-c", "raise SystemExit(1)"], timeout: 1_000 },
-      bootstrap: { argv: [python, "-I", "-c", "import time; time.sleep(600)"], timeout: 100 },
+      bootstrap: { argv: [python, "-I", "-c", "import time; time.sleep(600)"], timeout: 5_000 },
     })
     const running = ModalVolume.command({
       tokenId: "ak-test",
@@ -429,7 +431,7 @@ describe("ModalVolume", () => {
     const reason = new DOMException("abort after cleanup failure", "AbortError")
     await using _testing = ModalVolume.testing({
       probe: { argv: [python, "-I", "-c", "raise SystemExit(1)"], timeout: 1_000 },
-      bootstrap: { argv: [python, "-I", "-c", "import time; time.sleep(600)"], timeout: 100 },
+      bootstrap: { argv: [python, "-I", "-c", "import time; time.sleep(600)"], timeout: 5_000 },
       afterBootstrapSettled: () => controller.abort(reason),
     })
     const running = ModalVolume.command(

--- a/backend/cli/test/compute/modal-volume.test.ts
+++ b/backend/cli/test/compute/modal-volume.test.ts
@@ -43,6 +43,10 @@ async function waitEntry(previous: Set<string>) {
   throw new Error("Timed out waiting for the Modal Volume bridge ledger entry")
 }
 
+function passingBootstrap(python: string) {
+  return { argv: [python, "-I", "-c", "pass"], timeout: 1_000 }
+}
+
 async function fixture() {
   const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "openscience-modal-volume-"))
   roots.push(root)
@@ -161,6 +165,7 @@ describe("ModalVolume", () => {
     const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "openscience-modal-poison-"))
     roots.push(root)
     await Bun.write(path.join(root, "modal.py"), "raise RuntimeError('ambient modal module loaded')\n")
+    await using _testing = ModalVolume.testing({ bootstrap: passingBootstrap(python) })
 
     const selected = await ModalVolume.command({
       tokenId: "ak-test",
@@ -173,6 +178,7 @@ describe("ModalVolume", () => {
     expect(selected).toEqual([
       "/test/uv",
       "run",
+      "--offline",
       "--no-project",
       "--python",
       "3.12",
@@ -184,6 +190,270 @@ describe("ModalVolume", () => {
     ])
   })
 
+  test("prewarms the pinned uv runtime without Modal credentials before returning an offline bridge", async () => {
+    const python = Bun.which("python3") ?? Bun.which("python")
+    if (!python) throw new Error("Python is required for the Modal Volume driver test")
+    const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "openscience-modal-cold-prewarm-"))
+    roots.push(root)
+    const marker = path.join(root, "prewarmed")
+    const tokenID = "ak-never-bootstrap-id"
+    const tokenSecret = "as-never-bootstrap-secret"
+    await using _testing = ModalVolume.testing({
+      probe: { argv: [python, "-I", "-c", "raise SystemExit(1)"], timeout: 1_000 },
+      bootstrap: {
+        argv: [
+          python,
+          "-I",
+          "-c",
+          [
+            "import os, pathlib, sys",
+            "assert 'MODAL_TOKEN_ID' not in os.environ",
+            "assert 'MODAL_TOKEN_SECRET' not in os.environ",
+            "pathlib.Path(sys.argv[1]).write_text('cold-cache-ready')",
+          ].join("; "),
+          marker,
+        ],
+        timeout: 1_000,
+      },
+    })
+
+    const selected = await ModalVolume.command({
+      tokenId: tokenID,
+      tokenSecret,
+      python,
+      uv: "/test/uv",
+      env: { ...process.env, MODAL_TOKEN_ID: tokenID, MODAL_TOKEN_SECRET: tokenSecret },
+    })
+
+    expect(await Bun.file(marker).text()).toBe("cold-cache-ready")
+    expect(selected.slice(0, 3)).toEqual(["/test/uv", "run", "--offline"])
+    expect(selected).toContain(`modal==${ModalVolume.VERSION}`)
+  }, 30_000)
+
+  test("coalesces identical in-flight prewarms without retaining positive trust after completion", async () => {
+    const python = Bun.which("python3") ?? Bun.which("python")
+    if (!python) throw new Error("Python is required for the Modal Volume driver test")
+    const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "openscience-modal-coalesced-prewarm-"))
+    roots.push(root)
+    const marker = path.join(root, "starts")
+    const release = path.join(root, "release")
+    await using _testing = ModalVolume.testing({
+      probe: { argv: [python, "-I", "-c", "raise SystemExit(1)"], timeout: 1_000 },
+      bootstrap: {
+        argv: [
+          python,
+          "-I",
+          "-c",
+          [
+            "import pathlib, sys, time",
+            "marker = pathlib.Path(sys.argv[1])",
+            "with marker.open('a') as handle:",
+            "    handle.write('start\\n')",
+            "release = pathlib.Path(sys.argv[2])",
+            "while not release.exists():",
+            "    time.sleep(0.01)",
+          ].join("\n"),
+          marker,
+          release,
+        ],
+        timeout: 5_000,
+      },
+    })
+    const context = { tokenId: "ak-test", tokenSecret: "as-test", python, uv: "/test/uv" }
+
+    const first = ModalVolume.command(context)
+    const second = ModalVolume.command(context)
+    await waitText(marker)
+    await Bun.sleep(100)
+    expect((await Bun.file(marker).text()).trim().split("\n")).toHaveLength(1)
+    await Bun.write(release, "ready")
+    const selected = await Promise.all([first, second])
+
+    expect(selected.every((argv) => argv[2] === "--offline")).toBe(true)
+    await ModalVolume.command(context)
+    expect((await Bun.file(marker).text()).trim().split("\n")).toHaveLength(2)
+  }, 30_000)
+
+  test("fails closed when the token-free uv bootstrap times out", async () => {
+    const python = Bun.which("python3") ?? Bun.which("python")
+    if (!python) throw new Error("Python is required for the Modal Volume driver test")
+    const previous = new Set((await ledger()).map((entry) => entry.id))
+    await using _testing = ModalVolume.testing({
+      probe: { argv: [python, "-I", "-c", "raise SystemExit(1)"], timeout: 1_000 },
+      bootstrap: { argv: [python, "-I", "-c", "import time; time.sleep(600)"], timeout: 100 },
+    })
+    const running = ModalVolume.command({
+      tokenId: "ak-test",
+      tokenSecret: "as-test",
+      python,
+      uv: "/test/uv",
+    }).then(
+      () => undefined,
+      (error: unknown) => error,
+    )
+    const active = await waitEntry(previous)
+    const error = await running
+
+    expect(error).toBeInstanceOf(Error)
+    expect((error as Error).message).toContain("Modal Volume SDK bootstrap timed out after 100ms")
+    expect(await CredentialProcessLedger.owns(active.pid, active.identity)).toBe(false)
+    expect((await ledger()).some((entry) => entry.id === active.id)).toBe(false)
+  }, 30_000)
+
+  test("fails closed on a nonzero or signalled token-free uv bootstrap", async () => {
+    const python = Bun.which("python3") ?? Bun.which("python")
+    if (!python) throw new Error("Python is required for the Modal Volume driver test")
+    await using _nonzero = ModalVolume.testing({
+      probe: { argv: [python, "-I", "-c", "raise SystemExit(1)"], timeout: 1_000 },
+      bootstrap: {
+        argv: [python, "-I", "-c", "import sys; sys.stderr.write('bootstrap-only'); raise SystemExit(7)"],
+        timeout: 1_000,
+      },
+    })
+    const nonzero = await ModalVolume.command({
+      tokenId: "ak-never-log-id",
+      tokenSecret: "as-never-log-secret",
+      python,
+      uv: "/test/uv",
+    }).catch((error) => error as Error)
+
+    expect(nonzero).toBeInstanceOf(Error)
+    if (!(nonzero instanceof Error)) throw new Error("The nonzero bootstrap unexpectedly returned an argv")
+    expect(nonzero.message).toContain("Modal Volume SDK bootstrap failed (exit 7): bootstrap-only")
+    expect(nonzero.message).not.toContain("ak-never-log-id")
+    expect(nonzero.message).not.toContain("as-never-log-secret")
+
+    _nonzero[Symbol.dispose]()
+    await using _signalled = ModalVolume.testing({
+      probe: { argv: [python, "-I", "-c", "raise SystemExit(1)"], timeout: 1_000 },
+      bootstrap: {
+        argv: [python, "-I", "-c", "import os, signal; os.kill(os.getpid(), signal.SIGTERM)"],
+        timeout: 1_000,
+      },
+    })
+    const signalled = await ModalVolume.command({
+      tokenId: "ak-test",
+      tokenSecret: "as-test",
+      python,
+      uv: "/test/uv",
+    }).catch((error) => error as Error)
+
+    expect(signalled).toBeInstanceOf(Error)
+    if (!(signalled instanceof Error)) throw new Error("The signalled bootstrap unexpectedly returned an argv")
+    expect(signalled.message).toMatch(/Modal Volume SDK bootstrap (?:was killed|failed)/)
+  }, 30_000)
+
+  test("aborts and reaps a sole in-flight token-free uv bootstrap before returning credentials", async () => {
+    const python = Bun.which("python3") ?? Bun.which("python")
+    if (!python) throw new Error("Python is required for the Modal Volume driver test")
+    const previous = new Set((await ledger()).map((entry) => entry.id))
+    const controller = new AbortController()
+    const reason = new DOMException("canary cancelled", "AbortError")
+    await using _testing = ModalVolume.testing({
+      probe: { argv: [python, "-I", "-c", "raise SystemExit(1)"], timeout: 1_000 },
+      bootstrap: { argv: [python, "-I", "-c", "import time; time.sleep(600)"], timeout: 5_000 },
+    })
+    const running = ModalVolume.command(
+      { tokenId: "ak-test", tokenSecret: "as-test", python, uv: "/test/uv" },
+      controller.signal,
+    ).then(
+      () => undefined,
+      (error: unknown) => error,
+    )
+    const active = await waitEntry(previous)
+
+    controller.abort(reason)
+    const error = await running
+
+    expect(error).toBe(reason)
+    expect(await CredentialProcessLedger.owns(active.pid, active.identity)).toBe(false)
+    expect((await ledger()).some((entry) => entry.id === active.id)).toBe(false)
+  }, 30_000)
+
+  test("observes a caller abort delivered immediately before the prewarm listener is registered", async () => {
+    const python = Bun.which("python3") ?? Bun.which("python")
+    if (!python) throw new Error("Python is required for the Modal Volume driver test")
+    const controller = new AbortController()
+    const reason = new DOMException("abort in listener gap", "AbortError")
+    await using _testing = ModalVolume.testing({
+      probe: { argv: [python, "-I", "-c", "raise SystemExit(1)"], timeout: 1_000 },
+      bootstrap: { argv: [python, "-I", "-c", "import time; time.sleep(600)"], timeout: 5_000 },
+      beforeBootstrapListener: () => controller.abort(reason),
+    })
+
+    const error = await ModalVolume.command(
+      { tokenId: "ak-test", tokenSecret: "as-test", python, uv: "/test/uv" },
+      controller.signal,
+    ).catch((value) => value)
+
+    expect(error).toBe(reason)
+    expect((await ledger()).some((entry) => entry.kind === "modal-volume")).toBe(false)
+  }, 30_000)
+
+  test("propagates token-free uv bootstrap cleanup failures instead of returning an offline bridge", async () => {
+    const python = Bun.which("python3") ?? Bun.which("python")
+    if (!python) throw new Error("Python is required for the Modal Volume driver test")
+    const previous = new Set((await ledger()).map((entry) => entry.id))
+    await using _testing = ModalVolume.testing({
+      probe: { argv: [python, "-I", "-c", "raise SystemExit(1)"], timeout: 1_000 },
+      bootstrap: { argv: [python, "-I", "-c", "import time; time.sleep(600)"], timeout: 100 },
+    })
+    const running = ModalVolume.command({
+      tokenId: "ak-test",
+      tokenSecret: "as-test",
+      python,
+      uv: "/test/uv",
+    }).then(
+      () => undefined,
+      (error: unknown) => error,
+    )
+    const active = await waitEntry(previous)
+    const failure = new Error("synthetic bootstrap cleanup failure")
+    const revoke = spyOn(CredentialProcessLedger, "revoke").mockRejectedValue(failure)
+
+    try {
+      const error = await running
+      expect(error).toBeInstanceOf(AggregateError)
+      expect((error as AggregateError).errors).toContain(failure)
+    } finally {
+      revoke.mockRestore()
+      await CredentialProcessLedger.revoke({ id: active.id, kind: "modal-volume" }).catch(() => undefined)
+    }
+  }, 30_000)
+
+  test("does not mask a settled bootstrap cleanup failure with a simultaneous caller abort", async () => {
+    const python = Bun.which("python3") ?? Bun.which("python")
+    if (!python) throw new Error("Python is required for the Modal Volume driver test")
+    const previous = new Set((await ledger()).map((entry) => entry.id))
+    const controller = new AbortController()
+    const reason = new DOMException("abort after cleanup failure", "AbortError")
+    await using _testing = ModalVolume.testing({
+      probe: { argv: [python, "-I", "-c", "raise SystemExit(1)"], timeout: 1_000 },
+      bootstrap: { argv: [python, "-I", "-c", "import time; time.sleep(600)"], timeout: 100 },
+      afterBootstrapSettled: () => controller.abort(reason),
+    })
+    const running = ModalVolume.command(
+      { tokenId: "ak-test", tokenSecret: "as-test", python, uv: "/test/uv" },
+      controller.signal,
+    ).then(
+      () => undefined,
+      (error: unknown) => error,
+    )
+    const active = await waitEntry(previous)
+    const failure = new Error("synthetic settled cleanup failure")
+    const revoke = spyOn(CredentialProcessLedger, "revoke").mockRejectedValue(failure)
+
+    try {
+      const error = await running
+      expect(controller.signal.aborted).toBe(true)
+      expect(error).toBeInstanceOf(AggregateError)
+      expect((error as AggregateError).errors).toContain(failure)
+    } finally {
+      revoke.mockRestore()
+      await CredentialProcessLedger.revoke({ id: active.id, kind: "modal-volume" }).catch(() => undefined)
+    }
+  }, 30_000)
+
   test("reaps a timed-out ambient SDK probe before selecting the pinned uv runtime", async () => {
     const python = Bun.which("python3") ?? Bun.which("python")
     if (!python) throw new Error("Python is required for the Modal Volume driver test")
@@ -191,6 +461,7 @@ describe("ModalVolume", () => {
     let active: LedgerEntry | undefined
     await using _testing = ModalVolume.testing({
       probe: { argv: [python, "-I", "-c", "import time; time.sleep(600)"], timeout: 1_000 },
+      bootstrap: passingBootstrap(python),
       beforeUv: async () => {
         expect(active).toBeDefined()
         expect(await CredentialProcessLedger.owns(active!.pid, active!.identity)).toBe(false)
@@ -212,6 +483,7 @@ describe("ModalVolume", () => {
     expect(selected).toEqual([
       "/test/uv",
       "run",
+      "--offline",
       "--no-project",
       "--python",
       "3.12",

--- a/backend/cli/test/compute/modal-volume.test.ts
+++ b/backend/cli/test/compute/modal-volume.test.ts
@@ -395,10 +395,11 @@ describe("ModalVolume", () => {
   test("propagates token-free uv bootstrap cleanup failures instead of returning an offline bridge", async () => {
     const python = Bun.which("python3") ?? Bun.which("python")
     if (!python) throw new Error("Python is required for the Modal Volume driver test")
-    const previous = new Set((await ledger()).map((entry) => entry.id))
+    const bootstrapBaseline = Promise.withResolvers<Set<string>>()
     await using _testing = ModalVolume.testing({
       probe: { argv: [python, "-I", "-c", "raise SystemExit(1)"], timeout: 1_000 },
       bootstrap: { argv: [python, "-I", "-c", "import time; time.sleep(600)"], timeout: 5_000 },
+      beforeUv: async () => bootstrapBaseline.resolve(new Set((await ledger()).map((entry) => entry.id))),
     })
     const running = ModalVolume.command({
       tokenId: "ak-test",
@@ -409,7 +410,7 @@ describe("ModalVolume", () => {
       () => undefined,
       (error: unknown) => error,
     )
-    const active = await waitEntry(previous)
+    const active = await waitEntry(await bootstrapBaseline.promise)
     const failure = new Error("synthetic bootstrap cleanup failure")
     const revoke = spyOn(CredentialProcessLedger, "revoke").mockRejectedValue(failure)
 
@@ -426,12 +427,13 @@ describe("ModalVolume", () => {
   test("does not mask a settled bootstrap cleanup failure with a simultaneous caller abort", async () => {
     const python = Bun.which("python3") ?? Bun.which("python")
     if (!python) throw new Error("Python is required for the Modal Volume driver test")
-    const previous = new Set((await ledger()).map((entry) => entry.id))
+    const bootstrapBaseline = Promise.withResolvers<Set<string>>()
     const controller = new AbortController()
     const reason = new DOMException("abort after cleanup failure", "AbortError")
     await using _testing = ModalVolume.testing({
       probe: { argv: [python, "-I", "-c", "raise SystemExit(1)"], timeout: 1_000 },
       bootstrap: { argv: [python, "-I", "-c", "import time; time.sleep(600)"], timeout: 5_000 },
+      beforeUv: async () => bootstrapBaseline.resolve(new Set((await ledger()).map((entry) => entry.id))),
       afterBootstrapSettled: () => controller.abort(reason),
     })
     const running = ModalVolume.command(
@@ -441,7 +443,7 @@ describe("ModalVolume", () => {
       () => undefined,
       (error: unknown) => error,
     )
-    const active = await waitEntry(previous)
+    const active = await waitEntry(await bootstrapBaseline.promise)
     const failure = new Error("synthetic settled cleanup failure")
     const revoke = spyOn(CredentialProcessLedger, "revoke").mockRejectedValue(failure)
 


### PR DESCRIPTION
## Root cause

The exact release canary failed before any scientific workload because a fresh isolated XDG cache made the pinned uv/Modal SDK bootstrap consume the credential-bearing Volume check operation deadline. The check bridge itself only imports Modal and reports its version; it performs no provider I/O.

## Fix

- Prewarm the exact `modal==1.1.4` uv runtime through the governed child-process lifecycle with a token-free environment.
- Run the subsequent credential-bearing bridge with `uv run --offline`, preserving its full existing provider deadline.
- Coalesce only identical in-flight prewarms; retain no long-lived positive trust cache.
- Fail closed on bootstrap timeout, nonzero/signal exit, caller abort, and process ownership or cleanup failures.
- Preserve cleanup failures over simultaneous caller aborts and close the pre-listener abort race.
- Do not widen provider operation timeouts or log Modal credentials.

## Verification

- `bun test test/compute/modal-volume.test.ts test/compute/modal-adapter.test.ts test/compute/jobs.test.ts` — 93 passed, 0 failed, 410 assertions.
- Backend CLI `bun run typecheck` — passed.
- Repository pre-push `turbo typecheck` — 7/7 tasks passed.
- Prettier check and `git diff --check` — passed.
- Fresh-XDG, exact-source, provider-free dry bridge: token-free prewarm 1.620s; authenticated argv starts `uv run --offline`; offline action=check 0.180s; helper ledger empty afterward.

No live Modal canary was retried, no provider resource was created by the dry check, and no production publish was triggered. The release remains blocked pending landing and a new exact candidate.