### PR TITLE
fix(release): pin native macOS architectures

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -336,14 +336,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: macos-14
+          - runner: macos-15
             target: mac
             arch: arm64
             sidecar: backend/cli/dist/@synsci/openscience-darwin-arm64/bin/openscience
             asset: OpenScience-mac-arm64.dmg
             assets: OpenScience-mac-arm64.dmg OpenScience-mac-arm64.zip
             signing: mac
-          - runner: macos-14
+          - runner: macos-15-intel
             target: mac
             arch: x64
             sidecar: backend/cli/dist/@synsci/openscience-darwin-x64/bin/openscience

--- a/backend/cli/test/installation/release-order.test.ts
+++ b/backend/cli/test/installation/release-order.test.ts
@@ -40,6 +40,8 @@ test("production is a single release pass without a rehearsal gate", async () =>
 test("stable macOS artifacts remain signed, notarized, stapled, and smoked", async () => {
   const workflow = await read(".github/workflows/publish.yml")
 
+  expect(workflow).toContain("runner: macos-15")
+  expect(workflow).toContain("runner: macos-15-intel")
   expect(workflow).toContain("Apple-Actions/import-codesign-certs")
   expect(workflow).toContain("codesign --force --options runtime --timestamp")
   expect(workflow).toContain("xcrun notarytool submit")


### PR DESCRIPTION
Pin arm64 packaging to macos-15 and Intel packaging/smoke to macos-15-intel so architecture-native updater verification remains deterministic as GitHub runner aliases move.