### PR TITLE
fix(release): qualify resumed macOS downloads

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -433,7 +433,9 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
           set -euo pipefail
-          for name in $DESKTOP_ASSETS; do gh release download "$OPENSCIENCE_TAG" --pattern "$name"; done
+          for name in $DESKTOP_ASSETS; do
+            gh release download "$OPENSCIENCE_TAG" --repo "$GITHUB_REPOSITORY" --pattern "$name"
+          done
           dmg="$(find . -maxdepth 1 -name '*.dmg' -print -quit)"
           zip="$(find . -maxdepth 1 -name '*.zip' -print -quit)"
           codesign --verify --strict --verbose=2 "$dmg"

--- a/backend/cli/test/installation/release-order.test.ts
+++ b/backend/cli/test/installation/release-order.test.ts
@@ -55,6 +55,7 @@ test("release caches and resumed mac assets are bound and reverified", async () 
   const version = await read("tooling/repo/version.ts")
 
   expect(workflow).toContain('gh release view "$OPENSCIENCE_TAG" --repo "$GITHUB_REPOSITORY" --json assets')
+  expect(workflow).toContain('gh release download "$OPENSCIENCE_TAG" --repo "$GITHUB_REPOSITORY" --pattern "$name"')
 
   expect(workflow).toContain(
     "key: cli-build-${{ needs.version.outputs.version }}-${{ needs.version.outputs.artifact_source }}",


### PR DESCRIPTION
Pass the repository explicitly when a completed macOS asset set is verified without a checkout. This closes the remaining exact-version resume cwd assumption.