### PR TITLE
fix(desktop): notarize distributable disk images

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -791,6 +791,33 @@ jobs:
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_NOTARY_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
+      - name: Notarize and staple signed macOS disk image
+        if: steps.existing.outputs.found != 'true' && inputs.release_mode == 'signed' && matrix.signing == 'mac'
+        shell: bash
+        env:
+          APPLE_ID: ${{ secrets.APPLE_NOTARY_APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_NOTARY_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          OPENSCIENCE_DMG: frontend/desktop/dist/${{ matrix.asset }}
+        run: |
+          set -euo pipefail
+          [[ -s "$OPENSCIENCE_DMG" ]] || {
+            echo "::error::electron-builder did not produce $OPENSCIENCE_DMG"
+            exit 1
+          }
+          codesign --verify --strict --verbose=2 "$OPENSCIENCE_DMG"
+          details="$(codesign -dv --verbose=4 "$OPENSCIENCE_DMG" 2>&1)"
+          grep -Fq 'Authority=Developer ID Application:' <<<"$details"
+          grep -Fxq "TeamIdentifier=$APPLE_TEAM_ID" <<<"$details"
+          xcrun notarytool submit "$OPENSCIENCE_DMG" \
+            --apple-id "$APPLE_ID" \
+            --team-id "$APPLE_TEAM_ID" \
+            --password "$APPLE_APP_SPECIFIC_PASSWORD" \
+            --wait
+          xcrun stapler staple "$OPENSCIENCE_DMG"
+          xcrun stapler validate "$OPENSCIENCE_DMG"
+          spctl -a -t open --context context:primary-signature -vv "$OPENSCIENCE_DMG"
+
       - name: Build unsigned desktop installer
         if: steps.existing.outputs.found != 'true' && (inputs.release_mode == 'unsigned' || (inputs.release_mode == 'signed' && matrix.signing == 'windows' && steps.windows-signing.outputs.enabled != 'true'))
         shell: bash

--- a/backend/cli/test/installation/release-order.test.ts
+++ b/backend/cli/test/installation/release-order.test.ts
@@ -347,7 +347,24 @@ test("desktop packaging explicitly separates signed and unsigned installers", as
   expect(config).toContain("forceCodeSigning: signed")
   expect(config).toContain("hardenedRuntime: true")
   expect(config).toContain("notarize: signed && process.env.APPLE_ID ? true : false")
+  expect(config).toContain("dmg: { sign: signed }")
   expect(config).toContain("signExecutable: signed")
+
+  const workflow = await Bun.file(path.join(import.meta.dir, "../../../../.github/workflows/publish.yml")).text()
+  const desktop = workflow.slice(workflow.indexOf("\n  build-desktop:"), workflow.indexOf("\n  verify-native-cli:"))
+  const image = desktop.slice(
+    desktop.indexOf("Notarize and staple signed macOS disk image"),
+    desktop.indexOf("Build unsigned desktop installer"),
+  )
+  expect(image).toContain("matrix.signing == 'mac'")
+  expect(image).toContain('codesign --verify --strict --verbose=2 "$OPENSCIENCE_DMG"')
+  expect(image).toContain('xcrun notarytool submit "$OPENSCIENCE_DMG"')
+  expect(image).toContain('xcrun stapler staple "$OPENSCIENCE_DMG"')
+  expect(image).toContain('xcrun stapler validate "$OPENSCIENCE_DMG"')
+  expect(image).toContain("spctl -a -t open --context context:primary-signature")
+  expect(desktop.indexOf("Notarize and staple signed macOS disk image")).toBeLessThan(
+    desktop.indexOf("Verify or upload immutable desktop artifacts"),
+  )
 })
 
 test("production mac updater archives preserve the exact OpenScience.app bundle name", async () => {

--- a/frontend/desktop/README.md
+++ b/frontend/desktop/README.md
@@ -8,6 +8,6 @@ Release builds produce:
 - Windows NSIS `.exe`
 - Linux `.AppImage`
 
-Set `OPENSCIENCE_DESKTOP_SIDECAR` to the native runtime before running `bun run dist`. Electron Builder automatically signs when `CSC_LINK` and `CSC_KEY_PASSWORD` are present. macOS notarization additionally uses `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, and `APPLE_TEAM_ID`.
+Set `OPENSCIENCE_DESKTOP_SIDECAR` to the native runtime before running `bun run dist`. Electron Builder automatically signs when `CSC_LINK` and `CSC_KEY_PASSWORD` are present. macOS notarization additionally uses `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, and `APPLE_TEAM_ID`. Signed production releases sign, notarize, and staple both the app bundle and its outer DMG installer.
 
 The first launch of an unsigned macOS build still requires Apple's explicit **Open Anyway** flow. After that one-time approval, the desktop app can download the exact architecture-specific ZIP from a published GitHub release, verify GitHub's SHA-256 asset digest and the app bundle identity/version/signature, replace itself, and restart. A Developer ID certificate plus notarization credentials remain the only way to remove the first-launch Gatekeeper warning.

--- a/frontend/desktop/electron-builder.mjs
+++ b/frontend/desktop/electron-builder.mjs
@@ -52,7 +52,10 @@ export default {
         "OpenScience accesses network volumes only when you choose a project or file there.",
     },
   },
-  dmg: { sign: false },
+  // Sign the outermost installer as well as the app bundle. The release
+  // workflow notarizes and staples this signed DMG after electron-builder
+  // finishes so Gatekeeper can validate the exact downloaded container.
+  dmg: { sign: signed },
   win: {
     target: ["nsis"],
     icon: "build/icon.ico",


### PR DESCRIPTION
## Summary
- sign the outer DMG container for signed macOS builds
- submit each architecture-specific DMG to Apple after packaging
- staple and validate the DMG ticket, then require Gatekeeper acceptance before upload
- keep unsigned development/backfill builds certificate-free

## Why
The 2.0.54 app bundle and update ZIP are Developer ID signed, notarized, stapled, and Gatekeeper accepted, but the distributed DMG container itself is not signed or stapled. Apple recommends signing from the inside out, notarizing the outermost container, and stapling the distributed container. This closes that last distribution gap.

## Validation
- 35 targeted release, installer, shell, and updater tests pass
- release-order assertions require DMG codesign, notarization, stapling, validation, and Gatekeeper assessment before upload
- Prettier and git diff checks pass
- pre-push monorepo typecheck passes
- the real public 2.0.54 updater ZIP stages and passes Gatekeeper; this PR specifically hardens the DMG container