### PR TITLE
fix(release): resume desktop assets outside checkout

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -387,7 +387,7 @@ jobs:
           DESKTOP_ASSETS: ${{ matrix.assets }}
         run: |
           set -euo pipefail
-          release="$(gh release view "$OPENSCIENCE_TAG" --json assets)"
+          release="$(gh release view "$OPENSCIENCE_TAG" --repo "$GITHUB_REPOSITORY" --json assets)"
           source_label="${OPENSCIENCE_ARTIFACT_SOURCE:0:16}"
           found=0
           total=0

--- a/backend/cli/test/installation/release-order.test.ts
+++ b/backend/cli/test/installation/release-order.test.ts
@@ -52,6 +52,8 @@ test("release caches and resumed mac assets are bound and reverified", async () 
   const workflow = await read(".github/workflows/publish.yml")
   const version = await read("tooling/repo/version.ts")
 
+  expect(workflow).toContain('gh release view "$OPENSCIENCE_TAG" --repo "$GITHUB_REPOSITORY" --json assets')
+
   expect(workflow).toContain(
     "key: cli-build-${{ needs.version.outputs.version }}-${{ needs.version.outputs.artifact_source }}",
   )


### PR DESCRIPTION
Qualify the draft release lookup with the repository before checkout so desktop resume checks work on hosted runners. Adds a focused workflow contract assertion.