### PR TITLE
Keep app credentials out of project undo snapshots

### DIFF
--- a/backend/cli/src/snapshot/index.ts
+++ b/backend/cli/src/snapshot/index.ts
@@ -69,14 +69,66 @@ export namespace Snapshot {
   // stale (or empty) index, and a later revert() against that tree deletes every
   // file the tree is missing. Retry once for transient failures (index.lock
   // contention), then report the failure to the caller.
+  async function privatePaths() {
+    const worktrees = [path.resolve(Instance.worktree), await Filesystem.canonical(Instance.worktree)].filter(
+      (value): value is string => !!value,
+    )
+    const owned = [
+      { path: Global.Path.data, projects: true },
+      { path: Global.Path.config },
+      { path: Global.Path.cache },
+      { path: Global.Path.state },
+      ...(Global.LegacyData ? [{ path: Global.LegacyData, projects: true }] : []),
+      ...Global.LegacyConflicts.map((entry) => ({ path: entry.legacy })),
+    ]
+    const roots = await Promise.all(
+      owned.map(async (entry) => ({ ...entry, canonical: await Filesystem.canonical(entry.path) })),
+    )
+    const paths = new Set<string>()
+    for (const root of roots) {
+      for (const target of [path.resolve(root.path), root.canonical]) {
+        if (!target) continue
+        for (const worktree of worktrees) {
+          if (Filesystem.contains(worktree, target)) {
+            paths.add(path.relative(worktree, target).split(path.sep).join("/"))
+            continue
+          }
+          if (!Filesystem.contains(target, worktree)) continue
+          // Managed project folders are user work, despite living below data/.
+          const projects = path.join(target, "projects")
+          if (root.projects && worktree !== projects && Filesystem.contains(projects, worktree)) continue
+          paths.add("")
+        }
+      }
+    }
+    return [...paths]
+  }
+
+  async function exclusions() {
+    return (await privatePaths()).map((value) => (value ? `:(top,exclude,literal)${value}` : ":(top,exclude)**"))
+  }
+
   async function stageAll(git: string) {
-    let result = await $`git --git-dir ${git} --work-tree ${Instance.worktree} add -A -- .`
+    const paths = await privatePaths()
+    const excluded = paths.map((value) => (value ? `:(top,exclude,literal)${value}` : ":(top,exclude)**"))
+    if (paths.length) {
+      // Only prune our private undo index, never the project's real index or
+      // working files. Existing historical objects are left untouched.
+      const tracked = paths.map((value) => (value ? `:(top,literal)${value}` : ":(top)**"))
+      const removed =
+        await $`git --git-dir ${git} --work-tree ${Instance.worktree} rm -r -f --cached --ignore-unmatch -- ${tracked}`
+          .quiet()
+          .cwd(Instance.directory)
+          .nothrow()
+      if (removed.exitCode !== 0) return false
+    }
+    let result = await $`git --git-dir ${git} --work-tree ${Instance.worktree} add -A -- . ${excluded}`
       .quiet()
       .cwd(Instance.directory)
       .nothrow()
     if (result.exitCode !== 0) {
       log.warn("add failed, retrying", { exitCode: result.exitCode, stderr: result.stderr.toString() })
-      result = await $`git --git-dir ${git} --work-tree ${Instance.worktree} add -A -- .`
+      result = await $`git --git-dir ${git} --work-tree ${Instance.worktree} add -A -- . ${excluded}`
         .quiet()
         .cwd(Instance.directory)
         .nothrow()
@@ -149,8 +201,9 @@ export namespace Snapshot {
   export async function patch(hash: string): Promise<Patch> {
     const git = gitdir()
     if (!(await stageAll(git))) throw new Error("Could not stage the project before computing its snapshot patch.")
+    const excluded = await exclusions()
     const result =
-      await $`git -c core.autocrlf=false -c core.quotepath=false --git-dir ${git} --work-tree ${Instance.worktree} diff --no-ext-diff --no-renames --name-only -z ${hash} -- .`
+      await $`git -c core.autocrlf=false -c core.quotepath=false --git-dir ${git} --work-tree ${Instance.worktree} diff --no-ext-diff --no-renames --name-only -z ${hash} -- . ${excluded}`
         .quiet()
         .cwd(Instance.directory)
         .nothrow()
@@ -213,8 +266,9 @@ export namespace Snapshot {
   }
 
   async function changedFiles(git: string, from: string, to: string) {
+    const excluded = await exclusions()
     const result =
-      await $`git -c core.autocrlf=false -c core.quotepath=false --git-dir ${git} --work-tree ${Instance.worktree} diff --no-ext-diff --no-renames --name-only -z ${from} ${to} -- .`
+      await $`git -c core.autocrlf=false -c core.quotepath=false --git-dir ${git} --work-tree ${Instance.worktree} diff --no-ext-diff --no-renames --name-only -z ${from} ${to} -- . ${excluded}`
         .quiet()
         .cwd(Instance.directory)
         .nothrow()
@@ -260,12 +314,18 @@ export namespace Snapshot {
       }
     }
 
+    const privateRoots = await privatePaths()
     const plans = new Map<string, PlannedEntry | undefined>()
     for (const file of files) {
       const relative = treePath(file)
       if (!relative) {
         skipped.push(file)
         errors.push({ file, message: "Path is outside the project worktree." })
+        continue
+      }
+      if (privateRoots.some((value) => !value || relative === value || relative.startsWith(`${value}/`))) {
+        skipped.push(relative)
+        errors.push({ file: relative, message: "OpenScience private state is excluded from project snapshots." })
         continue
       }
       if (plans.has(relative)) continue
@@ -391,8 +451,9 @@ export namespace Snapshot {
   export async function diff(hash: string) {
     const git = gitdir()
     if (!(await stageAll(git))) throw new Error("Could not stage the project before computing its snapshot diff.")
+    const excluded = await exclusions()
     const result =
-      await $`git -c core.autocrlf=false -c core.quotepath=false --git-dir ${git} --work-tree ${Instance.worktree} diff --no-ext-diff ${hash} -- .`
+      await $`git -c core.autocrlf=false -c core.quotepath=false --git-dir ${git} --work-tree ${Instance.worktree} diff --no-ext-diff ${hash} -- . ${excluded}`
         .quiet()
         .cwd(Instance.worktree)
         .nothrow()
@@ -425,7 +486,8 @@ export namespace Snapshot {
   export async function diffFull(from: string, to: string): Promise<FileDiff[]> {
     const git = gitdir()
     const result: FileDiff[] = []
-    for await (const line of $`git -c core.autocrlf=false -c core.quotepath=false --git-dir ${git} --work-tree ${Instance.worktree} diff --no-ext-diff --no-renames --numstat ${from} ${to} -- .`
+    const excluded = await exclusions()
+    for await (const line of $`git -c core.autocrlf=false -c core.quotepath=false --git-dir ${git} --work-tree ${Instance.worktree} diff --no-ext-diff --no-renames --numstat ${from} ${to} -- . ${excluded}`
       .quiet()
       .cwd(Instance.directory)
       .nothrow()

--- a/backend/cli/test/snapshot/private-data.test.ts
+++ b/backend/cli/test/snapshot/private-data.test.ts
@@ -1,0 +1,92 @@
+import { expect, test } from "bun:test"
+import path from "node:path"
+import { tmpdir } from "../fixture/fixture"
+
+test("parent-folder snapshots exclude private roots and old credentials without touching source Git or managed projects", async () => {
+  await using tmp = await tmpdir({ git: true })
+  const script = `
+    import assert from "node:assert/strict"
+    import fs from "node:fs/promises"
+    import path from "node:path"
+    import { $ } from "bun"
+    const root = ${JSON.stringify(tmp.path)}
+    for (const [target, alias] of [["secrets[1]", "data-link"], ["private-config", "config-link"]]) {
+      await fs.mkdir(path.join(root, target), { recursive: true })
+      await fs.symlink(path.join(root, target), path.join(root, alias), "junction")
+    }
+    const { Global } = await import(${JSON.stringify(new URL("../../src/global/index.ts", import.meta.url).href)})
+    const { Snapshot } = await import(${JSON.stringify(new URL("../../src/snapshot/index.ts", import.meta.url).href)})
+    const { Instance } = await import(${JSON.stringify(new URL("../../src/project/instance.ts", import.meta.url).href)})
+    const secret = path.join(Global.Path.data, "workspace-credentials.json")
+    const key = path.join(Global.Path.data, "credentials.key")
+    await Bun.write(secret, "fixture-secret-cache")
+    await Bun.write(key, "fixture-secret-key")
+    await Bun.write(path.join(Global.Path.config, "private-config.json"), "fixture-secret-config")
+    await Bun.write(path.join(Global.Path.cache, "cache-secret"), "fixture-secret-cache")
+    await Bun.write(path.join(Global.Path.state, "state-secret"), "fixture-secret-state")
+    await Bun.write(path.join(root, "notes.txt"), "ordinary research")
+    await Bun.write(path.join(root, "secrets1", "public.txt"), "literal-path sibling")
+    await $\`git add -- notes.txt ':(literal)secrets[1]/workspace-credentials.json'\`.cwd(root).quiet()
+    const original = await Bun.file(path.join(root, ".git", "index")).arrayBuffer()
+    await Instance.provide({ directory: root, fn: async () => {
+      const git = path.join(Global.Path.data, "snapshot", Instance.project.id)
+      const first = await Snapshot.track()
+      assert.ok(first)
+      const files = await $\`git --git-dir \${git} ls-tree -r --name-only \${first}\`.text()
+      assert.ok(files.includes("notes.txt"))
+      assert.ok(files.includes("secrets1/public.txt"))
+      assert.ok(!/workspace-credentials|credentials.key|private-config.json|cache-secret|state-secret/.test(files))
+      const absent = await $\`git --git-dir \${git} grep -F fixture-secret \${first}\`.quiet().nothrow()
+      assert.equal(absent.exitCode, 1, absent.stdout.toString())
+
+      // Simulate a snapshot index created before the private-root guard.
+      await $\`git --git-dir \${git} --work-tree \${root} add -f -- ':(literal)secrets[1]/workspace-credentials.json' ':(literal)secrets[1]/credentials.key'\`.cwd(root).quiet()
+      const old = (await $\`git --git-dir \${git} write-tree\`.text()).trim()
+      await Bun.write(secret, "fixture-secret-current")
+      const next = await Snapshot.track()
+      assert.ok(next)
+      assert.equal((await $\`git --git-dir \${git} grep -F fixture-secret \${next}\`.quiet().nothrow()).exitCode, 1)
+      assert.deepEqual((await Snapshot.patch(old)).files, [])
+      assert.equal(await Snapshot.diff(old), "")
+      assert.deepEqual(await Snapshot.diffFull(old, next), [])
+      const restored = await Snapshot.restore(old, [secret])
+      assert.equal(restored.status, "partial")
+      assert.equal(await Bun.file(secret).text(), "fixture-secret-current")
+      assert.equal(await Bun.file(key).text(), "fixture-secret-key")
+      assert.equal((await $\`git --git-dir \${git} cat-file -e \${old}\`.quiet().nothrow()).exitCode, 0)
+      assert.deepEqual(await Bun.file(path.join(root, ".git", "index")).arrayBuffer(), original)
+    }})
+    const project = path.join(Global.Path.data, "projects", "2b6a0aaf-aee6-4b3c-a2d4-447c82c0703f")
+    await fs.mkdir(project, { recursive: true })
+    await $\`git init\`.cwd(project).quiet()
+    await $\`git -c user.name=Fixture -c user.email=fixture@example.invalid commit --allow-empty -m init\`.cwd(project).quiet()
+    await Bun.write(path.join(project, "paper.md"), "managed research")
+    await Instance.provide({ directory: project, fn: async () => {
+      const hash = await Snapshot.track()
+      assert.ok(hash)
+      const git = path.join(Global.Path.data, "snapshot", Instance.project.id)
+      assert.equal((await $\`git --git-dir \${git} ls-tree -r --name-only \${hash}\`.text()).trim(), "paper.md")
+    }})
+  `
+  const child = Bun.spawn([process.execPath, "--conditions=browser", "--eval", script], {
+    cwd: tmp.path,
+    env: {
+      ...process.env,
+      BUN_RUNTIME_TRANSPILER_CACHE_PATH: "0",
+      OPENSCIENCE_DATA_DIR: path.join(tmp.path, "data-link"),
+      OPENSCIENCE_CONFIG_DIR: path.join(tmp.path, "config-link"),
+      OPENSCIENCE_TEST_HOME: path.join(tmp.path, "home"),
+      XDG_DATA_HOME: path.join(tmp.path, "legacy-data"),
+      XDG_CACHE_HOME: path.join(tmp.path, "cache"),
+      XDG_STATE_HOME: path.join(tmp.path, "state"),
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  const [code, output, error] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ])
+  expect(code, `${output}\n${error}`).toBe(0)
+}, 20_000)


### PR DESCRIPTION
Exclude private application roots and their canonical aliases from the internal snapshot index, diffs and undo. Preserve source Git, research files, managed projects and historical objects. This closes the parent-folder edge case for both existing stores and the new workspace credential cache. Verified real-Git parent/alias/legacy-index/managed-project behavior, four existing snapshot cases and backend typecheck.