### PR TITLE
fix(desktop): render splash pages as UTF-8

### DIFF
--- a/backend/cli/test/installation/desktop-shell-contract.test.ts
+++ b/backend/cli/test/installation/desktop-shell-contract.test.ts
@@ -6,6 +6,13 @@ test("lists existing macOS windows before the New Window Dock action", async () 
   expect(dock.indexOf("...entries")).toBeLessThan(dock.indexOf('label: "New Window"'))
 })
 
+test("declares UTF-8 for every inline desktop document", async () => {
+  const source = await Bun.file(new URL("../../../../frontend/desktop/src/main.mjs", import.meta.url)).text()
+
+  expect(source).not.toContain("data:text/html,")
+  expect(source.match(/data:text\/html;charset=utf-8,/g)).toHaveLength(3)
+})
+
 test("wires the packaged macOS shell to the authenticated desktop updater", async () => {
   const source = await Bun.file(new URL("../../../../frontend/desktop/src/main.mjs", import.meta.url)).text()
   const updater = await Bun.file(new URL("../../../../frontend/desktop/src/updater.mjs", import.meta.url)).text()

--- a/frontend/desktop/src/main.mjs
+++ b/frontend/desktop/src/main.mjs
@@ -604,7 +604,7 @@ async function bootstrap(splash) {
   })
   if (prompt.response !== 0) return false
   await splash.loadURL(
-    `data:text/html,${encodeURIComponent('<main style="background:#11110f;color:#e8e5dc;display:grid;font:14px system-ui;height:100vh;margin:0;place-items:center"><div><h1 style="font-size:20px;margin:0 0 8px">OpenScience</h1><p style="color:#9d998f;margin:0">Installing in Applications…</p></div></main>')}`,
+    `data:text/html;charset=utf-8,${encodeURIComponent('<main style="background:#11110f;color:#e8e5dc;display:grid;font:14px system-ui;height:100vh;margin:0;place-items:center"><div><h1 style="font-size:20px;margin:0 0 8px">OpenScience</h1><p style="color:#9d998f;margin:0">Installing in Applications…</p></div></main>')}`,
   )
   let staged
   try {
@@ -912,7 +912,7 @@ app
         },
       })
       await splash.loadURL(
-        `data:text/html,${encodeURIComponent('<main style="background:#11110f;color:#e8e5dc;display:grid;font:14px system-ui;height:100vh;margin:0;place-items:center"><div><h1 style="font-size:20px;margin:0 0 8px">OpenScience</h1><p style="color:#9d998f;margin:0">Starting your local workspace…</p></div></main>')}`,
+        `data:text/html;charset=utf-8,${encodeURIComponent('<main style="background:#11110f;color:#e8e5dc;display:grid;font:14px system-ui;height:100vh;margin:0;place-items:center"><div><h1 style="font-size:20px;margin:0 0 8px">OpenScience</h1><p style="color:#9d998f;margin:0">Starting your local workspace…</p></div></main>')}`,
       )
       splash.show()
       if (await bootstrap(splash)) return
@@ -966,7 +966,7 @@ app
         return
       }
       await splash.loadURL(
-        `data:text/html,${encodeURIComponent(`<main style="font:16px system-ui;padding:48px"><h1>OpenScience could not start</h1><p>${html(message)}</p></main>`)}`,
+        `data:text/html;charset=utf-8,${encodeURIComponent(`<main style="font:16px system-ui;padding:48px"><h1>OpenScience could not start</h1><p>${html(message)}</p></main>`)}`,
       )
     }
   })


### PR DESCRIPTION
## Summary
- declare UTF-8 on every inline Electron desktop document
- prevent the splash ellipsis and Unicode startup errors from rendering as mojibake
- add a regression contract covering all three inline pages

## Test Coverage
All changed paths are covered by the desktop shell contract. The regression rejects the prior unqualified `data:text/html,` form and pins all three UTF-8 documents.

## Pre-Landing Review
No issues found. Independent review confirmed the MIME charset fixes the exact `%E2%80%A6` → `â€¦` failure mode.

## Design Review
No design issues found; this preserves the existing splash layout and corrects text decoding only.

## Verification
- [x] 32 desktop installer/updater/shell tests pass
- [x] `node --check frontend/desktop/src/main.mjs`
- [x] scoped Prettier check
- [x] `git diff --check`

## Release
No source version/changelog edit: this repository's signed publish workflow creates the patch release commit and changelog metadata after merge.
