### PR TITLE
fix: normalize compute_job's tool schema for openai-compatible providers too

### DIFF
--- a/backend/cli/src/provider/tool-schema.ts
+++ b/backend/cli/src/provider/tool-schema.ts
@@ -52,9 +52,11 @@ function normalize(value: unknown): unknown {
 }
 
 /**
- * Normalize only representational differences accepted by DeepSeek while
- * preserving the set of valid tool inputs. Runtime Zod validation remains the
- * authority; this function never strips constraints or makes fields optional.
+ * Normalize only representational differences accepted by DeepSeek (and other
+ * providers with the same object-rooted-schema expectation, e.g.
+ * openai-compatible) while preserving the set of valid tool inputs. Runtime
+ * Zod validation remains the authority; this function never strips
+ * constraints or makes fields optional.
  */
 export function normalizeDeepSeekToolSchema(schema: JSONSchema.BaseSchema): JSONSchema.BaseSchema {
   return normalize(schema) as JSONSchema.BaseSchema

--- a/backend/cli/src/provider/transform.ts
+++ b/backend/cli/src/provider/transform.ts
@@ -1207,7 +1207,14 @@ export namespace ProviderTransform {
       schema = sanitizeGemini(schema)
     }
 
-    if (model.api.npm === "@ai-sdk/deepseek") {
+    // Not actually DeepSeek-specific: any provider whose function-calling
+    // parser expects an object-rooted schema chokes on a bare root oneOf, the
+    // shape Zod emits for a discriminated union (e.g. compute_job's action
+    // parameter). openai-compatible (Ollama and others) hits the same defect,
+    // just silently — the tool disappears from the model's tool list instead
+    // of the request being rejected outright the way DeepSeek's strict
+    // validator rejects it.
+    if (model.api.npm === "@ai-sdk/deepseek" || model.api.npm === "@ai-sdk/openai-compatible") {
       schema = normalizeDeepSeekToolSchema(schema)
     }
 

--- a/backend/cli/test/provider/tool-schema-deepseek.test.ts
+++ b/backend/cli/test/provider/tool-schema-deepseek.test.ts
@@ -90,8 +90,38 @@ describe("DeepSeek tool schema normalization", () => {
     expect(result.anyOf[0].properties.scope).toEqual({ type: "string", enum: ["project"] })
   })
 
-  test("runs only at the native DeepSeek provider boundary", () => {
+  test("runs at the DeepSeek and openai-compatible provider boundaries, not elsewhere", () => {
     expect((ProviderTransform.schema(model("@ai-sdk/deepseek"), union as any) as any).type).toBe("object")
-    expect((ProviderTransform.schema(model("@ai-sdk/openai-compatible"), union as any) as any).type).toBeUndefined()
+    expect((ProviderTransform.schema(model("@ai-sdk/openai-compatible"), union as any) as any).type).toBe("object")
+    expect((ProviderTransform.schema(model("@ai-sdk/anthropic"), union as any) as any).type).toBeUndefined()
+  })
+
+  test("normalizes compute_job's real discriminated-union schema for an openai-compatible model (e.g. local Ollama)", () => {
+    // Regression for: compute_job silently disappeared from the tool list for
+    // openai-compatible providers (confirmed with a local Ollama model) even
+    // though it has "allow" permission — the un-normalized root oneOf from its
+    // discriminatedUnion("action", [...]) parameter schema isn't a shape most
+    // openai-compatible function-calling parsers accept, so the tool was
+    // dropped rather than the request being rejected outright.
+    const computeJobLikeSchema = {
+      oneOf: [
+        {
+          type: "object",
+          properties: { action: { type: "string", const: "start" }, target: { type: "object" } },
+          required: ["action", "target"],
+          additionalProperties: false,
+        },
+        {
+          type: "object",
+          properties: { action: { type: "string", const: "status" }, job_id: { type: "string", minLength: 1 } },
+          required: ["action", "job_id"],
+          additionalProperties: false,
+        },
+      ],
+    }
+    const result = ProviderTransform.schema(model("@ai-sdk/openai-compatible"), computeJobLikeSchema as any) as any
+    expect(result.type).toBe("object")
+    expect(result.oneOf).toBeUndefined()
+    expect(result.anyOf).toHaveLength(2)
   })
 })


### PR DESCRIPTION
Fixes #472

## Problem

`compute_job`'s parameter schema is a `z.discriminatedUnion("action", [...])` (`backend/cli/src/tool/compute-job.ts:110`), which Zod compiles to a root `oneOf` in JSON Schema. `normalizeDeepSeekToolSchema` (`backend/cli/src/provider/tool-schema.ts`) already exists to rewrite that into an object-rooted `anyOf` that plain function-calling parsers accept — but the call site (`backend/cli/src/provider/transform.ts`) only applied it when `model.api.npm === "@ai-sdk/deepseek"`:

```ts
if (model.api.npm === "@ai-sdk/deepseek") {
  schema = normalizeDeepSeekToolSchema(schema)
}
```

`openai-compatible` providers (e.g. a local Ollama model) hit the exact same schema defect, just with a different failure mode: instead of the whole request being rejected the way DeepSeek's strict validator rejects it (#283, #298), the one tool with the unparseable root `oneOf` is silently dropped from the model's tool list — no error, nothing in the logs. `compute_job` has "allow" permission for the `research` agent, but a real session running a local Ollama model never saw it in its own available-tools list at all.

The existing test even locked this gap in as expected behavior:
```ts
test("runs only at the native DeepSeek provider boundary", () => {
  expect((ProviderTransform.schema(model("@ai-sdk/deepseek"), union as any) as any).type).toBe("object")
  expect((ProviderTransform.schema(model("@ai-sdk/openai-compatible"), union as any) as any).type).toBeUndefined()
})
```

## Fix

Broaden the gate to `@ai-sdk/deepseek || @ai-sdk/openai-compatible`. The normalization function itself has no DeepSeek-specific logic — it's a generic root-`oneOf`-to-`anyOf` rewrite — so this just closes the gap for the other provider family that needs the same treatment. Also updated the doc comment (it previously read as if the fix were DeepSeek-exclusive) and fixed the test that asserted the old, incorrect boundary.

## Verification

- Updated `test("runs only at the native DeepSeek provider boundary")` → now also asserts `@ai-sdk/openai-compatible` gets normalized, and that an unrelated provider (`@ai-sdk/anthropic`) does not.
- Added a regression test using `compute_job`'s real discriminated-union schema shape against an `openai-compatible`-shaped model.
- Full `bun test` across `backend/cli`: 2852 pass / 92 fail with this fix, vs. 2851 pass / 92 fail on a clean `main` baseline — identical failure set (unrelated, pre-existing), one new passing test, zero regressions.
- `bun run typecheck` and `prettier --check` on all three changed files — clean.
