### PR TITLE
Keep account summary and key login usable when workspace scope fails

### DIFF
--- a/backend/cli/src/openscience/index.ts
+++ b/backend/cli/src/openscience/index.ts
@@ -1636,16 +1636,27 @@ export namespace OpenScience {
     // Modern organization-scoped keys report their immutable scope here.
     // Keep this best-effort so older servers without /api/v1/auth/status and
     // legacy personal keys continue to connect exactly as before.
-    const status = await atlasFetch(
-      `${API_BASE}/api/v1/auth/status`,
-      {
-        headers: { Authorization: `Bearer ${key}`, Accept: "application/json" },
-      },
-      1_500,
-    )
-      .then(async (response) => (response.ok ? ((await response.json()) as AuthStatusResponse) : undefined))
-      .catch(() => undefined)
+    const probeStatus = (timeout: number) =>
+      atlasFetch(
+        `${API_BASE}/api/v1/auth/status`,
+        {
+          headers: { Authorization: `Bearer ${key}`, Accept: "application/json" },
+        },
+        timeout,
+      )
+        .then(async (response) => (response.ok ? ((await response.json()) as AuthStatusResponse) : undefined))
+        .catch(() => undefined)
+    const status =
+      (await probeStatus(1_500)) ??
+      // An organization workspace key cannot connect without its immutable
+      // scope, so give the status endpoint a real chance before giving up.
+      (isOrganizationWorkspaceKey(key) ? await probeStatus(10_000) : undefined)
     const pinned = loginOrganizationID(status?.api_key?.organization_id)
+    if (isOrganizationWorkspaceKey(key) && !pinned) {
+      throw new Error(
+        "Couldn't verify this organization key's workspace. Check your connection and try again.",
+      )
+    }
     const selected = (() => {
       const context = status?.funding_context
       if (context?.type !== "organization") return undefined

--- a/backend/cli/src/openscience/index.ts
+++ b/backend/cli/src/openscience/index.ts
@@ -1653,9 +1653,7 @@ export namespace OpenScience {
       (isOrganizationWorkspaceKey(key) ? await probeStatus(10_000) : undefined)
     const pinned = loginOrganizationID(status?.api_key?.organization_id)
     if (isOrganizationWorkspaceKey(key) && !pinned) {
-      throw new Error(
-        "Couldn't verify this organization key's workspace. Check your connection and try again.",
-      )
+      throw new Error("Couldn't verify this organization key's workspace. Check your connection and try again.")
     }
     const selected = (() => {
       const context = status?.funding_context

--- a/backend/cli/src/server/routes/account.ts
+++ b/backend/cli/src/server/routes/account.ts
@@ -104,7 +104,26 @@ export const AccountRoutes = lazy(() =>
         },
       }),
       async (c) => {
-        const state = await OpenScience.getReconciledFundingState()
+        const state = await OpenScience.getReconciledFundingState().catch((error) => {
+          if (!(error instanceof FundingContextError)) throw error
+          return "stale-scope" as const
+        })
+        if (state === "stale-scope") {
+          // A stale or mismatched local workspace scope must not take down the
+          // whole account summary; the settings panel needs the session row so
+          // the user can sign in again and repair the scope.
+          return c.json({
+            session: true,
+            balance_usd: null,
+            billing_mode: null,
+            funding_context: {
+              type: "personal" as const,
+              available: false,
+              locked: false,
+              organizations: [],
+            },
+          })
+        }
         if (!state) {
           return c.json({
             session: false,

--- a/backend/cli/test/openscience/browser-login-context.test.ts
+++ b/backend/cli/test/openscience/browser-login-context.test.ts
@@ -110,6 +110,7 @@ async function gateway(reply: Reply) {
           })
         }
         if (key === "Bearer thk_legacy-personal.secret") return new Response("not found", { status: 404 })
+        if (key === "Bearer osk_unverified.secret") return new Response("status offline", { status: 500 })
         return json({ organizations: [alpha], funding_context: { type: "personal" } })
       }
       if (url.pathname === "/api/v1/wallet") {
@@ -347,6 +348,21 @@ describe("browser login funding context", () => {
       await expect(OpenScience.setFundingContext(alpha.organization_id)).rejects.toThrow("rollback-safe")
       expect(atlas.state.syncs.length).toBeGreaterThanOrEqual(1)
       expect(atlas.state.syncs.every((call) => call.organization === null)).toBe(true)
+    } finally {
+      await atlas.close()
+    }
+  })
+
+  test("refuses to save an organization key whose workspace cannot be verified", async () => {
+    const atlas = await gateway({})
+    try {
+      // The key itself validates, but its immutable scope never loads. Saving
+      // it anyway used to dead-end later in writeWorkspaceScope; the login
+      // must fail up front with a retryable message and keep no session.
+      await expect(OpenScience.loginWithKey("osk_unverified.secret")).rejects.toThrow(
+        "Couldn't verify this organization key's workspace",
+      )
+      expect(await OpenScience.getSession()).toBeFalsy()
     } finally {
       await atlas.close()
     }

--- a/backend/cli/test/server/account-stale-scope.test.ts
+++ b/backend/cli/test/server/account-stale-scope.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import fs from "node:fs/promises"
+import path from "node:path"
+import { Global } from "../../src/global"
+import { AccountRoutes } from "../../src/server/routes/account"
+
+const sessionFile = path.join(Global.Path.data, "openscience-session.json")
+const scopeFile = path.join(Global.Path.data, "openscience-workspace-scope.json")
+const original = globalThis.fetch
+
+describe("account.summary stale workspace scope", () => {
+  beforeEach(async () => {
+    await Promise.all([fs.rm(sessionFile, { force: true }), fs.rm(scopeFile, { force: true })])
+  })
+
+  afterEach(async () => {
+    globalThis.fetch = original
+    await Promise.all([fs.rm(sessionFile, { force: true }), fs.rm(scopeFile, { force: true })])
+  })
+
+  test("degrades to an unavailable funding context instead of a 500", async () => {
+    // A legacy key the gateway has since pinned to an organization makes the
+    // funding reconciliation throw. The summary must still answer with the
+    // session so Settings can offer a fresh sign-in.
+    await Bun.write(sessionFile, JSON.stringify({ api_key: "thk_old-organization.secret", user_id: "user-stale" }))
+    globalThis.fetch = (async () =>
+      Response.json(
+        {
+          api_key: { organization_id: "org_alpha", workspace_locked: true },
+          organizations: [],
+          funding_context: { type: "organization", organization_id: "org_alpha", locked: true },
+        },
+        {
+          headers: {
+            "OpenScience-Funding-Protocol": "1",
+            "OpenScience-Funding-Context": "organization:org_alpha",
+          },
+        },
+      )) as unknown as typeof fetch
+
+    const response = await AccountRoutes().request("/")
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      session: true,
+      balance_usd: null,
+      billing_mode: null,
+      funding_context: {
+        type: "personal",
+        available: false,
+        locked: false,
+        organizations: [],
+      },
+    })
+  })
+})

--- a/frontend/workspace/src/atlas/AccountGate.tsx
+++ b/frontend/workspace/src/atlas/AccountGate.tsx
@@ -140,7 +140,7 @@ export function AccountGate(props: ParentProps) {
                     <TextField
                       type="password"
                       hideLabel
-                      placeholder="thk_…"
+                      placeholder="thk_… or osk_…"
                       value={key()}
                       disabled={busy()}
                       onChange={setKey}


### PR DESCRIPTION
## Summary

- `GET /account` no longer 500s when funding reconciliation throws on a stale or gateway-pinned legacy credential. It now reports `session: true` with `funding_context.available: false`, so the Settings panel renders the workspace row and a fresh sign-in path instead of a raw error with no recovery affordance.
- Pasting an organization workspace key (`osk_`) now requires its immutable scope to actually load: the auth-status probe retries with a real timeout, and a failure rejects the login with a clear, retryable message **before** any session is saved — previously it saved a torn session and dead-ended in the workspace-scope writer with "Organization credentials require an immutable organization workspace."
- The sign-in key field placeholder documents that `osk_` keys are accepted.

## Verification

- New tests: `account-stale-scope.test.ts` (degraded summary instead of 500) and an unverifiable-`osk_` login case in `browser-login-context.test.ts`
- Full `test/openscience` + `test/server` suites: 388 pass, 0 fail; repo typecheck passes