### PR TITLE
fix: auto-recover from a pre-flight context-window rejection instead of stalling

### DIFF
--- a/backend/cli/src/session/loop-state.ts
+++ b/backend/cli/src/session/loop-state.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto"
 import type { MessageV2 } from "./message-v2"
 
 export namespace SessionLoopState {
-  export type Continuation = "output" | "contract" | "compaction" | "task"
+  export type Continuation = "output" | "contract" | "compaction" | "task" | "context"
 
   export type ContractMarker = {
     progress: string
@@ -15,6 +15,7 @@ export namespace SessionLoopState {
     outputContinuations: number
     contractContinuations: number
     overflowCompactions: number
+    preflightCompactions: number
   }
 
   export type PendingCompaction = {
@@ -90,7 +91,8 @@ export namespace SessionLoopState {
    * normal task on the current research agent; no reviewer profile or writable
    * review workflow is reintroduced. */
   function compatibleContinuation(value: unknown): Continuation | undefined {
-    if (value === "output" || value === "contract" || value === "compaction" || value === "task") return value
+    if (value === "output" || value === "contract" || value === "compaction" || value === "task" || value === "context")
+      return value
     if (value === "review" || value === "review-summary") return "task"
   }
 
@@ -271,6 +273,7 @@ export namespace SessionLoopState {
         return kinds.reduce<Info & { durableStep?: number }>((next, value) => {
           if (value === "output") return { ...next, outputContinuations: next.outputContinuations + 1 }
           if (value === "contract") return { ...next, contractContinuations: next.contractContinuations + 1 }
+          if (value === "context") return { ...next, preflightCompactions: next.preflightCompactions + 1 }
           return next
         }, state)
       },
@@ -280,6 +283,7 @@ export namespace SessionLoopState {
         outputContinuations: 0,
         contractContinuations: 0,
         overflowCompactions: 0,
+        preflightCompactions: 0,
       },
     )
     return {
@@ -288,6 +292,7 @@ export namespace SessionLoopState {
       outputContinuations: state.outputContinuations,
       contractContinuations: state.contractContinuations,
       overflowCompactions: state.overflowCompactions,
+      preflightCompactions: state.preflightCompactions,
     }
   }
 
@@ -348,6 +353,17 @@ export namespace SessionLoopState {
     if (!input.unanswered || input.assistant?.finish !== "compact") return "none"
     if (input.assistant.summary === true || input.attempts > 1) return "fail"
     return "compact"
+  }
+
+  /** A pre-flight rejection ("the current turn alone is too large") records a
+   * terminal error reply, which makes that turn answered and therefore no
+   * longer protected from compaction. One automatic retry via a synthetic
+   * continuation lets that now-compactable bulk get reclaimed; a second
+   * rejection in the same epoch means the turn's own content doesn't fit even
+   * after everything else has been compacted away, and needs a real user
+   * decision instead of looping forever. */
+  export function preflightRecovery(input: { attempts: number }): "none" | "compact" {
+    return input.attempts > 0 ? "none" : "compact"
   }
 
   export function terminalError(input: { user: MessageV2.User; assistant?: MessageV2.Assistant }) {

--- a/backend/cli/src/session/message-v2.ts
+++ b/backend/cli/src/session/message-v2.ts
@@ -398,7 +398,7 @@ export namespace MessageV2 {
           // Legacy reviewer continuations still parse so 2.x session archives
           // remain readable; SessionLoopState normalizes both to ordinary task
           // continuations and no reviewer workflow is launched.
-          kind: z.enum(["output", "contract", "review", "review-summary", "compaction", "task"]),
+          kind: z.enum(["output", "contract", "review", "review-summary", "compaction", "task", "context"]),
           text: z.string(),
           epoch: z.string(),
           transaction: z.string(),

--- a/backend/cli/src/session/prompt.ts
+++ b/backend/cli/src/session/prompt.ts
@@ -748,6 +748,14 @@ export namespace SessionPrompt {
     // Reset on any non-overflow result; a second overflow means the pending
     // message itself is too large to ever fit.
     let overflowCompactions = recovered.overflowCompactions
+    // Consecutive pre-flight "current turn alone is too large" rejections.
+    // Capped at one automatic retry: the first rejection compacts (via a
+    // synthetic continuation, since the failed turn's own error reply makes it
+    // no longer "unanswered" and therefore no longer protected from
+    // compaction) and retries; a second rejection for the same epoch means
+    // the turn's own content doesn't fit even after everything else has been
+    // compacted away, and requires a real user decision instead of looping.
+    let preflightCompactions = recovered.preflightCompactions
     // Compact once, then don't compact again until context drops back under the
     // threshold. Prevents an infinite compaction loop when fixed system+tool+
     // summary overhead alone already exceeds the 0.75 threshold.
@@ -827,6 +835,7 @@ export namespace SessionPrompt {
         epoch = current
         step = 0
         overflowCompactions = 0
+        preflightCompactions = 0
         outputContinuations = 0
         compactionArmed = true
         SessionCompaction.resetBreaker(sessionID)
@@ -1509,6 +1518,22 @@ export namespace SessionPrompt {
         await failTooLarge(
           `This message cannot fit in ${window.name}'s context window: the newest request plus required instructions and tool schemas is estimated at ${preflight.newest.toLocaleString()} tokens, above the safe input budget of ${preflight.hard.toLocaleString()}. Shorten or split the request, remove large attachments, or choose a model with a larger context window. No provider request was sent.`,
         )
+        // The error reply just recorded makes this turn terminal (answered,
+        // even though it failed), so it's no longer protected from compaction
+        // on the next attempt. One automatic retry via a synthetic
+        // continuation lets that now-compactable bulk get reclaimed instead
+        // of leaving the session stuck until a human notices and sends
+        // anything at all to unstick it (this used to require exactly that).
+        if (SessionLoopState.preflightRecovery({ attempts: preflightCompactions }) === "compact") {
+          preflightCompactions++
+          await enqueue({
+            user: lastUser,
+            kind: "context",
+            epoch: turn,
+            text: "The previous request did not fit in the context window and was not sent. Earlier history has been compacted automatically to make room — continue from the existing work without repeating it.",
+          })
+          continue
+        }
         break
       }
       if (preflight.total > preflight.hard && config.compaction?.auto === false) {

--- a/backend/cli/test/session/loop-state.test.ts
+++ b/backend/cli/test/session/loop-state.test.ts
@@ -122,6 +122,7 @@ describe("session loop restart state", () => {
       outputContinuations: 0,
       contractContinuations: 0,
       overflowCompactions: 0,
+      preflightCompactions: 0,
     })
   })
 
@@ -233,6 +234,7 @@ describe("session loop restart state", () => {
       outputContinuations: 0,
       contractContinuations: 0,
       overflowCompactions: 0,
+      preflightCompactions: 0,
     })
 
     const manual = user("compact", [
@@ -475,6 +477,25 @@ describe("session loop restart state", () => {
     expect(SessionLoopState.overflowRecovery({ assistant: normal, unanswered: true, attempts: 2 })).toBe("fail")
     expect(SessionLoopState.overflowRecovery({ assistant: summary, unanswered: true, attempts: 1 })).toBe("fail")
     expect(SessionLoopState.overflowRecovery({ assistant: normal, unanswered: false, attempts: 1 })).toBe("none")
+  })
+
+  test("retries a pre-flight context-window rejection exactly once, then stops", () => {
+    // Regression for a real overnight stall: "the current turn alone is too
+    // large" hard-failed with no retry, leaving the session stuck until a
+    // human noticed and sent anything at all (e.g. "resume") to unstick it.
+    expect(SessionLoopState.preflightRecovery({ attempts: 0 })).toBe("compact")
+    expect(SessionLoopState.preflightRecovery({ attempts: 1 })).toBe("none")
+    expect(SessionLoopState.preflightRecovery({ attempts: 2 })).toBe("none")
+  })
+
+  test("restores preflightCompactions from a synthetic context continuation, resumable after reload", () => {
+    const history = [
+      user("u1", [text("u1", "run the long pipeline")]),
+      assistant("a1", "u1", "stop"),
+      user("c1", [text("c1", "continue", { synthetic: true, kind: "context" })], "context"),
+    ]
+    const reloaded = JSON.parse(JSON.stringify(history)) as MessageV2.WithParts[]
+    expect(SessionLoopState.restore(reloaded)).toMatchObject({ preflightCompactions: 1 })
   })
 
   test("recognizes pre-marker contract continuations from existing sessions", () => {


### PR DESCRIPTION
Fixes #478

## Problem

When the current turn's own unreducible content — `contextPreflight()`'s `newest`, the protected active-turn span plus tool schemas — alone exceeds the safe input budget (`hard`), the session hard-fails with:

```
This message cannot fit in <model>'s context window: the newest request plus
required instructions and tool schemas is estimated at N tokens, above the
safe input budget of M. Shorten or split the request, remove large
attachments, or choose a model with a larger context window. No provider
request was sent.
```

`backend/cli/src/session/prompt.ts`:
```ts
if (preflight.newest > preflight.hard) {
  await failTooLarge(...)
  break
}
```

That's it — the loop just stops. No retry, nothing automatic. In a real overnight run, a session stalled here for hours before an unrelated issue happened later — recovery required a human to notice and send literally anything (even just "resume") to unstick it.

That manual recovery works only because `failTooLarge()`'s error reply makes the failed turn *terminal* (`SessionLoopState.terminalError` treats any assistant reply with `error` as answered) — so it's no longer "protected" from compaction the next time around, and *any* new message triggers a fresh preflight where the previously-stuck bulk is now compactable. There's no reason that recovery needs a human in the loop; the session already has everything it needs to do this itself once the error is recorded.

## Fix

Mirrors the existing `overflowRecovery`/`outputRecovery` pattern (`backend/cli/src/session/loop-state.ts`) already used for two structurally similar recoverable-failure cases in this same loop:

```ts
export function preflightRecovery(input: { attempts: number }): "none" | "compact" {
  return input.attempts > 0 ? "none" : "compact"
}
```

After recording the same error as before (unchanged, for transcript/observability — nothing about what the user sees on the *first* failure changes), the loop now automatically enqueues a synthetic `"context"` continuation (a new `Continuation` kind, same mechanism `output`/`contract` continuations already use) and retries once per epoch:

```ts
if (preflight.newest > preflight.hard) {
  await failTooLarge(...)
  if (SessionLoopState.preflightRecovery({ attempts: preflightCompactions }) === "compact") {
    preflightCompactions++
    await enqueue({ user: lastUser, kind: "context", epoch: turn, text: "..." })
    continue
  }
  break
}
```

A second rejection in the same epoch means the turn's own content doesn't fit even after everything else has been compacted away — that still hard-fails exactly as before, since no amount of compaction could ever help there.

## Verification

- New tests in `test/session/loop-state.test.ts`: `preflightRecovery`'s cap-at-one-retry behavior, and `restore()`'s replay correctly recovering `preflightCompactions` from a synthetic `context` continuation after a session reload (mirrors the existing `output`-continuation restart test directly above it).
- `bun run typecheck` — clean.
- Full `backend/cli` suite: 2906 pass / 115 fail / 16 errors (3058 total) on this branch vs. 2900 pass / 116 fail / 16 errors (3053 total) on a clean `main` baseline — net +6 passing (this PR's 2 new tests plus normal variance), one fewer failure, identical error count. Same pre-existing, unrelated failures both times (confirmed the increase from an earlier ~90-fail baseline was entirely from two newly-merged, environment-dependent test suites unrelated to this change).
- No existing full-loop integration harness exists for `SessionPrompt`'s `while(true)` loop anywhere in this codebase — every other recovery path in it (`overflowRecovery`, `outputRecovery`, `terminalError`) is tested purely at the extracted-decision-function level, which this follows exactly.
