### PR TITLE
fix: restore full Ace managed inference

### DIFF
--- a/backend/cli/src/agent/agent.ts
+++ b/backend/cli/src/agent/agent.ts
@@ -25,6 +25,8 @@ import { ProjectTrust } from "@/project/trust"
 import { ProjectAccess } from "@/project/access"
 import { randomUUID } from "node:crypto"
 import { Flag } from "@/flag/flag"
+import { OpenScience } from "@/openscience"
+import { requiresWalletBalance, resolveCredentialSource } from "@/session/access-route"
 
 export namespace Agent {
   export const Info = z
@@ -551,6 +553,17 @@ export namespace Agent {
 
     const selected = input.model ?? (await Provider.defaultModel())
     const model = await Provider.getModel(selected.providerID, selected.modelID)
+    const credentialSource = await resolveCredentialSource(model.providerID, model.id)
+    const funding = credentialSource === "managed" ? await OpenScience.getFundingSnapshot() : undefined
+    if (requiresWalletBalance(credentialSource)) {
+      if (!funding) throw new Error("Ace could not snapshot the connected funding account. Sign in again.")
+      const balance = await OpenScience.getBalance(funding)
+      if (balance === null)
+        throw new Error("Ace could not verify the current balance. Retry when the connection returns.")
+      if (balance <= 0) {
+        throw new Error("Your Ace balance is empty. Add credits or switch model access to BYOK / Subscription.")
+      }
+    }
 
     const defaultModel = selected
     const language = await Provider.getLanguage(model)
@@ -597,7 +610,7 @@ export namespace Agent {
         })
       : undefined
 
-    const requestContext = { sessionID, messageID, attempt: 1 }
+    const requestContext = { sessionID, messageID, attempt: 1, ...(funding ? { funding } : {}) }
 
     if (oauthStream) {
       const result = Provider.withRequestContext(requestContext, () =>

--- a/backend/cli/src/auth/index.ts
+++ b/backend/cli/src/auth/index.ts
@@ -4,11 +4,14 @@ import { JsonStore } from "../util/jsonstore"
 import z from "zod"
 import { CredentialLifecycle } from "../credentials/lifecycle"
 import { isAtlasManagedKey } from "../credentials/managed-key"
+import { Config } from "../config/config"
+import { Log } from "../util/log"
 
 export const OAUTH_DUMMY_KEY = "synsc-oauth-dummy-key"
+const log = Log.create({ service: "auth" })
 
 export namespace Auth {
-  /** Detect retired product credentials so they cannot escape into provider calls.
+  /** Detect Ace account credentials so they cannot escape into direct provider calls.
    *  Canonical home: `auth/index.ts` is a near-leaf module (only
    *  path/global/jsonstore/zod besides this file's own Config import), so
    *  `provider.ts` - which already imports Auth - depends on this instead of
@@ -71,11 +74,51 @@ export namespace Auth {
 
   export async function set(key: string, info: Info) {
     if (info.type === "api" && isAtlasApiKey(info.key)) {
-      throw new Error("Managed workspace credentials are not supported. Connect a provider account you control.")
+      throw new Error(
+        "Ace workspace credentials belong to OpenScience sign-in, not provider keys. Sign in to Ace or add a provider key you control.",
+      )
     }
-    await CredentialLifecycle.mutate(`provider-auth.set:${key}`, () =>
-      JsonStore.update(filepath, (data) => ({ ...data, [key]: info })),
-    )
+    const selectsByok = key === "openrouter" && info.type === "api" && !isAtlasApiKey(info.key)
+    await CredentialLifecycle.mutate(`provider-auth.set:${key}`, async () => {
+      if (!selectsByok) {
+        await JsonStore.update(filepath, (data) => ({ ...data, [key]: info }))
+        return
+      }
+      const previous = await JsonStore.read(filepath)
+      const previousMode = (await Config.getGlobal()).billing?.llm ?? null
+      try {
+        await JsonStore.update(filepath, (data) => ({ ...data, [key]: info }))
+        const config = await Config.getGlobal()
+        if (config.billing?.llm === "managed") {
+          await Config.updateGlobal({ billing: { llm: "byok" } }, { preserveInstances: true })
+        }
+      } catch (cause) {
+        let credentialRollback: unknown
+        let modeRollback: unknown
+        try {
+          await JsonStore.update(filepath, () => previous)
+        } catch (error) {
+          credentialRollback = error
+        }
+        try {
+          await Config.updateGlobal({ billing: { llm: previousMode } }, { preserveInstances: true })
+        } catch (error) {
+          modeRollback = error
+        }
+        log.warn("OpenRouter BYOK handoff failed; compensation attempted", {
+          error: cause instanceof Error ? cause.message : String(cause),
+          credentialRollback: credentialRollback instanceof Error ? credentialRollback.message : credentialRollback,
+          modeRollback: modeRollback instanceof Error ? modeRollback.message : modeRollback,
+        })
+        if (credentialRollback || modeRollback) {
+          throw new AggregateError(
+            [cause, ...(credentialRollback ? [credentialRollback] : []), ...(modeRollback ? [modeRollback] : [])],
+            "OpenRouter setup failed and could not be fully restored. Review Customize → Models before retrying.",
+          )
+        }
+        throw cause
+      }
+    })
   }
 
   export async function remove(key: string) {

--- a/backend/cli/src/cli/cmd/billing.ts
+++ b/backend/cli/src/cli/cmd/billing.ts
@@ -1,0 +1,65 @@
+import * as prompts from "@clack/prompts"
+import { BILLING_URL } from "../../endpoints"
+import { OpenScience } from "../../openscience"
+import { ACE_CONTRACT, aceActivationCopy } from "../../openscience/ace-contract"
+import { openUrl } from "../../util/open-url"
+import { UI } from "../ui"
+import { cmd } from "./cmd"
+
+export const WalletCommand = cmd({
+  command: ["wallet", "billing"],
+  describe: "show your purchased Wallet balance and Ace model access",
+  builder: (yargs) => yargs.command(ShowCommand).command(TopupCommand).demandCommand(),
+  async handler() {},
+})
+
+const ShowCommand = cmd({
+  command: ["show", "$0"],
+  describe: "show purchased Wallet balance and model access",
+  async handler() {
+    UI.empty()
+    prompts.intro("OpenScience Wallet")
+
+    if (!(await OpenScience.getSession())) {
+      prompts.log.warn("Not authenticated. Run `openscience login` first.")
+      prompts.outro("Done")
+      return
+    }
+
+    const creditsRequest = OpenScience.getCredits()
+    const [mode, credits] = await Promise.all([OpenScience.getBillingMode(undefined, creditsRequest), creditsRequest])
+    prompts.log.info(credits ? `Purchased Wallet: $${credits.balanceUsd.toFixed(2)}` : "Purchased Wallet: unavailable")
+    if (!mode) {
+      prompts.log.error(`Model access is unavailable. Check your connection or visit ${BILLING_URL}`)
+      prompts.outro("Done")
+      return
+    }
+
+    prompts.log.info(`Model access: ${mode.mode === "managed" ? "Managed (Ace)" : "BYOK / Subscription"}`)
+    if (!mode.managed_supported) {
+      prompts.log.warn("Managed inference is not available for this account.")
+    }
+    if (mode.managed_supported && !mode.managed_unlocked) {
+      prompts.log.info("Turn on Ace in Settings to use managed models.")
+    }
+    prompts.log.info(`Manage your purchased Wallet and Ace at ${BILLING_URL}`)
+    prompts.outro("Done")
+  },
+})
+
+const TopupCommand = cmd({
+  command: "topup",
+  describe: "open billing to add purchased Wallet credit",
+  async handler() {
+    UI.empty()
+    prompts.intro("OpenScience Wallet")
+    prompts.log.info(`Open: ${BILLING_URL}`)
+    prompts.log.info(
+      `$${ACE_CONTRACT.reloadAmountUsd} adds $${ACE_CONTRACT.reloadAmountUsd} to your purchased Wallet; the processing fee is shown separately at checkout.`,
+    )
+    prompts.log.info(aceActivationCopy())
+    prompts.log.info("Provider accounts and local models never draw down your Wallet.")
+    openUrl(BILLING_URL)
+    prompts.outro("Done")
+  },
+})

--- a/backend/cli/src/cli/cmd/connect.ts
+++ b/backend/cli/src/cli/cmd/connect.ts
@@ -1,0 +1,209 @@
+import * as prompts from "@clack/prompts"
+import { OpenScience } from "../../openscience"
+import { MANAGED_API_BASE } from "../../endpoints"
+import { openUrl } from "../../util/open-url"
+import { UI } from "../ui"
+import { cmd } from "./cmd"
+
+function headless() {
+  if (!process.stdout.isTTY) return true
+  if (process.env.CI) return true
+  return process.platform === "linux" && !process.env.DISPLAY && !process.env.WAYLAND_DISPLAY
+}
+
+async function withKey(key: string) {
+  const spinner = prompts.spinner()
+  spinner.start("Validating key...")
+  return OpenScience.loginWithKey(key)
+    .then(() => {
+      spinner.stop("Authenticated")
+      return true
+    })
+    .catch((error) => {
+      spinner.stop("Login failed", 1)
+      prompts.log.error(error instanceof Error ? error.message : "Unknown error")
+      return false
+    })
+}
+
+async function withBrowser() {
+  return OpenScience.browserLogin({
+    onApprovalUrl(url) {
+      prompts.log.info("Opening your browser to approve this device...")
+      prompts.log.message(url)
+      openUrl(url)
+    },
+  })
+    .then(() => {
+      prompts.log.success("Authenticated")
+      return true
+    })
+    .catch((error) => {
+      const reason = error instanceof Error ? error.message : "Unknown error"
+      prompts.log.warn(`Browser login didn't complete: ${reason}`)
+      return false
+    })
+}
+
+async function manual() {
+  prompts.log.info("Finish login from any device with a browser:")
+  prompts.log.message(`1. Open ${OpenScience.authPageUrl()} and sign in\n2. Create an OpenScience API key and copy it`)
+
+  if (!process.stdin.isTTY) {
+    prompts.log.error("No interactive terminal. Re-run with `--key ...` or set SYNSC_CLI_KEY.")
+    return false
+  }
+
+  const key = await prompts.password({ message: "Paste your OpenScience API key" })
+  if (!prompts.isCancel(key)) return withKey(key)
+  prompts.cancel("Cancelled")
+  return false
+}
+
+/** Shared Ace sign-in used by the top-level login command and onboarding. */
+export async function runAtlasLogin(args: { key?: string; browser?: boolean } = {}) {
+  const session = await OpenScience.getSession()
+  if (session) {
+    prompts.log.success(`Already authenticated (backend: ${MANAGED_API_BASE})`)
+    return true
+  }
+
+  const key = args.key || process.env.SYNSC_CLI_KEY || process.env.SYNSC_API_KEY
+  if (key) return withKey(key)
+  if (args.browser !== false && !headless() && (await withBrowser())) return true
+  return manual()
+}
+
+export const LoginCommand = cmd({
+  command: "login",
+  describe: "log in to your Synthetic Sciences account for Ace and Wallet credits",
+  builder: (yargs) =>
+    yargs
+      .option("key", {
+        type: "string",
+        describe: "paste an OpenScience API key directly (for headless or CI machines)",
+      })
+      .option("browser", {
+        type: "boolean",
+        default: true,
+        describe: "open a browser to log in; pass --no-browser on headless machines",
+      }),
+  async handler(args) {
+    UI.empty()
+    prompts.intro("OpenScience Ace")
+    const ok = await runAtlasLogin({ key: args.key, browser: args.browser })
+    prompts.outro(ok ? "Done" : "Not signed in")
+  },
+})
+
+export const LogoutCommand = cmd({
+  command: "logout",
+  describe: "log out of your Synthetic Sciences account",
+  async handler() {
+    UI.empty()
+    prompts.intro("OpenScience Ace")
+
+    const session = await OpenScience.getSession()
+    if (!session) {
+      prompts.log.warn("Not signed in to Synthetic Sciences.")
+      prompts.log.info("To remove a provider account instead, use `openscience disconnect` or `openscience keys rm`.")
+      prompts.outro("Done")
+      return
+    }
+
+    const revoked = await OpenScience.revokeCurrentDevice()
+    await OpenScience.clearSession()
+    prompts.log.success("Signed out of Synthetic Sciences")
+    if (!revoked) {
+      prompts.log.info("This device could not be revoked remotely. You can remove it from your account settings.")
+    }
+    prompts.outro("Done")
+  },
+})
+
+export const StatusCommand = cmd({
+  command: ["status", "whoami"],
+  describe: "show your Ace account, model access, and purchased Wallet balance",
+  async handler() {
+    UI.empty()
+    prompts.intro("OpenScience Ace")
+
+    const session = await OpenScience.getSession()
+    if (!session) {
+      prompts.log.warn("Not connected to Synthetic Sciences")
+      prompts.log.info("Run `openscience login` for Ace, or connect your own provider account.")
+      prompts.outro("Done")
+      return
+    }
+
+    prompts.log.success("Connected")
+    prompts.log.info(`Backend: ${MANAGED_API_BASE}`)
+    if (session.user_id) prompts.log.info(`User: ${session.user_id}`)
+    if (session.device_name) prompts.log.info(`Device: ${session.device_name}`)
+
+    const creditsRequest = OpenScience.getCredits().catch(() => null)
+    const [profile, mode, credits, transactions] = await Promise.all([
+      OpenScience.getProfile().catch(() => null),
+      OpenScience.getBillingMode(undefined, creditsRequest).catch(() => null),
+      creditsRequest,
+      OpenScience.getTransactions(5).catch(() => null),
+    ])
+    if (profile?.display_name) prompts.log.info(`Name: ${profile.display_name}`)
+    if (profile?.email) prompts.log.info(`Email: ${profile.email}`)
+    if (!profile) prompts.log.warn("Saved locally; account status is currently unavailable.")
+
+    if (credits) {
+      const spent =
+        credits.lifetimeSpentCents === null ? "" : ` (spent $${(credits.lifetimeSpentCents / 100).toFixed(2)} lifetime)`
+      prompts.log.info(`Purchased Wallet: $${credits.balanceUsd.toFixed(2)}${spent}`)
+    }
+    if (mode) {
+      prompts.log.info(`Model access: ${mode.mode === "managed" ? "Managed (Ace)" : "BYOK / Subscription"}`)
+      if (mode.mode === "managed" && !mode.managed_supported) prompts.log.warn("Managed inference is unavailable.")
+      if (mode.mode === "managed" && mode.managed_supported && !mode.managed_unlocked) {
+        prompts.log.warn("Ace needs to be enabled before managed inference can run.")
+      }
+    }
+    if (transactions?.length) {
+      const latest = transactions[0].description.slice(0, 64)
+      prompts.log.info(
+        `Recent Wallet activity: ${transactions.length} ${transactions.length === 1 ? "entry" : "entries"}${latest ? ` — ${latest}` : ""}`,
+      )
+    }
+    prompts.outro("Done")
+  },
+})
+
+export const DevicesCommand = cmd({
+  command: "devices",
+  describe: "list devices signed in to your Synthetic Sciences account",
+  async handler() {
+    UI.empty()
+    prompts.intro("OpenScience Ace")
+
+    if (!(await OpenScience.getSession())) {
+      prompts.log.warn("Not connected")
+      prompts.log.info("Run `openscience login` to authenticate")
+      prompts.outro("Done")
+      return
+    }
+
+    const devices = await OpenScience.listDevices()
+    if (!devices) {
+      prompts.log.error("Failed to list devices")
+      prompts.outro("Done")
+      return
+    }
+    if (!devices.length) {
+      prompts.log.info("No active devices")
+      prompts.outro("Done")
+      return
+    }
+    for (const device of devices) {
+      const last = device.last_used_at ? new Date(device.last_used_at).toLocaleString() : "never"
+      prompts.log.info(`${device.name}  [${device.key_prefix}…]  last used: ${last}`)
+    }
+    prompts.log.info("Revoke devices from your Synthetic Sciences account settings.")
+    prompts.outro("Done")
+  },
+})

--- a/backend/cli/src/config/config.ts
+++ b/backend/cli/src/config/config.ts
@@ -223,9 +223,6 @@ export namespace Config {
       }
     }
 
-    result.billing = { ...result.billing, llm: "byok" as const }
-    execution.billing = { ...execution.billing, llm: "byok" as const }
-
     // Migrate deprecated mode field to agent field
     for (const [name, mode] of Object.entries(result.mode ?? {})) {
       result.agent = mergeDeep(result.agent ?? {}, {
@@ -1177,12 +1174,11 @@ export namespace Config {
       billing: z
         .object({
           llm: z
-            .literal("byok")
+            .enum(["managed", "byok"])
             .nullable()
             .optional()
-            .catch("byok")
             .describe(
-              "Provider access uses your own API keys, first-party OAuth subscriptions, or local models. Legacy values are migrated to 'byok'.",
+              "How LLM inference is paid for. 'managed' uses Ace Credits; 'byok' uses only user-owned keys, subscriptions, or local models.",
             ),
           compute: z
             .literal("byok")
@@ -1193,7 +1189,7 @@ export namespace Config {
             ),
         })
         .optional()
-        .describe("Provider access configuration. OpenScience uses only user-owned credentials."),
+        .describe("Provider access configuration for Ace or user-owned credentials."),
       username: z
         .string()
         .optional()
@@ -1426,7 +1422,7 @@ export namespace Config {
         .catch(() => {})
     }
 
-    return { ...result, billing: { ...result.billing, llm: "byok" as const } }
+    return result
   })
 
   async function loadFile(filepath: string): Promise<Info> {

--- a/backend/cli/src/endpoints.ts
+++ b/backend/cli/src/endpoints.ts
@@ -1,0 +1,32 @@
+/** Public managed-backend endpoint resolver. */
+export const DEFAULT_MANAGED_API_BASE = "https://app.syntheticsciences.ai"
+
+function stripTrailingSlashes(url: string): string {
+  return url.replace(/\/+$/, "")
+}
+
+export const MANAGED_API_BASE_ENV_KEYS = [
+  "OPENSCIENCE_API_BASE",
+  "SYNSC_API_BASE",
+  "MANAGED_API_BASE",
+  "ATLAS_BASE_URL",
+  "THESIS_BASE_URL",
+] as const
+
+export function managedApiBase(env: NodeJS.ProcessEnv = process.env): string {
+  const override = MANAGED_API_BASE_ENV_KEYS.map((key) => env[key]).find((value) => !!value)
+  return stripTrailingSlashes(override || DEFAULT_MANAGED_API_BASE)
+}
+
+export function dashboardUrl(pathname: string, env: NodeJS.ProcessEnv = process.env): string {
+  const frontend = env.SYNSC_AUTH_URL?.trim() || managedApiBase(env)
+  const fallback = new URL(pathname, `${DEFAULT_MANAGED_API_BASE}/`).toString()
+  try {
+    return new URL(pathname, `${stripTrailingSlashes(frontend)}/`).toString()
+  } catch {
+    return fallback
+  }
+}
+
+export const MANAGED_API_BASE = managedApiBase()
+export const BILLING_URL = dashboardUrl("/billing")

--- a/backend/cli/src/index.ts
+++ b/backend/cli/src/index.ts
@@ -28,6 +28,8 @@ import { EOL } from "os"
 import { WebCommand } from "./cli/cmd/web"
 import { PrCommand } from "./cli/cmd/pr"
 import { SessionCommand } from "./cli/cmd/session"
+import { DevicesCommand, LoginCommand, LogoutCommand, StatusCommand } from "./cli/cmd/connect"
+import { WalletCommand } from "./cli/cmd/billing"
 import { KeysCommand, ConnectCommand, DisconnectCommand } from "./cli/cmd/auth"
 import { LocalCommand } from "./cli/cmd/local"
 import { SandboxCommand } from "./cli/cmd/sandbox"
@@ -200,7 +202,12 @@ const cli = yargs(hideBin(process.argv))
   .command(PrCommand)
   .command(SessionCommand)
   .command(InitCommand)
+  .command(LoginCommand)
+  .command(LogoutCommand)
+  .command(StatusCommand)
+  .command(DevicesCommand)
   .command(KeysCommand)
+  .command(WalletCommand)
   .command(DoctorCommand)
   .command(ConnectCommand)
   .command(DisconnectCommand)

--- a/backend/cli/src/openscience/ace-contract.ts
+++ b/backend/cli/src/openscience/ace-contract.ts
@@ -1,0 +1,13 @@
+/** Public Ace terms mirrored by the local client. Atlas remains authoritative. */
+export const ACE_CONTRACT = Object.freeze({
+  activationAuthorizationUsd: 0,
+  reloadThresholdUsd: 5,
+  reloadAmountUsd: 20,
+  serviceMarginPercent: 2,
+  processingFeeDisclosedSeparately: true,
+  reloadControlledByAce: true,
+})
+
+export function aceActivationCopy() {
+  return `Ace is a $${ACE_CONTRACT.activationAuthorizationUsd} authorization, not a purchase or subscription. While Ace is on, a purchased Wallet balance below $${ACE_CONTRACT.reloadThresholdUsd} triggers one fixed $${ACE_CONTRACT.reloadAmountUsd} reload; the processing fee is disclosed separately before payment.`
+}

--- a/backend/cli/src/openscience/index.ts
+++ b/backend/cli/src/openscience/index.ts
@@ -1,21 +1,21 @@
 import os from "node:os"
 import path from "node:path"
+import fs from "node:fs/promises"
+import { existsSync } from "node:fs"
+import { createHash, randomUUID } from "node:crypto"
 import { Auth } from "@/auth"
 import { CredentialLifecycle } from "@/credentials/lifecycle"
-import { isAtlasManagedKey } from "@/credentials/managed-key"
+import { isAtlasManagedKey, isWorkspaceKey } from "@/credentials/managed-key"
 import { Global } from "@/global"
+import { DataRootBarrier } from "@/global/data-root-barrier"
 import { ToolOutputPath } from "@/tool/tool-output-path"
+import { Lock } from "@/util/lock"
+import { Log } from "@/util/log"
+import { BILLING_URL, DEFAULT_MANAGED_API_BASE, MANAGED_API_BASE } from "@/endpoints"
 import { BYOK_LLM_ENV_KEYS, LOCAL_COMPUTE_CLI_ENV_KEYS, SYNCED_SERVICE_ENV_KEYS } from "./synced-env-policy"
 
-/**
- * Local runtime boundary.
- *
- * OpenScience has no product account, hosted inference, wallet, usage
- * reporting, credential sync, or telemetry transport. This module keeps the
- * local security helpers that sanitize child processes and redact secrets. A
- * few explicitly disabled methods remain as narrow compatibility seams for
- * older provider code; none performs network or account work.
- */
+const log = Log.create({ service: "openscience" })
+export const API_BASE = MANAGED_API_BASE
 
 export interface OpenScienceSession {
   api_key: string
@@ -25,12 +25,40 @@ export interface OpenScienceSession {
   workspace_locked?: boolean
 }
 
+export interface FundingOrganization {
+  organization_id: string
+  name: string
+  slug: string
+  is_personal: boolean
+  status: string
+  role: string
+  membership_status: string
+  funding_available: boolean
+  effective_permissions: string[]
+}
+
 export interface FundingSnapshot {
   readonly api_key: string
   readonly user_id: string
   readonly account: string
   readonly organization_id?: string
   readonly workspace_locked?: boolean
+}
+
+export interface FundingContext {
+  type: "personal" | "organization"
+  organization_id?: string
+  available: boolean
+  locked: boolean
+  organizations: FundingOrganization[]
+}
+
+export interface AccountProfile {
+  user_id?: string
+  email?: string | null
+  display_name?: string | null
+  github_username?: string | null
+  [key: string]: unknown
 }
 
 export interface ResearchSearchInput {
@@ -161,28 +189,338 @@ const BYOK_SUBPROCESS_PROVIDERS: Record<string, { keys: string[]; baseUrl?: stri
   },
 }
 
+export class InsufficientCreditsError extends Error {
+  constructor(message = `Credits are empty. Add credits at ${BILLING_URL} or switch back to your own keys.`) {
+    super(message)
+    this.name = "InsufficientCreditsError"
+  }
+}
+
+const SESSION_PATH = path.join(Global.Path.data, "openscience-session.json")
+const SCOPE_PATH = path.join(Global.Path.data, "openscience-workspace-scope.json")
+const FUNDING_PROTOCOL = "1"
+const FUNDING_PROTOCOL_HEADER = "OpenScience-Funding-Protocol"
+const FUNDING_CONTEXT_HEADER = "OpenScience-Funding-Context"
+const ATLAS_FETCH_TIMEOUT_MS = Number(process.env.OPENSCIENCE_ATLAS_TIMEOUT_MS) || 60_000
+const VERIFICATION_PAGE = process.env.SYNSC_AUTH_URL?.replace(/\/+$/, "") || `${DEFAULT_MANAGED_API_BASE}/cli`
+
+interface WorkspaceScope {
+  protocol: 1
+  key_fingerprint: string
+  organization_id?: string
+  workspace_locked: true
+}
+
+interface AuthStatusResponse {
+  user?: AccountProfile
+  organizations?: unknown
+  available_organizations?: unknown
+  api_key?: { organization_id?: unknown; workspace_locked?: unknown }
+  funding_context?: { type?: "personal" | "organization"; organization_id?: string; locked?: boolean }
+}
+
+function isAccountKey(value: unknown): value is string {
+  return typeof value === "string" && (value.startsWith("thk_") || value.startsWith("osk_"))
+}
+
+function validOrganizationID(value: unknown): value is string {
+  return typeof value === "string" && /^[A-Za-z0-9_-]{1,128}$/.test(value)
+}
+
+function loginOrganizationID(value: unknown): string | undefined {
+  if (value === undefined || value === null || value === "") return undefined
+  if (validOrganizationID(value)) return value
+  throw new Error("Login returned an invalid organization id.")
+}
+
+function keyFingerprint(key: string): string {
+  return createHash("sha256").update(key).digest("hex")
+}
+
+function accountTag(session: Pick<OpenScienceSession, "api_key" | "user_id">): string {
+  return session.user_id || `k:${keyFingerprint(session.api_key).slice(0, 16)}`
+}
+
+function contextTag(session: Pick<OpenScienceSession, "api_key" | "user_id" | "organization_id">): string {
+  return `${accountTag(session)}\0${session.organization_id ? `organization:${session.organization_id}` : "personal"}`
+}
+
+async function atomicWrite(filepath: string, content: string, mode = 0o600): Promise<void> {
+  await using operation = await DataRootBarrier.enter(filepath)
+  const temp = `${filepath}.${process.pid}.${randomUUID()}.tmp`
+  await fs.mkdir(path.dirname(filepath), { recursive: true })
+  try {
+    const handle = await fs.open(temp, "wx", mode)
+    await handle
+      .writeFile(content, "utf8")
+      .then(() => (process.platform === "win32" ? undefined : handle.chmod(mode)))
+      .then(() => handle.sync())
+      .finally(() => handle.close())
+    await fs.rename(temp, filepath)
+    const directory = await fs.open(path.dirname(filepath), "r").catch(() => undefined)
+    await directory?.sync().catch(() => undefined)
+    await directory?.close().catch(() => undefined)
+  } catch (error) {
+    await fs.rm(temp, { force: true }).catch(() => undefined)
+    throw error
+  }
+}
+
+function atlasFetch(input: string, init: RequestInit = {}, timeoutMs = ATLAS_FETCH_TIMEOUT_MS): Promise<Response> {
+  const timeout = AbortSignal.timeout(timeoutMs)
+  const signal = init.signal ? AbortSignal.any([init.signal, timeout]) : timeout
+  return fetch(input, { ...init, signal })
+}
+
+async function readWorkspaceScope(key: string): Promise<WorkspaceScope | null | undefined> {
+  if (!existsSync(SCOPE_PATH)) return undefined
+  try {
+    const value = (await Bun.file(SCOPE_PATH).json()) as Partial<WorkspaceScope>
+    if (value.protocol !== 1 || value.workspace_locked !== true) return null
+    if (value.key_fingerprint !== keyFingerprint(key)) return undefined
+    if (value.organization_id !== undefined && !validOrganizationID(value.organization_id)) return null
+    return {
+      protocol: 1,
+      key_fingerprint: value.key_fingerprint,
+      ...(value.organization_id ? { organization_id: value.organization_id } : {}),
+      workspace_locked: true,
+    }
+  } catch {
+    return null
+  }
+}
+
+async function writeWorkspaceScope(session: OpenScienceSession): Promise<void> {
+  if (!session.workspace_locked) {
+    if (isWorkspaceKey(session.api_key))
+      throw new FundingContextError("Workspace credentials require an immutable workspace.")
+    await fs.rm(SCOPE_PATH, { force: true }).catch(() => undefined)
+    return
+  }
+  if (isWorkspaceKey(session.api_key) && !session.organization_id) {
+    throw new FundingContextError("A workspace credential is missing its workspace id.")
+  }
+  await atomicWrite(
+    SCOPE_PATH,
+    JSON.stringify(
+      {
+        protocol: 1,
+        key_fingerprint: keyFingerprint(session.api_key),
+        ...(session.organization_id ? { organization_id: session.organization_id } : {}),
+        workspace_locked: true,
+      } satisfies WorkspaceScope,
+      null,
+      2,
+    ),
+  )
+}
+
+function organizations(value: unknown): FundingOrganization[] {
+  if (!Array.isArray(value)) return []
+  return value.flatMap((item) => {
+    if (!item || typeof item !== "object" || Array.isArray(item)) return []
+    const row = item as Record<string, unknown>
+    const id = typeof row.organization_id === "string" ? row.organization_id : row.id
+    if (!validOrganizationID(id) || typeof row.name !== "string" || !row.name.trim()) return []
+    return [
+      {
+        organization_id: id,
+        name: row.name,
+        slug: typeof row.slug === "string" ? row.slug : "",
+        is_personal: row.is_personal === true,
+        status: typeof row.status === "string" ? row.status : "active",
+        role: typeof row.role === "string" ? row.role : "member",
+        membership_status: typeof row.membership_status === "string" ? row.membership_status : "active",
+        funding_available: row.funding_available === true,
+        effective_permissions: Array.isArray(row.effective_permissions)
+          ? row.effective_permissions.filter((value): value is string => typeof value === "string")
+          : [],
+      },
+    ]
+  })
+}
+
+function organizationAvailable(row: FundingOrganization | undefined): boolean {
+  return (
+    !!row &&
+    row.status === "active" &&
+    row.membership_status === "active" &&
+    row.funding_available &&
+    row.effective_permissions.includes("use_shared_wallet")
+  )
+}
+
+async function accountAtlasFetch(
+  session: Pick<OpenScienceSession, "api_key" | "organization_id">,
+  input: string,
+  init: RequestInit = {},
+  funding = false,
+  timeoutMs = ATLAS_FETCH_TIMEOUT_MS,
+): Promise<Response> {
+  const headers = new Headers(init.headers)
+  headers.set("Authorization", `Bearer ${session.api_key}`)
+  headers.delete("X-Organization-ID")
+  headers.delete(FUNDING_PROTOCOL_HEADER)
+  if (funding) {
+    headers.set(FUNDING_PROTOCOL_HEADER, FUNDING_PROTOCOL)
+    if (session.organization_id) headers.set("X-Organization-ID", session.organization_id)
+  }
+  const response = await atlasFetch(input, { ...init, headers }, timeoutMs)
+  if (response.status === 401) void OpenScience.clearSession(session.api_key).catch(() => undefined)
+  return response
+}
+
+async function authenticatedAtlasFetch(
+  session: OpenScienceSession,
+  input: string,
+  init: RequestInit = {},
+): Promise<Response> {
+  return accountAtlasFetch(session, input, init, false)
+}
+
+async function fundedAtlasFetch(
+  session: FundingSnapshot | OpenScienceSession,
+  input: string,
+  init: RequestInit = {},
+): Promise<Response> {
+  const response = await accountAtlasFetch(session, input, init, true)
+  return OpenScience.validateFundingResponse(response, session)
+}
+
 export namespace OpenScience {
   export async function getSession(): Promise<OpenScienceSession | null> {
-    return null
+    if (!existsSync(SESSION_PATH)) return null
+    try {
+      const data = (await Bun.file(SESSION_PATH).json()) as Partial<OpenScienceSession>
+      if (!isAccountKey(data.api_key)) return null
+      const persistedOrganizationID = loginOrganizationID(data.organization_id)
+      const scope = await readWorkspaceScope(data.api_key)
+      if (scope === null) throw new FundingContextError("The saved workspace scope is invalid. Sign in again.")
+      const organizationID = scope ? scope.organization_id : persistedOrganizationID
+      const locked = scope?.workspace_locked === true || data.workspace_locked === true
+      return {
+        api_key: data.api_key,
+        user_id: typeof data.user_id === "string" ? data.user_id : "",
+        device_name: typeof data.device_name === "string" ? data.device_name : undefined,
+        ...(organizationID ? { organization_id: organizationID } : {}),
+        ...(locked ? { workspace_locked: true } : {}),
+      }
+    } catch (error) {
+      log.warn("could not read account session", { error: error instanceof Error ? error.message : String(error) })
+      return null
+    }
+  }
+
+  export async function saveSession(session: OpenScienceSession): Promise<void> {
+    if (!isAccountKey(session.api_key)) throw new Error("Invalid OpenScience account key.")
+    if (session.organization_id !== undefined && !validOrganizationID(session.organization_id)) {
+      throw new Error("Invalid organization id.")
+    }
+    await CredentialLifecycle.mutate("managed-session.set", async () => {
+      using _ = await Lock.write(SESSION_PATH)
+      await writeWorkspaceScope(session)
+      await atomicWrite(SESSION_PATH, JSON.stringify(session, null, 2))
+    })
+    invalidateBalance()
+    const { Provider } = await import("@/provider/provider")
+    Provider.invalidate()
+  }
+
+  export async function clearSession(expectedApiKey?: string): Promise<boolean> {
+    const action = async () => {
+      using _ = await Lock.write(SESSION_PATH)
+      if (expectedApiKey && (await getSession())?.api_key !== expectedApiKey) return false
+      await fs.rm(SESSION_PATH, { force: true })
+      await fs.rm(SCOPE_PATH, { force: true })
+      return true
+    }
+    const result = await CredentialLifecycle.mutate("managed-session.clear", action)
+    if (result) {
+      invalidateBalance()
+      const { Provider } = await import("@/provider/provider")
+      Provider.invalidate()
+    }
+    return result
+  }
+
+  export async function isAuthenticated(): Promise<boolean> {
+    return (await getSession()) !== null
+  }
+
+  export function deviceName(): string {
+    let host = "device"
+    try {
+      host = os.hostname().split(".")[0] || host
+    } catch {}
+    return `openscience · ${process.platform} · ${host}`
+  }
+
+  export function authPageUrl(): string {
+    return VERIFICATION_PAGE
   }
 
   export async function getFundingSnapshot(): Promise<FundingSnapshot | null> {
-    return null
+    const session = await getSession()
+    if (!session) return null
+    return Object.freeze({
+      api_key: session.api_key,
+      user_id: session.user_id,
+      account: accountTag(session),
+      ...(session.organization_id ? { organization_id: session.organization_id } : {}),
+      ...(session.workspace_locked ? { workspace_locked: true } : {}),
+    })
   }
 
   export async function managedRequestSnapshot(
-    _apiKey?: string,
-    _snapshot?: FundingSnapshot | null,
+    apiKey?: string,
+    snapshot?: FundingSnapshot | null,
   ): Promise<FundingSnapshot> {
-    throw new FundingContextError("Retired product routes are not supported. Connect a provider account you control.")
+    if (!apiKey || !isAtlasManagedKey(apiKey)) throw new FundingContextError("Expected an Atlas managed API key.")
+    const selected = snapshot ?? (await getFundingSnapshot())
+    if (selected) {
+      if (selected.api_key !== apiKey) {
+        throw new FundingContextError("The connected account changed during managed inference. Retry it.")
+      }
+      return selected
+    }
+    if (existsSync(SESSION_PATH)) {
+      throw new FundingContextError("OpenScience could not safely read the selected funding account. Sign in again.")
+    }
+    if (isWorkspaceKey(apiKey)) {
+      throw new FundingContextError("A workspace credential requires a saved workspace scope. Sign in again.")
+    }
+    return Object.freeze({ api_key: apiKey, user_id: "", account: accountTag({ api_key: apiKey, user_id: "" }) })
   }
 
-  export function fundingHeaders(_snapshot: FundingSnapshot): Record<string, string> {
-    return {}
+  export function fundingHeaders(snapshot: FundingSnapshot): Record<string, string> {
+    return {
+      [FUNDING_PROTOCOL_HEADER]: FUNDING_PROTOCOL,
+      ...(snapshot.organization_id ? { "X-Organization-ID": snapshot.organization_id } : {}),
+    }
   }
 
-  export async function validateFundingResponse(response: Response, _snapshot?: FundingSnapshot): Promise<Response> {
-    return response
+  export async function validateFundingResponse(
+    response: Response,
+    snapshot?: Pick<FundingSnapshot, "api_key" | "organization_id">,
+  ): Promise<Response> {
+    if (!snapshot || !response.ok) return response
+    const protocol = response.headers.get(FUNDING_PROTOCOL_HEADER)
+    const context = response.headers.get(FUNDING_CONTEXT_HEADER)
+    if (!snapshot.organization_id) {
+      if ((!context || context === "personal") && protocol !== FUNDING_PROTOCOL) return response
+      if (protocol === FUNDING_PROTOCOL && context === "personal") return response
+      if (protocol === FUNDING_PROTOCOL && context?.startsWith("organization:") && !isWorkspaceKey(snapshot.api_key)) {
+        return response
+      }
+    } else if (
+      isAtlasManagedKey(snapshot.api_key) &&
+      protocol === FUNDING_PROTOCOL &&
+      context === `organization:${snapshot.organization_id}`
+    ) {
+      return response
+    }
+    await response.body?.cancel().catch(() => undefined)
+    throw new FundingContextError("OpenScience could not verify the selected workspace with the gateway.")
   }
 
   export function scheduleRefresh(): Promise<void> {
@@ -193,6 +531,288 @@ export namespace OpenScience {
 
   export function isSyncedEnv(_key?: string, _value?: string): boolean {
     return false
+  }
+
+  const CALLBACK_SUCCESS_HTML =
+    "<!doctype html><meta charset=utf-8><title>OpenScience</title>" +
+    '<body style="font-family:system-ui,sans-serif;background:#0b0b12;color:#eee;display:grid;place-items:center;height:100vh;margin:0">' +
+    '<div style="text-align:center"><h1>Login complete</h1><p>You can close this tab.</p></div>'
+  const CALLBACK_ERROR_HTML =
+    "<!doctype html><meta charset=utf-8><title>OpenScience</title>" +
+    '<body style="font-family:system-ui,sans-serif;background:#0b0b12;color:#eee;display:grid;place-items:center;height:100vh;margin:0">' +
+    '<div style="text-align:center"><h1>Login failed</h1><p>Return to OpenScience and try again.</p></div>'
+
+  function startCallbackServer(expectedState: string) {
+    let resolve!: (value: { exchange_token: string }) => void
+    let reject!: (error: Error) => void
+    const done = new Promise<{ exchange_token: string }>((res, rej) => {
+      resolve = res
+      reject = rej
+    })
+    const server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch(request) {
+        const url = new URL(request.url)
+        if (url.pathname !== "/callback") return new Response("Not found", { status: 404 })
+        const state = url.searchParams.get("state") ?? ""
+        const token = url.searchParams.get("exchange_token") ?? ""
+        if (state !== expectedState || !token) {
+          reject(new Error("Browser login failed: callback state mismatch."))
+          return new Response(CALLBACK_ERROR_HTML, { status: 400, headers: { "Content-Type": "text/html" } })
+        }
+        resolve({ exchange_token: token })
+        return new Response(CALLBACK_SUCCESS_HTML, { headers: { "Content-Type": "text/html" } })
+      },
+    })
+    return { port: server.port!, done, stop: () => server.stop(true) }
+  }
+
+  async function loginError(response: Response, phase: string): Promise<string> {
+    if (response.status === 426) return "This OpenScience version is out of date. Update it and try again."
+    const detail = (await response.text().catch(() => "")).trim().slice(0, 200)
+    return `Login ${phase} failed: HTTP ${response.status}${detail ? ` — ${detail}` : ""}`
+  }
+
+  export async function browserLogin(opts?: {
+    onApprovalUrl?: (url: string) => void
+    timeoutMs?: number
+    organizationID?: string
+  }): Promise<OpenScienceSession> {
+    const state = randomUUID()
+    const name = deviceName()
+    const callback = startCallbackServer(state)
+    const redirectUri = `http://127.0.0.1:${callback.port}/callback`
+    let timer: ReturnType<typeof setTimeout> | undefined
+    try {
+      const start = await atlasFetch(`${API_BASE}/api/v1/auth/cli/browser/start`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Accept: "application/json" },
+        body: JSON.stringify({
+          state,
+          redirect_uri: redirectUri,
+          name,
+          ...(opts?.organizationID ? { organization_id: opts.organizationID } : {}),
+        }),
+      })
+      if (!start.ok) throw new Error(await loginError(start, "start"))
+      const started = (await start.json()) as { approval_url?: unknown }
+      if (typeof started.approval_url !== "string" || !started.approval_url) {
+        throw new Error("Login start did not return an approval URL.")
+      }
+      opts?.onApprovalUrl?.(started.approval_url)
+      const result = await Promise.race([
+        callback.done,
+        new Promise<never>((_, rejectTimeout) => {
+          timer = setTimeout(
+            () => rejectTimeout(new Error("Timed out waiting for browser authorization.")),
+            opts?.timeoutMs ?? 300_000,
+          )
+        }),
+      ])
+      const redeem = await atlasFetch(`${API_BASE}/api/v1/auth/cli/browser/redeem`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Accept: "application/json" },
+        body: JSON.stringify({ state, exchange_token: result.exchange_token, redirect_uri: redirectUri }),
+      })
+      if (!redeem.ok) throw new Error(await loginError(redeem, "redeem"))
+      const body = (await redeem.json()) as {
+        api_key?: unknown
+        key?: unknown
+        organization_id?: unknown
+        workspace_locked?: unknown
+        user_id?: unknown
+        user?: AccountProfile & { id?: unknown }
+      }
+      const key = body.api_key ?? body.key
+      if (!isAccountKey(key)) throw new Error("Login did not return a valid OpenScience API key.")
+      const organizationID = loginOrganizationID(body.organization_id)
+      const identity = body.user?.user_id ?? body.user?.id ?? body.user_id
+      const session: OpenScienceSession = {
+        api_key: key,
+        user_id: typeof identity === "string" ? identity : "",
+        device_name: name,
+        ...(organizationID ? { organization_id: organizationID } : {}),
+        ...(body.workspace_locked === true || organizationID ? { workspace_locked: true } : {}),
+      }
+      await saveSession(session)
+      return session
+    } finally {
+      if (timer) clearTimeout(timer)
+      callback.stop()
+    }
+  }
+
+  async function readAuthStatus(
+    session: FundingSnapshot | OpenScienceSession,
+  ): Promise<{
+    organizations: FundingOrganization[]
+    pinned?: string
+    locked: boolean
+    context?: AuthStatusResponse["funding_context"]
+    user?: AccountProfile
+  } | null> {
+    try {
+      const response = await fundedAtlasFetch(session, `${API_BASE}/api/v1/auth/status`, {
+        headers: { Accept: "application/json" },
+      })
+      if (!response.ok) return null
+      const body = (await response.json()) as AuthStatusResponse
+      const selected = body.funding_context?.type === "organization" ? body.funding_context.organization_id : undefined
+      const pinned = loginOrganizationID(body.api_key?.organization_id ?? selected)
+      return {
+        organizations: organizations(body.organizations ?? body.available_organizations),
+        pinned,
+        locked: body.api_key?.workspace_locked === true || body.funding_context?.locked === true || !!pinned,
+        context: body.funding_context,
+        user: body.user,
+      }
+    } catch {
+      return null
+    }
+  }
+
+  export async function loginWithKey(rawKey: string): Promise<OpenScienceSession> {
+    const key = rawKey.trim()
+    if (!isAccountKey(key)) throw new Error("Expected an OpenScience API key starting with `thk_` or `osk_`.")
+    const probe = await atlasFetch(`${API_BASE}/api/cli/balance`, {
+      headers: { Authorization: `Bearer ${key}`, [FUNDING_PROTOCOL_HEADER]: FUNDING_PROTOCOL },
+    })
+    if (probe.status === 401 || probe.status === 403)
+      throw new Error("That key was rejected. Double-check it and try again.")
+    if (!probe.ok) throw new Error(`Could not validate key: HTTP ${probe.status}`)
+
+    const response = await atlasFetch(`${API_BASE}/api/v1/auth/status`, {
+      headers: {
+        Authorization: `Bearer ${key}`,
+        Accept: "application/json",
+        [FUNDING_PROTOCOL_HEADER]: FUNDING_PROTOCOL,
+      },
+    }).catch(() => undefined)
+    const status = response?.ok ? ((await response.json()) as AuthStatusResponse) : undefined
+    const selected =
+      status?.funding_context?.type === "organization" ? status.funding_context.organization_id : undefined
+    const organizationID = loginOrganizationID(status?.api_key?.organization_id ?? selected)
+    const locked =
+      status?.api_key?.workspace_locked === true || status?.funding_context?.locked === true || !!organizationID
+    if (isWorkspaceKey(key) && (!locked || !organizationID)) {
+      throw new Error("Couldn't verify this workspace key's organization. Check your connection and try again.")
+    }
+    const session: OpenScienceSession = {
+      api_key: key,
+      user_id: typeof status?.user?.user_id === "string" ? status.user.user_id : "",
+      device_name: deviceName(),
+      ...(organizationID ? { organization_id: organizationID } : {}),
+      ...(locked ? { workspace_locked: true } : {}),
+    }
+    await saveSession(session)
+    return session
+  }
+
+  export async function getProfile(snapshot?: FundingSnapshot): Promise<AccountProfile | null> {
+    const session = snapshot ?? (await getFundingSnapshot())
+    if (!session) return null
+    return (await readAuthStatus(session))?.user ?? (session.user_id ? { user_id: session.user_id } : null)
+  }
+
+  export async function getFundingContext(operation?: FundingSnapshot): Promise<FundingContext> {
+    const snapshot = operation ?? (await getFundingSnapshot())
+    if (!snapshot) return { type: "personal", available: true, locked: false, organizations: [] }
+    const status = await readAuthStatus(snapshot)
+    if (snapshot.organization_id) {
+      const row = status?.organizations.find((item) => item.organization_id === snapshot.organization_id)
+      const echoed = status?.context
+      return {
+        type: "organization",
+        organization_id: snapshot.organization_id,
+        available:
+          organizationAvailable(row) &&
+          echoed?.type === "organization" &&
+          echoed.organization_id === snapshot.organization_id,
+        locked: snapshot.workspace_locked === true || status?.locked === true,
+        organizations: status?.organizations ?? [],
+      }
+    }
+    return {
+      type: "personal",
+      available: !status?.context || status.context.type === "personal",
+      locked: snapshot.workspace_locked === true || status?.locked === true,
+      organizations: status?.organizations ?? [],
+    }
+  }
+
+  export async function getReconciledFundingState(): Promise<{
+    snapshot: FundingSnapshot
+    context: FundingContext
+  } | null> {
+    const snapshot = await getFundingSnapshot()
+    if (!snapshot) return null
+    return { snapshot, context: await getFundingContext(snapshot) }
+  }
+
+  export async function setFundingContext(organizationID: string | null): Promise<FundingContext> {
+    const session = await getSession()
+    if (!session) throw new FundingContextError("Sign in before choosing a funding account.")
+    if (organizationID !== null && !validOrganizationID(organizationID))
+      throw new FundingContextError("Invalid organization id.")
+    const requested = organizationID ?? undefined
+    if (session.workspace_locked && requested !== session.organization_id) {
+      throw new FundingContextError("This sign-in is tied to one workspace. Sign in again to choose another account.")
+    }
+    if (requested && !isWorkspaceKey(session.api_key)) {
+      throw new FundingContextError("Sign in again to create a workspace-scoped organization credential.")
+    }
+    if (session.workspace_locked) return getFundingContext()
+    const status = requested ? await readAuthStatus((await getFundingSnapshot()) as FundingSnapshot) : null
+    if (requested && !organizationAvailable(status?.organizations.find((item) => item.organization_id === requested))) {
+      throw new FundingContextError("That organization is not available to the connected account.")
+    }
+    await saveSession({ ...session, organization_id: requested })
+    return getFundingContext()
+  }
+
+  export interface DeviceInfo {
+    key_id: string
+    name: string
+    key_prefix: string
+    created_at: string
+    last_used_at: string | null
+    expires_at: string | null
+  }
+
+  export async function listDevices(): Promise<DeviceInfo[] | null> {
+    const session = await getSession()
+    if (!session) return null
+    try {
+      const response = await authenticatedAtlasFetch(session, `${API_BASE}/api/cli/devices`)
+      return response.ok ? ((await response.json()) as DeviceInfo[]) : null
+    } catch {
+      return null
+    }
+  }
+
+  export async function revokeDevice(keyID: string): Promise<boolean> {
+    const session = await getSession()
+    if (!session) return false
+    try {
+      const response = await authenticatedAtlasFetch(
+        session,
+        `${API_BASE}/api/cli/devices/${encodeURIComponent(keyID)}`,
+        { method: "DELETE" },
+      )
+      return response.ok || response.status === 204
+    } catch {
+      return false
+    }
+  }
+
+  export async function revokeCurrentDevice(): Promise<boolean> {
+    const session = await getSession()
+    if (!session) return false
+    const devices = await listDevices()
+    const matches =
+      devices?.filter((device) => device.key_prefix.length > 4 && session.api_key.startsWith(device.key_prefix)) ?? []
+    return matches.length === 1 ? revokeDevice(matches[0].key_id) : false
   }
 
   export async function refreshByokSecrets(env: NodeJS.ProcessEnv = process.env): Promise<void> {
@@ -379,11 +999,214 @@ export namespace OpenScience {
     return Object.fromEntries(names.filter((name) => !env[name]).map((name) => [name, cap]))
   }
 
-  export function invalidateBalance(): void {}
+  let cachedBalance: { context: string; value: number; at: number } | null = null
+  let pendingBalance: { context: string; promise: Promise<number | null> } | undefined
+  let balanceRevision = 0
+  const BALANCE_CACHE_TTL_MS = 30_000
 
-  export async function getBalance(_snapshot?: FundingSnapshot): Promise<number | null> {
+  export function invalidateBalance(): void {
+    balanceRevision++
+    cachedBalance = null
+    pendingBalance = undefined
+  }
+
+  export function invalidateBalanceCache(): void {
+    invalidateBalance()
+  }
+
+  export async function getBalance(snapshot?: FundingSnapshot): Promise<number | null> {
+    const session = snapshot ?? (await getFundingSnapshot())
+    if (!session) return null
+    const context = contextTag(session)
+    if (cachedBalance?.context === context && Date.now() - cachedBalance.at < BALANCE_CACHE_TTL_MS) {
+      return cachedBalance.value
+    }
+    if (pendingBalance?.context === context) return pendingBalance.promise
+    const revision = balanceRevision
+    const request = (async () => {
+      try {
+        const response = await fundedAtlasFetch(session, `${API_BASE}/api/cli/balance`)
+        if (!response.ok) return null
+        const body = (await response.json()) as Record<string, unknown>
+        const value =
+          typeof body.effective_balance_usd === "number"
+            ? body.effective_balance_usd
+            : typeof body.effective_balance_cents === "number"
+              ? body.effective_balance_cents / 100
+              : typeof body.balance_usd === "number"
+                ? body.balance_usd
+                : typeof body.balance_cents === "number"
+                  ? body.balance_cents / 100
+                  : null
+        if (revision !== balanceRevision) {
+          return cachedBalance?.context === context ? cachedBalance.value : null
+        }
+        if (value !== null) cachedBalance = { context, value, at: Date.now() }
+        return value
+      } catch {
+        return null
+      }
+    })()
+    pendingBalance = { context, promise: request }
+    void request.finally(() => {
+      if (pendingBalance?.promise === request) pendingBalance = undefined
+    })
+    return request
+  }
+
+  export interface Credits {
+    balanceUsd: number
+    balanceCents: number
+    cliBalanceCents: number
+    spendableBalanceCents: number
+    promotionalBalanceCents: number
+    cycleCreditsRemainingCents: number
+    lifetimeSpentCents: number | null
+  }
+
+  export function walletCents(value: {
+    cli_balance_cents?: number
+    unified_balance_cents?: number
+    balance_cents?: number
+  }): number {
+    return value.balance_cents ?? value.cli_balance_cents ?? value.unified_balance_cents ?? 0
+  }
+
+  export async function getCredits(snapshot?: FundingSnapshot): Promise<Credits | null> {
+    const session = snapshot ?? (await getFundingSnapshot())
+    if (!session) return null
+    try {
+      let currentWallet = true
+      let response = await fundedAtlasFetch(session, `${API_BASE}/api/v1/wallet`)
+      if (response.status === 404 || response.status === 405) {
+        currentWallet = false
+        response = await fundedAtlasFetch(session, `${API_BASE}/api/credits`)
+      }
+      if (!response.ok) return null
+      const body = (await response.json()) as {
+        unified_balance_cents?: number
+        balance_cents?: number
+        cli_balance_cents?: number
+        purchased_cents?: number
+        purchased_credits_cents?: number
+        promotional_cents?: number
+        cycle_credits_remaining_cents?: number
+        lifetime_spent_cents?: number
+      }
+      let lifetimeSpent = body.lifetime_spent_cents ?? null
+      if (currentWallet && lifetimeSpent === null) {
+        const metadata = await fundedAtlasFetch(session, `${API_BASE}/api/credits`).catch(() => undefined)
+        if (metadata?.ok) {
+          const legacy = (await metadata.json()) as { lifetime_spent_cents?: number }
+          lifetimeSpent = legacy.lifetime_spent_cents ?? null
+        }
+      }
+      const spendable = walletCents(body)
+      const promotional = body.promotional_cents ?? body.cycle_credits_remaining_cents ?? 0
+      const purchased = body.purchased_cents ?? body.purchased_credits_cents ?? spendable - promotional
+      return {
+        balanceUsd: purchased / 100,
+        balanceCents: purchased,
+        cliBalanceCents: purchased,
+        spendableBalanceCents: spendable,
+        promotionalBalanceCents: promotional,
+        cycleCreditsRemainingCents: promotional,
+        lifetimeSpentCents: lifetimeSpent,
+      }
+    } catch (error) {
+      log.warn("wallet read failed", { error: error instanceof Error ? error.message : String(error) })
+      return null
+    }
+  }
+
+  export interface Transaction {
+    id: string
+    amountCents: number
+    source: string
+    description: string
+    createdAt: string
+  }
+
+  export async function getTransactions(limit = 20, snapshot?: FundingSnapshot): Promise<Transaction[] | null> {
+    const session = snapshot ?? (await getFundingSnapshot())
+    if (!session) return null
+    try {
+      const response = await fundedAtlasFetch(session, `${API_BASE}/api/credits/transactions`)
+      if (!response.ok) return null
+      const body = (await response.json()) as
+        | Array<Record<string, unknown>>
+        | { transactions?: Array<Record<string, unknown>> }
+      const rows = Array.isArray(body) ? body : (body.transactions ?? [])
+      return rows.slice(0, Math.max(0, limit)).map((row) => ({
+        id: String(row.id ?? ""),
+        amountCents: Number(row.amount_cents ?? 0),
+        source: String(row.source ?? ""),
+        description: String(row.description ?? ""),
+        createdAt: String(row.created_at ?? ""),
+      }))
+    } catch {
+      return null
+    }
+  }
+
+  export interface BillingMode {
+    mode: "byok" | "managed"
+    balance_cents: number
+    balance_usd: number
+    managed_supported: boolean
+    managed_unlocked: boolean
+    ace_enabled?: boolean
+  }
+
+  export async function getBillingMode(
+    snapshot?: FundingSnapshot,
+    knownCredits?: Credits | null | Promise<Credits | null>,
+  ): Promise<BillingMode | null> {
+    const session = snapshot ?? (await getFundingSnapshot())
+    if (!session) return null
+    const [configModule, accessResponse, credits] = await Promise.all([
+      import("@/config/config"),
+      fundedAtlasFetch(session, `${API_BASE}/api/cli/access`).catch(() => undefined),
+      knownCredits === undefined ? getCredits(session).catch(() => null) : Promise.resolve(knownCredits),
+    ])
+    const access = accessResponse?.ok
+      ? ((await accessResponse.json()) as {
+          cli_balance_cents?: number
+          managed_supported?: boolean
+          managed_unlocked?: boolean
+          ace_enabled?: boolean
+        })
+      : undefined
+    const configured = (await configModule.Config.getGlobal()).billing?.llm
+    const openrouterAuth = await Auth.get("openrouter").catch(() => undefined)
+    const storedOwnKey = openrouterAuth?.type === "api" && !isAtlasManagedKey(openrouterAuth.key)
+    const envOpenRouterKey = process.env.OPENROUTER_API_KEY
+    const envOwnKey = !!envOpenRouterKey && !isAtlasManagedKey(envOpenRouterKey)
+    const balance = credits?.balanceCents ?? access?.cli_balance_cents ?? 0
+    const supported = access?.managed_supported ?? true
+    return {
+      mode:
+        configured === "managed" ? "managed" : configured === "byok" || storedOwnKey || envOwnKey ? "byok" : "managed",
+      balance_cents: balance,
+      balance_usd: balance / 100,
+      managed_supported: supported,
+      managed_unlocked: access?.managed_unlocked ?? (supported && balance > 0),
+      ace_enabled: access?.ace_enabled ?? false,
+    }
+  }
+
+  export async function setBillingMode(
+    mode: "byok" | "managed",
+    localMode: "byok" | "managed" | null = mode,
+  ): Promise<BillingMode | null> {
+    const { Config } = await import("@/config/config")
+    await Config.updateGlobal({ billing: { llm: localMode } }, { preserveInstances: true })
+    const { Provider } = await import("@/provider/provider")
+    Provider.invalidate()
     return null
   }
+
+  export async function waitForBillingModeMirror(): Promise<void> {}
 
   export async function reportUsage(
     _params: Record<string, unknown>,

--- a/backend/cli/src/openscience/synced-env-policy.ts
+++ b/backend/cli/src/openscience/synced-env-policy.ts
@@ -1,3 +1,5 @@
+import { managedApiBase } from "../endpoints"
+
 /** User-owned credentials that approved local subprocesses may receive. */
 export const BYOK_LLM_ENV_KEYS = [
   "ANTHROPIC_API_KEY",
@@ -45,3 +47,36 @@ export const LOCAL_COMPUTE_CLI_ENV_KEYS = [
   "VAST_API_KEY",
   "RUNPOD_API_KEY",
 ] as const
+
+export function managedOpenRouterBaseURL(atlasBase = managedApiBase()): string {
+  return `${atlasBase.replace(/\/+$/, "")}/api/llm/proxy/openrouter/v1`
+}
+
+/** Exact managed-proxy origin and path validation; lookalike origins fail. */
+export function isAtlasProxyURL(
+  value: unknown,
+  route = "/api/llm/proxy/",
+  atlasBase = managedApiBase(),
+): value is string {
+  if (typeof value !== "string") return false
+  try {
+    const candidate = new URL(value)
+    const atlas = new URL(atlasBase)
+    if ((candidate.protocol !== "http:" && candidate.protocol !== "https:") || candidate.origin !== atlas.origin)
+      return false
+    if (
+      candidate.username ||
+      candidate.password ||
+      candidate.search ||
+      candidate.hash ||
+      candidate.pathname.includes("%")
+    )
+      return false
+    const basePath = atlas.pathname.replace(/\/+$/, "")
+    const routePath = route.startsWith("/") ? route : `/${route}`
+    const expected = `${basePath}${routePath}`.replace(/\/{2,}/g, "/").replace(/\/+$/, "")
+    return candidate.pathname === expected || candidate.pathname.startsWith(`${expected}/`)
+  } catch {
+    return false
+  }
+}

--- a/backend/cli/src/provider/inference.ts
+++ b/backend/cli/src/provider/inference.ts
@@ -3,7 +3,7 @@ import { Config } from "@/config/config"
 import z from "zod"
 
 export namespace Inference {
-  export const Source = z.enum(["byok", "chatgpt", "local", "oauth", "unknown"])
+  export const Source = z.enum(["managed", "byok", "chatgpt", "local", "oauth", "unknown"])
   export type Source = z.infer<typeof Source>
 
   export const Info = z.object({
@@ -24,19 +24,18 @@ export namespace Inference {
 
   export function classify(input: {
     providerID: string
-    providerSource?: "env" | "config" | "custom" | "api"
+    providerSource?: "env" | "config" | "custom" | "api" | "managed"
     baseURL?: string
     auth?: Auth.Info["type"]
   }): Source {
     if (input.providerID === "openai-codex") return "chatgpt"
     if (local(input.baseURL)) return "local"
+    if (input.providerID === "openrouter" && input.providerSource === "managed") return "managed"
     if (input.auth === "oauth") return "oauth"
     if (input.auth === "api" || input.auth === "wellknown") return "byok"
     // The resolved provider source is the route authority. A billing preference
     // alone cannot turn a surviving user-owned OpenRouter key into managed spend.
-    if (
-      input.providerSource === "env" || input.providerSource === "config" || input.providerSource === "api"
-    ) {
+    if (input.providerSource === "env" || input.providerSource === "config" || input.providerSource === "api") {
       return "byok"
     }
     return "unknown"

--- a/backend/cli/src/provider/managed-catalog.ts
+++ b/backend/cli/src/provider/managed-catalog.ts
@@ -1,0 +1,30 @@
+/** Reviewed Ace roster shipped with the client. No dashboard sync is required. */
+export const MANAGED_OPENROUTER_MODELS = Object.freeze([
+  "openai/gpt-5.6-sol",
+  "openai/gpt-5.6-terra",
+  "openai/gpt-5.6-luna",
+  "openai/gpt-5.5",
+  "openai/gpt-5.4",
+  "openai/gpt-5.4-mini",
+  "anthropic/claude-opus-5",
+  "anthropic/claude-fable-5",
+  "anthropic/claude-sonnet-5",
+  "anthropic/claude-haiku-4.5",
+  "google/gemini-3.1-pro-preview",
+  "google/gemini-3.5-flash",
+  "google/gemini-3.1-flash-lite",
+  "x-ai/grok-4.6",
+  "z-ai/glm-5.3",
+  "z-ai/glm-5.3-flash",
+  "deepseek/deepseek-v4-pro",
+  "deepseek/deepseek-v4-flash",
+  "qwen/qwen3.7-max",
+  "moonshotai/kimi-k3",
+  "moonshotai/kimi-k2.7-code",
+  "minimax/minimax-m3",
+  "mistralai/mistral-large-2512",
+  "meta/muse-spark-1.1",
+  "qwen/qwen3.8-27b",
+] as const)
+
+export const MANAGED_OPENROUTER_MODEL_SET = new Set<string>(MANAGED_OPENROUTER_MODELS)

--- a/backend/cli/src/provider/provider.ts
+++ b/backend/cli/src/provider/provider.ts
@@ -14,10 +14,12 @@ import { Instance } from "../project/instance"
 import { ProjectTrust } from "../project/trust"
 import { Flag } from "../flag/flag"
 import { iife } from "@/util/iife"
-import type { FundingSnapshot } from "../openscience"
+import { OpenScience, type FundingSnapshot } from "../openscience"
+import { isAtlasProxyURL, managedOpenRouterBaseURL } from "../openscience/synced-env-policy"
 import { CredentialLifecycle } from "../credentials/lifecycle"
 import { ProviderTokenCommand } from "./token-command"
 import { AsyncLocalStorage } from "node:async_hooks"
+import { MANAGED_OPENROUTER_MODEL_SET } from "./managed-catalog"
 
 // Direct imports for bundled providers
 import { createAmazonBedrock, type AmazonBedrockProviderSettings } from "@ai-sdk/amazon-bedrock"
@@ -451,6 +453,111 @@ export namespace Provider {
     return REMOVED_MODEL_IDS.has(normalized)
   }
 
+  export function isAtlasProxyBaseURL(baseURL: unknown): baseURL is string {
+    return isAtlasProxyURL(baseURL)
+  }
+
+  export function requestFundingHeaders(input: {
+    baseURL: unknown
+    apiKey: unknown
+    headers?: HeadersInit
+    funding?: FundingSnapshot
+  }): Headers {
+    const headers = new Headers(input.headers)
+    headers.delete("X-Organization-ID")
+    headers.delete("OpenScience-Funding-Protocol")
+    if (!isAtlasProxyBaseURL(input.baseURL) || !Auth.isAtlasApiKey(input.apiKey)) return headers
+    if (!input.funding) throw new Error("Managed inference has no funding-account snapshot. Retry the operation.")
+    if (input.funding.api_key !== input.apiKey) {
+      throw new Error("The connected account changed during managed inference. Retry the operation.")
+    }
+    for (const [key, value] of Object.entries(OpenScience.fundingHeaders(input.funding))) headers.set(key, value)
+    return headers
+  }
+
+  export function managedIdempotencyKey(input: {
+    endpoint: string
+    body: string
+    sessionID: string
+    messageID: string
+    operation: string
+  }): string {
+    const hash = new Bun.CryptoHasher("sha256")
+    for (const value of [
+      "openscience-managed-v1",
+      input.sessionID,
+      input.messageID,
+      input.operation,
+      input.endpoint,
+      input.body,
+    ]) {
+      hash.update(value)
+      hash.update("\0")
+    }
+    return `os_${hash.digest("hex")}`
+  }
+
+  const MANAGED_RELOAD_RETRY_MAX_SECONDS = 10
+  const MANAGED_RELOAD_RESPONSE_MAX_BYTES = 16_384
+  const ManagedReloadRetry = z.object({
+    error: z.literal("insufficient_balance"),
+    recovery: z.object({
+      kind: z.literal("ace_reload"),
+      retryable: z.literal(true),
+      retry_after_seconds: z.number().int().min(0).max(MANAGED_RELOAD_RETRY_MAX_SECONDS),
+      ace_reload: z.object({ state: z.literal("available"), pending: z.literal(true) }),
+    }),
+  })
+
+  /** Retry once only when Atlas proves a durable Ace reload is already pending. */
+  export async function retryManagedPaymentRequired(input: {
+    response: Response
+    managed: boolean
+    headers: Headers
+    signal?: AbortSignal | null
+    retry: () => Promise<Response>
+  }): Promise<Response> {
+    if (!input.managed || input.response.status !== 402 || !input.headers.get("Idempotency-Key")) return input.response
+    const declared = Number(input.response.headers.get("content-length"))
+    if (Number.isFinite(declared) && declared > MANAGED_RELOAD_RESPONSE_MAX_BYTES) return input.response
+    const text = await input.response
+      .clone()
+      .text()
+      .catch(() => "")
+    if (!text || text.length > MANAGED_RELOAD_RESPONSE_MAX_BYTES) return input.response
+    const parsed = iife(() => {
+      try {
+        return ManagedReloadRetry.safeParse(JSON.parse(text))
+      } catch {
+        return undefined
+      }
+    })
+    if (!parsed?.success) return input.response
+    const seconds = parsed.data.recovery.retry_after_seconds
+    const retryAfterHeader = input.response.headers.get("retry-after")
+    if (retryAfterHeader === null) return input.response
+    const retryAfter = Number(retryAfterHeader)
+    if (!Number.isFinite(retryAfter) || retryAfter !== seconds) return input.response
+    await input.response.body?.cancel().catch(() => undefined)
+    if (seconds > 0) {
+      await new Promise<void>((resolve, reject) => {
+        const signal = input.signal
+        if (signal?.aborted) return reject(signal.reason ?? new DOMException("Aborted", "AbortError"))
+        const aborted = () => {
+          clearTimeout(timer)
+          signal?.removeEventListener("abort", aborted)
+          reject(signal?.reason ?? new DOMException("Aborted", "AbortError"))
+        }
+        const timer = setTimeout(() => {
+          signal?.removeEventListener("abort", aborted)
+          resolve()
+        }, seconds * 1000)
+        signal?.addEventListener("abort", aborted, { once: true })
+      })
+    }
+    return input.retry()
+  }
+
   const PUBLIC_PROVIDER_BASE_URLS: Record<string, string> = {
     anthropic: "https://api.anthropic.com/v1",
     openai: "https://api.openai.com/v1",
@@ -503,17 +610,36 @@ export namespace Provider {
     }
   }
 
-  function rejectRetiredProviderRoute(provider: Info, options: Record<string, any>) {
+  export function isManagedProxyBaseURL(baseURL: unknown): baseURL is string {
+    if (!hasManagedProxyPath(baseURL)) return false
+    try {
+      const url = new URL(baseURL)
+      return !url.search && !url.hash
+    } catch {
+      return false
+    }
+  }
+
+  function requireAtlasProxyForManagedKey(provider: Info, options: Record<string, any>) {
     const effective = effectiveKey(provider, options)
-    if (!Auth.isAtlasApiKey(effective) && !hasManagedProxyPath(options["baseURL"])) return
+    if (!Auth.isAtlasApiKey(effective)) return
+    if (provider.id === "openrouter" && isAtlasProxyBaseURL(options["baseURL"])) return
     throw new Error(
-      `${provider.id} is configured with a retired managed credential or proxy. Connect a provider account you control.`,
+      `${provider.id} is using an Ace credential outside the managed OpenRouter proxy. Sign in again or connect your own provider account.`,
     )
   }
 
-  /** A user-owned API key rather than a retired product token. */
+  /** A user-owned API key rather than an Ace account token. */
   function isByokKey(key: unknown): key is string {
     return typeof key === "string" && key.length > 0 && !Auth.isAtlasApiKey(key)
+  }
+
+  export function managedRoutesCuratedProvidersOnly(config: Config.Info): boolean {
+    return config.billing?.llm === "managed"
+  }
+
+  export function managedProviderAllowed(providerID: string): boolean {
+    return providerID === "openrouter"
   }
 
   /** The credential that actually authenticates a provider: an explicit apiKey
@@ -838,18 +964,28 @@ export namespace Provider {
         "HTTP-Referer": "https://github.com/synthetic-sciences/OpenScience",
         "X-Title": "OpenScience",
       }
-      // OpenRouter is always a user-owned route. Retired product tokens and
-      // proxy URLs are ignored rather than becoming a hidden fallback.
       const auth = await Auth.get("openrouter").catch(() => undefined)
       const authKey = auth?.type === "api" ? auth.key : undefined
       const envKey = Env.get("OPENROUTER_API_KEY")
-      const ownKey = isByokKey(authKey) ? authKey : isByokKey(envKey) ? envKey : undefined
+      const mode = (await Config.get().catch(() => undefined))?.billing?.llm
+      const ownKey =
+        mode === "managed" ? undefined : isByokKey(authKey) ? authKey : isByokKey(envKey) ? envKey : undefined
       if (ownKey) {
-        // Honour a user's own OpenRouter-compatible gateway (custom
-        // OPENROUTER_BASE_URL); retired proxy paths fall back to the public endpoint.
         const envBase = Env.get("OPENROUTER_BASE_URL")
         const baseURL = envBase && !hasManagedProxyPath(envBase) ? envBase : "https://openrouter.ai/api/v1"
         return { autoload: false, options: { apiKey: ownKey, baseURL, headers } }
+      }
+      if (mode !== "byok") {
+        const session = await OpenScience.getSession().catch(() => null)
+        if (session?.api_key && Auth.isAtlasApiKey(session.api_key)) {
+          return {
+            // Account sync used to pre-register this provider. Ace now has no
+            // sync dependency, so the saved session itself is the autoload seam.
+            autoload: true,
+            options: { apiKey: session.api_key, baseURL: managedOpenRouterBaseURL(), headers },
+            source: "managed",
+          }
+        }
       }
       return { autoload: false, options: { headers } }
     },
@@ -1192,7 +1328,7 @@ export namespace Provider {
     .object({
       id: z.string(),
       name: z.string(),
-      source: z.enum(["env", "config", "custom", "api"]),
+      source: z.enum(["env", "config", "custom", "api", "managed"]),
       env: z.string().array(),
       key: z.string().optional(),
       options: z.record(z.string(), z.any()),
@@ -1475,6 +1611,12 @@ export namespace Provider {
     const disabled = new Set(config.disabled_providers ?? [])
     const enabled = config.enabled_providers ? new Set(config.enabled_providers) : null
     const authEntries = await Auth.all()
+    const managedCuratedProvidersOnly = managedRoutesCuratedProvidersOnly(config)
+    const localProviderIDs = new Set(
+      Object.entries(config.provider ?? {})
+        .filter(([, provider]) => isLocalBaseURL(provider?.options?.baseURL ?? provider?.api))
+        .map(([id]) => id),
+    )
 
     function isProviderAllowed(providerID: string): boolean {
       // The former hosted/demo catalog is retired. Keep the package namespace
@@ -1482,6 +1624,16 @@ export namespace Provider {
       // models.dev, env, auth, or user config.
       if (providerID === "synsci" || providerID.startsWith("synsci-")) return false
       if (disabled.has(providerID)) return false
+      const credential = authEntries[providerID]
+      const baseURL = providers[providerID]?.options?.["baseURL"]
+      const direct =
+        providerID === "openai-codex" ||
+        localProviderIDs.has(providerID) ||
+        isLocalBaseURL(baseURL) ||
+        credential?.type === "oauth" ||
+        (credential?.type === "api" && isByokKey(credential.key)) ||
+        isByokKey(providers[providerID] ? effectiveKey(providers[providerID]) : undefined)
+      if (managedCuratedProvidersOnly && !managedProviderAllowed(providerID) && !direct) return false
       // A user- or administrator-authored enabled_providers list is an explicit local restriction.
       if (enabled && !enabled.has(providerID)) return false
       return true
@@ -1771,7 +1923,7 @@ export namespace Provider {
       // config.provider for its whitelist has always been, and must stay,
       // "config" here.
       const credentialSource = providers[providerID]?.source
-      const claimed = credentialSource === "env" || credentialSource === "api"
+      const claimed = credentialSource === "env" || credentialSource === "api" || credentialSource === "managed"
       const partial: Partial<Info> = claimed ? {} : { source: "config" }
       if (provider.env) partial.env = provider.env
       if (provider.name) partial.name = provider.name
@@ -1797,12 +1949,31 @@ export namespace Provider {
 
       const baseURL = provider.options?.["baseURL"] ?? config.provider?.[providerID]?.api
       const credential = effectiveKey(provider)
-      if (Auth.isAtlasApiKey(credential) || hasManagedProxyPath(baseURL)) {
+      const managedRoute =
+        providerID === "openrouter" &&
+        provider.source === "managed" &&
+        Auth.isAtlasApiKey(credential) &&
+        isAtlasProxyBaseURL(baseURL)
+      if (config.billing?.llm === "managed" && providerID === "openrouter" && !managedRoute) {
+        delete providers[providerID]
+        continue
+      }
+      if ((Auth.isAtlasApiKey(credential) || hasManagedProxyPath(baseURL)) && !managedRoute) {
+        delete providers[providerID]
+        continue
+      }
+      if (config.billing?.llm === "byok" && managedRoute) {
         delete providers[providerID]
         continue
       }
 
       const configProvider = config.provider?.[providerID]
+
+      if (managedRoute) {
+        for (const modelID of MANAGED_OPENROUTER_MODEL_SET) {
+          if (!(modelID in provider.models)) provider.models[modelID] = _syntheticOpenRouterModel(modelID)
+        }
+      }
 
       for (const [modelID, model] of Object.entries(provider.models)) {
         model.api.id = model.api.id ?? model.id ?? modelID
@@ -1811,6 +1982,7 @@ export namespace Provider {
           delete provider.models[modelID]
         if (model.status === "alpha" && !Flag.OPENSCIENCE_ENABLE_EXPERIMENTAL_MODELS) delete provider.models[modelID]
         if (model.status === "deprecated") delete provider.models[modelID]
+        if (managedRoute && !MANAGED_OPENROUTER_MODEL_SET.has(modelID)) delete provider.models[modelID]
         if (
           (configProvider?.blacklist && configProvider.blacklist.includes(modelID)) ||
           (configProvider?.whitelist && !configProvider.whitelist.includes(modelID))
@@ -2026,7 +2198,7 @@ export namespace Provider {
       // throw at construction (the real Bearer header is overwritten on each call).
       if (options["tokenCommand"] && options["apiKey"] === undefined) options["apiKey"] = "token-command"
       pinByokToPublicEndpoint(provider, options, model.api.url)
-      rejectRetiredProviderRoute(provider, options)
+      requireAtlasProxyForManagedKey(provider, options)
       if (model.headers)
         options["headers"] = {
           ...options["headers"],
@@ -2087,20 +2259,45 @@ export namespace Provider {
         }
 
         const apiKey = typeof options["apiKey"] === "string" ? options["apiKey"] : undefined
-        if (Auth.isAtlasApiKey(apiKey) || hasManagedProxyPath(options["baseURL"])) {
-          throw new Error("Retired product routes are not supported. Connect a provider account you control.")
+        const managed = isAtlasProxyBaseURL(options["baseURL"]) && Auth.isAtlasApiKey(apiKey)
+        if ((Auth.isAtlasApiKey(apiKey) || hasManagedProxyPath(options["baseURL"])) && !managed) {
+          throw new Error("Ace credentials are valid only on the managed OpenRouter proxy.")
         }
-        const cleanHeaders = new Headers(opts.headers as HeadersInit | undefined)
-        cleanHeaders.delete("X-Organization-ID")
-        cleanHeaders.delete("OpenScience-Funding-Protocol")
-        opts.headers = cleanHeaders
-
-        return fetchWithIdleWatchdog(fetchFn, input, opts, {
-          providerID: model.providerID,
-          modelID: model.id,
-          idleTimeout,
-          totalTimeout: options["timeout"],
+        const context = requestContext.getStore()
+        const funding = managed ? await OpenScience.managedRequestSnapshot(apiKey, context?.funding) : undefined
+        opts.headers = requestFundingHeaders({
+          baseURL: options["baseURL"],
+          apiKey,
+          headers: opts.headers as HeadersInit | undefined,
+          funding,
         })
+        const sessionID = context?.sessionID ?? opts.headers.get("x-openscience-session")
+        const messageID = context?.messageID ?? opts.headers.get("x-openscience-request")
+        if (managed && sessionID && messageID && typeof opts.body === "string") {
+          const endpoint = input instanceof Request ? input.url : input instanceof URL ? input.href : String(input)
+          opts.headers.set(
+            "Idempotency-Key",
+            managedIdempotencyKey({ endpoint, body: opts.body, sessionID, messageID, operation: "model" }),
+          )
+        }
+
+        const request = () =>
+          fetchWithIdleWatchdog(fetchFn, input, opts, {
+            providerID: model.providerID,
+            modelID: model.id,
+            idleTimeout,
+            totalTimeout: options["timeout"],
+          })
+        const response = await request()
+        const settled = await retryManagedPaymentRequired({
+          response,
+          managed,
+          headers: opts.headers,
+          signal: opts.signal,
+          retry: request,
+        })
+        if (managed) OpenScience.invalidateBalance()
+        return funding ? OpenScience.validateFundingResponse(settled, funding) : settled
       }
 
       // Special case: google-vertex-anthropic uses a subpath import
@@ -2241,7 +2438,7 @@ export namespace Provider {
   }
 
   export const NO_PROVIDER_HINT =
-    "No model providers are available. Add your own API key (`openscience keys add`) or connect a provider in Customize → Models, then choose a model."
+    "No model providers are available. Sign in to Ace, add your own API key, or connect a local/subscription model in Customize → Models."
 
   const priority = ["claude-sonnet-4", "claude-opus-4", "gpt-5", "gemini-3-pro"]
   export function sort(models: Model[]) {

--- a/backend/cli/src/server/routes/account.ts
+++ b/backend/cli/src/server/routes/account.ts
@@ -1,0 +1,302 @@
+import { Hono } from "hono"
+import { describeRoute, resolver, validator } from "hono-openapi"
+import z from "zod"
+import { FundingContextError, OpenScience } from "@/openscience"
+import { Provider } from "@/provider/provider"
+import { Instance } from "@/project/instance"
+import { GlobalBus } from "@/bus/global"
+import { lazy } from "@/util/lazy"
+import { GlobalDisposedEvent } from "./global"
+import { openUrl } from "@/util/open-url"
+import { isWorkspaceKey } from "@/credentials/managed-key"
+
+const Device = z.object({
+  key_id: z.string(),
+  name: z.string(),
+  key_prefix: z.string(),
+  created_at: z.string(),
+  last_used_at: z.string().nullable(),
+  expires_at: z.string().nullable(),
+})
+
+const BillingMode = z.object({
+  mode: z.enum(["byok", "managed"]),
+  balance_cents: z.number(),
+  balance_usd: z.number(),
+  managed_supported: z.boolean(),
+  managed_unlocked: z.boolean(),
+  ace_enabled: z.boolean().optional(),
+})
+
+const FundingOrganization = z.object({
+  organization_id: z.string(),
+  name: z.string(),
+  slug: z.string(),
+  is_personal: z.boolean(),
+  status: z.string(),
+  role: z.string(),
+  membership_status: z.string(),
+  funding_available: z.boolean(),
+  effective_permissions: z.array(z.string()),
+})
+
+const FundingContext = z.object({
+  type: z.enum(["personal", "organization"]),
+  organization_id: z.string().optional(),
+  available: z.boolean(),
+  locked: z.boolean(),
+  organizations: z.array(FundingOrganization),
+})
+
+const Credential = z.object({ type: z.enum(["personal", "organization"]), legacy: z.boolean() })
+
+function credential(session: { api_key: string; organization_id?: string } | null) {
+  if (!session) return null
+  return {
+    type:
+      session.organization_id || isWorkspaceKey(session.api_key) ? ("organization" as const) : ("personal" as const),
+    legacy: !isWorkspaceKey(session.api_key),
+  }
+}
+
+function emitDisposed() {
+  GlobalBus.emit("event", { directory: "global", payload: { type: GlobalDisposedEvent.type, properties: {} } })
+}
+
+const LoginResult = z.object({ ok: z.boolean(), error: z.string().optional() })
+
+export const AccountRoutes = lazy(() =>
+  new Hono()
+    .get(
+      "/session",
+      describeRoute({
+        summary: "Get local account session status",
+        operationId: "account.session",
+        responses: {
+          200: {
+            description: "Session status",
+            content: { "application/json": { schema: resolver(z.object({ session: z.boolean() })) } },
+          },
+        },
+      }),
+      async (c) => c.json({ session: await OpenScience.isAuthenticated() }),
+    )
+    .get(
+      "/",
+      describeRoute({
+        summary: "Get Ace account and funding summary",
+        operationId: "account.get",
+        responses: {
+          200: {
+            description: "Account summary",
+            content: {
+              "application/json": {
+                schema: resolver(
+                  z.object({
+                    session: z.boolean(),
+                    user: z.unknown().optional(),
+                    balance_usd: z.number().nullable(),
+                    billing_mode: BillingMode.nullable(),
+                    funding_context: FundingContext,
+                    credential: Credential.nullable(),
+                  }),
+                ),
+              },
+            },
+          },
+        },
+      }),
+      async (c) => {
+        const state = await OpenScience.getReconciledFundingState().catch(() => null)
+        if (!state) {
+          const session = await OpenScience.getSession()
+          return c.json({
+            session: !!session,
+            balance_usd: null,
+            billing_mode: null,
+            credential: credential(session),
+            funding_context: { type: "personal" as const, available: !session, locked: false, organizations: [] },
+          })
+        }
+        const creditsRequest = OpenScience.getCredits(state.snapshot)
+        const [user, credits, billing] = await Promise.all([
+          OpenScience.getProfile(state.snapshot),
+          creditsRequest,
+          OpenScience.getBillingMode(state.snapshot, creditsRequest),
+        ])
+        return c.json({
+          session: true,
+          user: user ?? (state.snapshot.user_id ? { user_id: state.snapshot.user_id } : undefined),
+          balance_usd: credits?.balanceUsd ?? null,
+          billing_mode: billing,
+          funding_context: state.context,
+          credential: credential(state.snapshot),
+        })
+      },
+    )
+    .get(
+      "/funding-context",
+      describeRoute({
+        summary: "Get Ace funding workspace",
+        operationId: "account.fundingContext.get",
+        responses: {
+          200: {
+            description: "Funding context",
+            content: { "application/json": { schema: resolver(FundingContext) } },
+          },
+        },
+      }),
+      async (c) => c.json(await OpenScience.getFundingContext()),
+    )
+    .put(
+      "/funding-context",
+      describeRoute({
+        summary: "Choose Ace funding workspace",
+        operationId: "account.fundingContext.set",
+        responses: {
+          200: {
+            description: "Funding context",
+            content: { "application/json": { schema: resolver(FundingContext) } },
+          },
+          400: {
+            description: "Invalid workspace",
+            content: { "application/json": { schema: resolver(z.object({ error: z.string() })) } },
+          },
+        },
+      }),
+      validator("json", z.object({ organization_id: z.string().min(1).max(128).nullable() })),
+      async (c) => {
+        try {
+          return c.json(await OpenScience.setFundingContext(c.req.valid("json").organization_id))
+        } catch (error) {
+          if (!(error instanceof FundingContextError)) throw error
+          return c.json({ error: error.message }, 400)
+        }
+      },
+    )
+    .get(
+      "/balance",
+      describeRoute({
+        summary: "Get purchased wallet balance",
+        operationId: "account.balance",
+        responses: {
+          200: {
+            description: "Balance",
+            content: { "application/json": { schema: resolver(z.object({ balance_usd: z.number().nullable() })) } },
+          },
+        },
+      }),
+      async (c) => c.json({ balance_usd: (await OpenScience.getCredits())?.balanceUsd ?? null }),
+    )
+    .get(
+      "/devices",
+      describeRoute({
+        summary: "List account devices",
+        operationId: "account.devices",
+        responses: {
+          200: { description: "Devices", content: { "application/json": { schema: resolver(Device.array()) } } },
+        },
+      }),
+      async (c) => c.json((await OpenScience.listDevices()) ?? []),
+    )
+    .delete(
+      "/devices/:keyID",
+      describeRoute({
+        summary: "Revoke account device",
+        operationId: "account.device.revoke",
+        responses: {
+          200: { description: "Revoked", content: { "application/json": { schema: resolver(z.boolean()) } } },
+        },
+      }),
+      validator("param", z.object({ keyID: z.string() })),
+      async (c) => c.json(await OpenScience.revokeDevice(c.req.valid("param").keyID)),
+    )
+    .get(
+      "/billing-mode",
+      describeRoute({
+        summary: "Get model billing mode",
+        operationId: "account.billingMode.get",
+        responses: {
+          200: {
+            description: "Billing mode",
+            content: { "application/json": { schema: resolver(BillingMode.nullable()) } },
+          },
+        },
+      }),
+      async (c) => c.json(await OpenScience.getBillingMode()),
+    )
+    .post(
+      "/billing-mode",
+      describeRoute({
+        summary: "Set model billing mode",
+        operationId: "account.billingMode.set",
+        responses: {
+          200: {
+            description: "Billing mode",
+            content: { "application/json": { schema: resolver(BillingMode.nullable()) } },
+          },
+        },
+      }),
+      validator("json", z.object({ mode: z.enum(["byok", "managed"]) })),
+      async (c) => c.json(await OpenScience.setBillingMode(c.req.valid("json").mode)),
+    )
+    .post(
+      "/login-browser",
+      describeRoute({
+        summary: "Sign in through the system browser",
+        operationId: "account.loginBrowser",
+        responses: {
+          200: { description: "Login result", content: { "application/json": { schema: resolver(LoginResult) } } },
+        },
+      }),
+      async (c) => {
+        try {
+          await OpenScience.browserLogin({ onApprovalUrl: openUrl })
+          Provider.invalidate()
+          emitDisposed()
+          return c.json({ ok: true })
+        } catch (error) {
+          return c.json({ ok: false, error: error instanceof Error ? error.message : String(error) })
+        }
+      },
+    )
+    .post(
+      "/login-key",
+      describeRoute({
+        summary: "Sign in with an OpenScience workspace key",
+        operationId: "account.loginKey",
+        responses: {
+          200: { description: "Login result", content: { "application/json": { schema: resolver(LoginResult) } } },
+        },
+      }),
+      validator("json", z.object({ key: z.string() })),
+      async (c) => {
+        try {
+          await OpenScience.loginWithKey(c.req.valid("json").key)
+          Provider.invalidate()
+          emitDisposed()
+          return c.json({ ok: true })
+        } catch (error) {
+          return c.json({ ok: false, error: error instanceof Error ? error.message : String(error) })
+        }
+      },
+    )
+    .post(
+      "/logout",
+      describeRoute({
+        summary: "Logout Ace account",
+        operationId: "account.logout",
+        responses: {
+          200: { description: "Logged out", content: { "application/json": { schema: resolver(z.boolean()) } } },
+        },
+      }),
+      async (c) => {
+        await OpenScience.revokeCurrentDevice()
+        await OpenScience.clearSession()
+        Provider.invalidate()
+        await Instance.disposeAll()
+        emitDisposed()
+        return c.json(true)
+      },
+    ),
+)

--- a/backend/cli/src/server/routes/onboarding-auth.ts
+++ b/backend/cli/src/server/routes/onboarding-auth.ts
@@ -3,8 +3,15 @@ import { describeRoute, resolver, validator } from "hono-openapi"
 import z from "zod"
 import { Auth } from "../../auth"
 
+type BillingMode = "managed" | "byok" | null
+
 export type OnboardingAuthDependencies = {
+  readCredential(providerID: string): Promise<Auth.Info | undefined>
   saveCredential(providerID: string, auth: Auth.Info): Promise<void>
+  removeCredential(providerID: string): Promise<void>
+  readBillingMode(): Promise<BillingMode>
+  selectByok(): Promise<void>
+  restoreBillingMode(mode: BillingMode): Promise<void>
   invalidate(): void
   serialize<T>(action: () => Promise<T>): Promise<T>
 }
@@ -13,14 +20,47 @@ function reason(error: unknown) {
   return error instanceof Error ? error.message : String(error)
 }
 
-/** Save one local provider credential under the shared credential lease. */
+/** Save a BYOK credential and select it as one compensating transaction. */
 export async function configureOnboardingProviderKey(
   providerID: string,
   auth: Auth.Info,
   dependencies: OnboardingAuthDependencies,
 ) {
   await dependencies.serialize(async () => {
-    await dependencies.saveCredential(providerID, auth)
+    const previousCredential = await dependencies.readCredential(providerID)
+    const previousMode = await dependencies.readBillingMode()
+    try {
+      await dependencies.saveCredential(providerID, auth)
+      await dependencies.selectByok()
+    } catch (cause) {
+      let credentialRollback: unknown
+      let modeRollback: unknown
+      try {
+        if (previousCredential) await dependencies.saveCredential(providerID, previousCredential)
+        else await dependencies.removeCredential(providerID)
+      } catch (error) {
+        credentialRollback = error
+      }
+      try {
+        await dependencies.restoreBillingMode(previousMode)
+      } catch (error) {
+        modeRollback = error
+      }
+      dependencies.invalidate()
+      if (credentialRollback) {
+        throw new AggregateError(
+          [cause, credentialRollback, ...(modeRollback ? [modeRollback] : [])],
+          `Provider setup failed and the previous credential could not be restored (${reason(credentialRollback)}). Review Customize → Models before retrying.`,
+        )
+      }
+      if (modeRollback) {
+        throw new AggregateError(
+          [cause, modeRollback],
+          `Provider setup failed; the credential was restored, but model access could not be restored (${reason(modeRollback)}). Review Customize → Models before retrying.`,
+        )
+      }
+      throw cause
+    }
     dependencies.invalidate()
   })
 }
@@ -32,15 +72,15 @@ export function OnboardingAuthRoutes(dependencies: OnboardingAuthDependencies) {
     "/:providerID/onboarding",
     describeRoute({
       summary: "Configure an onboarding provider credential",
-      description: "Save one local provider key.",
+      description: "Atomically save one provider key and select BYOK model access.",
       operationId: "auth.onboarding",
       responses: {
         200: {
-          description: "Provider credential configured",
+          description: "Provider credential and BYOK mode configured",
           content: { "application/json": { schema: resolver(Result) } },
         },
         500: {
-          description: "Configuration failed",
+          description: "Configuration failed and compensation was attempted",
           content: { "application/json": { schema: resolver(z.object({ error: z.string() })) } },
         },
       },

--- a/backend/cli/src/server/routes/settings/billing.ts
+++ b/backend/cli/src/server/routes/settings/billing.ts
@@ -1,0 +1,66 @@
+import { Hono } from "hono"
+import { describeRoute, resolver, validator } from "hono-openapi"
+import z from "zod"
+import { Config } from "../../../config/config"
+import { OpenScience } from "../../../openscience"
+import { lazy } from "../../../util/lazy"
+
+export const BillingState = z.object({
+  llm: z.enum(["managed", "byok"]).nullable(),
+  compute: z.literal("byok"),
+  wallet: z.object({ signedIn: z.boolean(), balanceUsd: z.number().nullable() }),
+})
+export type BillingState = z.infer<typeof BillingState>
+
+const BillingPatch = z.object({
+  llm: z.enum(["managed", "byok"]).nullable().optional(),
+  compute: z.literal("byok").optional(),
+})
+
+async function readState(): Promise<BillingState> {
+  // Routing is local-authoritative. Keep this read off the Atlas hot path so
+  // opening Models and changing access never waits on account or Wallet I/O;
+  // the dedicated Wallet endpoint owns the authoritative balance refresh.
+  const [config, session] = await Promise.all([Config.getGlobal(), OpenScience.getSession().catch(() => null)])
+  return {
+    llm: config.billing?.llm ?? null,
+    compute: "byok",
+    wallet: { signedIn: !!session, balanceUsd: null },
+  }
+}
+
+export const BillingSettingsRoutes = lazy(() =>
+  new Hono()
+    .get(
+      "/",
+      describeRoute({
+        summary: "Get Ace/model billing state",
+        operationId: "settings.billing.get",
+        responses: {
+          200: { description: "Billing state", content: { "application/json": { schema: resolver(BillingState) } } },
+        },
+      }),
+      async (c) => c.json(await readState()),
+    )
+    .put(
+      "/",
+      describeRoute({
+        summary: "Update Ace/model billing state",
+        operationId: "settings.billing.update",
+        responses: {
+          200: { description: "Billing state", content: { "application/json": { schema: resolver(BillingState) } } },
+        },
+      }),
+      validator("json", BillingPatch),
+      async (c) => {
+        const patch = c.req.valid("json")
+        if (Object.hasOwn(patch, "llm")) await OpenScience.setBillingMode(patch.llm ?? "byok", patch.llm ?? null)
+        const [config, session] = await Promise.all([Config.getGlobal(), OpenScience.getSession().catch(() => null)])
+        return c.json({
+          llm: config.billing?.llm ?? null,
+          compute: "byok" as const,
+          wallet: { signedIn: !!session, balanceUsd: null },
+        })
+      },
+    ),
+)

--- a/backend/cli/src/server/routes/settings/wallet.ts
+++ b/backend/cli/src/server/routes/settings/wallet.ts
@@ -1,0 +1,86 @@
+import { Hono } from "hono"
+import { describeRoute, resolver } from "hono-openapi"
+import z from "zod"
+import { OpenScience } from "../../../openscience"
+import { ACE_CONTRACT } from "../../../openscience/ace-contract"
+import { lazy } from "../../../util/lazy"
+
+export const WalletState = z.object({
+  signedIn: z.boolean(),
+  balanceUsd: z.number().nullable(),
+  billingMode: z.enum(["managed", "byok"]).nullable(),
+  managedSupported: z.boolean(),
+  managedUnlocked: z.boolean(),
+  aceEnabled: z.boolean(),
+  aceContract: z.object({
+    activationAuthorizationUsd: z.number().nonnegative(),
+    reloadThresholdUsd: z.number().positive(),
+    reloadAmountUsd: z.number().positive(),
+    serviceMarginPercent: z.number().nonnegative(),
+    processingFeeDisclosedSeparately: z.boolean(),
+    reloadControlledByAce: z.boolean(),
+  }),
+  lifetimeSpentUsd: z.number().nullable(),
+  transactions: z.array(
+    z.object({
+      id: z.string(),
+      amountCents: z.number(),
+      source: z.string(),
+      description: z.string(),
+      createdAt: z.string(),
+    }),
+  ),
+})
+export type WalletState = z.infer<typeof WalletState>
+
+const SIGNED_OUT: WalletState = {
+  signedIn: false,
+  balanceUsd: null,
+  billingMode: null,
+  managedSupported: false,
+  managedUnlocked: false,
+  aceEnabled: false,
+  aceContract: { ...ACE_CONTRACT },
+  lifetimeSpentUsd: null,
+  transactions: [],
+}
+
+async function readWallet(): Promise<WalletState> {
+  // The local immutable funding snapshot plus gateway response proof is the
+  // authorization boundary. Avoid a separate auth-status round trip before
+  // the three Wallet reads so the default Models panel can load them together.
+  const snapshot = await OpenScience.getFundingSnapshot().catch(() => null)
+  if (!snapshot) return SIGNED_OUT
+  const creditsRequest = OpenScience.getCredits(snapshot).catch(() => null)
+  const [credits, mode, transactions] = await Promise.all([
+    creditsRequest,
+    OpenScience.getBillingMode(snapshot, creditsRequest).catch(() => null),
+    OpenScience.getTransactions(20, snapshot).catch(() => null),
+  ])
+  const balance = credits?.balanceUsd ?? null
+  return {
+    signedIn: true,
+    balanceUsd: balance,
+    billingMode: mode?.mode ?? null,
+    managedSupported: mode?.managed_supported ?? false,
+    managedUnlocked: Boolean(mode?.managed_unlocked || mode?.ace_enabled || (balance !== null && balance > 0)),
+    aceEnabled: mode?.ace_enabled ?? false,
+    aceContract: { ...ACE_CONTRACT },
+    lifetimeSpentUsd: credits?.lifetimeSpentCents == null ? null : credits.lifetimeSpentCents / 100,
+    transactions: transactions ?? [],
+  }
+}
+
+export const WalletSettingsRoutes = lazy(() =>
+  new Hono().get(
+    "/",
+    describeRoute({
+      summary: "Get purchased wallet and Ace ledger",
+      operationId: "settings.wallet.get",
+      responses: {
+        200: { description: "Wallet state", content: { "application/json": { schema: resolver(WalletState) } } },
+      },
+    }),
+    async (c) => c.json(await readWallet()),
+  ),
+)

--- a/backend/cli/src/server/server.ts
+++ b/backend/cli/src/server/server.ts
@@ -65,6 +65,9 @@ import { CommandRuntime } from "../science/command/registry"
 import { CredentialProcessLedger } from "../credentials/process-ledger"
 import { DataRootBarrier } from "../global/data-root-barrier"
 import { OnboardingAuthRoutes } from "./routes/onboarding-auth"
+import { AccountRoutes } from "./routes/account"
+import { BillingSettingsRoutes } from "./routes/settings/billing"
+import { WalletSettingsRoutes } from "./routes/settings/wallet"
 
 // @ts-ignore This global is needed to prevent ai-sdk from logging warnings to stdout https://github.com/vercel/ai/blob/2dc67e0ef538307f21368db32d5a12345d98831b/packages/ai/src/logger/log-warnings.ts#L85
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -267,6 +270,7 @@ export namespace Server {
           await DataRootBarrier.during(Global.Path.data, next, 120_000)
         })
         .route("/global", GlobalRoutes())
+        .route("/account", AccountRoutes())
         // Settings panels backed by global (project-independent) stores, so
         // mounted before the Instance.provide wrapper below (no directory).
         .route("/settings/credentials", CredentialsRoutes())
@@ -277,10 +281,21 @@ export namespace Server {
         .route("/settings/sandbox", SandboxSettingsRoutes())
         .route("/settings/updates", UpdatesSettingsRoutes())
         .route("/settings/scientific-tools", ScientificToolsSettingsRoutes())
+        .route("/settings/billing", BillingSettingsRoutes())
+        .route("/settings/wallet", WalletSettingsRoutes())
         .route(
           "/auth",
           OnboardingAuthRoutes({
+            readCredential: (providerID) => Auth.get(providerID),
             saveCredential: (providerID, auth) => Auth.set(providerID, auth),
+            removeCredential: (providerID) => Auth.remove(providerID),
+            readBillingMode: async () => (await Config.getGlobal()).billing?.llm ?? null,
+            selectByok: async () => {
+              await Config.updateGlobal({ billing: { llm: "byok" } }, { preserveInstances: true })
+            },
+            restoreBillingMode: async (mode) => {
+              await Config.updateGlobal({ billing: { llm: mode } }, { preserveInstances: true })
+            },
             // Defer this call because Provider imports Server for local fetches;
             // the route module itself intentionally has no Provider dependency.
             invalidate: () => Provider.invalidate(),

--- a/backend/cli/src/session/access-route.ts
+++ b/backend/cli/src/session/access-route.ts
@@ -1,18 +1,13 @@
 /** Classify user-owned provider access for local trace labels. */
 
 import { Auth } from "@/auth"
+import { OpenScience } from "@/openscience"
 import { Provider } from "@/provider/provider"
 
-export type CredentialSource = "byok" | "oauth"
-export type AccessRoute = "byok" | "chatgpt" | "subscription" | "local" | "custom"
+export type CredentialSource = "byok" | "managed" | "oauth"
+export type AccessRoute = "managed" | "byok" | "chatgpt" | "subscription" | "local" | "custom"
 
-const OAUTH_PROVIDERS = new Set([
-  "anthropic",
-  "openai",
-  "openai-codex",
-  "github-copilot",
-  "github-copilot-enterprise",
-])
+const OAUTH_PROVIDERS = new Set(["anthropic", "openai", "openai-codex", "github-copilot", "github-copilot-enterprise"])
 
 export function isCodexOAuthProvider(providerID: string): boolean {
   return providerID === "openai-codex"
@@ -20,6 +15,11 @@ export function isCodexOAuthProvider(providerID: string): boolean {
 
 export async function resolveCredentialSource(providerID: string, _modelID: string): Promise<CredentialSource> {
   const auth = await Auth.get(providerID).catch(() => undefined)
+  const provider = await Provider.getProvider(providerID).catch(() => undefined)
+  const effective = provider ? Provider.effectiveKey(provider) : undefined
+  if (providerID === "openrouter" && provider?.source === "managed" && OpenScience.isManagedKeyValue(effective)) {
+    return "managed"
+  }
   if (auth?.type === "oauth") return "oauth"
   if (OAUTH_PROVIDERS.has(providerID) && !auth) return "oauth"
   return "byok"
@@ -35,7 +35,12 @@ export function accessRoute(source: CredentialSource, model: Provider.Model): Ac
   }
   if (source === "oauth" && model.providerID === "openai-codex") return "chatgpt"
   if (source === "oauth") return "subscription"
+  if (source === "managed") return "managed"
   return "byok"
+}
+
+export function requiresWalletBalance(source: CredentialSource): boolean {
+  return source === "managed"
 }
 
 export async function resolveAccessRoute(providerID: string, modelID: string): Promise<AccessRoute> {

--- a/backend/cli/src/session/billing-gate.ts
+++ b/backend/cli/src/session/billing-gate.ts
@@ -1,0 +1,15 @@
+/** Compatibility exports for the managed inference billing boundary. */
+export {
+  accessRoute as telemetryRoute,
+  isCodexOAuthProvider,
+  requiresWalletBalance,
+  resolveAccessRoute as resolveTelemetryRoute,
+  resolveCredentialSource,
+  type AccessRoute as TelemetryRoute,
+  type CredentialSource,
+} from "./access-route"
+
+export function shouldReportUsage(): boolean {
+  // Atlas proxy settlement is authoritative; the retired usage endpoint is not.
+  return false
+}

--- a/backend/cli/src/session/processor.ts
+++ b/backend/cli/src/session/processor.ts
@@ -16,6 +16,8 @@ import { SessionCompaction } from "./compaction"
 import { PermissionNext } from "@/permission/next"
 import { Question } from "@/question"
 import { accessRoute, resolveCredentialSource } from "./access-route"
+import { requiresWalletBalance } from "./access-route"
+import { OpenScience } from "@/openscience"
 import { SessionTraceStore } from "./trace-store"
 import type { NamedError } from "@synsci/util/error"
 import { ToolRetryGuard } from "./tool-retry-guard"
@@ -35,6 +37,15 @@ export namespace SessionProcessor {
   // provider (or a permanent error arriving as JSON) looped forever.
   const MAX_RETRY_ATTEMPTS = 10
   const log = Log.create({ service: "session.processor" })
+
+  export function managedPauseError(message: string) {
+    return new MessageV2.APIError({
+      message,
+      statusCode: 503,
+      isRetryable: true,
+      metadata: { openscience_state: "paused", action: "retry" },
+    })
+  }
 
   /** True when the last `threshold` TOOL calls are the same tool with the same
    *  input, ignoring reasoning/text/step parts interleaved between them. A naive
@@ -535,6 +546,9 @@ export namespace SessionProcessor {
       },
       async process(streamInput: LLM.StreamInput) {
         log.info("process")
+        // One immutable funding choice spans preflight and every retry/step in
+        // this provider operation. A settings change applies to the next turn.
+        const funding = await OpenScience.getFundingSnapshot()
         const tracking = tracks({ tools: streamInput.tools, toolcall: input.model.capabilities.toolcall })
         needsCompaction = false
         overflow = false
@@ -548,10 +562,31 @@ export namespace SessionProcessor {
             const credentialSource = await resolveCredentialSource(input.model.providerID, input.model.id)
             traceRoute = accessRoute(credentialSource, input.model)
 
+            if (requiresWalletBalance(credentialSource)) {
+              if (!funding) {
+                throw managedPauseError(
+                  "Ace is paused because OpenScience could not snapshot the connected funding account. Sign in again or switch to a direct provider or local model.",
+                )
+              }
+              const balance = await OpenScience.getBalance(funding)
+              if (balance === null) {
+                throw managedPauseError(
+                  "Ace is paused because OpenScience could not verify the current balance. Retry when the connection returns or switch to a direct provider or local model.",
+                )
+              }
+              if (balance <= 0) {
+                OpenScience.invalidateBalance()
+                throw new Error(
+                  "Your Ace balance is empty. Add credits at app.syntheticsciences.ai/billing or switch model access to BYOK / Subscription.",
+                )
+              }
+            }
+
             const requestContext = {
               sessionID: input.sessionID,
               messageID: input.assistantMessage.id,
               attempt: attempt + 1,
+              ...(credentialSource === "managed" && funding ? { funding } : {}),
             }
             // The conversation-first Research agent does not create or require
             // legacy research contracts, so an old persisted contract must not

--- a/backend/cli/src/tool/bash.ts
+++ b/backend/cli/src/tool/bash.ts
@@ -435,7 +435,7 @@ export const BashTool = Tool.define("bash", async () => {
               cwd,
               // Re-sanitize at the final process boundary too: runtime/cache
               // overlays must never restore a managed token or re-pair a
-              // user's key with a retired product proxy after subprocessEnv ran.
+              // user's key with the Ace managed proxy after subprocessEnv ran.
               env: OpenScience.filterEnvForSubprocess({ ...env, ...(runtime.env ?? {}), ...cache }),
               stdio: ["ignore", "pipe", "pipe"],
               detached: process.platform !== "win32",

--- a/frontend/workspace/src/components/model-settings-popover.test.ts
+++ b/frontend/workspace/src/components/model-settings-popover.test.ts
@@ -54,9 +54,10 @@ describe("inference source classification", () => {
     expect(subject.inferenceSource({ providerID: "xai", credential: "config" })).toBe("byok")
     // Own gateway key in the local auth store is decisive: own key wins server-side.
     expect(subject.inferenceSource({ providerID: "openrouter", credential: "api" })).toBe("byok")
-    // Environment credentials are user-owned; retired managed credentials are not surfaced.
-    expect(subject.inferenceSource({ providerID: "openrouter", credential: "env" })).toBe("byok")
-    expect(subject.inferenceSource({ providerID: "openrouter", credential: "env" })).toBe("byok")
+    expect(subject.inferenceSource({ providerID: "openrouter", credential: "managed" })).toBe("managed")
+    // An ambient gateway is ambiguous until the explicit access mode resolves it.
+    expect(subject.inferenceSource({ providerID: "openrouter", credential: "env" })).toBeUndefined()
+    expect(subject.inferenceSource({ providerID: "openrouter", credential: "env", billing: "byok" })).toBe("byok")
     // OAuth subscriptions outside ChatGPT and config-defined custom providers stay unlabeled.
     expect(subject.inferenceSource({ providerID: "github-copilot", credential: "custom" })).toBeUndefined()
   })
@@ -64,6 +65,7 @@ describe("inference source classification", () => {
   test("labels model access without changing provider routing ids", () => {
     expect(subject.inferenceSourceLabel("chatgpt")).toBe("ChatGPT")
     expect(subject.inferenceSourceLabel("byok")).toBe("BYOK")
+    expect(subject.inferenceSourceLabel("managed")).toBe("Ace")
     expect(subject.inferenceSourceLabel(undefined, "Local runtime")).toBe("Local runtime")
   })
 })

--- a/frontend/workspace/src/components/model-settings-popover.tsx
+++ b/frontend/workspace/src/components/model-settings-popover.tsx
@@ -389,25 +389,17 @@ export const ModelSettingsPopover: Component<{ trigger?: "label" | "icon" }> = (
   const [catalogFocus, setCatalogFocus] = createSignal("")
   const [notice, setNotice] = createSignal("")
   const refs = { content: undefined as HTMLElement | undefined }
-  const owned = (model: NonNullable<ReturnType<typeof local.model.current>>) =>
-    !model.provider.id.startsWith("synsci")
-  const current = createMemo(() => {
-    const model = local.model.current()
-    return model && owned(model) ? model : undefined
-  })
+  const current = createMemo(() => local.model.current())
   const exact = (model: NonNullable<ReturnType<typeof current>>) => `${model.provider.id}/${model.id}`
   const recent = createMemo(() =>
-    local.model.recent().filter((model): model is NonNullable<typeof model> => (model ? owned(model) : false)),
+    local.model.recent().filter((model): model is NonNullable<typeof model> => Boolean(model)),
   )
   const available = createMemo(() =>
-    local.model
-      .list()
-      .filter(owned)
-      .filter((model) => local.model.visible({ providerID: model.provider.id, modelID: model.id })),
+    local.model.list().filter((model) => local.model.visible({ providerID: model.provider.id, modelID: model.id })),
   )
   const allChoices = createMemo(() =>
     groupModelRoutes({
-      models: local.model.list().filter(owned),
+      models: local.model.list(),
       current: current() ? { providerID: current()!.provider.id, modelID: current()!.id } : undefined,
       recent: recent().map((model) => ({ providerID: model.provider.id, modelID: model.id })),
     }),
@@ -598,12 +590,18 @@ export const ModelSettingsPopover: Component<{ trigger?: "label" | "icon" }> = (
   const selectChoice = (choice: ReturnType<typeof choices>[number]) => {
     const selected = current()
     const configured = parseModelRoute(sync.data.config.model)
+    const billing = sync.data.config.billing?.llm
     const model =
       preservedModelRoute(
         choice.routes,
         selected ? { providerID: selected.provider.id, modelID: selected.id } : undefined,
       ) ??
       preservedModelRoute(choice.routes, configured) ??
+      (billing === "managed"
+        ? choice.routes.find((route) => route.provider.id === "openrouter" || route.provider.id.startsWith("synsci"))
+        : billing === "byok"
+          ? choice.routes.find((route) => route.provider.id !== "openrouter" && !route.provider.id.startsWith("synsci"))
+          : undefined) ??
       choice.routes.find((route) => route.provider.id === "openai-codex") ??
       choice.model
     local.model.set({ providerID: model.provider.id, modelID: model.id }, { recent: true })

--- a/frontend/workspace/src/components/settings/General.test.ts
+++ b/frontend/workspace/src/components/settings/General.test.ts
@@ -30,39 +30,34 @@ describe("General preference writes", () => {
   })
 })
 
-describe("General workspace switching", () => {
-  test("requires browser reauthorization instead of relabeling the active credential locally", async () => {
+describe("General Ace account", () => {
+  test("keeps Ace optional while providing login, logout, Wallet, and billing controls", async () => {
     const source = await Bun.file(new URL("./General.tsx", import.meta.url)).text()
-    expect(source).toContain('title="Workspace"')
+    expect(source).toContain('title="Ace account"')
+    expect(source).toContain('"/account/login-browser"')
+    expect(source).toContain('"/account/logout"')
+    expect(source).toContain("walletBalanceLabel")
+    expect(source).toContain("URLS.dashboardBilling")
+    expect(source).toContain("Sign in only if you want Ace")
+    expect(source).not.toMatch(/promotional|promo credit/i)
+    expect(source).not.toContain("AccountGate")
+    expect(source).not.toContain("DataUse")
+  })
+
+  test("switches unlocked funding context locally but reauthorizes locked workspace keys", async () => {
+    const source = await Bun.file(new URL("./General.tsx", import.meta.url)).text()
+    const start = source.indexOf("const setWorkspace")
+    const flow = source.slice(start, source.indexOf("onMount", start))
+    expect(source).toContain('account()?.credential?.type === "organization"')
+    expect(source).toContain("account()?.credential?.legacy === false")
+    expect(flow).toContain("!canDirectlySwitchWorkspace()")
+    expect(flow).toContain('await login("workspace")')
+    expect(flow).toContain('"/account/funding-context"')
     expect(source).toContain("Switch workspace")
-    expect(source).toContain("sdk.client.account.loginBrowser()")
-    expect(source).not.toContain("sdk.client.account.fundingContext.set")
-    expect(source).not.toContain("<FilterMenu")
-    expect(source).toContain("approve any workspace, including Personal")
-    expect(source).toContain("Create workspace")
-    expect(source).toContain("URLS.dashboardWorkspaces")
-    expect(source).toContain("This legacy thk_ key remains valid and is mapped to Personal")
-  })
-
-  test("keeps the current workspace active while browser approval is pending or fails", async () => {
-    const source = await Bun.file(new URL("./General.tsx", import.meta.url)).text()
-    const start = source.indexOf("const switchWorkspace")
-    const flow = source.slice(start, source.indexOf("return (", start))
-    const changed = 'window.dispatchEvent(new Event("openscience:account-changed"))'
-    const event = flow.indexOf(changed)
-    expect(flow.indexOf("sdk.client.account.loginBrowser()")).toBeGreaterThan(-1)
-    expect(event).toBeGreaterThan(-1)
-    expect(flow.indexOf("await loadAccount()")).toBeGreaterThan(event)
-    expect(source).toContain("Your current workspace stays active until approval completes.")
-    expect(source).toContain('title: "Workspace unchanged"')
-    expect(source).toContain("disabled={fundingBusy()}")
-  })
-
-  test("shows the resolved Personal and unavailable workspace labels", async () => {
-    const source = await Bun.file(new URL("./General.tsx", import.meta.url)).text()
-    expect(source).toContain('return "Personal"')
-    expect(source).toContain('"Unavailable workspace"')
-    expect(source).toContain("description: `OpenScience is now connected to ${fundingLabel()}.`")
-    expect(source).toContain("Switch workspaces to choose another one.")
+    expect(source).toContain("Personal")
+    expect(source).toContain("Unavailable")
+    expect(source).toContain('organization.membership_status === "active"')
+    expect(source).toContain("organization.funding_available !== false")
+    expect(source).toContain("organization.use_shared_wallet !== false")
   })
 })

--- a/frontend/workspace/src/components/settings/General.tsx
+++ b/frontend/workspace/src/components/settings/General.tsx
@@ -1,16 +1,306 @@
+import { Button } from "@synsci/ui/button"
+import { Icon, type IconProps } from "@synsci/ui/icon"
+import { Select } from "@synsci/ui/select"
+import { useDialog } from "@synsci/ui/context/dialog"
+import { Show, createMemo, createSignal, onCleanup, onMount, type Component, type JSX } from "solid-js"
+import { confirmDialog } from "@/atlas/dialogs"
+import { URLS } from "@/config/urls"
+import { useGlobalSDK } from "@/context/global-sdk"
+import { useGlobalSync } from "@/context/global-sync"
+import { usePlatform } from "@/context/platform"
 import { AppearanceSections } from "../settings-general"
-import { PanelBody, PanelHeader, PanelScroll } from "./_shared"
+import { PanelBody, PanelHeader, PanelScroll, Section } from "./_shared"
+import { settingsApi } from "./api"
+import { walletBalanceLabel } from "./credit-balance"
+import { ProviderLogo } from "./ProviderLogo"
 import "./preference-panels.css"
 
+type FundingOrganization = {
+  organization_id: string
+  name: string
+  is_personal: boolean
+  status: string
+  membership_status: string
+  funding_available?: boolean
+  use_shared_wallet?: boolean
+}
+
+type FundingContext = {
+  type: "personal" | "organization"
+  organization_id?: string
+  available: boolean
+  locked: boolean
+  organizations: FundingOrganization[]
+}
+
+type Account = {
+  session: boolean
+  user?: Record<string, unknown> & { email?: string }
+  balance_usd: number | null
+  funding_context: FundingContext
+  credential?: { type: "personal" | "organization"; legacy: boolean } | null
+}
+
+type LoginResult = { ok: boolean; error?: string }
+type WorkspaceOption = { value: string; label: string }
+
+const errorMessage = (error: unknown) => (error instanceof Error ? error.message : String(error))
+
 export default function General() {
+  const sdk = useGlobalSDK()
+  const sync = useGlobalSync()
+  const platform = usePlatform()
+  const dialog = useDialog()
+  const fetchFn = platform.fetch ?? fetch
+  const [account, setAccount] = createSignal<Account>()
+  const [error, setError] = createSignal<string>()
+  const [busy, setBusy] = createSignal<"login" | "logout" | "workspace">()
+
+  const loadAccount = () =>
+    settingsApi<Account>(sdk.url, fetchFn, "/account")
+      .then(setAccount)
+      .catch((cause) => setError(errorMessage(cause)))
+
+  const refreshAccount = () => {
+    setError(undefined)
+    void loadAccount()
+  }
+
+  const login = async (context: "login" | "workspace") => {
+    if (busy()) return
+    setBusy(context)
+    setError(undefined)
+    try {
+      const result = await settingsApi<LoginResult>(sdk.url, fetchFn, "/account/login-browser", { method: "POST" })
+      if (!result.ok) throw new Error(result.error || "Sign in did not complete. Try again.")
+      window.dispatchEvent(new Event("openscience:account-changed"))
+      void sync
+        .refreshProviders()
+        .catch((cause) => setError(`Account connected, but models could not refresh: ${errorMessage(cause)}`))
+    } catch (cause) {
+      setError(errorMessage(cause))
+    } finally {
+      setBusy(undefined)
+    }
+  }
+
+  const logout = async () => {
+    if (busy()) return
+    const confirmed = await confirmDialog(dialog, {
+      title: "Disconnect Ace account?",
+      message: "This disconnects this device. Local projects, files, and your provider connections stay here.",
+      confirmLabel: "Disconnect",
+      danger: true,
+    })
+    if (!confirmed) return
+    setBusy("logout")
+    setError(undefined)
+    try {
+      await settingsApi<boolean>(sdk.url, fetchFn, "/account/logout", { method: "POST" })
+      window.dispatchEvent(new Event("openscience:account-changed"))
+      void sync
+        .refreshProviders()
+        .catch((cause) => setError(`Account disconnected, but models could not refresh: ${errorMessage(cause)}`))
+    } catch (cause) {
+      setError(errorMessage(cause))
+    } finally {
+      setBusy(undefined)
+    }
+  }
+
+  const workspaceOptions = createMemo<WorkspaceOption[]>(() => {
+    const context = account()?.funding_context
+    if (!context) return []
+    const personal: WorkspaceOption = { value: "personal", label: "Personal" }
+    const organizations = context.organizations
+      .filter(
+        (organization) =>
+          !organization.is_personal &&
+          organization.status === "active" &&
+          organization.membership_status === "active" &&
+          organization.funding_available !== false &&
+          organization.use_shared_wallet !== false,
+      )
+      .map((organization) => ({ value: organization.organization_id, label: organization.name }))
+    return [personal, ...organizations]
+  })
+  const workspaceValue = createMemo(() => account()?.funding_context.organization_id ?? "personal")
+  const workspace = createMemo(() => workspaceOptions().find((option) => option.value === workspaceValue()))
+  const canDirectlySwitchWorkspace = createMemo(
+    () =>
+      account()?.credential?.type === "organization" &&
+      account()?.credential?.legacy === false &&
+      account()?.funding_context.locked === false,
+  )
+  const needsBrowserWorkspaceApproval = createMemo(() => workspaceOptions().length > 1 && !canDirectlySwitchWorkspace())
+
+  const setWorkspace = async (option: WorkspaceOption | undefined) => {
+    if (!option || busy() || option.value === workspaceValue()) return
+    if (!canDirectlySwitchWorkspace()) {
+      await login("workspace")
+      return
+    }
+    setBusy("workspace")
+    setError(undefined)
+    try {
+      const funding_context = await settingsApi<FundingContext>(sdk.url, fetchFn, "/account/funding-context", {
+        method: "PUT",
+        body: JSON.stringify({ organization_id: option.value === "personal" ? null : option.value }),
+      })
+      setAccount((current) => (current ? { ...current, funding_context } : current))
+      window.dispatchEvent(new Event("openscience:account-changed"))
+      void sync
+        .refreshProviders()
+        .catch((cause) => setError(`Workspace changed, but models could not refresh: ${errorMessage(cause)}`))
+    } catch (cause) {
+      setError(errorMessage(cause))
+    } finally {
+      setBusy(undefined)
+    }
+  }
+
+  onMount(() => {
+    refreshAccount()
+    window.addEventListener("focus", refreshAccount)
+    window.addEventListener("openscience:account-changed", refreshAccount)
+  })
+  onCleanup(() => {
+    window.removeEventListener("focus", refreshAccount)
+    window.removeEventListener("openscience:account-changed", refreshAccount)
+  })
+
+  const email = () => {
+    if (!account()) return "Checking…"
+    if (!account()!.session) return "Not connected"
+    return account()!.user?.email || "Connected"
+  }
+  const wallet = () => {
+    if (!account()) return "Checking…"
+    return walletBalanceLabel({ signedIn: account()!.session, balanceUsd: account()!.balance_usd })
+  }
+
   return (
     <PanelScroll>
       <div class="settings-preferences-panel settings-preferences-panel--general">
-        <PanelHeader title="General" description="Appearance, notifications, sound, and app updates." />
+        <PanelHeader title="General" description="Ace account and app preferences." />
         <PanelBody>
+          <Show when={error()}>
+            <div class="settings-alert" data-tone="critical" role="alert">
+              {error()}
+            </div>
+          </Show>
+
+          <Section
+            id="ace-account"
+            title="Ace account"
+            description="Your optional Synthetic Sciences sign-in and purchased Wallet balance."
+          >
+            <div class="settings-card settings-preferences-card settings-account-card">
+              <div class="settings-row settings-preference-row">
+                <span class="settings-preference-icon settings-account-logo" aria-hidden="true">
+                  <ProviderLogo id="synsci" label="Ace" />
+                </span>
+                <div class="settings-row-copy">
+                  <strong>{email()}</strong>
+                  <span>{account()?.session ? "Connected on this device" : "Sign in only if you want Ace"}</span>
+                </div>
+                <div class="settings-preference-row__actions">
+                  <Show
+                    when={account()?.session}
+                    fallback={
+                      <Button
+                        size="small"
+                        variant="primary"
+                        disabled={Boolean(busy())}
+                        onClick={() => void login("login")}
+                      >
+                        {busy() === "login" ? "Waiting for browser…" : "Sign in"}
+                      </Button>
+                    }
+                  >
+                    <Button size="small" variant="secondary" disabled={Boolean(busy())} onClick={() => void logout()}>
+                      {busy() === "logout" ? "Disconnecting…" : "Disconnect"}
+                    </Button>
+                  </Show>
+                </div>
+              </div>
+
+              <AccountRow icon="star" title="Purchased Wallet" description="Available purchased funds for Ace.">
+                <span class="settings-account-value">{wallet()}</span>
+                <Button size="small" variant="secondary" onClick={() => platform.openLink(URLS.dashboardBilling)}>
+                  Manage billing
+                </Button>
+              </AccountRow>
+
+              <Show when={account()?.session && account()?.funding_context}>
+                <AccountRow
+                  icon="home"
+                  title="Funding workspace"
+                  description={
+                    needsBrowserWorkspaceApproval()
+                      ? "Switching this account requires browser approval."
+                      : "Used for Ace usage and purchased Wallet funds."
+                  }
+                >
+                  <Show
+                    when={canDirectlySwitchWorkspace() && workspaceOptions().length > 1}
+                    fallback={
+                      <span class="settings-account-value">
+                        {workspace()?.label ?? (account()!.funding_context.available ? "Personal" : "Unavailable")}
+                      </span>
+                    }
+                  >
+                    <div class="settings-account-workspace">
+                      <Select
+                        aria-label="Funding workspace"
+                        options={workspaceOptions()}
+                        current={workspace()}
+                        value={(option) => option.value}
+                        label={(option) => option.label}
+                        disabled={busy() === "workspace"}
+                        onSelect={(option) => void setWorkspace(option)}
+                        variant="secondary"
+                        size="small"
+                        triggerVariant="settings"
+                      />
+                    </div>
+                  </Show>
+                  <Show when={needsBrowserWorkspaceApproval()}>
+                    <Button
+                      size="small"
+                      variant="secondary"
+                      disabled={Boolean(busy())}
+                      onClick={() => void login("workspace")}
+                    >
+                      {busy() === "workspace" ? "Waiting for browser…" : "Switch workspace"}
+                    </Button>
+                  </Show>
+                </AccountRow>
+              </Show>
+            </div>
+          </Section>
+
           <AppearanceSections />
         </PanelBody>
       </div>
     </PanelScroll>
   )
 }
+
+const AccountRow: Component<{
+  icon: IconProps["name"]
+  title: string
+  description: string
+  children: JSX.Element
+}> = (props) => (
+  <div class="settings-row settings-preference-row">
+    <span class="settings-preference-icon" aria-hidden="true">
+      <Icon name={props.icon} size="small" />
+    </span>
+    <div class="settings-row-copy">
+      <strong>{props.title}</strong>
+      <span>{props.description}</span>
+    </div>
+    <div class="settings-preference-row__actions">{props.children}</div>
+  </div>
+)

--- a/frontend/workspace/src/components/settings/ManagedInference.test.ts
+++ b/frontend/workspace/src/components/settings/ManagedInference.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test"
+import {
+  aceContractLabel,
+  canSelectManaged,
+  commitBilling,
+  formatCreditBalance,
+  walletBalanceLabel,
+} from "./ManagedInference"
+
+const source = await Bun.file(new URL("./ManagedInference.tsx", import.meta.url)).text()
+
+describe("Ace model access", () => {
+  test("keeps BYOK and Ace as explicit routing contracts", () => {
+    expect(source.indexOf('title: "BYOK / Subscription"')).toBeGreaterThan(-1)
+    expect(source.indexOf('title: "Ace"')).toBeGreaterThan(source.indexOf('title: "BYOK / Subscription"'))
+    expect(source).toContain('id="synsci"')
+    expect(source).toContain('settingsApi<LoginResult>(sdk.url, fetchFn, "/account/login-browser"')
+    expect(source).toContain("platform.openLink(URLS.dashboardBilling)")
+    expect(source).toContain('return "Turn on Ace"')
+    expect(source).not.toContain("setInterval")
+  })
+
+  test("shows only exact purchased-Wallet dollars", () => {
+    expect(formatCreditBalance(984)).toBe("$984.00")
+    expect(formatCreditBalance(984.6)).toBe("$984.60")
+    expect(walletBalanceLabel({ signedIn: true, balanceUsd: -1 })).toBe("$-1.00 balance")
+    expect(walletBalanceLabel({ signedIn: true, balanceUsd: null })).toBe("Balance unavailable")
+    expect(walletBalanceLabel({ signedIn: false, balanceUsd: 20 })).toBe("Not signed in")
+    expect(source).not.toMatch(/promotional balance|promo credit/i)
+  })
+
+  test("renders the server-authoritative authorization and fixed reload terms", () => {
+    expect(
+      aceContractLabel({
+        activationAuthorizationUsd: 0,
+        reloadThresholdUsd: 5,
+        reloadAmountUsd: 20,
+        serviceMarginPercent: 2,
+        processingFeeDisclosedSeparately: true,
+        reloadControlledByAce: true,
+      }),
+    ).toBe(
+      "Ace is a $0 authorization, not a purchase or subscription. While Ace is on, a purchased Wallet balance below $5 triggers one fixed $20 reload; the processing fee is disclosed separately before payment.",
+    )
+  })
+
+  test("requires an authorized signed-in Wallet for managed routing", () => {
+    expect(canSelectManaged(undefined)).toBe(false)
+    expect(
+      canSelectManaged({
+        signedIn: true,
+        managedSupported: true,
+        managedUnlocked: true,
+        aceEnabled: false,
+        balanceUsd: 20,
+        billingMode: null,
+      }),
+    ).toBe(true)
+    expect(
+      canSelectManaged({
+        signedIn: false,
+        managedSupported: true,
+        managedUnlocked: true,
+        aceEnabled: true,
+        balanceUsd: 20,
+        billingMode: null,
+      }),
+    ).toBe(false)
+  })
+
+  test("acknowledges the billing write before catalog refresh", async () => {
+    const order: string[] = []
+    await commitBilling(
+      async () => {
+        order.push("write")
+        return { llm: "managed" }
+      },
+      () => order.push("apply"),
+    )
+    expect(order).toEqual(["write", "apply"])
+  })
+
+  test("refreshes account state immediately and provider availability in the background", () => {
+    expect(source).toContain('window.addEventListener("openscience:account-changed", accountChanged)')
+    expect(source).toContain("void Promise.all([loadWallet(), loadBilling()])")
+    expect(source).toContain('void syncProviders("The Ace account changed")')
+  })
+})

--- a/frontend/workspace/src/components/settings/ManagedInference.tsx
+++ b/frontend/workspace/src/components/settings/ManagedInference.tsx
@@ -1,0 +1,262 @@
+import { Button } from "@synsci/ui/button"
+import { For, Show, createMemo, createSignal, onCleanup, onMount } from "solid-js"
+import { URLS } from "@/config/urls"
+import { useGlobalSDK } from "@/context/global-sdk"
+import { useGlobalSync } from "@/context/global-sync"
+import { usePlatform } from "@/context/platform"
+import { settingsApi } from "./api"
+import { formatCreditBalance, walletBalanceLabel } from "./credit-balance"
+import { ProviderLogo } from "./ProviderLogo"
+
+export { formatCreditBalance, walletBalanceLabel } from "./credit-balance"
+
+type Mode = "managed" | "byok"
+type BillingState = { llm: Mode | null }
+type LoginResult = { ok: boolean; error?: string }
+type Wallet = {
+  signedIn: boolean
+  balanceUsd: number | null
+  billingMode: Mode | null
+  managedSupported: boolean
+  managedUnlocked: boolean
+  aceEnabled: boolean
+  aceContract?: {
+    activationAuthorizationUsd: number
+    reloadThresholdUsd: number
+    reloadAmountUsd: number
+    serviceMarginPercent: number
+    processingFeeDisclosedSeparately: boolean
+    reloadControlledByAce: boolean
+  }
+}
+
+export const canSelectManaged = (wallet: Wallet | undefined) =>
+  Boolean(wallet?.signedIn && wallet.managedSupported && wallet.managedUnlocked)
+
+export function aceContractLabel(contract: NonNullable<Wallet["aceContract"]>) {
+  return `Ace is a $${contract.activationAuthorizationUsd} authorization, not a purchase or subscription. While Ace is on, a purchased Wallet balance below $${contract.reloadThresholdUsd} triggers one fixed $${contract.reloadAmountUsd} reload; the processing fee is disclosed separately before payment.`
+}
+
+const MODES: { value: Mode; title: string; body: string }[] = [
+  {
+    value: "byok",
+    title: "BYOK / Subscription",
+    body: "Use connected provider keys or models included with an eligible subscription.",
+  },
+  {
+    value: "managed",
+    title: "Ace",
+    body: "Use supported models with your purchased Wallet balance, without configuring provider keys.",
+  },
+]
+
+const normalizeMode = (value: unknown): Mode => (value === "managed" ? "managed" : "byok")
+
+/** Apply the small routing write before refreshing the much larger catalog. */
+export async function commitBilling<T>(write: () => Promise<T>, apply: (data: T) => void): Promise<void> {
+  const result = await write()
+  apply(result)
+}
+
+export function ManagedInference(props: { onError?: (error: string | undefined) => void }) {
+  const sdk = useGlobalSDK()
+  const globalSync = useGlobalSync()
+  const platform = usePlatform()
+  const fetchFn = platform.fetch ?? fetch
+  const [wallet, setWallet] = createSignal<Wallet>()
+  const [mode, setMode] = createSignal<Mode>(normalizeMode(globalSync.data.config.billing?.llm))
+  const [saving, setSaving] = createSignal(false)
+  const [signingIn, setSigningIn] = createSignal(false)
+  const [refreshing, setRefreshing] = createSignal(false)
+  const selected = createMemo(() => MODES.find((item) => item.value === mode()) ?? MODES[0])
+
+  const reason = (error: unknown) => (error instanceof Error ? error.message : String(error))
+  const fail = (error: unknown) => props.onError?.(reason(error))
+  const loadWallet = () =>
+    settingsApi<Wallet>(sdk.url, fetchFn, "/settings/wallet")
+      .then((next) => {
+        setWallet(next)
+        if (!saving() && next.billingMode) setMode(normalizeMode(next.billingMode))
+      })
+      .catch(fail)
+  const loadBilling = () =>
+    settingsApi<BillingState>(sdk.url, fetchFn, "/settings/billing")
+      .then((next) => {
+        if (!saving()) setMode(normalizeMode(next.llm))
+      })
+      .catch(fail)
+  const refresh = () => {
+    props.onError?.(undefined)
+    void Promise.all([loadWallet(), loadBilling()])
+  }
+  const syncProviders = (context: string) => {
+    setRefreshing(true)
+    return globalSync
+      .refreshProviders()
+      .catch((error) =>
+        props.onError?.(
+          `${context}, but the model list could not be reloaded (${reason(error)}). It will catch up on the next refresh.`,
+        ),
+      )
+      .finally(() => setRefreshing(false))
+  }
+  const accountChanged = () => {
+    props.onError?.(undefined)
+    void Promise.all([loadWallet(), loadBilling()])
+  }
+
+  const update = (value: Mode) => {
+    if (saving() || (value === "managed" && !canSelectManaged(wallet()))) return
+    const previous = mode()
+    setMode(value)
+    setSaving(true)
+    props.onError?.(undefined)
+    void commitBilling(
+      () =>
+        settingsApi<BillingState>(sdk.url, fetchFn, "/settings/billing", {
+          method: "PUT",
+          body: JSON.stringify({ llm: value }),
+        }),
+      (data) => setMode(normalizeMode(data.llm)),
+    )
+      .then(() => {
+        // The routing choice is already durable. Provider synchronization is
+        // follow-up work and must not keep the controls feeling stuck.
+        setSaving(false)
+        void syncProviders("Model access was saved")
+      })
+      .catch((error) => {
+        setMode(previous)
+        fail(error)
+      })
+      .finally(() => setSaving(false))
+  }
+
+  const signIn = () => {
+    if (signingIn()) return
+    setSigningIn(true)
+    props.onError?.(undefined)
+    void settingsApi<LoginResult>(sdk.url, fetchFn, "/account/login-browser", { method: "POST" })
+      .then((result) => {
+        if (!result.ok) throw new Error(result.error || "Sign in did not complete. Try again.")
+        window.dispatchEvent(new Event("openscience:account-changed"))
+        void syncProviders("The Ace account changed")
+      })
+      .catch(fail)
+      .finally(() => setSigningIn(false))
+  }
+
+  const unsubscribe = globalSync.onProvidersRefreshed(() => void loadBilling())
+  onMount(() => {
+    refresh()
+    window.addEventListener("focus", refresh)
+    window.addEventListener("openscience:account-changed", accountChanged)
+  })
+  onCleanup(() => {
+    window.removeEventListener("focus", refresh)
+    window.removeEventListener("openscience:account-changed", accountChanged)
+    unsubscribe()
+  })
+
+  const managedUnavailable = () => wallet() !== undefined && !canSelectManaged(wallet())
+  const aceLabel = () => {
+    if (!wallet()) return "Checking account"
+    if (!wallet()!.signedIn) return "Account required"
+    if (!wallet()!.managedSupported) return "Ace unavailable"
+    if (!wallet()!.managedUnlocked) return "No purchased balance"
+    if (wallet()!.aceEnabled) return "Ace on"
+    return "Wallet funded"
+  }
+  const accountAction = () => {
+    if (!wallet()?.signedIn) return signingIn() ? "Waiting for browser…" : "Sign in"
+    if (!wallet()?.managedSupported) return "Manage Wallet"
+    if (!wallet()?.managedUnlocked) return "Turn on Ace"
+    return wallet()?.aceEnabled ? "Manage Ace" : "Manage Wallet"
+  }
+  const actOnAccount = () => {
+    if (!wallet()?.signedIn) {
+      signIn()
+      return
+    }
+    platform.openLink(URLS.dashboardBilling)
+  }
+
+  return (
+    <div class="models-inference">
+      <div class="models-routing" aria-label="Model access">
+        <div class="models-routing__identity">
+          <ProviderLogo id="synsci" label="Ace" />
+          <div class="models-routing__identity-copy">
+            <strong>Ace</strong>
+            <span>Managed models, one purchased Wallet.</span>
+          </div>
+        </div>
+        <div
+          class="models-routing__options"
+          role="group"
+          aria-label="Model access mode"
+          aria-describedby="managed-inference-description"
+        >
+          <For each={MODES}>
+            {(option) => (
+              <button
+                type="button"
+                aria-pressed={mode() === option.value}
+                aria-busy={saving()}
+                disabled={saving() || (option.value === "managed" && !canSelectManaged(wallet()))}
+                class="models-routing__option"
+                title={
+                  option.value === "managed" && managedUnavailable()
+                    ? "Sign in, add purchased Wallet funds, or turn on Ace to use managed models"
+                    : undefined
+                }
+                onClick={() => update(option.value)}
+              >
+                <span class="models-routing__option-label">
+                  <span>{option.title}</span>
+                </span>
+              </button>
+            )}
+          </For>
+        </div>
+        <div class="models-routing__details">
+          <p id="managed-inference-description" class="models-routing__description" aria-live="polite">
+            {saving() ? `Saving ${selected().title}…` : selected().body}
+            <Show when={!saving() && refreshing()}>
+              <span class="models-routing__sync"> Updating model availability…</span>
+            </Show>
+          </p>
+          <div class="models-routing__account">
+            <span class="models-routing__account-state">{aceLabel()}</span>
+            <span aria-live="polite" class="models-account-summary__balance">
+              <Show when={wallet()} fallback="Checking balance…">
+                {walletBalanceLabel(wallet()!)}
+              </Show>
+            </span>
+            <Button
+              class="settings-panel-action models-secondary-action"
+              size="small"
+              variant="secondary"
+              disabled={signingIn()}
+              onClick={actOnAccount}
+            >
+              {accountAction()}
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <Show when={wallet()?.aceContract}>
+        {(contract) => (
+          <p class="settings-inline-note text-12-regular text-text-weak">{aceContractLabel(contract())}</p>
+        )}
+      </Show>
+
+      <Show when={wallet() && !wallet()!.signedIn}>
+        <p class="settings-inline-note text-12-regular text-text-weak">
+          Sign in to use purchased Wallet funds or authorize Ace. Your own provider connections remain separate.
+        </p>
+      </Show>
+    </div>
+  )
+}

--- a/frontend/workspace/src/components/settings/Models.tsx
+++ b/frontend/workspace/src/components/settings/Models.tsx
@@ -1,9 +1,10 @@
-import { For, Show, createEffect, createMemo, createResource, createSignal } from "solid-js"
+import { For, Show, createEffect, createMemo, createResource, createSignal, onCleanup } from "solid-js"
 import { Button } from "@synsci/ui/button"
 import { Icon } from "@synsci/ui/icon"
 import { Select } from "@synsci/ui/select"
 import { Switch } from "@synsci/ui/switch"
 import { useGlobalSDK } from "@/context/global-sdk"
+import { useGlobalSync } from "@/context/global-sync"
 import { useModels, type ModelKey } from "@/context/models"
 import { usePlatform } from "@/context/platform"
 import { productPreferences } from "@/context/product-preferences"
@@ -18,6 +19,7 @@ import {
 } from "@/context/model-catalog"
 import { resolveModelAccessRoute, type ModelRouteAccess } from "@/context/model-route-resolution"
 import { CodexConnection } from "./CodexConnection"
+import { ManagedInference } from "./ManagedInference"
 import { ProviderKeys } from "./ProviderKeys"
 import { ProviderLogo } from "./ProviderLogo"
 import { modelGroup, modelGroupLabel, modelGroupRank } from "../model-groups"
@@ -63,6 +65,7 @@ type Option = {
 }
 
 type Scope = "all" | "reasoning" | "latest" | "long"
+type BillingPreference = { llm: "managed" | "byok" | null }
 type OptionGroup<T> = { id: string; label: string; models: T[] }
 type WorkerOption = {
   value: string
@@ -71,8 +74,6 @@ type WorkerOption = {
   providerLogo?: string
   model?: DelegationModel
 }
-
-const isUserOwnedRoute = (model: AvailableModel) => !model.provider.id.startsWith("synsci")
 
 export function takeModelGroups<T>(groups: OptionGroup<T>[], limit: number): OptionGroup<T>[] {
   let remaining = Math.max(0, limit)
@@ -94,6 +95,7 @@ const scopes: Array<{ id: Scope; label: string }> = [
 ]
 
 export default function Models() {
+  const sync = useGlobalSync()
   const sdk = useGlobalSDK()
   const models = useModels()
   const platform = usePlatform()
@@ -105,6 +107,11 @@ export default function Models() {
   const [preferences, preferenceActions] = createResource(() =>
     settingsApi<CapabilityPreferences>(sdk.url, fetchFn, "/settings/preferences"),
   )
+  const [billing, billingActions] = createResource(() =>
+    settingsApi<BillingPreference>(sdk.url, fetchFn, "/settings/billing"),
+  )
+  const unsubscribeBilling = sync.onProvidersRefreshed(() => void billingActions.refetch())
+  onCleanup(unsubscribeBilling)
   const routeOption = (item: AvailableModel): RouteOption => {
     const display = displayProviderForModel(item.provider, item.id)
     const key = { providerID: item.provider.id, modelID: item.id }
@@ -112,7 +119,8 @@ export default function Models() {
       inferenceSource({
         providerID: item.provider.id,
         credential: item.provider.source,
-      }) ?? "byok"
+        billing: sync.data.config.billing?.llm,
+      }) ?? (item.provider.id.startsWith("synsci") ? "managed" : "byok")
     return {
       key,
       source: item,
@@ -127,7 +135,7 @@ export default function Models() {
   const options = createMemo<Option[]>(() => {
     models.pinned.list()
     return groupModelRoutes({
-      models: models.list().filter(isUserOwnedRoute),
+      models: models.list(),
       recent: models.recent.list(),
     })
       .map((choice) => {
@@ -205,6 +213,7 @@ export default function Models() {
   const visibleCount = createMemo(() => options().filter((model) => model.visible).length)
   const workerOptions = createMemo<WorkerOption[]>(() => {
     const selected = preferences()?.delegation_worker_model ?? undefined
+    const currentBilling = billing.latest?.llm ?? sync.data.config.billing?.llm
     const routes = options()
       .filter(
         (model) =>
@@ -216,7 +225,7 @@ export default function Models() {
       .flatMap((model): WorkerOption[] => {
         const resolved = resolveModelAccessRoute({
           routes: model.routes.map((route) => ({ ...route.key, access: route.routeAccess, route })),
-          billing: null,
+          billing: currentBilling,
           current: selected,
         })
         const route = resolved?.route
@@ -234,12 +243,6 @@ export default function Models() {
       .toSorted((a, b) => a.label.localeCompare(b.label) || a.value.localeCompare(b.value))
     const saved =
       selected &&
-      models
-        .list()
-        .some(
-          (model) =>
-            model.provider.id === selected.providerID && model.id === selected.modelID && isUserOwnedRoute(model),
-        ) &&
       !routes.some(
         (option) => option.model?.providerID === selected.providerID && option.model.modelID === selected.modelID,
       )
@@ -317,6 +320,12 @@ export default function Models() {
               {error()}
             </div>
           </Show>
+          <Section id="model-access" title="Ace" description="Managed model access and your purchased Wallet balance.">
+            <div class="settings-card models-access-card">
+              <ManagedInference onError={setError} />
+            </div>
+          </Section>
+
           <Section
             id="model-connections"
             title="Connections"

--- a/frontend/workspace/src/components/settings/ProviderKeys.test.ts
+++ b/frontend/workspace/src/components/settings/ProviderKeys.test.ts
@@ -9,4 +9,5 @@ test("opening Models does not run a destructive dashboard sync", async () => {
   expect(source).toContain("refreshAfterSave")
   expect(source).toContain("disabled={saving()}")
   expect(source).toContain('if (adding()) setKey("")')
+  expect(source).toContain('item.source !== "managed"')
 })

--- a/frontend/workspace/src/components/settings/ProviderKeys.tsx
+++ b/frontend/workspace/src/components/settings/ProviderKeys.tsx
@@ -18,7 +18,9 @@ import { ProviderLogo } from "./ProviderLogo"
  * set themselves in a .env or a config file — nobody else manages it, and the
  * phrase suggests an administrator does.
  */
-const SOURCES: Record<Provider["source"], { label: string; removable: boolean; title: string; note?: string }> = {
+type ProviderSource = Provider["source"] | "managed"
+
+const SOURCES: Record<ProviderSource, { label: string; removable: boolean; title: string; note?: string }> = {
   api: {
     label: "local file",
     removable: true,
@@ -42,6 +44,12 @@ const SOURCES: Record<Provider["source"], { label: string; removable: boolean; t
     note: "set in openscience.json",
     title: "Custom provider supplied by openscience.json; edit that file to remove it",
   },
+  managed: {
+    label: "Ace",
+    removable: false,
+    note: "managed through your Ace account",
+    title: "Ace model access; manage it in the Ace section above",
+  },
 }
 
 export function ProviderKeys(props: { onError?: (error: string | undefined) => void }) {
@@ -57,9 +65,9 @@ export function ProviderKeys(props: { onError?: (error: string | undefined) => v
   const connected = createMemo(() =>
     providers
       .connected()
-      .filter((item) => MODEL_PROVIDERS.some((provider) => provider.id === item.id)),
+      .filter((item) => item.source !== "managed" && MODEL_PROVIDERS.some((provider) => provider.id === item.id)),
   )
-  const source = (item: { id: string }) => SOURCES[(item as { source?: Provider["source"] }).source ?? "api"]
+  const source = (item: { id: string; source?: ProviderSource }) => SOURCES[item.source ?? "api"]
   const refreshAfterSave = (done: string) => {
     void sync
       .refreshProviders()

--- a/frontend/workspace/src/components/settings/ProviderLogo.test.ts
+++ b/frontend/workspace/src/components/settings/ProviderLogo.test.ts
@@ -42,6 +42,11 @@ describe("provider logos", () => {
     expect(providerLogoSource("ollama")).toEqual({ kind: "vector", id: "ollama" })
   })
 
+  test("uses the canonical Synthetic Sciences mark for Ace", () => {
+    expect(providerLogoSource("synsci")).toEqual({ kind: "provider", id: "synsci" })
+    expect(providerLogoSource("ace")).toEqual({ kind: "provider", id: "synsci" })
+  })
+
   test("covers every built-in compute and integration credential", () => {
     for (const id of CREDENTIALS) expect(providerLogoSource(id).kind).not.toBe("fallback")
   })

--- a/frontend/workspace/src/components/settings/ProviderLogo.tsx
+++ b/frontend/workspace/src/components/settings/ProviderLogo.tsx
@@ -79,6 +79,7 @@ const VECTORS = {
 } satisfies Record<string, Vector>
 
 const SOURCES: Record<string, Source> = {
+  synsci: { kind: "provider", id: "synsci" },
   anthropic: { kind: "provider", id: "anthropic" },
   openai: { kind: "provider", id: "openai" },
   "openai-codex": { kind: "provider", id: "openai" },
@@ -126,6 +127,8 @@ const SOURCES: Record<string, Source> = {
 // as the icon pack. Normalize the known spellings so a real provider never
 // falls back to a generic initial (notably DeepSeek, Kimi, and Z.AI).
 const ALIASES: Record<string, keyof typeof SOURCES> = {
+  ace: "synsci",
+  "synthetic-sciences": "synsci",
   "deep-seek": "deepseek",
   "deepseek-ai": "deepseek",
   together: "togetherai",

--- a/frontend/workspace/src/components/settings/credit-balance.ts
+++ b/frontend/workspace/src/components/settings/credit-balance.ts
@@ -1,0 +1,15 @@
+export function formatCreditBalance(value: number) {
+  return `$${value.toFixed(2)}`
+}
+
+/**
+ * Wallet means purchased credit only. Promotional plan benefits are deliberately
+ * absent from this display contract and must never be folded into balanceUsd.
+ */
+export function walletBalanceLabel(input: { signedIn: boolean; balanceUsd: number | null }) {
+  if (!input.signedIn) return "Not signed in"
+  if (input.balanceUsd === null) return "Balance unavailable"
+  return input.balanceUsd >= 0
+    ? `${formatCreditBalance(input.balanceUsd)} available`
+    : `${formatCreditBalance(input.balanceUsd)} balance`
+}

--- a/frontend/workspace/src/components/settings/models.css
+++ b/frontend/workspace/src/components/settings/models.css
@@ -25,8 +25,10 @@
   border-radius: var(--settings-radius-control);
 }
 
+.models-access-card,
 .models-connections-card,
 .models-preferences-card,
+.models-inference,
 .models-provider-keys,
 .models-connected-providers {
   display: flex;
@@ -34,10 +36,20 @@
   flex-direction: column;
 }
 
+.models-access-card,
 .models-connections-card,
 .models-preferences-card,
+.models-inference,
 .models-provider-keys {
   gap: 0;
+}
+
+.models-access-card {
+  width: 100%;
+  min-height: 0;
+  height: auto;
+  flex: 0 0 auto;
+  align-self: flex-start;
 }
 
 .models-connections-card,
@@ -66,6 +78,10 @@
   flex: 0 0 auto;
   align-items: center;
   margin-left: auto;
+}
+
+.models-account-summary__balance {
+  font-variant-numeric: tabular-nums;
 }
 
 .settings-dialog .settings-models-panel [data-component="button"] {
@@ -110,6 +126,147 @@
 .settings-dialog .settings-models-panel :where(button, input):focus-visible,
 .settings-dialog .settings-models-panel [data-slot="select-select-trigger"]:focus-visible {
   outline-color: var(--border-focus);
+}
+
+/* Ace stays one flat decision surface: brand and mode first, account truth and
+   purchased-Wallet terms directly below. No catalog work is mounted here. */
+.models-routing {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--models-gap-3);
+  padding: var(--models-gap-3);
+  border: 0;
+  border-radius: var(--settings-radius-control);
+  background: transparent;
+  box-shadow: none;
+}
+
+.models-routing__identity,
+.models-routing__details,
+.models-routing__account {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+}
+
+.models-routing__identity {
+  gap: var(--models-gap-3);
+}
+
+.models-routing__identity-copy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.models-routing__identity-copy strong {
+  color: var(--text-strong);
+  font-size: 12px;
+  font-weight: var(--font-weight-medium);
+}
+
+.models-routing__identity-copy span {
+  overflow: hidden;
+  color: var(--text-weak);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.models-routing__options {
+  width: min(100%, 320px);
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 2px;
+  padding: 2px;
+  border-radius: var(--settings-radius-control);
+  background: var(--settings-surface-muted);
+}
+
+.settings-dialog .settings-models-panel .models-routing__option {
+  min-width: 0;
+  min-height: var(--models-control-height);
+  height: var(--models-control-height);
+  padding: 0 var(--models-gap-2);
+  border: 0;
+  border-radius: calc(var(--settings-radius-control) - 2px);
+  background: transparent;
+  color: var(--text-weak);
+  font-size: 12px;
+  font-weight: var(--font-weight-medium);
+  transition:
+    background-color 140ms ease,
+    color 140ms ease,
+    transform 140ms ease;
+}
+
+.settings-dialog .settings-models-panel .models-routing__option:hover:not(:disabled) {
+  background: var(--settings-surface-hover);
+  color: var(--text-strong);
+}
+
+.settings-dialog .settings-models-panel .models-routing__option:active:not(:disabled) {
+  transform: scale(0.98);
+}
+
+.settings-dialog .settings-models-panel .models-routing__option[aria-pressed="true"] {
+  background: var(--settings-surface-hover);
+  color: var(--text-strong);
+  box-shadow: none;
+}
+
+.models-routing__option-label {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: center;
+}
+
+.models-routing__option-label > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.models-routing__description {
+  min-width: 0;
+  flex: 1 1 auto;
+  margin: 0;
+  color: var(--text-weak);
+  font-size: 11px;
+  line-height: 16px;
+  text-wrap: pretty;
+}
+
+.models-routing__details {
+  justify-content: space-between;
+  gap: var(--models-gap-3);
+  padding: 0 2px;
+}
+
+.models-routing__account {
+  flex: 0 1 auto;
+  justify-content: flex-end;
+  gap: var(--models-gap-2);
+  color: var(--text-weak);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.models-routing__account-state {
+  color: var(--text-strong);
+  font-weight: var(--font-weight-medium);
+}
+
+.models-routing__sync {
+  color: var(--text-weaker);
+}
+
+.models-inference > .settings-inline-note {
+  margin: 0;
+  padding: 0 var(--models-gap-3) 8px;
 }
 
 .models-connection-row,
@@ -441,6 +598,21 @@
 }
 
 @container settings-main (max-width: 700px) {
+  .models-routing__details {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .models-routing__options {
+    width: 100%;
+    flex-basis: auto;
+  }
+
+  .models-routing__account {
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+
   .models-provider-key-form {
     grid-template-columns: minmax(0, 1fr) minmax(0, 1.35fr);
   }
@@ -513,5 +685,11 @@
   .settings-dialog .settings-models-panel :where(button, [role="button"]),
   .settings-dialog .settings-models-panel :where(input, [data-slot="select-select-trigger"]) {
     min-height: 44px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .settings-dialog .settings-models-panel .models-routing__option {
+    transition: none;
   }
 }

--- a/frontend/workspace/src/components/settings/preference-panels.css
+++ b/frontend/workspace/src/components/settings/preference-panels.css
@@ -756,6 +756,50 @@
   text-wrap: pretty;
 }
 
+.settings-account-card {
+  overflow: hidden;
+  padding: var(--settings-space-1);
+}
+
+.settings-account-card > * + * {
+  border-top: 1px solid var(--border-weak-base);
+}
+
+.settings-account-logo .settings-provider-logo {
+  width: 20px;
+  height: 20px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.settings-preference-row__actions {
+  min-width: 0;
+  display: flex;
+  flex: 0 1 auto;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--settings-space-2);
+  margin-left: auto;
+}
+
+.settings-account-value {
+  max-width: min(320px, 100%);
+  color: var(--text-strong);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  overflow-wrap: anywhere;
+}
+
+.settings-account-workspace {
+  width: min(220px, 100%);
+  min-width: 160px;
+}
+
+.settings-account-workspace [data-slot="select-select-trigger"] {
+  width: 100%;
+}
+
 @container settings-main (max-width: 680px) {
   .settings-compute-host-row {
     align-items: flex-start;
@@ -789,7 +833,13 @@
   .settings-preference-row__actions,
   .settings-storage-location__actions {
     width: 100%;
+    justify-content: flex-start;
+    margin-left: 0;
     padding-left: 42px;
+  }
+
+  .settings-account-workspace {
+    width: 100%;
   }
 
   .settings-inline-editor,

--- a/frontend/workspace/src/components/settings/preference-panels.test.ts
+++ b/frontend/workspace/src/components/settings/preference-panels.test.ts
@@ -6,6 +6,7 @@ const panelNames = ["Network", "Permissions", "Storage", "Sandbox", "General"] a
 const source = (name: (typeof panelNames)[number]) =>
   readFileSync(fileURLToPath(new URL(`./${name}.tsx`, import.meta.url)), "utf8")
 const compute = readFileSync(fileURLToPath(new URL("./Compute.tsx", import.meta.url)), "utf8")
+const appearance = readFileSync(fileURLToPath(new URL("../settings-general.tsx", import.meta.url)), "utf8")
 const styles = readFileSync(fileURLToPath(new URL("./preference-panels.css", import.meta.url)), "utf8")
 
 describe("minimal grouped settings panels", () => {
@@ -28,8 +29,8 @@ describe("minimal grouped settings panels", () => {
   test("uses progressive disclosure and aligned numeric metrics", () => {
     expect(source("Permissions")).toContain("Show all tool defaults")
     expect(source("Permissions")).toContain("aria-expanded={showAllDefaults()}")
-    expect(source("General")).toContain("Show sound settings")
-    expect(source("General")).toContain("aria-expanded={showAdvanced()}")
+    expect(source("General")).toContain("<AppearanceSections />")
+    expect(appearance).toContain("settings.general.section.sounds")
     expect(styles).toContain('data-expanded="false"] > .settings-section:nth-child(n + 3):not(:last-child)')
     expect(styles).toContain("font-variant-numeric: tabular-nums")
   })
@@ -43,7 +44,7 @@ describe("minimal grouped settings panels", () => {
     expect(source("Storage")).toContain('role="progressbar"')
     expect(source("Sandbox")).toContain('call<SelfTest>("/test", { method: "POST" })')
     expect(source("Sandbox")).toContain('aria-live="polite"')
-    expect(source("General")).toContain("sdk.client.account.logout()")
+    expect(source("General")).toContain('"/account/logout", { method: "POST" }')
     expect(source("General")).not.toContain('settingsApi<Preferences>(base(), fetchFn(), "/settings/preferences"')
     expect(source("General")).not.toContain('title="Gateway"')
     expect(source("General")).not.toContain('title="Trace"')

--- a/frontend/workspace/src/components/settings/registry-contract.test.ts
+++ b/frontend/workspace/src/components/settings/registry-contract.test.ts
@@ -36,8 +36,8 @@ describe("settings registry source contract", () => {
       "Models",
       "Local models",
       "Skills",
-      "Scientific tools",
-      "MCP & connectors",
+      "Tools",
+      "Connectors",
       "Research tools",
       "Compute",
       "Security & access",
@@ -68,10 +68,12 @@ describe("settings registry source contract", () => {
     const models = await Bun.file(new URL("Models.tsx", root)).text()
     const general = await Bun.file(new URL("General.tsx", root)).text()
 
-    expect(models).not.toContain("ManagedInference")
+    expect(models).toContain("ManagedInference")
     expect(models).toContain("<CodexConnection")
     expect(models).toContain("<ProviderKeys")
     expect(general).toContain("<AppearanceSections")
+    expect(general).toContain('title="Ace account"')
+    expect(general).toContain('"/account/login-browser"')
     expect(general).not.toContain('title="Navigation"')
     expect(general).not.toContain('title="Gateway"')
     expect(general).not.toContain('title="Trace"')

--- a/frontend/workspace/src/config/urls.ts
+++ b/frontend/workspace/src/config/urls.ts
@@ -2,4 +2,5 @@ export const URLS = {
   docs: "https://github.com/synthetic-sciences/OpenScience#readme",
   changelog: "/settings/updates/releases",
   releases: "https://github.com/synthetic-sciences/OpenScience/releases",
+  dashboardBilling: "https://app.syntheticsciences.ai/billing",
 } as const

--- a/frontend/workspace/src/context/local.tsx
+++ b/frontend/workspace/src/context/local.tsx
@@ -121,7 +121,8 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         }
 
         // Resolve one connected Sol route without treating provider identities
-        // as interchangeable. Automatic prefers the user's ChatGPT connection.
+        // as interchangeable. The active access contract decides which route
+        // is eligible; Automatic still prefers the user's ChatGPT connection.
         const connected = new Map(providers.connected().map((provider) => [provider.id, provider]))
         const candidates = [
           { providerID: "openai", modelID: "gpt-5.6-sol" },
@@ -130,7 +131,12 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         ].flatMap((route): ModelAccessRoute[] => {
           const provider = connected.get(route.providerID)
           if (!provider?.models[route.modelID]) return []
-          const access: ModelRouteAccess = provider.id === "openai-codex" ? "chatgpt" : "byok"
+          const access: ModelRouteAccess =
+            provider.id === "openai-codex"
+              ? "chatgpt"
+              : provider.source === "managed" || provider.id.startsWith("synsci")
+                ? "managed"
+                : "byok"
           return [{ ...route, access }]
         })
         const initial = resolveModelAccessRoute({

--- a/frontend/workspace/src/context/model-catalog.ts
+++ b/frontend/workspace/src/context/model-catalog.ts
@@ -105,21 +105,24 @@ export function displayProviderForModel(provider: ModelProviderDisplay, modelID:
   return OPENROUTER_VENDOR_DISPLAY[vendor?.toLowerCase() ?? ""] ?? provider
 }
 
-export type InferenceSource = "byok" | "chatgpt"
+export type InferenceSource = "managed" | "byok" | "chatgpt"
 
 /** Factual access route for a connected provider; ambiguous routes stay unlabeled. */
 export function inferenceSource(input: {
   providerID: string
-  credential: "env" | "config" | "custom" | "api"
+  credential: "env" | "config" | "custom" | "api" | "managed"
+  billing?: "managed" | "byok" | null
 }): InferenceSource | undefined {
   if (input.providerID === "openai-codex") return "chatgpt"
+  if (input.providerID === "openrouter" && input.credential === "managed") return "managed"
   if (input.credential === "api") return "byok"
-  if (input.providerID === "openrouter") return "byok"
+  if (input.providerID === "openrouter") return input.billing === "byok" ? "byok" : undefined
   if (input.credential === "env" || input.credential === "config") return "byok"
   return undefined
 }
 
 export function inferenceSourceLabel(source: InferenceSource | undefined, fallback = "Provider") {
+  if (source === "managed") return "Ace"
   if (source === "byok") return "BYOK"
   if (source === "chatgpt") return "ChatGPT"
   return fallback
@@ -304,7 +307,7 @@ export function isChatModel(model: CatalogModel): boolean {
 
 export function isUserProviderConnection(input: {
   providerID: string
-  source?: "env" | "config" | "custom" | "api"
+  source?: "env" | "config" | "custom" | "api" | "managed"
 }): boolean {
   // Connected rows are account-backed credentials or keys explicitly saved in
   // this UI. Ambient shell variables and project/config providers can still be

--- a/frontend/workspace/src/context/model-route-resolution.test.ts
+++ b/frontend/workspace/src/context/model-route-resolution.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test"
+import { resolveModelAccessRoute, type ModelAccessRoute } from "./model-route-resolution"
+
+const managed: ModelAccessRoute = {
+  providerID: "openrouter",
+  modelID: "openai/gpt-5.6-sol",
+  access: "managed",
+}
+const byok: ModelAccessRoute = { providerID: "openai", modelID: "gpt-5.6-sol", access: "byok" }
+const chatgpt: ModelAccessRoute = { providerID: "openai-codex", modelID: "gpt-5.6-sol", access: "chatgpt" }
+
+describe("exact model access route resolution", () => {
+  test("Automatic prefers connected ChatGPT, Ace stays managed, and BYOK stays direct", () => {
+    const routes = [managed, byok, chatgpt]
+    expect(resolveModelAccessRoute({ routes, billing: null })).toBe(chatgpt)
+    expect(resolveModelAccessRoute({ routes, billing: "managed" })).toBe(managed)
+    expect(resolveModelAccessRoute({ routes, billing: "byok" })).toBe(byok)
+    expect(resolveModelAccessRoute({ routes: [managed], billing: "byok" })).toBeUndefined()
+  })
+
+  test("never swaps an existing exact route for a logical sibling", () => {
+    const routes = [managed, byok, chatgpt]
+    expect(resolveModelAccessRoute({ routes, billing: "managed", current: chatgpt })).toBe(chatgpt)
+    expect(resolveModelAccessRoute({ routes, billing: null, current: managed })).toBe(managed)
+  })
+})

--- a/frontend/workspace/src/context/model-route-resolution.ts
+++ b/frontend/workspace/src/context/model-route-resolution.ts
@@ -1,7 +1,7 @@
 import type { ModelKey } from "./model-catalog"
 
 export type ModelBillingMode = "managed" | "byok" | null | undefined
-export type ModelRouteAccess = "byok" | "chatgpt"
+export type ModelRouteAccess = "managed" | "byok" | "chatgpt"
 export type ModelAccessRoute = ModelKey & { access: ModelRouteAccess }
 
 const exactRoute = (left: ModelKey, right: ModelKey) =>
@@ -9,8 +9,8 @@ const exactRoute = (left: ModelKey, right: ModelKey) =>
 
 /**
  * Pick one connected route for a logical model without folding provider
- * identities together. An attached ChatGPT subscription is preferred, then a
- * user API key.
+ * identities together. Automatic prefers an attached ChatGPT subscription;
+ * Ace stays on managed inference; BYOK prefers a direct user route.
  * An already selected exact route always wins so changing effort or speed can
  * never move a request onto another credential.
  */
@@ -24,7 +24,12 @@ export function resolveModelAccessRoute<T extends ModelAccessRoute>(input: {
     if (current) return current
   }
 
-  const priority: readonly ModelRouteAccess[] = input.billing === "byok" ? ["byok", "chatgpt"] : ["chatgpt", "byok"]
+  const priority: readonly ModelRouteAccess[] =
+    input.billing === "managed"
+      ? ["managed"]
+      : input.billing === "byok"
+        ? ["byok", "chatgpt"]
+        : ["chatgpt", "byok", "managed"]
 
   for (const access of priority) {
     const route = input.routes.find((candidate) => candidate.access === access)

--- a/tooling/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/tooling/sdk/js/src/v2/gen/sdk.gen.ts
@@ -3,6 +3,19 @@
 import { client } from "./client.gen.js"
 import { buildClientParams, type Client, type Options as Options2, type TDataShape } from "./client/index.js"
 import type {
+  AccountBalanceResponses,
+  AccountBillingModeGetResponses,
+  AccountBillingModeSetResponses,
+  AccountDeviceRevokeResponses,
+  AccountDevicesResponses,
+  AccountFundingContextGetResponses,
+  AccountFundingContextSetErrors,
+  AccountFundingContextSetResponses,
+  AccountGetResponses,
+  AccountLoginBrowserResponses,
+  AccountLoginKeyResponses,
+  AccountLogoutResponses,
+  AccountSessionResponses,
   AgentPartInput,
   ApiAuth,
   AppAgentsResponses,
@@ -280,6 +293,8 @@ import type {
   SessionUnrevertResponses,
   SessionUpdateErrors,
   SessionUpdateResponses,
+  SettingsBillingGetResponses,
+  SettingsBillingUpdateResponses,
   SettingsComputeEnvironmentsRepairResponses,
   SettingsComputeGetResponses,
   SettingsComputeJobsCancelErrors,
@@ -352,6 +367,7 @@ import type {
   SettingsUpdatesInstallResponses,
   SettingsUpdatesStageResponses,
   SettingsUpdatesStateResponses,
+  SettingsWalletGetResponses,
   SubtaskPartInput,
   TextPartInput,
   ToolIdsErrors,
@@ -602,6 +618,196 @@ export class Global extends HeyApiClient {
   private _config?: Config
   get config(): Config {
     return (this._config ??= new Config({ client: this.client }))
+  }
+}
+
+export class FundingContext extends HeyApiClient {
+  /**
+   * Get Ace funding workspace
+   */
+  public get<ThrowOnError extends boolean = false>(options?: Options<never, ThrowOnError>) {
+    return (options?.client ?? this.client).get<AccountFundingContextGetResponses, unknown, ThrowOnError>({
+      url: "/account/funding-context",
+      ...options,
+    })
+  }
+
+  /**
+   * Choose Ace funding workspace
+   */
+  public set<ThrowOnError extends boolean = false>(
+    parameters: {
+      organization_id: string | null
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams([parameters], [{ args: [{ in: "body", key: "organization_id" }] }])
+    return (options?.client ?? this.client).put<
+      AccountFundingContextSetResponses,
+      AccountFundingContextSetErrors,
+      ThrowOnError
+    >({
+      url: "/account/funding-context",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+}
+
+export class Device extends HeyApiClient {
+  /**
+   * Revoke account device
+   */
+  public revoke<ThrowOnError extends boolean = false>(
+    parameters: {
+      keyID: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams([parameters], [{ args: [{ in: "path", key: "keyID" }] }])
+    return (options?.client ?? this.client).delete<AccountDeviceRevokeResponses, unknown, ThrowOnError>({
+      url: "/account/devices/{keyID}",
+      ...options,
+      ...params,
+    })
+  }
+}
+
+export class BillingMode extends HeyApiClient {
+  /**
+   * Get model billing mode
+   */
+  public get<ThrowOnError extends boolean = false>(options?: Options<never, ThrowOnError>) {
+    return (options?.client ?? this.client).get<AccountBillingModeGetResponses, unknown, ThrowOnError>({
+      url: "/account/billing-mode",
+      ...options,
+    })
+  }
+
+  /**
+   * Set model billing mode
+   */
+  public set<ThrowOnError extends boolean = false>(
+    parameters: {
+      mode: "byok" | "managed"
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams([parameters], [{ args: [{ in: "body", key: "mode" }] }])
+    return (options?.client ?? this.client).post<AccountBillingModeSetResponses, unknown, ThrowOnError>({
+      url: "/account/billing-mode",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+}
+
+export class Account extends HeyApiClient {
+  /**
+   * Get local account session status
+   */
+  public session<ThrowOnError extends boolean = false>(options?: Options<never, ThrowOnError>) {
+    return (options?.client ?? this.client).get<AccountSessionResponses, unknown, ThrowOnError>({
+      url: "/account/session",
+      ...options,
+    })
+  }
+
+  /**
+   * Get Ace account and funding summary
+   */
+  public get<ThrowOnError extends boolean = false>(options?: Options<never, ThrowOnError>) {
+    return (options?.client ?? this.client).get<AccountGetResponses, unknown, ThrowOnError>({
+      url: "/account",
+      ...options,
+    })
+  }
+
+  /**
+   * Get purchased wallet balance
+   */
+  public balance<ThrowOnError extends boolean = false>(options?: Options<never, ThrowOnError>) {
+    return (options?.client ?? this.client).get<AccountBalanceResponses, unknown, ThrowOnError>({
+      url: "/account/balance",
+      ...options,
+    })
+  }
+
+  /**
+   * List account devices
+   */
+  public devices<ThrowOnError extends boolean = false>(options?: Options<never, ThrowOnError>) {
+    return (options?.client ?? this.client).get<AccountDevicesResponses, unknown, ThrowOnError>({
+      url: "/account/devices",
+      ...options,
+    })
+  }
+
+  /**
+   * Sign in through the system browser
+   */
+  public loginBrowser<ThrowOnError extends boolean = false>(options?: Options<never, ThrowOnError>) {
+    return (options?.client ?? this.client).post<AccountLoginBrowserResponses, unknown, ThrowOnError>({
+      url: "/account/login-browser",
+      ...options,
+    })
+  }
+
+  /**
+   * Sign in with an OpenScience workspace key
+   */
+  public loginKey<ThrowOnError extends boolean = false>(
+    parameters: {
+      key: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams([parameters], [{ args: [{ in: "body", key: "key" }] }])
+    return (options?.client ?? this.client).post<AccountLoginKeyResponses, unknown, ThrowOnError>({
+      url: "/account/login-key",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
+  /**
+   * Logout Ace account
+   */
+  public logout<ThrowOnError extends boolean = false>(options?: Options<never, ThrowOnError>) {
+    return (options?.client ?? this.client).post<AccountLogoutResponses, unknown, ThrowOnError>({
+      url: "/account/logout",
+      ...options,
+    })
+  }
+
+  private _fundingContext?: FundingContext
+  get fundingContext(): FundingContext {
+    return (this._fundingContext ??= new FundingContext({ client: this.client }))
+  }
+
+  private _device?: Device
+  get device(): Device {
+    return (this._device ??= new Device({ client: this.client }))
+  }
+
+  private _billingMode?: BillingMode
+  get billingMode(): BillingMode {
+    return (this._billingMode ??= new BillingMode({ client: this.client }))
   }
 }
 
@@ -1792,6 +1998,63 @@ export class Updates extends HeyApiClient {
   }
 }
 
+export class Billing extends HeyApiClient {
+  /**
+   * Get Ace/model billing state
+   */
+  public get<ThrowOnError extends boolean = false>(options?: Options<never, ThrowOnError>) {
+    return (options?.client ?? this.client).get<SettingsBillingGetResponses, unknown, ThrowOnError>({
+      url: "/settings/billing",
+      ...options,
+    })
+  }
+
+  /**
+   * Update Ace/model billing state
+   */
+  public update<ThrowOnError extends boolean = false>(
+    parameters?: {
+      llm?: "managed" | "byok" | null
+      compute?: "byok"
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "body", key: "llm" },
+            { in: "body", key: "compute" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).put<SettingsBillingUpdateResponses, unknown, ThrowOnError>({
+      url: "/settings/billing",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+}
+
+export class Wallet extends HeyApiClient {
+  /**
+   * Get purchased wallet and Ace ledger
+   */
+  public get<ThrowOnError extends boolean = false>(options?: Options<never, ThrowOnError>) {
+    return (options?.client ?? this.client).get<SettingsWalletGetResponses, unknown, ThrowOnError>({
+      url: "/settings/wallet",
+      ...options,
+    })
+  }
+}
+
 export class Skills extends HeyApiClient {
   /**
    * Install skill from git
@@ -1931,6 +2194,16 @@ export class Settings extends HeyApiClient {
     return (this._updates ??= new Updates({ client: this.client }))
   }
 
+  private _billing?: Billing
+  get billing(): Billing {
+    return (this._billing ??= new Billing({ client: this.client }))
+  }
+
+  private _wallet?: Wallet
+  get wallet(): Wallet {
+    return (this._wallet ??= new Wallet({ client: this.client }))
+  }
+
   private _skills?: Skills
   get skills(): Skills {
     return (this._skills ??= new Skills({ client: this.client }))
@@ -1946,7 +2219,7 @@ export class Auth extends HeyApiClient {
   /**
    * Configure an onboarding provider credential
    *
-   * Save one local provider key.
+   * Atomically save one provider key and select BYOK model access.
    */
   public onboarding<ThrowOnError extends boolean = false>(
     parameters: {
@@ -7789,6 +8062,11 @@ export class OpenScienceClient extends HeyApiClient {
   private _global?: Global
   get global(): Global {
     return (this._global ??= new Global({ client: this.client }))
+  }
+
+  private _account?: Account
+  get account(): Account {
+    return (this._account ??= new Account({ client: this.client }))
   }
 
   private _settings?: Settings

--- a/tooling/sdk/js/src/v2/gen/types.gen.ts
+++ b/tooling/sdk/js/src/v2/gen/types.gen.ts
@@ -265,7 +265,7 @@ export type UserMessage = {
   tier?: string
   context?: number
   inference?: {
-    source: "byok" | "chatgpt" | "local" | "oauth" | "unknown"
+    source: "managed" | "byok" | "chatgpt" | "local" | "oauth" | "unknown"
     effort: string
   }
 }
@@ -1918,13 +1918,13 @@ export type Config = {
    */
   default_agent?: string
   /**
-   * Provider access configuration. OpenScience uses only user-owned credentials.
+   * Provider access configuration for Ace or user-owned credentials.
    */
   billing?: {
     /**
-     * Provider access uses your own API keys, first-party OAuth subscriptions, or local models. Legacy values are migrated to 'byok'.
+     * How LLM inference is paid for. 'managed' uses Ace Credits; 'byok' uses only user-owned keys, subscriptions, or local models.
      */
-    llm?: "byok" | null
+    llm?: "managed" | "byok" | null
     /**
      * @deprecated Retained so existing 2.x config files keep parsing. Compute always uses user-owned routes.
      */
@@ -2225,7 +2225,7 @@ export type Model = {
 export type Provider = {
   id: string
   name: string
-  source: "env" | "config" | "custom" | "api"
+  source: "env" | "config" | "custom" | "api" | "managed"
   env: Array<string>
   key?: string
   options: {
@@ -2759,6 +2759,315 @@ export type GlobalDisposeResponses = {
 }
 
 export type GlobalDisposeResponse = GlobalDisposeResponses[keyof GlobalDisposeResponses]
+
+export type AccountSessionData = {
+  body?: never
+  path?: never
+  query?: never
+  url: "/account/session"
+}
+
+export type AccountSessionResponses = {
+  /**
+   * Session status
+   */
+  200: {
+    session: boolean
+  }
+}
+
+export type AccountSessionResponse = AccountSessionResponses[keyof AccountSessionResponses]
+
+export type AccountGetData = {
+  body?: never
+  path?: never
+  query?: never
+  url: "/account"
+}
+
+export type AccountGetResponses = {
+  /**
+   * Account summary
+   */
+  200: {
+    session: boolean
+    user?: unknown
+    balance_usd: number | null
+    billing_mode: {
+      mode: "byok" | "managed"
+      balance_cents: number
+      balance_usd: number
+      managed_supported: boolean
+      managed_unlocked: boolean
+      ace_enabled?: boolean
+    } | null
+    funding_context: {
+      type: "personal" | "organization"
+      organization_id?: string
+      available: boolean
+      locked: boolean
+      organizations: Array<{
+        organization_id: string
+        name: string
+        slug: string
+        is_personal: boolean
+        status: string
+        role: string
+        membership_status: string
+        funding_available: boolean
+        effective_permissions: Array<string>
+      }>
+    }
+    credential: {
+      type: "personal" | "organization"
+      legacy: boolean
+    } | null
+  }
+}
+
+export type AccountGetResponse = AccountGetResponses[keyof AccountGetResponses]
+
+export type AccountFundingContextGetData = {
+  body?: never
+  path?: never
+  query?: never
+  url: "/account/funding-context"
+}
+
+export type AccountFundingContextGetResponses = {
+  /**
+   * Funding context
+   */
+  200: {
+    type: "personal" | "organization"
+    organization_id?: string
+    available: boolean
+    locked: boolean
+    organizations: Array<{
+      organization_id: string
+      name: string
+      slug: string
+      is_personal: boolean
+      status: string
+      role: string
+      membership_status: string
+      funding_available: boolean
+      effective_permissions: Array<string>
+    }>
+  }
+}
+
+export type AccountFundingContextGetResponse =
+  AccountFundingContextGetResponses[keyof AccountFundingContextGetResponses]
+
+export type AccountFundingContextSetData = {
+  body?: {
+    organization_id: string | null
+  }
+  path?: never
+  query?: never
+  url: "/account/funding-context"
+}
+
+export type AccountFundingContextSetErrors = {
+  /**
+   * Invalid workspace
+   */
+  400: {
+    error: string
+  }
+}
+
+export type AccountFundingContextSetError = AccountFundingContextSetErrors[keyof AccountFundingContextSetErrors]
+
+export type AccountFundingContextSetResponses = {
+  /**
+   * Funding context
+   */
+  200: {
+    type: "personal" | "organization"
+    organization_id?: string
+    available: boolean
+    locked: boolean
+    organizations: Array<{
+      organization_id: string
+      name: string
+      slug: string
+      is_personal: boolean
+      status: string
+      role: string
+      membership_status: string
+      funding_available: boolean
+      effective_permissions: Array<string>
+    }>
+  }
+}
+
+export type AccountFundingContextSetResponse =
+  AccountFundingContextSetResponses[keyof AccountFundingContextSetResponses]
+
+export type AccountBalanceData = {
+  body?: never
+  path?: never
+  query?: never
+  url: "/account/balance"
+}
+
+export type AccountBalanceResponses = {
+  /**
+   * Balance
+   */
+  200: {
+    balance_usd: number | null
+  }
+}
+
+export type AccountBalanceResponse = AccountBalanceResponses[keyof AccountBalanceResponses]
+
+export type AccountDevicesData = {
+  body?: never
+  path?: never
+  query?: never
+  url: "/account/devices"
+}
+
+export type AccountDevicesResponses = {
+  /**
+   * Devices
+   */
+  200: Array<{
+    key_id: string
+    name: string
+    key_prefix: string
+    created_at: string
+    last_used_at: string | null
+    expires_at: string | null
+  }>
+}
+
+export type AccountDevicesResponse = AccountDevicesResponses[keyof AccountDevicesResponses]
+
+export type AccountDeviceRevokeData = {
+  body?: never
+  path: {
+    keyID: string
+  }
+  query?: never
+  url: "/account/devices/{keyID}"
+}
+
+export type AccountDeviceRevokeResponses = {
+  /**
+   * Revoked
+   */
+  200: boolean
+}
+
+export type AccountDeviceRevokeResponse = AccountDeviceRevokeResponses[keyof AccountDeviceRevokeResponses]
+
+export type AccountBillingModeGetData = {
+  body?: never
+  path?: never
+  query?: never
+  url: "/account/billing-mode"
+}
+
+export type AccountBillingModeGetResponses = {
+  /**
+   * Billing mode
+   */
+  200: {
+    mode: "byok" | "managed"
+    balance_cents: number
+    balance_usd: number
+    managed_supported: boolean
+    managed_unlocked: boolean
+    ace_enabled?: boolean
+  } | null
+}
+
+export type AccountBillingModeGetResponse = AccountBillingModeGetResponses[keyof AccountBillingModeGetResponses]
+
+export type AccountBillingModeSetData = {
+  body?: {
+    mode: "byok" | "managed"
+  }
+  path?: never
+  query?: never
+  url: "/account/billing-mode"
+}
+
+export type AccountBillingModeSetResponses = {
+  /**
+   * Billing mode
+   */
+  200: {
+    mode: "byok" | "managed"
+    balance_cents: number
+    balance_usd: number
+    managed_supported: boolean
+    managed_unlocked: boolean
+    ace_enabled?: boolean
+  } | null
+}
+
+export type AccountBillingModeSetResponse = AccountBillingModeSetResponses[keyof AccountBillingModeSetResponses]
+
+export type AccountLoginBrowserData = {
+  body?: never
+  path?: never
+  query?: never
+  url: "/account/login-browser"
+}
+
+export type AccountLoginBrowserResponses = {
+  /**
+   * Login result
+   */
+  200: {
+    ok: boolean
+    error?: string
+  }
+}
+
+export type AccountLoginBrowserResponse = AccountLoginBrowserResponses[keyof AccountLoginBrowserResponses]
+
+export type AccountLoginKeyData = {
+  body?: {
+    key: string
+  }
+  path?: never
+  query?: never
+  url: "/account/login-key"
+}
+
+export type AccountLoginKeyResponses = {
+  /**
+   * Login result
+   */
+  200: {
+    ok: boolean
+    error?: string
+  }
+}
+
+export type AccountLoginKeyResponse = AccountLoginKeyResponses[keyof AccountLoginKeyResponses]
+
+export type AccountLogoutData = {
+  body?: never
+  path?: never
+  query?: never
+  url: "/account/logout"
+}
+
+export type AccountLogoutResponses = {
+  /**
+   * Logged out
+   */
+  200: boolean
+}
+
+export type AccountLogoutResponse = AccountLogoutResponses[keyof AccountLogoutResponses]
 
 export type SettingsCredentialsListData = {
   body?: never
@@ -8918,6 +9227,94 @@ export type SettingsScientificToolsResponses = {
 
 export type SettingsScientificToolsResponse = SettingsScientificToolsResponses[keyof SettingsScientificToolsResponses]
 
+export type SettingsBillingGetData = {
+  body?: never
+  path?: never
+  query?: never
+  url: "/settings/billing"
+}
+
+export type SettingsBillingGetResponses = {
+  /**
+   * Billing state
+   */
+  200: {
+    llm: "managed" | "byok" | null
+    compute: "byok"
+    wallet: {
+      signedIn: boolean
+      balanceUsd: number | null
+    }
+  }
+}
+
+export type SettingsBillingGetResponse = SettingsBillingGetResponses[keyof SettingsBillingGetResponses]
+
+export type SettingsBillingUpdateData = {
+  body?: {
+    llm?: "managed" | "byok" | null
+    compute?: "byok"
+  }
+  path?: never
+  query?: never
+  url: "/settings/billing"
+}
+
+export type SettingsBillingUpdateResponses = {
+  /**
+   * Billing state
+   */
+  200: {
+    llm: "managed" | "byok" | null
+    compute: "byok"
+    wallet: {
+      signedIn: boolean
+      balanceUsd: number | null
+    }
+  }
+}
+
+export type SettingsBillingUpdateResponse = SettingsBillingUpdateResponses[keyof SettingsBillingUpdateResponses]
+
+export type SettingsWalletGetData = {
+  body?: never
+  path?: never
+  query?: never
+  url: "/settings/wallet"
+}
+
+export type SettingsWalletGetResponses = {
+  /**
+   * Wallet state
+   */
+  200: {
+    signedIn: boolean
+    balanceUsd: number | null
+    billingMode: "managed" | "byok" | null
+    managedSupported: boolean
+    managedUnlocked: boolean
+    aceEnabled: boolean
+    aceContract: {
+      activationAuthorizationUsd: number
+      reloadThresholdUsd: number
+      reloadAmountUsd: number
+      serviceMarginPercent: number
+      processingFeeDisclosedSeparately: boolean
+      reloadControlledByAce: boolean
+    }
+    lifetimeSpentUsd: number | null
+    transactions: Array<{
+      id: string
+      amountCents: number
+      source: string
+      description: string
+      createdAt: string
+    }>
+  }
+}
+
+export type SettingsWalletGetResponse = SettingsWalletGetResponses[keyof SettingsWalletGetResponses]
+
 export type AuthOnboardingData = {
   body?: ApiAuth
   path: {
@@ -8929,7 +9326,7 @@ export type AuthOnboardingData = {
 
 export type AuthOnboardingErrors = {
   /**
-   * Configuration failed
+   * Configuration failed and compensation was attempted
    */
   500: {
     error: string
@@ -8940,7 +9337,7 @@ export type AuthOnboardingError = AuthOnboardingErrors[keyof AuthOnboardingError
 
 export type AuthOnboardingResponses = {
   /**
-   * Provider credential configured
+   * Provider credential and BYOK mode configured
    */
   200: {
     configured: true

--- a/tooling/sdk/openapi.json
+++ b/tooling/sdk/openapi.json
@@ -426,6 +426,860 @@
         ]
       }
     },
+    "/account/session": {
+      "get": {
+        "operationId": "account.session",
+        "summary": "Get local account session status",
+        "responses": {
+          "200": {
+            "description": "Session status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "session": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "session"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpenScienceClient } from \"@synsci/sdk\"\n\nconst client = createOpenScienceClient()\nawait client.account.session({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/account": {
+      "get": {
+        "operationId": "account.get",
+        "summary": "Get Ace account and funding summary",
+        "responses": {
+          "200": {
+            "description": "Account summary",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "session": {
+                      "type": "boolean"
+                    },
+                    "user": {},
+                    "balance_usd": {
+                      "anyOf": [
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "billing_mode": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "mode": {
+                              "type": "string",
+                              "enum": [
+                                "byok",
+                                "managed"
+                              ]
+                            },
+                            "balance_cents": {
+                              "type": "number"
+                            },
+                            "balance_usd": {
+                              "type": "number"
+                            },
+                            "managed_supported": {
+                              "type": "boolean"
+                            },
+                            "managed_unlocked": {
+                              "type": "boolean"
+                            },
+                            "ace_enabled": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "mode",
+                            "balance_cents",
+                            "balance_usd",
+                            "managed_supported",
+                            "managed_unlocked"
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "funding_context": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "personal",
+                            "organization"
+                          ]
+                        },
+                        "organization_id": {
+                          "type": "string"
+                        },
+                        "available": {
+                          "type": "boolean"
+                        },
+                        "locked": {
+                          "type": "boolean"
+                        },
+                        "organizations": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "organization_id": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "slug": {
+                                "type": "string"
+                              },
+                              "is_personal": {
+                                "type": "boolean"
+                              },
+                              "status": {
+                                "type": "string"
+                              },
+                              "role": {
+                                "type": "string"
+                              },
+                              "membership_status": {
+                                "type": "string"
+                              },
+                              "funding_available": {
+                                "type": "boolean"
+                              },
+                              "effective_permissions": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "required": [
+                              "organization_id",
+                              "name",
+                              "slug",
+                              "is_personal",
+                              "status",
+                              "role",
+                              "membership_status",
+                              "funding_available",
+                              "effective_permissions"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "available",
+                        "locked",
+                        "organizations"
+                      ]
+                    },
+                    "credential": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "personal",
+                                "organization"
+                              ]
+                            },
+                            "legacy": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "type",
+                            "legacy"
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "session",
+                    "balance_usd",
+                    "billing_mode",
+                    "funding_context",
+                    "credential"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpenScienceClient } from \"@synsci/sdk\"\n\nconst client = createOpenScienceClient()\nawait client.account.get({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/account/funding-context": {
+      "get": {
+        "operationId": "account.fundingContext.get",
+        "summary": "Get Ace funding workspace",
+        "responses": {
+          "200": {
+            "description": "Funding context",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "personal",
+                        "organization"
+                      ]
+                    },
+                    "organization_id": {
+                      "type": "string"
+                    },
+                    "available": {
+                      "type": "boolean"
+                    },
+                    "locked": {
+                      "type": "boolean"
+                    },
+                    "organizations": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "organization_id": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "slug": {
+                            "type": "string"
+                          },
+                          "is_personal": {
+                            "type": "boolean"
+                          },
+                          "status": {
+                            "type": "string"
+                          },
+                          "role": {
+                            "type": "string"
+                          },
+                          "membership_status": {
+                            "type": "string"
+                          },
+                          "funding_available": {
+                            "type": "boolean"
+                          },
+                          "effective_permissions": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "organization_id",
+                          "name",
+                          "slug",
+                          "is_personal",
+                          "status",
+                          "role",
+                          "membership_status",
+                          "funding_available",
+                          "effective_permissions"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "available",
+                    "locked",
+                    "organizations"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpenScienceClient } from \"@synsci/sdk\"\n\nconst client = createOpenScienceClient()\nawait client.account.fundingContext.get({\n  ...\n})"
+          }
+        ]
+      },
+      "put": {
+        "operationId": "account.fundingContext.set",
+        "summary": "Choose Ace funding workspace",
+        "responses": {
+          "200": {
+            "description": "Funding context",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "personal",
+                        "organization"
+                      ]
+                    },
+                    "organization_id": {
+                      "type": "string"
+                    },
+                    "available": {
+                      "type": "boolean"
+                    },
+                    "locked": {
+                      "type": "boolean"
+                    },
+                    "organizations": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "organization_id": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "slug": {
+                            "type": "string"
+                          },
+                          "is_personal": {
+                            "type": "boolean"
+                          },
+                          "status": {
+                            "type": "string"
+                          },
+                          "role": {
+                            "type": "string"
+                          },
+                          "membership_status": {
+                            "type": "string"
+                          },
+                          "funding_available": {
+                            "type": "boolean"
+                          },
+                          "effective_permissions": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "organization_id",
+                          "name",
+                          "slug",
+                          "is_personal",
+                          "status",
+                          "role",
+                          "membership_status",
+                          "funding_available",
+                          "effective_permissions"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "available",
+                    "locked",
+                    "organizations"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid workspace",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "organization_id": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 128
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "organization_id"
+                ]
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpenScienceClient } from \"@synsci/sdk\"\n\nconst client = createOpenScienceClient()\nawait client.account.fundingContext.set({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/account/balance": {
+      "get": {
+        "operationId": "account.balance",
+        "summary": "Get purchased wallet balance",
+        "responses": {
+          "200": {
+            "description": "Balance",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "balance_usd": {
+                      "anyOf": [
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "balance_usd"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpenScienceClient } from \"@synsci/sdk\"\n\nconst client = createOpenScienceClient()\nawait client.account.balance({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/account/devices": {
+      "get": {
+        "operationId": "account.devices",
+        "summary": "List account devices",
+        "responses": {
+          "200": {
+            "description": "Devices",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "key_id": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "key_prefix": {
+                        "type": "string"
+                      },
+                      "created_at": {
+                        "type": "string"
+                      },
+                      "last_used_at": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "expires_at": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      }
+                    },
+                    "required": [
+                      "key_id",
+                      "name",
+                      "key_prefix",
+                      "created_at",
+                      "last_used_at",
+                      "expires_at"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpenScienceClient } from \"@synsci/sdk\"\n\nconst client = createOpenScienceClient()\nawait client.account.devices({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/account/devices/{keyID}": {
+      "delete": {
+        "operationId": "account.device.revoke",
+        "summary": "Revoke account device",
+        "responses": {
+          "200": {
+            "description": "Revoked",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "keyID",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpenScienceClient } from \"@synsci/sdk\"\n\nconst client = createOpenScienceClient()\nawait client.account.device.revoke({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/account/billing-mode": {
+      "get": {
+        "operationId": "account.billingMode.get",
+        "summary": "Get model billing mode",
+        "responses": {
+          "200": {
+            "description": "Billing mode",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "mode": {
+                          "type": "string",
+                          "enum": [
+                            "byok",
+                            "managed"
+                          ]
+                        },
+                        "balance_cents": {
+                          "type": "number"
+                        },
+                        "balance_usd": {
+                          "type": "number"
+                        },
+                        "managed_supported": {
+                          "type": "boolean"
+                        },
+                        "managed_unlocked": {
+                          "type": "boolean"
+                        },
+                        "ace_enabled": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "mode",
+                        "balance_cents",
+                        "balance_usd",
+                        "managed_supported",
+                        "managed_unlocked"
+                      ]
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpenScienceClient } from \"@synsci/sdk\"\n\nconst client = createOpenScienceClient()\nawait client.account.billingMode.get({\n  ...\n})"
+          }
+        ]
+      },
+      "post": {
+        "operationId": "account.billingMode.set",
+        "summary": "Set model billing mode",
+        "responses": {
+          "200": {
+            "description": "Billing mode",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "mode": {
+                          "type": "string",
+                          "enum": [
+                            "byok",
+                            "managed"
+                          ]
+                        },
+                        "balance_cents": {
+                          "type": "number"
+                        },
+                        "balance_usd": {
+                          "type": "number"
+                        },
+                        "managed_supported": {
+                          "type": "boolean"
+                        },
+                        "managed_unlocked": {
+                          "type": "boolean"
+                        },
+                        "ace_enabled": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "mode",
+                        "balance_cents",
+                        "balance_usd",
+                        "managed_supported",
+                        "managed_unlocked"
+                      ]
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "mode": {
+                    "type": "string",
+                    "enum": [
+                      "byok",
+                      "managed"
+                    ]
+                  }
+                },
+                "required": [
+                  "mode"
+                ]
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpenScienceClient } from \"@synsci/sdk\"\n\nconst client = createOpenScienceClient()\nawait client.account.billingMode.set({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/account/login-browser": {
+      "post": {
+        "operationId": "account.loginBrowser",
+        "summary": "Sign in through the system browser",
+        "responses": {
+          "200": {
+            "description": "Login result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpenScienceClient } from \"@synsci/sdk\"\n\nconst client = createOpenScienceClient()\nawait client.account.loginBrowser({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/account/login-key": {
+      "post": {
+        "operationId": "account.loginKey",
+        "summary": "Sign in with an OpenScience workspace key",
+        "responses": {
+          "200": {
+            "description": "Login result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "key": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "key"
+                ]
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpenScienceClient } from \"@synsci/sdk\"\n\nconst client = createOpenScienceClient()\nawait client.account.loginKey({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/account/logout": {
+      "post": {
+        "operationId": "account.logout",
+        "summary": "Logout Ace account",
+        "responses": {
+          "200": {
+            "description": "Logged out",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpenScienceClient } from \"@synsci/sdk\"\n\nconst client = createOpenScienceClient()\nawait client.account.logout({\n  ...\n})"
+          }
+        ]
+      }
+    },
     "/settings/credentials": {
       "get": {
         "operationId": "settings.credentials.list",
@@ -22163,14 +23017,331 @@
         ]
       }
     },
+    "/settings/billing": {
+      "get": {
+        "operationId": "settings.billing.get",
+        "summary": "Get Ace/model billing state",
+        "responses": {
+          "200": {
+            "description": "Billing state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "llm": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "enum": [
+                            "managed",
+                            "byok"
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "compute": {
+                      "type": "string",
+                      "const": "byok"
+                    },
+                    "wallet": {
+                      "type": "object",
+                      "properties": {
+                        "signedIn": {
+                          "type": "boolean"
+                        },
+                        "balanceUsd": {
+                          "anyOf": [
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "signedIn",
+                        "balanceUsd"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "llm",
+                    "compute",
+                    "wallet"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpenScienceClient } from \"@synsci/sdk\"\n\nconst client = createOpenScienceClient()\nawait client.settings.billing.get({\n  ...\n})"
+          }
+        ]
+      },
+      "put": {
+        "operationId": "settings.billing.update",
+        "summary": "Update Ace/model billing state",
+        "responses": {
+          "200": {
+            "description": "Billing state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "llm": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "enum": [
+                            "managed",
+                            "byok"
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "compute": {
+                      "type": "string",
+                      "const": "byok"
+                    },
+                    "wallet": {
+                      "type": "object",
+                      "properties": {
+                        "signedIn": {
+                          "type": "boolean"
+                        },
+                        "balanceUsd": {
+                          "anyOf": [
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "signedIn",
+                        "balanceUsd"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "llm",
+                    "compute",
+                    "wallet"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "llm": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "managed",
+                          "byok"
+                        ]
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "compute": {
+                    "type": "string",
+                    "const": "byok"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpenScienceClient } from \"@synsci/sdk\"\n\nconst client = createOpenScienceClient()\nawait client.settings.billing.update({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/settings/wallet": {
+      "get": {
+        "operationId": "settings.wallet.get",
+        "summary": "Get purchased wallet and Ace ledger",
+        "responses": {
+          "200": {
+            "description": "Wallet state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "signedIn": {
+                      "type": "boolean"
+                    },
+                    "balanceUsd": {
+                      "anyOf": [
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "billingMode": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "enum": [
+                            "managed",
+                            "byok"
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "managedSupported": {
+                      "type": "boolean"
+                    },
+                    "managedUnlocked": {
+                      "type": "boolean"
+                    },
+                    "aceEnabled": {
+                      "type": "boolean"
+                    },
+                    "aceContract": {
+                      "type": "object",
+                      "properties": {
+                        "activationAuthorizationUsd": {
+                          "type": "number",
+                          "minimum": 0
+                        },
+                        "reloadThresholdUsd": {
+                          "type": "number",
+                          "exclusiveMinimum": 0
+                        },
+                        "reloadAmountUsd": {
+                          "type": "number",
+                          "exclusiveMinimum": 0
+                        },
+                        "serviceMarginPercent": {
+                          "type": "number",
+                          "minimum": 0
+                        },
+                        "processingFeeDisclosedSeparately": {
+                          "type": "boolean"
+                        },
+                        "reloadControlledByAce": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "activationAuthorizationUsd",
+                        "reloadThresholdUsd",
+                        "reloadAmountUsd",
+                        "serviceMarginPercent",
+                        "processingFeeDisclosedSeparately",
+                        "reloadControlledByAce"
+                      ]
+                    },
+                    "lifetimeSpentUsd": {
+                      "anyOf": [
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "transactions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "amountCents": {
+                            "type": "number"
+                          },
+                          "source": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "amountCents",
+                          "source",
+                          "description",
+                          "createdAt"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "signedIn",
+                    "balanceUsd",
+                    "billingMode",
+                    "managedSupported",
+                    "managedUnlocked",
+                    "aceEnabled",
+                    "aceContract",
+                    "lifetimeSpentUsd",
+                    "transactions"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpenScienceClient } from \"@synsci/sdk\"\n\nconst client = createOpenScienceClient()\nawait client.settings.wallet.get({\n  ...\n})"
+          }
+        ]
+      }
+    },
     "/auth/{providerID}/onboarding": {
       "put": {
         "operationId": "auth.onboarding",
         "summary": "Configure an onboarding provider credential",
-        "description": "Save one local provider key.",
+        "description": "Atomically save one provider key and select BYOK model access.",
         "responses": {
           "200": {
-            "description": "Provider credential configured",
+            "description": "Provider credential and BYOK mode configured",
             "content": {
               "application/json": {
                 "schema": {
@@ -22189,7 +23360,7 @@
             }
           },
           "500": {
-            "description": "Configuration failed",
+            "description": "Configuration failed and compensation was attempted",
             "content": {
               "application/json": {
                 "schema": {
@@ -51518,6 +52689,7 @@
               "source": {
                 "type": "string",
                 "enum": [
+                  "managed",
                   "byok",
                   "chatgpt",
                   "local",
@@ -55981,16 +57153,18 @@
             "type": "string"
           },
           "billing": {
-            "description": "Provider access configuration. OpenScience uses only user-owned credentials.",
+            "description": "Provider access configuration for Ace or user-owned credentials.",
             "type": "object",
             "properties": {
               "llm": {
-                "description": "Provider access uses your own API keys, first-party OAuth subscriptions, or local models. Legacy values are migrated to 'byok'.",
-                "default": "byok",
+                "description": "How LLM inference is paid for. 'managed' uses Ace Credits; 'byok' uses only user-owned keys, subscriptions, or local models.",
                 "anyOf": [
                   {
                     "type": "string",
-                    "const": "byok"
+                    "enum": [
+                      "managed",
+                      "byok"
+                    ]
                   },
                   {
                     "type": "null"
@@ -56884,7 +58058,8 @@
               "env",
               "config",
               "custom",
-              "api"
+              "api",
+              "managed"
             ]
           },
           "env": {


### PR DESCRIPTION
## What changed
- restores full Ace account sign-in, device management, purchased-credit Wallet, funding context, and billing mode
- restores the managed model route across settings, model selection, CLI, runtime routing, and generated SDK contracts
- preserves BYOK, ChatGPT subscription, and local providers alongside Ace
- keeps Wallet strictly purchased credits and keeps managed credentials session-only
- uses local settings reads and no polling for responsive Customize menus

## Verification
- root monorepo typecheck: 7/7 packages
- production web build
- focused Ace UI tests: 50 passing
- managed route and bounded settlement retry smoke
- generated OpenAPI and JavaScript SDK contracts
- secret scan and diff validation