### PR TITLE
Add Ace context pricing and pinned image routing

### DIFF
--- a/backend/cli/src/openscience/synced-env-policy.ts
+++ b/backend/cli/src/openscience/synced-env-policy.ts
@@ -98,14 +98,17 @@ export const RETIRED_SYNCED_COMPUTE_ENV_KEYS = new Set<string>([
   ...LOCAL_COMPUTE_CLI_ENV_KEYS,
 ])
 
-const MANAGED_SYNCED_LLM_KEYS = new Set(["OPENROUTER_API_KEY"])
+const MANAGED_SYNCED_LLM_KEYS = new Set(["OPENROUTER_API_KEY", "OPENSCIENCE_IMAGE_API_KEY"])
 const MANAGED_SYNCED_BASE_URLS: Record<string, string> = {
   OPENROUTER_BASE_URL: "/api/llm/proxy/openrouter/",
+  OPENSCIENCE_IMAGE_BASE_URL: "/api/llm/proxy/openrouter/",
 }
 const ALLOWED_SYNCED_ENV_KEYS = new Set<string>([
   ...BYOK_LLM_ENV_KEYS,
   ...SYNCED_SERVICE_ENV_KEYS,
   ...Object.keys(MANAGED_SYNCED_BASE_URLS),
+  "OPENSCIENCE_IMAGE_API_KEY",
+  "OPENSCIENCE_IMAGE_MODEL",
 ])
 
 export function managedOpenRouterBaseURL(atlasBase = managedApiBase()): string {
@@ -157,9 +160,11 @@ export function isSyncedEnvAllowed(key: string, value?: string, atlasBase = mana
   if (BLOCKED_SYNCED_ENV.has(key)) return false
   if (!ALLOWED_SYNCED_ENV_KEYS.has(key)) return false
   if (isAtlasManagedKey(value) && !MANAGED_SYNCED_LLM_KEYS.has(key)) return false
+  if (key === "OPENSCIENCE_IMAGE_API_KEY") return isAtlasManagedKey(value)
   // Likewise, managed routing may only target the provider-specific Atlas
   // proxy. A mismatched/public URL is dropped before it reaches process.env.
   const route = MANAGED_SYNCED_BASE_URLS[key]
   if (route) return isAtlasProxyURL(value, route, atlasBase)
+  if (key === "OPENSCIENCE_IMAGE_MODEL") return value === "google/gemini-3-pro-image"
   return true
 }

--- a/backend/cli/src/provider/models.ts
+++ b/backend/cli/src/provider/models.ts
@@ -74,6 +74,17 @@ export namespace ModelsDev {
         output: z.number(),
         cache_read: z.number().optional(),
         cache_write: z.number().optional(),
+        tiers: z
+          .array(
+            z.object({
+              input: z.number(),
+              output: z.number(),
+              cache_read: z.number().optional(),
+              cache_write: z.number().optional(),
+              tier: z.object({ type: z.literal("context"), size: z.number().positive() }),
+            }),
+          )
+          .optional(),
         context_over_200k: z
           .object({
             input: z.number(),

--- a/backend/cli/src/provider/provider.ts
+++ b/backend/cli/src/provider/provider.ts
@@ -1395,6 +1395,16 @@ export namespace Provider {
           read: z.number(),
           write: z.number(),
         }),
+        tiers: z
+          .array(
+            z.object({
+              input: z.number(),
+              output: z.number(),
+              cache: z.object({ read: z.number(), write: z.number() }),
+              threshold: z.number().positive(),
+            }),
+          )
+          .optional(),
         experimentalOver200K: z
           .object({
             input: z.number(),
@@ -1512,6 +1522,9 @@ export namespace Provider {
       },
       release_date: "",
       variants: {},
+      modes: {
+        fast: { provider: { body: { provider: { sort: "throughput" } } } },
+      },
     }
     m.variants = mapValues(ProviderTransform.variants(m), (v) => v)
     return m
@@ -1565,28 +1578,13 @@ export namespace Provider {
 
   function modelModes(provider: ModelsDev.Provider, model: ModelsDev.Model): Model["modes"] | undefined {
     const direct = directModes(provider.id, model.id, model.experimental) ?? {}
-    // OpenRouter Nitro is a broad throughput-routing preference, not a
-    // model-specific Fast capability. Only advertise Fast when the catalog
-    // contains a dedicated immutable sibling that the request can select.
-    const openrouter: NonNullable<Model["modes"]> = {}
-    if (provider.id === "openrouter" && !/-fast$/.test(model.id)) {
-      const route = provider.models[`${model.id}-fast`]
-      if (route && route.status !== "deprecated") {
-        openrouter.fast = {
-          model: route.id,
-          cost: route.cost
-            ? {
-                input: route.cost.input,
-                output: route.cost.output,
-                cache: {
-                  read: route.cost.cache_read ?? 0,
-                  write: route.cost.cache_write ?? 0,
-                },
-              }
-            : undefined,
-        }
-      }
-    }
+    // OpenRouter's Fast mode is a routing preference: sort eligible endpoints
+    // by observed throughput. The chosen endpoint can have a different rate,
+    // so managed settlement remains provider-reported usage.cost.
+    const openrouter: NonNullable<Model["modes"]> =
+      provider.id === "openrouter" && !/-fast$/.test(model.id)
+        ? { fast: { provider: { body: { provider: { sort: "throughput" } } } } }
+        : {}
     const result = { ...direct, ...openrouter }
     if (Object.keys(result).length === 0) return undefined
     return result
@@ -1632,6 +1630,15 @@ export namespace Provider {
           read: cacheRead,
           write: model.cost?.cache_write ?? 0,
         },
+        tiers: model.cost?.tiers?.map((tier) => ({
+          input: tier.input,
+          output: tier.output,
+          cache: {
+            read: tier.cache_read ?? 0,
+            write: tier.cache_write ?? 0,
+          },
+          threshold: tier.tier.size,
+        })),
         experimentalOver200K: model.cost?.context_over_200k
           ? {
               cache: {

--- a/backend/cli/src/session/index.ts
+++ b/backend/cli/src/session/index.ts
@@ -649,11 +649,16 @@ export namespace Session {
       // request that really exceeded 200k was billed at the base tier (cost
       // under-report).
       const modeCost = input.tier ? input.model.modes?.[input.tier]?.cost : undefined
-      const costInfo =
-        modeCost ??
-        (input.model.cost?.experimentalOver200K && tokens.input + tokens.cache.read + tokens.cache.write > 200_000
+      const promptTokens = tokens.input + tokens.cache.read + tokens.cache.write
+      const tierCost = input.model.cost?.tiers
+        ?.filter((tier) => promptTokens >= tier.threshold)
+        .sort((a, b) => b.threshold - a.threshold)[0]
+      const catalogCost = input.model.cost?.tiers?.length
+        ? (tierCost ?? input.model.cost)
+        : input.model.cost?.experimentalOver200K && promptTokens > 200_000
           ? input.model.cost.experimentalOver200K
-          : input.model.cost)
+          : input.model.cost
+      const costInfo = modeCost ?? catalogCost
       return {
         cost: safe(
           new Decimal(0)

--- a/backend/cli/src/session/message-v2.ts
+++ b/backend/cli/src/session/message-v2.ts
@@ -430,6 +430,7 @@ export namespace MessageV2 {
     delegationSettings: DelegationSettings.optional(),
     variant: z.string().optional(),
     tier: z.string().optional(),
+    context: z.number().int().positive().optional(),
     inference: Inference.Info.optional(),
   }).meta({
     ref: "UserMessage",

--- a/backend/cli/src/session/prompt.ts
+++ b/backend/cli/src/session/prompt.ts
@@ -282,6 +282,7 @@ export namespace SessionPrompt {
     system: z.string().optional(),
     variant: z.string().optional(),
     tier: z.string().optional(),
+    context: z.number().int().positive().optional(),
     parts: z.array(
       z.discriminatedUnion("type", [
         MessageV2.TextPart.omit({
@@ -1483,7 +1484,19 @@ export namespace SessionPrompt {
         ...(codex && !minimal ? [SystemPrompt.instructions(route.direct, route.inspection)] : []),
       ]
       const tier = ProviderTransform.tier(model, lastUser.tier)
-      const window = tier.model ? await Provider.getModel(model.providerID, tier.model) : model
+      const routeModel = tier.model ? await Provider.getModel(model.providerID, tier.model) : model
+      const requestedContext = lastUser.context
+      const window =
+        requestedContext && requestedContext < routeModel.limit.context
+          ? {
+              ...routeModel,
+              limit: {
+                ...routeModel.limit,
+                context: requestedContext,
+                input: routeModel.limit.input ? Math.min(routeModel.limit.input, requestedContext) : requestedContext,
+              },
+            }
+          : routeModel
       const preflight = await contextPreflight({
         messages: sessionMessages,
         current: lastUser,
@@ -2237,6 +2250,7 @@ export namespace SessionPrompt {
       system: input.system,
       variant: input.variant,
       tier: input.tier,
+      context: input.context,
       inference: await Inference.resolve(model.providerID, input.variant),
     }
     using _ = defer(() => InstructionPrompt.clear(info.id))
@@ -3097,6 +3111,7 @@ or internal reasoning. Call plan_exit when the plan is ready for approval.`)
     delegationSettings: MessageV2.DelegationSettings.optional(),
     variant: z.string().optional(),
     tier: z.string().optional(),
+    context: z.number().int().positive().optional(),
     parts: z
       .array(
         z.discriminatedUnion("type", [
@@ -3587,6 +3602,10 @@ or internal reasoning. Call plan_exit when the plan is ready for approval.`)
       delegationSettings: input.delegationSettings ?? (await lastDelegationSettings(input.sessionID)),
       variant: input.variant,
       tier: modelTier(input.tier, selectedModel, userModel),
+      context:
+        selectedModel.providerID === userModel.providerID && selectedModel.modelID === userModel.modelID
+          ? input.context
+          : undefined,
     })) as MessageV2.WithParts
 
     Bus.publish(Command.Event.Executed, {

--- a/backend/cli/src/tool/generate-image.ts
+++ b/backend/cli/src/tool/generate-image.ts
@@ -12,12 +12,23 @@ import { Bus } from "@/bus"
 import { File } from "@/file"
 import { FileWatcher } from "@/file/watcher"
 import { Network } from "@/settings/network"
+import { Env } from "@/env"
 
 const MAX_IMAGE_BYTES = 30 * 1024 * 1024
 const MAX_IMAGE_RESPONSE_BYTES = Math.ceil(MAX_IMAGE_BYTES / 3) * 4 + 1024 * 1024
 const MAX_IMAGE_ERROR_BYTES = 1024 * 1024
 const MAX_IMAGE_ATTACHMENT_BYTES = 8 * 1024 * 1024
 const DEFAULT_MODEL = "google/gemini-3-pro-image"
+const GEMINI_MODEL = "gemini-3-pro-image"
+const GEMINI_ASPECT_RATIO = {
+  "1:1": "ASPECT_RATIO_ONE_BY_ONE",
+  "2:3": "ASPECT_RATIO_TWO_BY_THREE",
+  "3:2": "ASPECT_RATIO_THREE_BY_TWO",
+  "3:4": "ASPECT_RATIO_THREE_BY_FOUR",
+  "4:3": "ASPECT_RATIO_FOUR_BY_THREE",
+  "9:16": "ASPECT_RATIO_NINE_BY_SIXTEEN",
+  "16:9": "ASPECT_RATIO_SIXTEEN_BY_NINE",
+} as const
 
 function normalizedInputPath(value: string | undefined) {
   if (!value) return
@@ -50,6 +61,14 @@ type OpenRouterImage = {
     message?: {
       images?: unknown[]
       content?: unknown
+    }
+  }>
+  candidates?: Array<{
+    content?: {
+      parts?: Array<{
+        inlineData?: { data?: string; mimeType?: string }
+        inline_data?: { data?: string; mime_type?: string }
+      }>
     }
   }>
   error?:
@@ -114,6 +133,23 @@ function decodeImage(value: string) {
 }
 
 export function extractGeneratedImage(value: OpenRouterImage) {
+  const part = value.candidates
+    ?.flatMap((candidate) => candidate.content?.parts ?? [])
+    .find((item) => {
+      const data = item.inlineData?.data ?? item.inline_data?.data
+      return typeof data === "string" && data.length > 0
+    })
+  const inline =
+    part?.inlineData ??
+    (part?.inline_data ? { data: part.inline_data.data, mimeType: part.inline_data.mime_type } : undefined)
+  if (inline?.data) {
+    const mime = inline.mimeType ?? "image/png"
+    if (!/^image\/(?:png|jpeg|webp|gif)$/.test(mime)) {
+      throw new Error(`The image model returned an unsupported image format (${mime}).`)
+    }
+    return { mime, bytes: decodeImage(inline.data) }
+  }
+
   const generated = value.data?.find((item) => typeof item.b64_json === "string" && item.b64_json.length > 0)
   if (generated?.b64_json) {
     const mime = generated.media_type ?? "image/png"
@@ -260,7 +296,7 @@ function requestError(status: number, body: OpenRouterImage | undefined, raw: st
 
 export const GenerateImageTool = Tool.define("generate_image", {
   description:
-    "Generate or edit an image with Nano Banana through the user's connected OpenRouter key, falling back to funded OpenScience wallet Credits when managed spend is enabled. Saves the image directly in the connected workspace.",
+    "Generate or edit an image with the pinned Gemini 3 Pro Image model. Uses the user's Gemini key first, then OpenRouter, then a funded workspace Wallet fallback. Saves the image directly in the connected workspace.",
   parameters: z.object({
     prompt: z.string().trim().min(1).max(20_000).describe("Detailed description or editing instruction"),
     output_path: z
@@ -279,7 +315,6 @@ export const GenerateImageTool = Tool.define("generate_image", {
       .describe(
         "Existing regular image file to edit. Omit this field entirely when generating a new image; never use a directory, '.', /dev/null, or a blank placeholder.",
       ),
-    model: z.string().trim().min(1).max(300).default(DEFAULT_MODEL).describe("OpenRouter image model ID"),
     aspect_ratio: z
       .enum(["1:1", "3:2", "2:3", "4:3", "3:4", "16:9", "9:16"])
       .optional()
@@ -353,33 +388,86 @@ export const GenerateImageTool = Tool.define("generate_image", {
             : "image/png"
       : undefined
 
-    const provider = await Provider.getProvider("openrouter").catch(() => undefined)
-    const key = typeof provider?.options?.apiKey === "string" ? provider.options.apiKey : provider?.key
-    const base =
-      typeof provider?.options?.baseURL === "string" ? provider.options.baseURL.replace(/\/+$/, "") : undefined
-    if (!provider || !key || !base) {
+    const google = await Provider.getProvider("google").catch(() => undefined)
+    const openrouter = await Provider.getProvider("openrouter").catch(() => undefined)
+    const googleKey = typeof google?.options?.apiKey === "string" ? google.options.apiKey : google?.key
+    const openrouterKey = typeof openrouter?.options?.apiKey === "string" ? openrouter.options.apiKey : openrouter?.key
+    const openrouterBase =
+      typeof openrouter?.options?.baseURL === "string"
+        ? openrouter.options.baseURL.replace(/\/+$/, "")
+        : "https://openrouter.ai/api/v1"
+    const ambient = (key: string, names: string[]) => names.some((name) => Env.get(name) === key)
+    const candidates = [
+      ...(googleKey && !OpenScience.isManagedKeyValue(googleKey)
+        ? [
+            {
+              kind: "gemini" as const,
+              key: googleKey,
+              base:
+                typeof google?.options?.baseURL === "string"
+                  ? google.options.baseURL.replace(/\/+$/, "")
+                  : "https://generativelanguage.googleapis.com/v1beta",
+              label: "the connected Gemini key",
+              rank: ambient(googleKey, ["GOOGLE_GENERATIVE_AI_API_KEY", "GOOGLE_API_KEY", "GEMINI_API_KEY"]) ? 1 : 2,
+            },
+          ]
+        : []),
+      ...(openrouterKey && !OpenScience.isManagedKeyValue(openrouterKey)
+        ? [
+            {
+              kind: "openrouter" as const,
+              key: openrouterKey,
+              base: openrouterBase,
+              label: "the connected OpenRouter key",
+              rank: ambient(openrouterKey, ["OPENROUTER_API_KEY"]) ? 1 : 2,
+            },
+          ]
+        : []),
+      ...(openrouterKey && OpenScience.isManagedKeyValue(openrouterKey)
+        ? [
+            {
+              kind: "managed" as const,
+              key: openrouterKey,
+              base: openrouterBase,
+              label: "OpenScience wallet Credits",
+              rank: ambient(openrouterKey, ["OPENROUTER_API_KEY"]) ? 1 : 2,
+            },
+          ]
+        : []),
+      ...(Env.get("OPENSCIENCE_IMAGE_API_KEY") && Env.get("OPENSCIENCE_IMAGE_BASE_URL")
+        ? [
+            {
+              kind: "managed" as const,
+              key: Env.get("OPENSCIENCE_IMAGE_API_KEY")!,
+              base: Env.get("OPENSCIENCE_IMAGE_BASE_URL")!.replace(/\/+$/, ""),
+              label: "OpenScience wallet Credits",
+              rank: 0,
+            },
+          ]
+        : []),
+    ]
+    const route = candidates.sort((a, b) => b.rank - a.rank)[0]
+    if (!route) {
       throw new Error(
-        "Nano Banana is unavailable. Connect OpenRouter in Settings → Models, or choose Credits there and sign in with a funded Ace balance.",
+        "Nano Banana is unavailable. Connect Gemini or OpenRouter in Settings → Credentials, or sign in to use a funded workspace Wallet.",
       )
     }
+    if (route.kind === "gemini" && extension !== ".png") {
+      throw new Error("Gemini image generation returns PNG. Use an output_path ending in .png.")
+    }
 
-    // This tool calls fetch directly instead of going through Provider.getSDK(),
-    // so enforce the same credential/host invariant here. The effective token,
-    // not the spend-toggle label, determines whether this is a wallet request.
-    // Otherwise a custom/stale base URL could receive the scoped thk_* token.
-    const managed = OpenScience.isManagedKeyValue(key)
-    const proxy = Provider.isAtlasProxyBaseURL(base)
-    if (managed && !proxy) {
+    const managed = route.kind === "managed"
+    if (managed && (!OpenScience.isManagedKeyValue(route.key) || !Provider.isAtlasProxyBaseURL(route.base))) {
       throw new Error(
         "OpenScience refused to send the wallet credential outside its managed image proxy. Run openscience sync and retry.",
       )
     }
-    if (!managed && proxy) {
+    if (!managed && Provider.isAtlasProxyBaseURL(route.base)) {
       throw new Error(
-        "OpenScience refused to send your connected OpenRouter key to the managed wallet proxy. Reconnect OpenRouter and retry.",
+        "OpenScience refused to send your connected provider key to the managed wallet proxy. Reconnect the credential and retry.",
       )
     }
-    const funding = managed ? await OpenScience.managedRequestSnapshot(key) : undefined
+    const funding = managed ? await OpenScience.managedRequestSnapshot(route.key) : undefined
     if (managed) {
       const balance = await OpenScience.getBalance(funding).catch(() => null)
       if (balance !== null && balance <= 0) {
@@ -392,13 +480,13 @@ export const GenerateImageTool = Tool.define("generate_image", {
 
     await ctx.ask({
       permission: "generate_image",
-      patterns: [params.model],
+      patterns: [DEFAULT_MODEL],
       always: ["*"],
       metadata: {
-        model: params.model,
+        model: DEFAULT_MODEL,
         output,
         input: source,
-        route: managed ? "wallet" : "byok",
+        route: route.kind,
       },
     })
     await ctx.ask({
@@ -409,28 +497,36 @@ export const GenerateImageTool = Tool.define("generate_image", {
     })
 
     const format = extension === ".jpg" ? "jpeg" : extension.slice(1)
-    const headers = {
-      Authorization: `Bearer ${key}`,
-      "Content-Type": "application/json",
-      "HTTP-Referer": "https://syntheticsciences.ai",
-      "X-Title": "OpenScience",
-      ...(funding ? OpenScience.fundingHeaders(funding) : {}),
-    }
-    const request = async (endpoint: string, payload: Record<string, unknown>) => {
+    const headers =
+      route.kind === "gemini"
+        ? { "x-goog-api-key": route.key, "Content-Type": "application/json" }
+        : {
+            Authorization: `Bearer ${route.key}`,
+            "Content-Type": "application/json",
+            "HTTP-Referer": "https://syntheticsciences.ai",
+            "X-Title": "OpenScience",
+            ...(funding ? OpenScience.fundingHeaders(funding) : {}),
+          }
+    const request = async (url: string, payload: Record<string, unknown>) => {
       const text = JSON.stringify(payload)
       const idempotency = managed
         ? Provider.managedIdempotencyKey({
-            endpoint: `${base}/${endpoint}`,
+            endpoint: url,
             body: text,
             sessionID: ctx.sessionID,
             messageID: ctx.messageID,
             operation: "generate-image",
           })
         : undefined
-      const response = await fetch(`${base}/${endpoint}`, {
+      const requestHeaders = new Headers()
+      for (const [name, value] of Object.entries(headers)) {
+        if (value) requestHeaders.set(name, value)
+      }
+      if (idempotency) requestHeaders.set("Idempotency-Key", idempotency)
+      const response = await fetch(url, {
         method: "POST",
         signal: AbortSignal.any([ctx.abort, AbortSignal.timeout(120_000)]),
-        headers: { ...headers, ...(idempotency ? { "Idempotency-Key": idempotency } : {}) },
+        headers: requestHeaders,
         body: text,
       })
       if (funding) await OpenScience.validateFundingResponse(response, funding)
@@ -446,23 +542,42 @@ export const GenerateImageTool = Tool.define("generate_image", {
       })()
       return { response, raw, body }
     }
-    const direct = await request("images", {
-      model: params.model,
-      prompt: params.prompt,
-      n: 1,
-      output_format: format,
-      ...(params.aspect_ratio ? { aspect_ratio: params.aspect_ratio } : {}),
-      ...(input
-        ? {
-            input_references: [
+    const direct =
+      route.kind === "gemini"
+        ? await request(`${route.base}/models/${GEMINI_MODEL}:generateContent`, {
+            contents: [
               {
-                type: "image_url",
-                image_url: { url: `data:${inputMime};base64,${input.bytes.toString("base64")}` },
+                role: "user",
+                parts: [
+                  { text: params.prompt },
+                  ...(input ? [{ inlineData: { mimeType: inputMime, data: input.bytes.toString("base64") } }] : []),
+                ],
               },
             ],
-          }
-        : {}),
-    })
+            generationConfig: {
+              responseModalities: ["IMAGE"],
+              ...(params.aspect_ratio
+                ? { responseFormat: { image: { aspectRatio: GEMINI_ASPECT_RATIO[params.aspect_ratio] } } }
+                : {}),
+            },
+          })
+        : await request(`${route.base}/images`, {
+            model: DEFAULT_MODEL,
+            prompt: params.prompt,
+            n: 1,
+            output_format: format,
+            ...(params.aspect_ratio ? { aspect_ratio: params.aspect_ratio } : {}),
+            ...(input
+              ? {
+                  input_references: [
+                    {
+                      type: "image_url",
+                      image_url: { url: `data:${inputMime};base64,${input.bytes.toString("base64")}` },
+                    },
+                  ],
+                }
+              : {}),
+          })
     if (!direct.response.ok) throw requestError(direct.response.status, direct.body, direct.raw, managed)
     if (!direct.body) throw new Error("Nano Banana returned an unreadable response.")
     const approvedHosts = new Set<string>()
@@ -494,13 +609,13 @@ export const GenerateImageTool = Tool.define("generate_image", {
     })
     return {
       title: path.relative(directory, output),
-      output: `Generated ${path.basename(output)} with ${params.model} via ${managed ? "OpenScience wallet Credits" : "the connected OpenRouter key"}.`,
+      output: `Generated ${path.basename(output)} with ${DEFAULT_MODEL} via ${route.label}.`,
       metadata: {
         filepath: output,
         mime: image.mime,
         size: image.bytes.byteLength,
-        model: params.model,
-        route: managed ? "wallet" : "byok",
+        model: DEFAULT_MODEL,
+        route: route.kind,
         attachment: attachments.length ? "inline" : "artifact_only",
         artifact: {
           kind: "image",

--- a/backend/cli/test/installation/desktop-updater.test.ts
+++ b/backend/cli/test/installation/desktop-updater.test.ts
@@ -180,39 +180,51 @@ describe("desktop update release contract", () => {
     const final = { status: "succeeded", version: "3.2.1", recovered: true }
 
     expect(
-      await settleTransaction(info, { status: "succeeded", version: "3.2.1" }, {
-        timeout: 1,
-        waitForExit: async (identity: typeof helper) => {
-          events.push("helper-exit")
-          expect(identity).toEqual(helper)
-          return true
+      await settleTransaction(
+        info,
+        { status: "succeeded", version: "3.2.1" },
+        {
+          timeout: 1,
+          waitForExit: async (identity: typeof helper) => {
+            events.push("helper-exit")
+            expect(identity).toEqual(helper)
+            return true
+          },
+          assertClean: async (value: typeof info) => {
+            events.push("cache-clean")
+            expect(value).toBe(info)
+          },
+          readResult: async (file: string) => {
+            events.push("final-result")
+            expect(file).toBe(info.result)
+            return final
+          },
         },
-        assertClean: async (value: typeof info) => {
-          events.push("cache-clean")
-          expect(value).toBe(info)
-        },
-        readResult: async (file: string) => {
-          events.push("final-result")
-          expect(file).toBe(info.result)
-          return final
-        },
-      }),
+      ),
     ).toEqual(final)
     expect(events).toEqual(["helper-exit", "cache-clean", "final-result"])
 
     await expect(
-      settleTransaction(info, { status: "succeeded", version: "3.2.1" }, {
-        waitForExit: async () => true,
-        assertClean: async () => undefined,
-        readResult: async () => ({ ...final, cleanup_error: "purge failed" }),
-      }),
+      settleTransaction(
+        info,
+        { status: "succeeded", version: "3.2.1" },
+        {
+          waitForExit: async () => true,
+          assertClean: async () => undefined,
+          readResult: async () => ({ ...final, cleanup_error: "purge failed" }),
+        },
+      ),
     ).rejects.toThrow("final state did not match")
     await expect(
-      settleTransaction(info, { status: "succeeded", version: "3.2.1" }, {
-        waitForExit: async () => true,
-        assertClean: async () => undefined,
-        readResult: async () => ({ ...final, status: "failed" }),
-      }),
+      settleTransaction(
+        info,
+        { status: "succeeded", version: "3.2.1" },
+        {
+          waitForExit: async () => true,
+          assertClean: async () => undefined,
+          readResult: async () => ({ ...final, status: "failed" }),
+        },
+      ),
     ).rejects.toThrow("final state did not match")
     await expect(
       settleTransaction({ ...info, helper_identity: undefined }, { status: "succeeded", version: "3.2.1" }),

--- a/backend/cli/test/openscience/synced-env-policy.test.ts
+++ b/backend/cli/test/openscience/synced-env-policy.test.ts
@@ -51,6 +51,11 @@ test("allows the OpenRouter managed route and non-compute integrations", () => {
     expect(isSyncedEnvAllowed(key)).toBe(true)
   }
   expect(isSyncedEnvAllowed("OPENROUTER_BASE_URL", managedOpenRouterBaseURL())).toBe(true)
+  expect(isSyncedEnvAllowed("OPENSCIENCE_IMAGE_API_KEY", "thk_workspace-image")).toBe(true)
+  expect(isSyncedEnvAllowed("OPENSCIENCE_IMAGE_API_KEY", "sk-user-owned")).toBe(false)
+  expect(isSyncedEnvAllowed("OPENSCIENCE_IMAGE_BASE_URL", managedOpenRouterBaseURL())).toBe(true)
+  expect(isSyncedEnvAllowed("OPENSCIENCE_IMAGE_MODEL", "google/gemini-3-pro-image")).toBe(true)
+  expect(isSyncedEnvAllowed("OPENSCIENCE_IMAGE_MODEL", "meta/llama-3.3-70b-instruct")).toBe(false)
   expect(SYNCED_SERVICE_ENV_KEYS).not.toContain("MODAL_TOKEN_SECRET")
 })
 

--- a/backend/cli/test/provider/provider.test.ts
+++ b/backend/cli/test/provider/provider.test.ts
@@ -186,11 +186,15 @@ test("current frontier models are routable from the seeded catalog", async () =>
         service_tier: "priority",
       })
       expect(Object.keys(providers["openai"].models["gpt-5.6-sol"].modes ?? {})).toEqual(["fast"])
-      expect(providers["openrouter"].models["openai/gpt-5.6-sol"].modes?.fast).toBeUndefined()
-      expect(providers["openrouter"].models["x-ai/grok-4.5"].modes?.fast).toBeUndefined()
-      expect(providers["openrouter"].models["anthropic/claude-opus-5"].modes?.fast?.model).toBe(
-        "anthropic/claude-opus-5-fast",
-      )
+      expect(providers["openrouter"].models["openai/gpt-5.6-sol"].modes?.fast?.provider?.body).toEqual({
+        provider: { sort: "throughput" },
+      })
+      expect(providers["openrouter"].models["x-ai/grok-4.5"].modes?.fast?.provider?.body).toEqual({
+        provider: { sort: "throughput" },
+      })
+      expect(providers["openrouter"].models["anthropic/claude-opus-5"].modes?.fast?.provider?.body).toEqual({
+        provider: { sort: "throughput" },
+      })
       expect(providers["xai"].models["grok-4.5"].modes?.fast).toBeUndefined()
       expect(providers["openrouter"].models["openai/gpt-5.6-sol"].modes?.pro).toBeUndefined()
       expect(providers["openrouter"].models["openai/gpt-5.6-sol-pro"]).toBeDefined()

--- a/backend/cli/test/session/usage-accounting.test.ts
+++ b/backend/cli/test/session/usage-accounting.test.ts
@@ -71,6 +71,23 @@ describe("Session.getUsage cost/token accounting", () => {
     expect(r.cost).toBeCloseTo((1_000 * 3 + 100 * 15) / 1_000_000, 6)
   })
 
+  test("uses the catalog's exact context threshold instead of the legacy 200k guess", () => {
+    const priced = model()
+    priced.cost.tiers = [{ input: 10, output: 45, cache: { read: 1, write: 0 }, threshold: 272_000 }]
+    const below = Session.getUsage({
+      model: priced,
+      usage: { inputTokens: 271_999, outputTokens: 100, cachedInputTokens: 0 } as any,
+      metadata: { anthropic: {} } as any,
+    })
+    const exact = Session.getUsage({
+      model: priced,
+      usage: { inputTokens: 272_000, outputTokens: 100, cachedInputTokens: 0 } as any,
+      metadata: { anthropic: {} } as any,
+    })
+    expect(below.cost).toBeCloseTo((271_999 * 3 + 100 * 15) / 1_000_000, 6)
+    expect(exact.cost).toBeCloseTo((272_000 * 10 + 100 * 45) / 1_000_000, 6)
+  })
+
   test("clamps a would-be-negative input token count to zero (non-excludes provider)", () => {
     // inputTokens already excludes cached, but provider isn't in the excludes set:
     // 100 - 500 cacheRead = -400 → must clamp to 0, never negative tokens/cost.

--- a/backend/cli/test/tool/generate-image.test.ts
+++ b/backend/cli/test/tool/generate-image.test.ts
@@ -53,27 +53,26 @@ describe("generate_image response parsing", () => {
           const workspace = await SessionFilesystem.workspace(session.id)
           const asks: Parameters<Tool.Context["ask"]>[0][] = []
           const tool = await GenerateImageTool.init()
-          const result = await tool.execute(
-            {
-              prompt: "A precise monochrome benchmark schematic",
-              output_path: "figures/benchmark.png",
-              input_path: "/dev/null",
-              model: "google/gemini-3-pro-image",
-              aspect_ratio: "16:9",
+          const input = tool.parameters.parse({
+            prompt: "A precise monochrome benchmark schematic",
+            output_path: "figures/benchmark.png",
+            input_path: "/dev/null",
+            model: "meta-llama/llama-3.3-70b-instruct",
+            aspect_ratio: "16:9",
+          })
+          expect(input).not.toHaveProperty("model")
+          const result = await tool.execute(input, {
+            sessionID: session.id,
+            messageID: "msg_generate_image",
+            callID: "call_generate_image",
+            agent: "research",
+            abort: new AbortController().signal,
+            messages: [],
+            metadata() {},
+            async ask(input) {
+              asks.push(input)
             },
-            {
-              sessionID: session.id,
-              messageID: "msg_generate_image",
-              callID: "call_generate_image",
-              agent: "research",
-              abort: new AbortController().signal,
-              messages: [],
-              metadata() {},
-              async ask(input) {
-                asks.push(input)
-              },
-            },
-          )
+          })
 
           expect(requests).toHaveLength(1)
           expect(requests[0]).toMatchObject({
@@ -93,7 +92,7 @@ describe("generate_image response parsing", () => {
           )
           expect(result).toMatchObject({
             title: "figures/benchmark.png",
-            metadata: { route: "byok", mime: "image/png", size: image.byteLength, attachment: "inline" },
+            metadata: { route: "openrouter", mime: "image/png", size: image.byteLength, attachment: "inline" },
           })
           expect(result.attachments).toHaveLength(1)
 
@@ -102,7 +101,6 @@ describe("generate_image response parsing", () => {
               prompt: "A second precise monochrome benchmark schematic",
               output_path: "figures/benchmark-directory-placeholder.png",
               input_path: ".",
-              model: "google/gemini-3-pro-image",
             },
             {
               sessionID: session.id,
@@ -119,7 +117,7 @@ describe("generate_image response parsing", () => {
           )
           expect(requests).toHaveLength(2)
           expect(requests[1]?.body).not.toHaveProperty("input_references")
-          expect(directoryPlaceholder.metadata).toMatchObject({ mime: "image/png", route: "byok" })
+          expect(directoryPlaceholder.metadata).toMatchObject({ mime: "image/png", route: "openrouter" })
 
           await Bun.write(path.join(workspace, "input.png"), image)
           await tool.execute(
@@ -127,7 +125,6 @@ describe("generate_image response parsing", () => {
               prompt: "Preserve the source and improve its contrast",
               output_path: "figures/benchmark-edited.png",
               input_path: "input.png",
-              model: "google/gemini-3-pro-image",
             },
             {
               sessionID: session.id,
@@ -147,6 +144,100 @@ describe("generate_image response parsing", () => {
             input_references: [
               { type: "image_url", image_url: { url: expect.stringContaining("data:image/png;base64,") } },
             ],
+          })
+        },
+      })
+    } finally {
+      server.stop(true)
+    }
+  })
+
+  test("prefers a connected Gemini key and pins the stable image-only model", async () => {
+    const image = Buffer.from(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+      "base64",
+    )
+    const requests: Array<{ url: string; key: string | null; body: Record<string, unknown> }> = []
+    const server = Bun.serve({
+      port: 0,
+      async fetch(request) {
+        requests.push({
+          url: new URL(request.url).pathname,
+          key: request.headers.get("x-goog-api-key"),
+          body: (await request.json()) as Record<string, unknown>,
+        })
+        return Response.json({
+          candidates: [
+            { content: { parts: [{ inlineData: { mimeType: "image/png", data: image.toString("base64") } }] } },
+          ],
+        })
+      },
+    })
+    try {
+      await using tmp = await tmpdir({
+        git: true,
+        config: {
+          provider: {
+            google: {
+              options: {
+                apiKey: "gemini-local-image-route",
+                baseURL: `http://127.0.0.1:${server.port}/v1beta`,
+              },
+            },
+          },
+        },
+      })
+      await Instance.provide({
+        directory: tmp.path,
+        init: async () => Provider.invalidate(),
+        fn: async () => {
+          const session = await executionSession()
+          const tool = await GenerateImageTool.init()
+          const result = await tool.execute(
+            { prompt: "A precise benchmark diagram", output_path: "gemini.png" },
+            {
+              sessionID: session.id,
+              messageID: "msg_gemini_image",
+              callID: "call_gemini_image",
+              agent: "research",
+              abort: new AbortController().signal,
+              messages: [],
+              metadata() {},
+              async ask() {},
+            },
+          )
+          expect(requests).toHaveLength(1)
+          expect(requests[0]).toMatchObject({
+            url: "/v1beta/models/gemini-3-pro-image:generateContent",
+            key: "gemini-local-image-route",
+            body: {
+              contents: [{ role: "user", parts: [{ text: "A precise benchmark diagram" }] }],
+              generationConfig: { responseModalities: ["IMAGE"] },
+            },
+          })
+          expect(result.metadata).toMatchObject({
+            model: "google/gemini-3-pro-image",
+            route: "gemini",
+          })
+
+          await tool.execute(
+            { prompt: "A wide benchmark diagram", output_path: "gemini-wide.png", aspect_ratio: "16:9" },
+            {
+              sessionID: session.id,
+              messageID: "msg_gemini_wide_image",
+              callID: "call_gemini_wide_image",
+              agent: "research",
+              abort: new AbortController().signal,
+              messages: [],
+              metadata() {},
+              async ask() {},
+            },
+          )
+          expect(requests[1]?.body).toMatchObject({
+            generationConfig: {
+              responseModalities: ["IMAGE"],
+              responseFormat: { image: { aspectRatio: "ASPECT_RATIO_SIXTEEN_BY_NINE" } },
+            },
           })
         },
       })
@@ -177,19 +268,15 @@ describe("generate_image response parsing", () => {
           },
         }
 
-        await expect(
-          tool.execute(
-            { prompt: "figure", output_path: "/tmp/not-an-image.txt", model: "google/gemini-3-pro-image" },
-            ctx,
-          ),
-        ).rejects.toThrow("output_path must end in")
+        await expect(tool.execute({ prompt: "figure", output_path: "/tmp/not-an-image.txt" }, ctx)).rejects.toThrow(
+          "output_path must end in",
+        )
         await expect(
           tool.execute(
             {
               prompt: "figure",
               output_path: "figure.png",
               input_path: "/tmp/not-an-image",
-              model: "google/gemini-3-pro-image",
             },
             ctx,
           ),
@@ -233,7 +320,6 @@ describe("generate_image response parsing", () => {
               {
                 prompt: "A benchmark schematic",
                 output_path: "figure.png",
-                model: "google/gemini-3-pro-image",
               },
               {
                 sessionID: session.id,
@@ -268,7 +354,6 @@ describe("generate_image response parsing", () => {
             {
               prompt: "A benchmark schematic",
               output_path: "figure.gif",
-              model: "google/gemini-3-pro-image",
             },
             {
               sessionID: session.id,

--- a/frontend/workspace/src/components/model-settings-popover.test.ts
+++ b/frontend/workspace/src/components/model-settings-popover.test.ts
@@ -319,6 +319,31 @@ describe("reasoning effort and Fast mode", () => {
     })
   })
 
+  test("renders and selects an exact context cap independently", () => {
+    const selected = { value: "1050000" }
+    const host = mount(() =>
+      web.createComponent(subject.ModelEffortPanel, {
+        current: "standard",
+        options: [],
+        context: {
+          current: selected.value,
+          options: [
+            { id: "272000", label: "272K cap" },
+            { id: "1050000", label: "Full · 1.05M" },
+          ],
+        },
+        onEffortSelect: () => undefined,
+        onTierSelect: () => undefined,
+        onContextSelect: (context) => (selected.value = context),
+      }),
+    )
+
+    const choices = host.querySelectorAll('[data-model-option="context"]')
+    expect(choices).toHaveLength(2)
+    host.querySelector<HTMLButtonElement>('[data-model-option="context"][data-model-option-id="272000"]')?.click()
+    expect(selected.value).toBe("272000")
+  })
+
   test("uses a real dialog trigger and restores focus to its own effort chip", async () => {
     const host = mount(() =>
       web.createComponent(subject.ModelEffortPopover, {

--- a/frontend/workspace/src/components/model-settings-popover.tsx
+++ b/frontend/workspace/src/components/model-settings-popover.tsx
@@ -108,7 +108,7 @@ export { inferenceSource, inferenceSourceLabel, type InferenceSource } from "@/c
 
 type ModelOptionListProps = {
   id: string
-  kind: "effort" | "route"
+  kind: "effort" | "route" | "context"
   title: string
   current: string
   options: Array<{ id: string; label: string }>
@@ -199,7 +199,7 @@ const ModelPopoverSurface: Component<ModelPopoverSurfaceProps> = (props) => {
         data-model-settings-popover
         data-model-popover-kind={props.kind}
         data-model-settings-view={props.view}
-        class="z-50 outline-none"
+        class="z-50 outline-none focus-visible:outline focus-visible:outline-1 focus-visible:outline-border-strong focus-visible:outline-offset-2"
         onKeyDown={props.onKeyDown}
         onOpenAutoFocus={(event) => {
           if (!props.initialFocus) return
@@ -252,8 +252,10 @@ type ModelEffortPanelProps = {
   current: string
   options: Array<{ id: string; label: string }>
   fast?: { active: boolean }
+  context?: { current: string; options: Array<{ id: string; label: string }> }
   onEffortSelect: (id: string) => void
   onTierSelect: (id: "standard" | "fast") => void
+  onContextSelect?: (id: string) => void
 }
 
 export const ModelEffortPanel: Component<ModelEffortPanelProps> = (props) => (
@@ -279,6 +281,21 @@ export const ModelEffortPanel: Component<ModelEffortPanelProps> = (props) => (
               <span class="model-settings-fast-label">Fast mode</span>
             </Switch>
           </div>
+        </section>
+      )}
+    </Show>
+    <Show when={props.context && props.context.options.length > 1 ? props.context : undefined}>
+      {(context) => (
+        <section class="model-settings-option-section" aria-label="Context window">
+          <div class="model-settings-heading">Context window</div>
+          <ModelOptionList
+            id="model-context-options"
+            kind="context"
+            title="Context window"
+            current={context().current}
+            options={context().options}
+            onSelect={(id) => props.onContextSelect?.(id)}
+          />
         </section>
       )}
     </Show>
@@ -336,7 +353,9 @@ export const ModelEffortPopover: Component<ModelEffortPopoverProps> = (props) =>
         initialFocus={
           props.options.length > 0
             ? '[data-model-option="effort"][aria-checked="true"]'
-            : '[data-model-fast-toggle] [data-slot="switch-input"]'
+            : props.fast
+              ? '[data-model-fast-toggle] [data-slot="switch-input"]'
+              : '[data-model-option="context"][aria-checked="true"]'
         }
         contentRef={(element) => (content = element)}
       >
@@ -344,8 +363,10 @@ export const ModelEffortPopover: Component<ModelEffortPopoverProps> = (props) =>
           current={props.current}
           options={props.options}
           fast={props.fast}
+          context={props.context}
           onEffortSelect={props.onEffortSelect}
           onTierSelect={props.onTierSelect}
+          onContextSelect={props.onContextSelect}
         />
       </ModelPopoverSurface>
     </Kobalte>
@@ -889,12 +910,20 @@ export const ModelSettingsPopover: Component<{ trigger?: "label" | "icon" }> = (
           </Show>
         </ModelPopoverSurface>
       </Kobalte>
-      <Show when={props.trigger !== "icon" && (control().effort || fast())}>
+      <Show when={props.trigger !== "icon" && (control().effort || fast() || local.model.context.list().length > 1)}>
         <ModelEffortPopover
           value={control().effort?.value ?? "Fast"}
           current={control().effort?.current.id ?? "standard"}
           options={control().effort?.options ?? []}
           fast={fast()}
+          context={{
+            current: String(local.model.context.current()),
+            options: local.model.context.list().map((value) => ({
+              id: String(value),
+              label:
+                value === current()?.limit.context ? `Full · ${modelContext(value)}` : `${modelContext(value)} cap`,
+            })),
+          }}
           open={effortOpen()}
           onOpenChange={(next) => {
             setEffortOpen(next)
@@ -905,6 +934,7 @@ export const ModelSettingsPopover: Component<{ trigger?: "label" | "icon" }> = (
           modal={mobile()}
           onEffortSelect={(id) => local.model.variant.set(id)}
           onTierSelect={(id) => local.model.tier.set(id)}
+          onContextSelect={(id) => local.model.context.set(Number(id))}
         />
       </Show>
     </div>

--- a/frontend/workspace/src/components/prompt-input.tsx
+++ b/frontend/workspace/src/components/prompt-input.tsx
@@ -1886,6 +1886,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     const agent = currentAgent.name
     const variant = local.model.variant.prompt()
     const tier = local.model.tier.prompt()
+    const contextLimit = local.model.context.prompt()
 
     const restoreBootstrap = () => {
       setSubmitting(false)
@@ -2025,6 +2026,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
         delegationSettings: delegationConfig,
         variant,
         tier,
+        context: contextLimit,
         parts: images.map((attachment) => ({
           id: Identifier.ascending("part"),
           type: "file" as const,
@@ -2065,6 +2067,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
           delegationSettings: delegationConfig,
           variant,
           tier,
+          context: contextLimit,
           parts: images.map((attachment) => ({
             id: Identifier.ascending("part"),
             type: "file" as const,
@@ -2413,6 +2416,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
         delegationSettings: delegationConfig,
         variant,
         tier,
+        context: contextLimit,
       }
       await client.session.prompt(request)
     }
@@ -2777,7 +2781,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
             onKeyDown={handleKeyDown}
             classList={{
               "select-text": true,
-              "focus:outline-none whitespace-pre-wrap": true,
+              "focus:outline-none focus-visible:outline focus-visible:outline-1 focus-visible:outline-border-strong focus-visible:outline-offset-2 whitespace-pre-wrap": true,
               "[&_[data-type=file]]:text-syntax-property": true,
               "[&_[data-type=agent]]:text-syntax-type": true,
               "[&_[data-type=conversation]]:text-syntax-keyword": true,

--- a/frontend/workspace/src/context/local.tsx
+++ b/frontend/workspace/src/context/local.tsx
@@ -318,6 +318,35 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
             return promptTier(this.current(), Object.keys(m.modes ?? {}))
           },
         },
+        context: {
+          list() {
+            const m = current()
+            if (!m) return []
+            const thresholds = (m.cost.tiers ?? []).map((tier) => tier.threshold)
+            const defaults = m.limit.context > 272_000 ? [272_000] : []
+            return [...new Set([...thresholds, ...defaults, m.limit.context])]
+              .filter((value) => value > 0 && value <= m.limit.context)
+              .sort((a, b) => a - b)
+          },
+          current() {
+            const m = current()
+            if (!m) return 0
+            const value = models.context.get({ providerID: m.provider.id, modelID: m.id })
+            return value && this.list().includes(value) ? value : m.limit.context
+          },
+          set(value: number | undefined) {
+            const m = current()
+            if (!m) return
+            const selected = value && this.list().includes(value) && value < m.limit.context ? value : undefined
+            models.context.set({ providerID: m.provider.id, modelID: m.id }, selected)
+          },
+          prompt() {
+            const m = current()
+            if (!m) return undefined
+            const value = this.current()
+            return value < m.limit.context ? value : undefined
+          },
+        },
       }
     })()
 

--- a/frontend/workspace/src/context/model-catalog.ts
+++ b/frontend/workspace/src/context/model-catalog.ts
@@ -296,6 +296,7 @@ export function groupModelRoutes<T extends CatalogModel>(input: {
 }
 
 export function isChatModel(model: CatalogModel): boolean {
+  if (/(^|\/)gemini-3-pro-image(?:-preview)?$/i.test(model.id)) return false
   if (/(^|[/._-])(?:text-)?embeddings?([/._-]|$)/i.test(model.id)) return false
   if (/(^|[/._-])embed([/._-]|$)/i.test(model.id)) return false
   const output = model.capabilities?.output

--- a/frontend/workspace/src/context/models.tsx
+++ b/frontend/workspace/src/context/models.tsx
@@ -31,6 +31,7 @@ type Store = {
   pinned?: ModelKey[]
   variant?: Record<string, string | undefined>
   tier?: Record<string, string | undefined>
+  context?: Record<string, number | undefined>
 }
 
 export const composerModelPreferenceKey = (model: ModelKey) => logicalModelKey(model.providerID, model.modelID)
@@ -69,6 +70,7 @@ export const { use: useModels, provider: ModelsProvider } = createSimpleContext(
         pinned: [],
         variant: {},
         tier: {},
+        context: {},
       }),
     )
 
@@ -197,6 +199,17 @@ export const { use: useModels, provider: ModelsProvider } = createSimpleContext(
       setStore("tier", key, value)
     }
 
+    const getContext = (model: ModelKey) => store.context?.[variantKey(model)]
+
+    const setContext = (model: ModelKey, value: number | undefined) => {
+      const key = variantKey(model)
+      if (!store.context) {
+        setStore("context", { [key]: value })
+        return
+      }
+      setStore("context", key, value)
+    }
+
     return {
       ready,
       list,
@@ -219,6 +232,10 @@ export const { use: useModels, provider: ModelsProvider } = createSimpleContext(
       tier: {
         get: getTier,
         set: setTier,
+      },
+      context: {
+        get: getContext,
+        set: setContext,
       },
     }
   },

--- a/tooling/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/tooling/sdk/js/src/v2/gen/sdk.gen.ts
@@ -3818,6 +3818,7 @@ export class Session extends HeyApiClient {
       system?: string
       variant?: string
       tier?: string
+      context?: number
       parts: Array<TextPartInput | FilePartInput | AgentPartInput | ConversationPartInput | SubtaskPartInput>
     },
     options?: Options<never, ThrowOnError>,
@@ -3840,6 +3841,7 @@ export class Session extends HeyApiClient {
             { in: "body", key: "system" },
             { in: "body", key: "variant" },
             { in: "body", key: "tier" },
+            { in: "body", key: "context" },
             { in: "body", key: "parts" },
           ],
         },
@@ -3921,6 +3923,7 @@ export class Session extends HeyApiClient {
       system?: string
       variant?: string
       tier?: string
+      context?: number
       parts: Array<TextPartInput | FilePartInput | AgentPartInput | ConversationPartInput | SubtaskPartInput>
     },
     options?: Options<never, ThrowOnError>,
@@ -3943,6 +3946,7 @@ export class Session extends HeyApiClient {
             { in: "body", key: "system" },
             { in: "body", key: "variant" },
             { in: "body", key: "tier" },
+            { in: "body", key: "context" },
             { in: "body", key: "parts" },
           ],
         },
@@ -3986,6 +3990,7 @@ export class Session extends HeyApiClient {
       }
       variant?: string
       tier?: string
+      context?: number
       parts?: Array<{
         id?: string
         type: "file"
@@ -4014,6 +4019,7 @@ export class Session extends HeyApiClient {
             { in: "body", key: "delegationSettings" },
             { in: "body", key: "variant" },
             { in: "body", key: "tier" },
+            { in: "body", key: "context" },
             { in: "body", key: "parts" },
           ],
         },

--- a/tooling/sdk/js/src/v2/gen/types.gen.ts
+++ b/tooling/sdk/js/src/v2/gen/types.gen.ts
@@ -262,6 +262,7 @@ export type UserMessage = {
   }
   variant?: string
   tier?: string
+  context?: number
   inference?: {
     source: "managed" | "byok" | "chatgpt" | "local" | "oauth" | "unknown"
     effort: string
@@ -1654,6 +1655,16 @@ export type ProviderConfig = {
         output: number
         cache_read?: number
         cache_write?: number
+        tiers?: Array<{
+          input: number
+          output: number
+          cache_read?: number
+          cache_write?: number
+          tier: {
+            type: "context"
+            size: number
+          }
+        }>
         context_over_200k?: {
           input: number
           output: number
@@ -2155,6 +2166,15 @@ export type Model = {
       read: number
       write: number
     }
+    tiers?: Array<{
+      input: number
+      output: number
+      cache: {
+        read: number
+        write: number
+      }
+      threshold: number
+    }>
     experimentalOver200K?: {
       input: number
       output: number
@@ -11542,6 +11562,7 @@ export type SessionPromptData = {
     system?: string
     variant?: string
     tier?: string
+    context?: number
     parts: Array<TextPartInput | FilePartInput | AgentPartInput | ConversationPartInput | SubtaskPartInput>
   }
   path: {
@@ -11740,6 +11761,7 @@ export type SessionPromptAsyncData = {
     system?: string
     variant?: string
     tier?: string
+    context?: number
     parts: Array<TextPartInput | FilePartInput | AgentPartInput | ConversationPartInput | SubtaskPartInput>
   }
   path: {
@@ -11795,6 +11817,7 @@ export type SessionCommandData = {
     }
     variant?: string
     tier?: string
+    context?: number
     parts?: Array<{
       id?: string
       type: "file"

--- a/tooling/sdk/openapi.json
+++ b/tooling/sdk/openapi.json
@@ -30033,6 +30033,11 @@
                   "tier": {
                     "type": "string"
                   },
+                  "context": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  },
                   "parts": {
                     "type": "array",
                     "items": {
@@ -30468,6 +30473,11 @@
                   "tier": {
                     "type": "string"
                   },
+                  "context": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  },
                   "parts": {
                     "type": "array",
                     "items": {
@@ -30648,6 +30658,11 @@
                   },
                   "tier": {
                     "type": "string"
+                  },
+                  "context": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
                   },
                   "parts": {
                     "type": "array",
@@ -53373,6 +53388,11 @@
           "tier": {
             "type": "string"
           },
+          "context": {
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991
+          },
           "inference": {
             "type": "object",
             "properties": {
@@ -57259,6 +57279,48 @@
                     "cache_write": {
                       "type": "number"
                     },
+                    "tiers": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "input": {
+                            "type": "number"
+                          },
+                          "output": {
+                            "type": "number"
+                          },
+                          "cache_read": {
+                            "type": "number"
+                          },
+                          "cache_write": {
+                            "type": "number"
+                          },
+                          "tier": {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "const": "context"
+                              },
+                              "size": {
+                                "type": "number",
+                                "exclusiveMinimum": 0
+                              }
+                            },
+                            "required": [
+                              "type",
+                              "size"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "input",
+                          "output",
+                          "tier"
+                        ]
+                      }
+                    },
                     "context_over_200k": {
                       "type": "object",
                       "properties": {
@@ -58480,6 +58542,45 @@
                   "read",
                   "write"
                 ]
+              },
+              "tiers": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "input": {
+                      "type": "number"
+                    },
+                    "output": {
+                      "type": "number"
+                    },
+                    "cache": {
+                      "type": "object",
+                      "properties": {
+                        "read": {
+                          "type": "number"
+                        },
+                        "write": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "threshold": {
+                      "type": "number",
+                      "exclusiveMinimum": 0
+                    }
+                  },
+                  "required": [
+                    "input",
+                    "output",
+                    "cache",
+                    "threshold"
+                  ]
+                }
               },
               "experimentalOver200K": {
                 "type": "object",


### PR DESCRIPTION
## Summary

- add exact context-tier prices and user-selectable context caps, plus Standard, Fast, and supported reasoning-effort variants
- keep `google/gemini-3-pro-image` out of every chat-model picker and pin image generation to that model
- resolve image credentials in order from saved Gemini/OpenRouter credentials to the independent workspace-managed image fallback, even when chat uses BYOK
- route Fast mode through OpenRouter throughput selection and preserve exact tier billing
- regenerate the JavaScript SDK for the updated context contract

## Verification

- 113 focused CLI billing, provider, catalog, image, credential, and sync tests passed
- 38 workspace UI and generated-SDK contract tests passed
- root typecheck: 7/7 tasks passed
- workspace production build passed
- cross-platform CLI build passed
- 21st UI review: 0 findings
- exhaustive CLI suite: 3260 passed, 22 skipped; one process-isolation flake passed on isolated rerun, while one unrelated macOS updater test remains at its hardcoded 15-second timeout

This PR is intentionally not merged.