### PR TITLE
fix(release): grant draft gate visibility

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,7 +68,9 @@ jobs:
     timeout-minutes: 10
     permissions:
       actions: read
-      contents: read
+      # GitHub only returns draft releases to tokens with push access. Exact
+      # version resumes need the draft's immutable artifact-source marker.
+      contents: write
     outputs:
       source: ${{ steps.candidate.outputs.source }}
       run_id: ${{ steps.candidate.outputs.run_id }}

--- a/backend/cli/test/installation/release-order.test.ts
+++ b/backend/cli/test/installation/release-order.test.ts
@@ -53,7 +53,8 @@ test("production publish requires a complete exact-source npm rehearsal before r
 
   expect(gate).toContain("needs: release-source")
   expect(gate).toContain("actions: read")
-  expect(gate).toContain("contents: read")
+  expect(gate).toContain("contents: write")
+  expect(gate).toContain("GitHub only returns draft releases to tokens with push access")
   expect(gate).toContain("steps.candidate.outputs.source")
   expect(gate).toContain('"/repos/$GH_REPO/releases?per_page=100"')
   expect(gate).toContain("gh api --paginate --slurp")


### PR DESCRIPTION
## Summary
- grant the exact-source rehearsal gate the push-level repository access GitHub requires to return draft releases
- keep actions access read-only and preserve all immutable-source/rehearsal checks
- document and test the required scope

## Verification
- 28 release-order tests pass
- Prettier check passes
- pre-push typecheck: 7/7 tasks pass

## Production evidence
Run 33248664045 showed the read-only gate received no draft and fell back to current HEAD. The same draft is visible to release jobs with contents write and to an authenticated push-capable token. Stable v2.0.54 remains unpublished and its draft still has no assets.