### PR TITLE
fix(release): use workflow-scoped tag token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -220,6 +220,16 @@ jobs:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Require release tag token
+        shell: bash
+        env:
+          RELEASE_GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+        run: |
+          if [[ -z "$RELEASE_GITHUB_TOKEN" ]]; then
+            echo "::error::RELEASE_GITHUB_TOKEN must have repo and workflow scopes so the guarded release commit can update the version tag."
+            exit 1
+          fi
+
       # Authenticate and prove ownership of every package before creating a
       # draft release or making the first immutable npm registry write.
       - name: Preflight npm publisher identity and ownership
@@ -1002,6 +1012,9 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ needs.version.outputs.source }}
+          # github.token cannot push a tag whose release commit updates a
+          # workflow file; use the dedicated repo + workflow scoped token.
+          token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
 
       - uses: ./.github/actions/setup-bun
 
@@ -1169,7 +1182,7 @@ jobs:
           OPENSCIENCE_RELEASE_SOURCE: ${{ needs.version.outputs.source }}
           OPENSCIENCE_ARTIFACT_SOURCE: ${{ needs.version.outputs.artifact_source }}
           OPENSCIENCE_NPM_ARTIFACT_DIR: .release/npm/${{ needs.version.outputs.version }}
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
           # Fine-grained PAT with push access to synthetic-sciences/homebrew-tap;
           # github.token is repo-scoped and can't update the tap.
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/backend/cli/test/installation/release-order.test.ts
+++ b/backend/cli/test/installation/release-order.test.ts
@@ -92,6 +92,8 @@ test("production publish requires a complete exact-source npm rehearsal before r
   expect(gate).not.toContain("continue-on-error")
 
   expect(npmPreflight).toContain("- npm-test-gate")
+  expect(npmPreflight).toContain("Require release tag token")
+  expect(npmPreflight).toContain("RELEASE_GITHUB_TOKEN must have repo and workflow scopes")
   expect(signingPreflight).toContain("- npm-test-gate")
   expect(version).toContain("- npm-test-gate")
   expect(version).toContain("ARTIFACT_SOURCE: ${{ steps.version.outputs.artifact_source }}")
@@ -242,6 +244,9 @@ test("production release keeps signed publishing as the default and falls back t
   expect(desktop).toContain("OpenScience-mac-x64.dmg OpenScience-mac-x64.zip")
   expect(prepare).toContain("key: ${{ needs.sign-macos-cli.outputs.cache_key }}")
   expect(publish).toContain("key: ${{ needs.sign-macos-cli.outputs.cache_key }}")
+  expect(publish).toContain("token: ${{ secrets.RELEASE_GITHUB_TOKEN }}")
+  expect(publish).toContain("GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}")
+  expect(publish).not.toContain("GITHUB_TOKEN: ${{ github.token }}")
   expect(publish).toContain("!cancelled() &&")
   expect(publish).toContain("needs.build-desktop.result == 'success'")
   expect(publish).not.toContain("inputs.release_mode == 'unsigned' || needs.build-desktop.result == 'success'")


### PR DESCRIPTION
## Summary
- require the dedicated release token before any release mutation
- use it for the final checkout, tag push, and GitHub release publication
- preserve the built-in token everywhere that does not need workflow scope

## Why
The signed 2.0.54 run completed both notarized macOS builds, all desktop assets, and staged and verified all 15 npm packages. The final tag push was rejected only because its guarded release commit updates the publish workflow, which requires workflow scope in addition to repository write access.

The repository secret is configured with repo and workflow scopes. Retrying 2.0.54 will use the existing immutable assets and promotion-only npm resume path.

## Validation
- bun test test/installation/release-order.test.ts (28 pass)
- bunx prettier --check .github/workflows/publish.yml backend/cli/test/installation/release-order.test.ts
- git diff --check
- pre-push monorepo typecheck