### PR TITLE
ci: parallelize npm staging and slim desktop artifacts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -271,11 +271,12 @@ jobs:
       cache_key: cli-signed-${{ needs.version.outputs.version }}-${{ needs.version.outputs.artifact_source }}
 
   prepare-npm:
-    name: Pack npm release
+    name: Pack and stage npm release
     needs: [version, sign-macos-cli]
     runs-on: ubuntu-latest
     timeout-minutes: 25
     permissions:
+      id-token: write
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -289,13 +290,14 @@ jobs:
           WORKFLOW_SOURCE: ${{ needs.version.outputs.workflow_source }}
         run: |
           set -euo pipefail
-          for file in tooling/repo/npm-release.ts tooling/repo/prepare-npm.ts; do
+          for file in tooling/repo/npm-release.ts tooling/repo/prepare-npm.ts tooling/repo/publish.ts; do
             git show "$WORKFLOW_SOURCE:$file" > "$file"
           done
       - uses: ./.github/actions/setup-bun
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24"
+          registry-url: "https://registry.npmjs.org"
       - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
@@ -328,6 +330,20 @@ jobs:
         with:
           path: .release/npm/${{ needs.version.outputs.version }}
           key: npm-release-${{ needs.version.outputs.version }}-${{ needs.version.outputs.artifact_source }}
+
+      # npm's registry visibility wait overlaps desktop packaging. This phase
+      # never promotes latest or makes the draft GitHub release public.
+      - name: Stage immutable npm packages
+        run: ./tooling/repo/publish.ts --stage-only
+        env:
+          OPENSCIENCE_VERSION: ${{ needs.version.outputs.version }}
+          OPENSCIENCE_RELEASE: ${{ needs.version.outputs.release }}
+          OPENSCIENCE_RELEASE_SOURCE: ${{ needs.version.outputs.source }}
+          OPENSCIENCE_ARTIFACT_SOURCE: ${{ needs.version.outputs.artifact_source }}
+          OPENSCIENCE_NPM_ARTIFACT_DIR: .release/npm/${{ needs.version.outputs.version }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: "true"
+          OPENSCIENCE_REQUIRE_LAUNCHER_PUBLISH: "true"
 
   build-desktop:
     name: Desktop (${{ matrix.target }}-${{ matrix.arch }})

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -250,6 +250,21 @@ jobs:
           OPENSCIENCE_VERSION: ${{ needs.version.outputs.version }}
           OPENSCIENCE_RELEASE: ${{ needs.version.outputs.release }}
           GH_TOKEN: ${{ github.token }}
+      - name: Bind desktop sidecar digests
+        id: sidecars
+        env:
+          OPENSCIENCE_VERSION: ${{ needs.version.outputs.version }}
+          OPENSCIENCE_ARTIFACT_SOURCE: ${{ needs.version.outputs.artifact_source }}
+        run: |
+          bun -e '
+            const lines = (await Bun.file("backend/cli/dist/checksums.txt").text()).trim().split(/\r?\n/);
+            if (lines.length !== 11 || lines.some(line => !/^[0-9a-f]{64}  openscience-[a-z0-9-]+\.(zip|tar\.gz)$/.test(line))) throw new Error("Invalid signed CLI checksum manifest");
+            const checksums = Object.fromEntries(lines.map(line => [line.slice(66), line.slice(0, 64)]));
+            if (Object.keys(checksums).length !== 11) throw new Error("Duplicate CLI checksum entries");
+            const manifest = { source: process.env.OPENSCIENCE_ARTIFACT_SOURCE, version: process.env.OPENSCIENCE_VERSION, checksums };
+            const { appendFileSync } = await import("node:fs");
+            appendFileSync(process.env.GITHUB_OUTPUT, `manifest=${JSON.stringify(manifest)}\n`);
+          '
       - name: Disclose unsigned Windows installer
         shell: bash
         env:
@@ -269,6 +284,7 @@ jobs:
           fi
     outputs:
       cache_key: cli-signed-${{ needs.version.outputs.version }}-${{ needs.version.outputs.artifact_source }}
+      sidecar_manifest: ${{ steps.sidecars.outputs.manifest }}
 
   prepare-npm:
     name: Pack and stage npm release
@@ -494,15 +510,31 @@ jobs:
         if: steps.existing.outputs.found != 'true'
         with:
           node-version: "24"
-      - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Download source-bound desktop sidecar
         if: steps.existing.outputs.found != 'true'
-        with:
-          path: |
-            backend/cli/dist
-            frontend/workspace/dist/version.json
-          key: ${{ needs.sign-macos-cli.outputs.cache_key }}
-          enableCrossOsArchive: ${{ runner.os == 'Windows' }}
-          fail-on-cache-miss: true
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          OPENSCIENCE_DESKTOP_SIDECAR: ${{ matrix.sidecar }}
+          OPENSCIENCE_VERSION: ${{ needs.version.outputs.version }}
+          OPENSCIENCE_ARTIFACT_SOURCE: ${{ needs.version.outputs.artifact_source }}
+          OPENSCIENCE_SIDECAR_MANIFEST: ${{ needs.sign-macos-cli.outputs.sidecar_manifest }}
+          RELEASE_SOURCE: ${{ needs.version.outputs.source }}
+          WORKFLOW_SOURCE: ${{ needs.version.outputs.workflow_source }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          if [[ "$WORKFLOW_SOURCE" != "$RELEASE_SOURCE" ]]; then
+            git fetch origin "$WORKFLOW_SOURCE" --depth=1
+            git show "$WORKFLOW_SOURCE:tooling/repo/desktop-sidecar.ts" > tooling/repo/desktop-sidecar.ts
+          fi
+          bun tooling/repo/desktop-sidecar.ts
+          if [[ "${{ matrix.signing }}" == "mac" ]]; then
+            codesign --verify --strict --verbose=2 "$OPENSCIENCE_DESKTOP_SIDECAR"
+            details="$(codesign -dv --verbose=4 "$OPENSCIENCE_DESKTOP_SIDECAR" 2>&1)"
+            grep -Fxq 'Identifier=ai.syntheticsciences.openscience' <<<"$details"
+            grep -Fxq "TeamIdentifier=$APPLE_TEAM_ID" <<<"$details"
+          fi
       - name: Detect Windows signing
         id: windows
         if: steps.existing.outputs.found != 'true' && matrix.signing == 'windows'

--- a/backend/cli/test/installation/desktop-sidecar.test.ts
+++ b/backend/cli/test/installation/desktop-sidecar.test.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "bun:test"
+import path from "node:path"
+import os from "node:os"
+import { mkdtemp, rm } from "node:fs/promises"
+import { extractSidecar, selectSidecar, verifySidecarAsset } from "../../../../tooling/repo/desktop-sidecar"
+
+const source = "a".repeat(40)
+const digest = "b".repeat(64)
+const matrix = [
+  ["darwin-arm64", "openscience", "zip"],
+  ["darwin-x64", "openscience", "zip"],
+  ["windows-x64", "openscience.exe", "zip"],
+  ["linux-x64", "openscience", "tar.gz"],
+  ["linux-arm64", "openscience", "tar.gz"],
+] as const
+const manifest = JSON.stringify({
+  source,
+  version: "2.0.62",
+  checksums: Object.fromEntries(matrix.map(([target, , extension]) => [`openscience-${target}.${extension}`, digest])),
+})
+
+test.each(matrix)("desktop %s selects only its source-bound native archive", (target, member, extension) => {
+  const sidecar = `backend/cli/dist/@synsci/openscience-${target}/bin/${member}`
+  const selected = selectSidecar(sidecar, manifest, source, "2.0.62")
+  expect(selected.asset as string).toBe(`openscience-${target}.${extension}`)
+  expect(selected.digest).toBe(digest)
+  expect(selected.member).toBe(member)
+  expect(selected.destination).toBe(path.resolve(sidecar))
+})
+
+test("sidecar selection rejects unrelated paths, releases, and asset digests", () => {
+  const sidecar = "backend/cli/dist/@synsci/openscience-darwin-arm64/bin/openscience"
+  expect(() => selectSidecar(`../${sidecar}`, manifest, source, "2.0.62")).toThrow("matrix")
+  expect(() => selectSidecar(sidecar, manifest, "c".repeat(40), "2.0.62")).toThrow("mismatch")
+  expect(() => selectSidecar(sidecar, manifest, source, "2.0.63")).toThrow("mismatch")
+  expect(() => selectSidecar(sidecar, manifest.replace(digest, "invalid"), source, "2.0.62")).toThrow("digest")
+  expect(() => verifySidecarAsset(undefined, digest)).toThrow("source-bound")
+  expect(() => verifySidecarAsset({ state: "uploaded", size: 12, digest: `sha256:${source}` }, digest)).toThrow(
+    "source-bound",
+  )
+  expect(() => verifySidecarAsset({ state: "new", size: 12, digest: `sha256:${digest}` }, digest)).toThrow(
+    "source-bound",
+  )
+  verifySidecarAsset({ state: "uploaded", size: 12, digest: `sha256:${digest}` }, digest)
+})
+
+test.each(process.platform === "linux" ? ["tar.gz"] : ["zip", "tar.gz"])(
+  "extracts only the verified binary from a real %s archive",
+  async (extension) => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "openscience-sidecar-test-"))
+    try {
+      await Bun.write(path.join(directory, "openscience"), "native fixture")
+      await Bun.write(path.join(directory, "unrelated"), "must not be extracted")
+      const archive = path.join(directory, `fixture.${extension}`)
+      if (extension === "zip") await Bun.$`zip ${archive} openscience unrelated`.cwd(directory).quiet()
+      if (extension === "tar.gz") await Bun.$`tar -czf ${archive} openscience unrelated`.cwd(directory).quiet()
+      const digest = new Bun.CryptoHasher("sha256").update(await Bun.file(archive).arrayBuffer()).digest("hex")
+      const output = path.join(directory, "extracted")
+      await extractSidecar(archive, output, "openscience", digest)
+      expect(await Bun.file(output).text()).toBe("native fixture")
+      const rejected = path.join(directory, "rejected")
+      await expect(extractSidecar(archive, rejected, "openscience", "0".repeat(64))).rejects.toThrow("SHA-256")
+      expect(await Bun.file(rejected).exists()).toBe(false)
+      await expect(extractSidecar(archive, rejected, "../openscience", digest)).rejects.toThrow("member")
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  },
+)

--- a/backend/cli/test/installation/npm-release.test.ts
+++ b/backend/cli/test/installation/npm-release.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, expect, test } from "bun:test"
 import path from "path"
 import os from "os"
-import { mkdir, mkdtemp, rm } from "node:fs/promises"
+import { chmod, mkdir, mkdtemp, rm } from "node:fs/promises"
 import {
   NpmArtifactConflict,
   NpmPermissionError,
@@ -16,6 +16,7 @@ import {
   releasePackageNames,
   releaseCandidateTag,
   releasePromotionNames,
+  releaseStagingTag,
   saveReleaseArtifacts,
   sanitizeNpmDiagnostic,
   stageCandidateRelease,
@@ -26,6 +27,7 @@ import {
   type NpmCommandOptions,
   type PackedPackage,
 } from "../../../../tooling/repo/npm-release"
+import { releaseRoot } from "../../../../tooling/repo/release-workspace"
 
 type FakeState = {
   diff?: string
@@ -331,6 +333,56 @@ test("release artifacts persist exact packed bytes and reject a different source
   await Bun.write(manifestFile, `${JSON.stringify(manifest, null, 2)}\n`)
   await expect(loadReleaseArtifacts({ directory, source, version: "2.0.32" })).rejects.toThrow("expected 2.0.32")
 })
+
+test("stage-only verifies the complete immutable release without promoting latest", async () => {
+  const artifacts: PackedPackage[] = []
+  for (const name of releasePackageNames()) artifacts.push(await fixturePackage(name))
+  const source = (await Bun.$`git rev-parse HEAD`.cwd(releaseRoot).text()).trim()
+  const directory = path.join(root, "artifacts")
+  await saveReleaseArtifacts({ artifacts, directory, source, version: "2.0.32" })
+  const file = await stateFile({
+    // Only one missing package keeps the shared-file registry's write serial.
+    packages: Object.fromEntries(
+      artifacts.slice(1).map((artifact) => [`${artifact.name}@${artifact.version}`, { integrity: artifact.integrity }]),
+    ),
+    tags: Object.fromEntries(artifacts.map((artifact) => [artifact.name, { latest: "2.0.31" }])),
+  })
+  const command = path.join(root, "npm-fixture")
+  await Bun.write(command, `#!${process.execPath}\nawait import(${JSON.stringify(fake)})\n`)
+  await chmod(command, 0o755)
+  const proc = Bun.spawn([process.execPath, path.join(releaseRoot, "tooling/repo/publish.ts"), "--stage-only"], {
+    cwd: releaseRoot,
+    env: {
+      ...Bun.env,
+      ...fastOptions(file).env,
+      OPENSCIENCE_CHANNEL: "latest",
+      OPENSCIENCE_VERSION: "2.0.32",
+      // Never authorize Git/GitHub writes, even if the stage-only exit regresses.
+      OPENSCIENCE_RELEASE: "",
+      OPENSCIENCE_RELEASE_SOURCE: source,
+      OPENSCIENCE_ARTIFACT_SOURCE: source,
+      OPENSCIENCE_NPM_ARTIFACT_DIR: directory,
+      OPENSCIENCE_NPM_COMMAND: command,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+  expect({ code, stderr }).toEqual({ code: 0, stderr: "" })
+  expect(stdout).toContain("staging complete; latest tags and the GitHub draft are unchanged")
+  expect(stdout).not.toContain("promoting npm latest")
+  const state = await readState(file)
+  expect(state.publishCalls).toBe(1)
+  expect(state.publishSpecs).toEqual([`${artifacts[0].name}@2.0.32`])
+  for (const artifact of artifacts) {
+    expect(state.packages[`${artifact.name}@2.0.32`].integrity).toBe(artifact.integrity)
+    expect(state.tags[artifact.name]).toEqual({ latest: "2.0.31", [releaseStagingTag("2.0.32")]: "2.0.32" })
+  }
+}, 30_000)
 
 test("a missing artifact cache fails closed when any package version already exists", async () => {
   const version = "2.0.32-test.12345"

--- a/tooling/repo/desktop-sidecar.ts
+++ b/tooling/repo/desktop-sidecar.ts
@@ -1,0 +1,87 @@
+#!/usr/bin/env bun
+
+import path from "node:path"
+import os from "node:os"
+import { chmod, copyFile, mkdir, mkdtemp, rm } from "node:fs/promises"
+import { $ } from "bun"
+
+const sidecars = {
+  "backend/cli/dist/@synsci/openscience-darwin-arm64/bin/openscience": "openscience-darwin-arm64.zip",
+  "backend/cli/dist/@synsci/openscience-darwin-x64/bin/openscience": "openscience-darwin-x64.zip",
+  "backend/cli/dist/@synsci/openscience-windows-x64/bin/openscience.exe": "openscience-windows-x64.zip",
+  "backend/cli/dist/@synsci/openscience-linux-x64/bin/openscience": "openscience-linux-x64.tar.gz",
+  "backend/cli/dist/@synsci/openscience-linux-arm64/bin/openscience": "openscience-linux-arm64.tar.gz",
+} as const
+
+export function selectSidecar(sidecar: string, manifest: string, source: string, version: string) {
+  if (!Object.hasOwn(sidecars, sidecar)) throw new Error("Sidecar is not a desktop matrix target")
+  if (!/^[0-9a-f]{40}$/i.test(source) || !/^\d+\.\d+\.\d+$/.test(version)) {
+    throw new Error("Sidecar requires an immutable release source and stable version")
+  }
+  const receipt = JSON.parse(manifest) as { source: string; version: string; checksums: Record<string, string> }
+  if (receipt.source !== source || receipt.version !== version)
+    throw new Error("Sidecar manifest source/version mismatch")
+  const asset = sidecars[sidecar as keyof typeof sidecars]
+  const digest = receipt.checksums[asset]
+  if (!/^[0-9a-f]{64}$/.test(digest ?? "")) throw new Error("Sidecar manifest is missing its SHA-256 digest")
+  return { asset, digest, member: path.basename(sidecar), destination: path.resolve(sidecar) }
+}
+
+export function verifySidecarAsset(asset: { state: string; size: number; digest: string } | undefined, digest: string) {
+  if (
+    !asset ||
+    asset.state !== "uploaded" ||
+    !Number.isSafeInteger(asset.size) ||
+    asset.size <= 0 ||
+    asset.digest !== `sha256:${digest}`
+  ) {
+    throw new Error("Native release asset does not match the source-bound sidecar digest")
+  }
+}
+
+export async function extractSidecar(archive: string, destination: string, member: string, digest: string) {
+  const actual = new Bun.CryptoHasher("sha256").update(await Bun.file(archive).arrayBuffer()).digest("hex")
+  if (actual !== digest) throw new Error("Downloaded sidecar archive failed SHA-256 verification")
+  if (!["openscience", "openscience.exe"].includes(member)) throw new Error("Unexpected sidecar archive member")
+  // Native bsdtar handles Windows ZIPs; GNU tar handles Linux tar.gz files.
+  // Extract exactly one member to stdout, never arbitrary paths from an archive.
+  const tar =
+    process.platform === "win32" ? path.join(process.env.SystemRoot ?? "C:/Windows", "System32/tar.exe") : "tar"
+  const proc = Bun.spawn([tar, "-xOf", archive, member], { stdout: "pipe", stderr: "pipe" })
+  const [bytes, error, code] = await Promise.all([
+    new Response(proc.stdout).arrayBuffer(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+  if (code !== 0 || bytes.byteLength <= 0) throw new Error(`Could not extract the native sidecar: ${error}`)
+  await Bun.write(destination, bytes)
+}
+
+if (import.meta.main) {
+  const source = process.env.OPENSCIENCE_ARTIFACT_SOURCE ?? ""
+  const version = process.env.OPENSCIENCE_VERSION ?? ""
+  const selected = selectSidecar(
+    process.env.OPENSCIENCE_DESKTOP_SIDECAR ?? "",
+    process.env.OPENSCIENCE_SIDECAR_MANIFEST ?? "",
+    source,
+    version,
+  )
+  const repository = process.env.GITHUB_REPOSITORY
+  if (!repository) throw new Error("GITHUB_REPOSITORY is required")
+  const release = await $`gh release view ${`v${version}`} --repo ${repository} --json assets`.json()
+  const assets = release.assets.filter((asset: { name: string }) => asset.name === selected.asset)
+  if (assets.length !== 1) throw new Error("Release must contain exactly one selected native asset")
+  verifySidecarAsset(assets[0], selected.digest)
+  const directory = await mkdtemp(path.join(os.tmpdir(), "openscience-desktop-sidecar-"))
+  try {
+    await $`gh release download ${`v${version}`} --repo ${repository} --pattern ${selected.asset} --dir ${directory}`
+    const binary = path.join(directory, selected.member)
+    await extractSidecar(path.join(directory, selected.asset), binary, selected.member, selected.digest)
+    await mkdir(path.dirname(selected.destination), { recursive: true })
+    await copyFile(binary, selected.destination)
+    await chmod(selected.destination, 0o755)
+    console.log(`Verified ${selected.asset} for v${version} from ${source}`)
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
+}

--- a/tooling/repo/publish.ts
+++ b/tooling/repo/publish.ts
@@ -14,6 +14,9 @@ import {
 } from "./npm-release"
 import { assertReleaseSource, releaseRoot, setWorkspaceVersion } from "./release-workspace"
 
+const stageOnly = process.argv.includes("--stage-only")
+if (stageOnly && Script.preview) throw new Error("Release staging requires an exact stable version")
+
 if (Script.preview) {
   await import("./publish-preview")
 } else {
@@ -59,6 +62,14 @@ if (Script.preview) {
   await verifyPublishedPackages(ordered)
   for (const artifact of ordered) console.log(`  verified ${artifact.name}@${artifact.version}`)
   await ensureReleaseStagingTags(ordered, stagingTag)
+
+  // This path runs alongside desktop packaging with read-only GitHub access.
+  // The gated final job reruns verification before promotion; no receipt or
+  // environment flag is trusted as a substitute for checking the artifacts.
+  if (stageOnly) {
+    console.log("Npm staging complete; latest tags and the GitHub draft are unchanged")
+    process.exit(0)
+  }
 
   let releaseSha = source
   if (Script.release && !promotionOnly) {


### PR DESCRIPTION
Shortens the release critical path without changing final publication gates. Stages immutable npm artifacts under non-default tags alongside desktop packaging. Each desktop job downloads only its matrix architecture native archive instead of the 1.38 GB all-platform cache, with source/version-bound SHA-256 verification and macOS identity checks. Final latest-tag and GitHub promotion still waits for every installer, manifest, and provenance/integrity check. Current 2.0.62 release is unchanged. Validation: 21 npm release checks, 8 sidecar checks, backend typecheck, YAML and formatting passed. A real 2.0.62 ARM native archive was extracted and signature-verified without executing it.