### PR TITLE
fix(release): tolerate macOS runner keychain ACL error

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -414,7 +414,9 @@ jobs:
           security set-keychain-settings -lut 21600 "$keychain"
           security unlock-keychain -p "$keychain_password" "$keychain"
           security import "$certificate" -k "$keychain" -P "$APPLE_DEVELOPER_ID_P12_PASSWORD" -T /usr/bin/codesign
-          security set-key-partition-list -S apple-tool:,apple: -s -k "$keychain_password" "$keychain"
+          if ! security set-key-partition-list -S apple-tool:,apple: -s -k "$keychain_password" "$keychain"; then
+            echo "::warning::The runner could not update the imported key's partition list; continuing with the explicit codesign ACL from security import. Signature and Team ID verification remain mandatory."
+          fi
 
           identity="$(security find-identity -v -p codesigning "$keychain" | sed -n 's/.*"\(Developer ID Application:.*\)"/\1/p' | head -n 1)"
           if [[ -z "$identity" ]]; then

--- a/backend/cli/test/installation/release-order.test.ts
+++ b/backend/cli/test/installation/release-order.test.ts
@@ -188,6 +188,8 @@ test("production release keeps signed publishing as the default and falls back t
   expect(preflight).toContain("Set both WINDOWS_CSC_LINK and WINDOWS_CSC_KEY_PASSWORD, or remove both")
   expect(preflight).toContain("Publishing unsigned native CLI archives and desktop installers")
   expect(sign).toContain("Developer ID sign and notarize macOS binaries")
+  expect(sign).toContain("if ! security set-key-partition-list")
+  expect(sign).toContain("continuing with the explicit codesign ACL from security import")
   expect(sign).toContain("if: inputs.release_mode == 'signed' && steps.signed-cli-cache.outputs.cache-hit != 'true'")
   expect(sign).toContain("--identifier ai.syntheticsciences.openscience")
   expect(sign).toContain("codesign --verify --strict")


### PR DESCRIPTION
## Summary

- continue past the macOS runner partition-list adjustment when the Developer ID identity was imported with an explicit codesign ACL
- preserve mandatory codesign verification, Team ID verification, and Apple notarization gates
- add release workflow regression coverage

## Evidence

- Production run 33245654598 imported one Developer ID identity, then failed only in security set-key-partition-list before codesign ran.
- bun test test/installation/release-order.test.ts (28 pass)
- YAML workflow lint
- git diff --check
