### PR TITLE
fix: protectedContext floors compaction tail on long-superseded messages

### DIFF
--- a/backend/cli/src/session/compaction.ts
+++ b/backend/cli/src/session/compaction.ts
@@ -465,10 +465,22 @@ Output exactly this Markdown structure, keeping every section (write "(none)" wh
       if (summary.info.role !== "assistant" || !summary.info.tailStartId) return true
       return message.info.id < summary.info.tailStartId
     }
-    const start = messages.findIndex((message, index) => {
-      if (index > current || message.info.role !== "user") return false
-      return !answered.has(message.info.id) && !compacted(message)
-    })
+    // Walk backward from the current turn and stop at the first user message
+    // that's already been terminally answered (or is already compacted) — that
+    // boundary marks the start of the active, unanswered span. Scanning forward
+    // from the beginning of the whole transcript (as this used to) finds the
+    // *first* unanswered user message anywhere in history, which can be a
+    // long-since-superseded message (e.g. one immediately followed by a retry
+    // that itself got answered) — pinning the protected span, and therefore
+    // selectTail's cut point, to it forever regardless of how much later work
+    // has been properly resolved.
+    let start = -1
+    for (let index = current; index >= 0; index--) {
+      const message = messages[index]
+      if (message.info.role !== "user") continue
+      if (answered.has(message.info.id) || compacted(message)) break
+      start = index
+    }
     if (start < 0) return []
     return messages.slice(start)
   }

--- a/backend/cli/test/session/message-v2.test.ts
+++ b/backend/cli/test/session/message-v2.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import { MessageV2 } from "../../src/session/message-v2"
+import { SessionCompaction } from "../../src/session/compaction"
+import { Identifier } from "../../src/id/id"
 import type { Provider } from "../../src/provider/provider"
 
 const sessionID = "session"
@@ -1146,5 +1148,73 @@ describe("session.message-v2.filterCompacted — verbatim tail (P3.2)", () => {
     ]
     const out = await MessageV2.filterCompacted(streamOf(msgs))
     expect(out.map((m) => m.info.id)).toEqual(["cc", "sum", "cont"])
+  })
+})
+
+describe("session.compaction.selectTail — protectedContext floor (regression)", () => {
+  const mk = (
+    id: string,
+    role: "user" | "assistant",
+    parts: MessageV2.Part[],
+    extra: Record<string, unknown> = {},
+  ): MessageV2.WithParts => ({
+    info: {
+      id,
+      sessionID: "s",
+      role,
+      time: { created: 0 },
+      ...(role === "user"
+        ? { agent: "a", model: { providerID: "p", modelID: "m" } }
+        : {
+            parentID: "p",
+            modelID: "m",
+            providerID: "p",
+            mode: "",
+            agent: "a",
+            cost: 0,
+            tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+          }),
+      ...extra,
+    } as unknown as MessageV2.WithParts["info"],
+    parts: parts as unknown as MessageV2.Part[],
+  })
+  const txt = (mid: string, t: string) =>
+    ({ id: `${mid}t`, sessionID: "s", messageID: mid, type: "text", text: t }) as unknown as MessageV2.Part
+
+  test("a long-superseded, never-directly-answered user message does not permanently floor the tail", async () => {
+    // Real-world shape: an original request (u1) is immediately followed by a
+    // retry/resend (u2) that DOES get a terminal reply (a2). u1 itself never
+    // gets its own direct reply — it's simply superseded. protectedContext's
+    // job is to protect the span of the *currently active, unanswered* turn,
+    // not every unanswered message that ever occurred in the session. IDs use
+    // Identifier.ascending so id-comparisons behave exactly as in production.
+    const nextId = () => Identifier.ascending("message")
+    const earlier = Array.from({ length: 3 }, () => [nextId(), nextId()] as const)
+    const u1 = nextId()
+    const u2 = nextId()
+    const a2 = nextId()
+    const work = Array.from({ length: 8 }, () => [nextId(), nextId()] as const)
+
+    const oldestToNewest: MessageV2.WithParts[] = [
+      ...earlier.flatMap(([u, a], i) => [
+        mk(u, "user", [txt(u, `earlier turn ${i + 1}`)]),
+        mk(a, "assistant", [txt(a, `earlier reply ${i + 1}`)], { finish: "stop", parentID: u }),
+      ]),
+      mk(u1, "user", [txt("u1", "original request — never directly answered")]),
+      mk(u2, "user", [txt("u2", "retry of the same request")]),
+      mk(a2, "assistant", [txt("a2", "the retry's own reply")], { finish: "stop", parentID: u2 }),
+      ...work.flatMap(([wu, wa], i) => [
+        mk(wu, "user", [txt(wu, `work request ${i + 1}`)]),
+        mk(wa, "assistant", [txt(wa, `work reply ${i + 1}`)], { finish: "stop", parentID: wu }),
+      ]),
+    ]
+
+    const { tailStartId } = SessionCompaction.selectTail(oldestToNewest, {
+      tailTurns: SessionCompaction.TAIL_TURNS,
+      tailTokens: 32000,
+    })
+
+    expect(tailStartId).not.toBe(u1)
+    expect(work.some(([wu]) => wu === tailStartId)).toBe(true)
   })
 })


### PR DESCRIPTION
Fixes #470

## Problem

`protectedContext` in `backend/cli/src/session/compaction.ts` is documented as returning "the transcript span that still belongs to the active, unanswered turn," but the implementation scans **forward from the start of the whole transcript** for the first unanswered user message, not backward from the current turn. A common real pattern breaks this: a user message immediately superseded by a retry/resend (the retry gets answered, the original never does, since `answered` is keyed by `parentID`). That original message satisfies the scan forever, so `selectTail`'s `protectedStart` floor (`if (protectedStart > 0) cut = Math.min(cut, protectedStart)`) permanently pins `tailStartId` to it — no matter how much later work has been fully, properly resolved.

Found this via a real session where every subsequent compaction kept flooring `tailStartId` at an old, superseded message well past 100k+ tokens of genuine follow-up work, even after raising the model's context window.

## Fix

Scope the scan to the contiguous unanswered span ending at the current turn: walk backward from `current` and stop at the first user message that's already terminally answered or already compacted. This matches the function's own doc comment and still protects a run of genuinely-pending retries ending at the current turn — it just no longer reaches back to unrelated, long-resolved history.

## Verification

- Added a regression test in `message-v2.test.ts` (`session.compaction.selectTail — protectedContext floor (regression)`) that builds a realistic history with real `Identifier.ascending("message")` ids: 3 earlier answered turns, an orphaned original request + its answered retry, then 8 further fully-answered work turns. Fails on `main` (`tailStartId` resolves to the orphaned message); passes with this fix.
- `bun run typecheck` — clean.
- `bunx prettier --check` on both changed files — clean.
- `bun test` across `backend/cli`: 470 pass / 3 fail, same 3 pre-existing unrelated failures as on `main` (a stale MCP tool-description string assertion, unrelated to this change) — confirmed by running the full suite against `main` before this fix (469 pass / 4 fail there, the 4th being the bug this PR fixes).

See #470 for the full root-cause writeup and real-session evidence.
