### PR TITLE
fix: don't delete ordinary bold reasoning text that looks like an OpenRouter phase label

### DIFF
--- a/frontend/ui/src/components/tool-display.test.ts
+++ b/frontend/ui/src/components/tool-display.test.ts
@@ -49,9 +49,7 @@ describe("sessionErrorText", () => {
           responseBody: '{"error":"insufficient_balance","required_cents":374,"available_cents":258}',
         },
       }),
-    ).toBe(
-      "The connected provider account needs $3.74 for this step; $2.58 is available.",
-    )
+    ).toBe("The connected provider account needs $3.74 for this step; $2.58 is available.")
   })
 
   test("preserves ordinary provider errors", () => {
@@ -255,6 +253,18 @@ describe("provider reasoning presentation", () => {
     expect(reasoningDisplayText("**Inspecting assay quality**\nThe substantive analysis remains visible.")).toBe(
       "The substantive analysis remains visible.",
     )
+  })
+
+  test("keeps ordinary mid-sentence bold emphasis from a non-bridged provider", () => {
+    // Regression: a direct (non-OpenRouter) provider's reasoning can contain
+    // completely ordinary inline emphasis, preceded by a space like any real
+    // bold text - this must never be deleted just because it matches the
+    // shape of a concatenated OpenRouter phase label. The distinguishing
+    // signal is whitespace before the `**`, which OpenRouter's concatenated
+    // headers never have (they touch the previous phase directly).
+    const text =
+      "Let me also make sure about **featureCounts GTF requirement**: featureCounts works best with a GFF/GTF that has gene/transcript features."
+    expect(reasoningDisplayText(text)).toBe(text)
   })
 })
 

--- a/frontend/ui/src/components/tool-display.ts
+++ b/frontend/ui/src/components/tool-display.ts
@@ -27,7 +27,13 @@ export function stripRedactedReasoning(text: string): string {
   return visible.trim() ? visible : ""
 }
 
-const providerReasoningPhase = /\*\*([^*\n]+)\*\*(?:\r?\n[ \t]*)*/g
+// Only matches a bold span that isn't preceded by whitespace (i.e. it's at
+// the very start of the text, or directly touching the previous phase's
+// closing punctuation with no separator — OpenRouter's actual concatenation
+// shape, "done.**Next**"). Ordinary inline emphasis in a model's own prose
+// always has a space before it ("...make sure about **X**: ...") and must
+// never be silently deleted just because it happens to be bold.
+const providerReasoningPhase = /(?:^|(?<=\S))\*\*([^*\n]+)\*\*(?:\r?\n[ \t]*)*/g
 const providerStatusOnly =
   /^(?:planning|preparing|retrieving|exploring|inspecting|testing|verifying|checking|reviewing|analyzing|evaluating|designing|building|running|confirming|adjusting|patching|restarting|summarizing|finalizing)\b[^.!?]*$/i
 


### PR DESCRIPTION
Fixes #480

## Problem

`reasoningDisplayText()` (`frontend/ui/src/components/tool-display.ts`) strips OpenRouter's concatenated provider-summary phase headings from reasoning text before rendering — its doc comment explains the shape: "Each summary phase starts with a bold label, but adjacent phases are not guaranteed to include a separator (`...done.**Next**`)."

The regex matching those headings had no check confirming a bold span is actually one of them:

```ts
const providerReasoningPhase = /\*\*([^*\n]+)\*\*(?:\r?\n[ \t]*)*/g
```

It matches *any* `**bold**` span anywhere in reasoning text, from any provider, and replaces it with `"\n\n"` — deleting it entirely while leaving the surrounding text untouched. Confirmed against a real session: a direct (non-OpenRouter) provider's reasoning contained completely ordinary inline emphasis —

> Let me also make sure about **featureCounts GTF requirement**: featureCounts works best with a GFF/GTF that has...

— and the bold span vanished from the rendered UI, leaving the text stopping after "about", a blank line, then ": featureCounts works best...". Checked the raw stored message data first: the model's actual output was completely intact — this is purely a display bug in `reasoningDisplayText`, not anything wrong with generation or storage.

## Fix

OpenRouter's concatenated headings never have whitespace before the opening `**` — they touch the previous phase's closing punctuation directly (`done.**Next**`), or start the string. Ordinary inline emphasis in real prose always has a space before it. That's a clean, provider-agnostic signal to distinguish the two shapes without threading provider identity through the render tree:

```ts
const providerReasoningPhase = /(?:^|(?<=\S))\*\*([^*\n]+)\*\*(?:\r?\n[ \t]*)*/g
```

Requires the match to be at the start of the text or immediately preceded by a non-whitespace character.

## Verification

- All existing tests for this function still pass unchanged — every documented OpenRouter-shaped case (`**Evaluating Titanic dataset analysis**...`, `...started!**Choosing a reputable Titanic dataset**`, `**Inspecting assay quality**\n...`) is preceded by either start-of-string or punctuation with no space, so none of them regress.
- New regression test using the exact reported string, asserting it passes through unchanged.
- `bun run typecheck` (frontend/ui) — clean.
