### PR TITLE
Fix macOS Terminal CLI signing and legacy launcher recovery

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -222,7 +222,7 @@ jobs:
           path: |
             backend/cli/dist
             frontend/workspace/dist/version.json
-          key: cli-signed-${{ needs.version.outputs.version }}-${{ needs.version.outputs.artifact_source }}
+          key: cli-signed-jit-v1-${{ needs.version.outputs.version }}-${{ needs.version.outputs.artifact_source }}
       - name: Restore unsigned build
         if: steps.signed.outputs.cache-hit != 'true'
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -254,7 +254,7 @@ jobs:
           binaries=(backend/cli/dist/@synsci/openscience-darwin-*/bin/openscience)
           [[ ${#binaries[@]} -eq 3 ]] || { echo "::error::Expected three macOS binaries"; exit 1; }
           for binary in "${binaries[@]}"; do
-            codesign --force --options runtime --timestamp --identifier ai.syntheticsciences.openscience --sign "$identity" "$binary"
+            codesign --force --options runtime --timestamp --identifier ai.syntheticsciences.openscience --entitlements frontend/desktop/build/entitlements.mac.plist --sign "$identity" "$binary"
             codesign --verify --strict --verbose=2 "$binary"
             details="$(codesign -dv --verbose=4 "$binary" 2>&1)"
             grep -Fxq 'Identifier=ai.syntheticsciences.openscience' <<<"$details"
@@ -290,6 +290,28 @@ jobs:
           while IFS= read -r archive; do
             printf '%s  %s\n' "$(shasum -a 256 "$archive" | awk '{print $1}')" "$(basename "$archive")" >> backend/cli/dist/checksums.txt
           done < <(find backend/cli/dist -maxdepth 1 -type f \( -name 'openscience-*.zip' -o -name 'openscience-*.tar.gz' \) | sort)
+      - name: Verify standalone macOS runtime signatures
+        shell: bash
+        env:
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          binaries=(backend/cli/dist/@synsci/openscience-darwin-*/bin/openscience)
+          [[ ${#binaries[@]} -eq 3 ]] || { echo "::error::Expected three macOS binaries"; exit 1; }
+          for binary in "${binaries[@]}"; do
+            codesign --verify --strict --verbose=2 "$binary"
+            details="$(codesign -dv --verbose=4 "$binary" 2>&1)"
+            grep -Fxq 'Identifier=ai.syntheticsciences.openscience' <<<"$details"
+            grep -Fxq "TeamIdentifier=$APPLE_TEAM_ID" <<<"$details"
+            for key in \
+              com.apple.security.cs.allow-jit \
+              com.apple.security.cs.allow-unsigned-executable-memory \
+              com.apple.security.cs.disable-library-validation; do
+              keypath="${key//./\\.}"
+              value="$(codesign -d --entitlements :- "$binary" 2>/dev/null | /usr/bin/plutil -extract "$keypath" raw -o - -)"
+              [[ "$value" == "true" ]] || { echo "::error::$binary is missing $key"; exit 1; }
+            done
+          done
       - name: Save signed build
         if: steps.signed.outputs.cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -297,7 +319,7 @@ jobs:
           path: |
             backend/cli/dist
             frontend/workspace/dist/version.json
-          key: cli-signed-${{ needs.version.outputs.version }}-${{ needs.version.outputs.artifact_source }}
+          key: cli-signed-jit-v1-${{ needs.version.outputs.version }}-${{ needs.version.outputs.artifact_source }}
       - name: Upload native CLI assets
         run: ./tooling/repo/release-assets.ts backend/cli/dist
         env:
@@ -338,7 +360,7 @@ jobs:
             gh release edit "$OPENSCIENCE_TAG" --notes-file "$notes"
           fi
     outputs:
-      cache_key: cli-signed-${{ needs.version.outputs.version }}-${{ needs.version.outputs.artifact_source }}
+      cache_key: cli-signed-jit-v1-${{ needs.version.outputs.version }}-${{ needs.version.outputs.artifact_source }}
       sidecar_manifest: ${{ steps.sidecars.outputs.manifest }}
 
   prepare-npm:
@@ -380,7 +402,7 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .release/npm/${{ needs.version.outputs.version }}
-          key: npm-release-${{ needs.version.outputs.version }}-${{ needs.version.outputs.artifact_source }}
+          key: npm-release-jit-v1-${{ needs.version.outputs.version }}-${{ needs.version.outputs.artifact_source }}
       - name: Pack immutable npm artifacts
         if: steps.cache.outputs.cache-hit != 'true'
         run: ./tooling/repo/prepare-npm.ts
@@ -400,7 +422,7 @@ jobs:
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .release/npm/${{ needs.version.outputs.version }}
-          key: npm-release-${{ needs.version.outputs.version }}-${{ needs.version.outputs.artifact_source }}
+          key: npm-release-jit-v1-${{ needs.version.outputs.version }}-${{ needs.version.outputs.artifact_source }}
 
       # npm's registry visibility wait overlaps desktop packaging. This phase
       # never promotes latest or makes the draft GitHub release public.
@@ -589,7 +611,33 @@ jobs:
             details="$(codesign -dv --verbose=4 "$OPENSCIENCE_DESKTOP_SIDECAR" 2>&1)"
             grep -Fxq 'Identifier=ai.syntheticsciences.openscience' <<<"$details"
             grep -Fxq "TeamIdentifier=$APPLE_TEAM_ID" <<<"$details"
+            for key in \
+              com.apple.security.cs.allow-jit \
+              com.apple.security.cs.allow-unsigned-executable-memory \
+              com.apple.security.cs.disable-library-validation; do
+              keypath="${key//./\\.}"
+              value="$(codesign -d --entitlements :- "$OPENSCIENCE_DESKTOP_SIDECAR" 2>/dev/null | /usr/bin/plutil -extract "$keypath" raw -o - -)"
+              [[ "$value" == "true" ]] || { echo "::error::$OPENSCIENCE_DESKTOP_SIDECAR is missing $key"; exit 1; }
+            done
           fi
+      - name: Smoke native macOS desktop sidecar
+        if: steps.existing.outputs.found != 'true' && matrix.signing == 'mac'
+        shell: bash
+        env:
+          OPENSCIENCE_DESKTOP_SIDECAR: ${{ matrix.sidecar }}
+          OPENSCIENCE_VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          node -e '
+            const { execFileSync } = require("node:child_process")
+            const value = execFileSync(process.env.OPENSCIENCE_DESKTOP_SIDECAR, ["--version"], {
+              encoding: "utf8",
+              timeout: 15_000,
+            }).trim()
+            if (value !== process.env.OPENSCIENCE_VERSION) {
+              throw new Error(`Expected OpenScience ${process.env.OPENSCIENCE_VERSION}, received ${value}`)
+            }
+          '
       - name: Detect Windows signing
         id: windows
         if: steps.existing.outputs.found != 'true' && matrix.signing == 'windows'
@@ -736,7 +784,7 @@ jobs:
       - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .release/npm/${{ needs.version.outputs.version }}
-          key: npm-release-${{ needs.version.outputs.version }}-${{ needs.version.outputs.artifact_source }}
+          key: npm-release-jit-v1-${{ needs.version.outputs.version }}-${{ needs.version.outputs.artifact_source }}
           fail-on-cache-miss: true
       - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:

--- a/backend/cli/script/publish-manifest.ts
+++ b/backend/cli/script/publish-manifest.ts
@@ -22,13 +22,27 @@ const retiredPublicCopy = [
   /initialize-(?:atlas|research)-graph/i,
 ] as const
 
+const unsafePublicCode = [
+  {
+    name: "recursive xattr",
+    pattern: /\bxattr\b[\s\S]{0,120}["'`]-r[a-z]*\b/i,
+  },
+  {
+    name: "recursive OpenScience data-root deletion",
+    pattern: /\brmSync\s*\([\s\S]{0,160}(?:openscienceDir|\.openscience)[\s\S]{0,160}\brecursive\s*:\s*true/i,
+  },
+] as const
+
 /** Fail packaging when an npm-visible text file reintroduces a retired public
- * product or billing contract. Internal compatibility identifiers are not
- * scanned; callers pass only the files npm users can read or execute. */
+ * contract or destructive launcher behavior. Internal compatibility
+ * identifiers are not scanned; callers pass only files npm users can read or
+ * execute. */
 export function assertPublicPackageSurface(files: Record<string, string>) {
   for (const [file, content] of Object.entries(files)) {
     const match = retiredPublicCopy.find((pattern) => pattern.test(content))
     if (match) throw new Error(`${file} contains retired public copy matching ${match}`)
+    const unsafe = unsafePublicCode.find((entry) => entry.pattern.test(content))
+    if (unsafe) throw new Error(`${file} contains unsafe public package code: ${unsafe.name}`)
   }
 }
 

--- a/backend/cli/test/installation/desktop-shell-contract.test.ts
+++ b/backend/cli/test/installation/desktop-shell-contract.test.ts
@@ -13,6 +13,22 @@ test("declares UTF-8 for every inline desktop document", async () => {
   expect(source.match(/data:text\/html;charset=utf-8,/g)).toHaveLength(3)
 })
 
+test("desktop sidecar inherits the terminal's OpenScience root selectors unchanged", async () => {
+  const source = await Bun.file(new URL("../../../../frontend/desktop/src/main.mjs", import.meta.url)).text()
+  const begin = source.indexOf("async function start()")
+  const end = source.indexOf("function stop()")
+
+  expect(begin).toBeGreaterThan(-1)
+  expect(end).toBeGreaterThan(begin)
+  const start = source.slice(begin, end)
+
+  expect(start).toContain("...process.env")
+  expect(start).toContain("cwd: workspace")
+  for (const key of ["HOME", "XDG_CONFIG_HOME", "XDG_DATA_HOME", "OPENSCIENCE_DATA_DIR", "OPENSCIENCE_CONFIG_DIR"]) {
+    expect(start).not.toContain(`${key}:`)
+  }
+})
+
 test("wires the packaged macOS shell to the authenticated desktop updater", async () => {
   const source = await Bun.file(new URL("../../../../frontend/desktop/src/main.mjs", import.meta.url)).text()
   const updater = await Bun.file(new URL("../../../../frontend/desktop/src/updater.mjs", import.meta.url)).text()

--- a/backend/cli/test/installation/publish-manifest.test.ts
+++ b/backend/cli/test/installation/publish-manifest.test.ts
@@ -68,4 +68,17 @@ describe("wrapper package manifest", () => {
       expect(() => assertPublicPackageSurface({ "README.md": copy })).toThrow("retired public copy")
     }
   })
+
+  test("rejects recursive mutation of the OpenScience data root from npm-visible launchers", () => {
+    expect(() =>
+      assertPublicPackageSurface({
+        "bin/openscience": 'spawnSync("xattr", ["-rc", openscienceDir], { stdio: "ignore" })',
+      }),
+    ).toThrow("recursive xattr")
+    expect(() =>
+      assertPublicPackageSurface({
+        "bin/openscience": 'fs.rmSync(path.join(openscienceDir, "node_modules"), { recursive: true })',
+      }),
+    ).toThrow("recursive OpenScience data-root deletion")
+  })
 })

--- a/backend/cli/test/installation/release-order.test.ts
+++ b/backend/cli/test/installation/release-order.test.ts
@@ -95,13 +95,32 @@ test("a stale release tag cannot create or preflight a draft", async () => {
   expect(await Bun.file(log).text()).not.toContain("release create")
 })
 
-test("stable macOS artifacts remain signed, notarized, stapled, and smoked", async () => {
+test("stable macOS artifacts remain entitled, signed, notarized, stapled, and smoked", async () => {
   const workflow = await read(".github/workflows/publish.yml")
+  const entitlements = await read("frontend/desktop/build/entitlements.mac.plist")
 
   expect(workflow).toContain("runner: macos-15")
   expect(workflow).toContain("runner: macos-15-intel")
   expect(workflow).toContain("Apple-Actions/import-codesign-certs")
   expect(workflow).toContain("codesign --force --options runtime --timestamp")
+  expect(workflow).toContain("--entitlements frontend/desktop/build/entitlements.mac.plist")
+  expect(workflow).toContain("codesign -d --entitlements :-")
+  expect(workflow).toContain("name: Smoke native macOS desktop sidecar")
+  expect(workflow).toContain('execFileSync(process.env.OPENSCIENCE_DESKTOP_SIDECAR, ["--version"]')
+  expect(workflow).toContain("timeout: 15_000")
+  const smoke = workflow.slice(
+    workflow.indexOf("- name: Smoke native macOS desktop sidecar"),
+    workflow.indexOf("- name: Detect Windows signing"),
+  )
+  expect(smoke).not.toContain("GH_TOKEN")
+  for (const key of [
+    "com.apple.security.cs.allow-jit",
+    "com.apple.security.cs.allow-unsigned-executable-memory",
+    "com.apple.security.cs.disable-library-validation",
+  ]) {
+    expect(workflow).toContain(key)
+    expect(entitlements).toContain(`<key>${key}</key>\n  <true/>`)
+  }
   expect(workflow).toContain("xcrun notarytool submit")
   expect(workflow).toContain("xcrun stapler staple")
   expect(workflow).toContain("spctl -a -t open")
@@ -119,7 +138,10 @@ test("release caches and resumed mac assets are bound and reverified", async () 
     "key: cli-build-${{ needs.version.outputs.version }}-${{ needs.version.outputs.artifact_source }}",
   )
   expect(workflow).toContain(
-    "key: npm-release-${{ needs.version.outputs.version }}-${{ needs.version.outputs.artifact_source }}",
+    "key: cli-signed-jit-v1-${{ needs.version.outputs.version }}-${{ needs.version.outputs.artifact_source }}",
+  )
+  expect(workflow).toContain(
+    "key: npm-release-jit-v1-${{ needs.version.outputs.version }}-${{ needs.version.outputs.artifact_source }}",
   )
   expect(workflow).toContain("Verify resumed macOS assets")
   expect(workflow).toContain("TeamIdentifier=$APPLE_TEAM_ID")

--- a/backend/cli/test/installation/synsci-stale-wrapper.test.ts
+++ b/backend/cli/test/installation/synsci-stale-wrapper.test.ts
@@ -1,0 +1,440 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+
+const launcher = path.join(import.meta.dir, "../../../../tooling/launcher/bin/synsci.mjs")
+const scopes: string[] = []
+const posix = process.platform === "win32" ? test.skip : test
+const mac = process.platform === "darwin" ? test : test.skip
+const keys = [
+  "com.apple.security.cs.allow-jit",
+  "com.apple.security.cs.allow-unsigned-executable-memory",
+  "com.apple.security.cs.disable-library-validation",
+]
+const plist = (entries: string[]) =>
+  `<?xml version="1.0"?><plist><dict>${entries.map((key) => `<key>${key}</key><true/>`).join("")}</dict></plist>`
+const entitled = plist(keys)
+const noJit = plist(keys.slice(1))
+const jitOnly = plist(keys.slice(0, 1))
+
+afterEach(async () => {
+  await Promise.all(scopes.splice(0).map((scope) => fs.rm(scope, { recursive: true, force: true })))
+})
+
+async function fixture(options: {
+  standalone?: "safe" | "rejected"
+  version?: string
+  manifest?: "valid" | "missing" | "malformed"
+  globalEntitlements?: string | false
+  standaloneEntitlements?: string | false
+  installedEntitlements?: string | false
+  dependencyVersion?: string
+  override?: boolean
+  npmInstall?: "success" | "fail"
+  pathCandidate?: boolean
+}) {
+  const scope = await fs.mkdtemp(path.join(os.tmpdir(), "synsci-stale-wrapper-"))
+  scopes.push(scope)
+  const home = path.join(scope, "home")
+  const prefix = path.join(scope, "prefix")
+  const root = path.join(prefix, "lib", "node_modules")
+  const bin = path.join(prefix, "bin", "openscience")
+  const manifest = path.join(root, "@synsci", "openscience", "package.json")
+  const native = path.join(
+    root,
+    "@synsci",
+    "openscience",
+    "node_modules",
+    "@synsci",
+    `openscience-darwin-${process.arch}`,
+    "bin",
+    "openscience",
+  )
+  const nativeManifest = path.join(path.dirname(path.dirname(native)), "package.json")
+  const tools = path.join(home, "tools")
+  const npm = path.join(tools, "npm")
+  const codesign = path.join(tools, "codesign")
+  const data = path.join(home, ".openscience")
+  const local = path.join(data, "bin", "openscience")
+  const globalMarker = path.join(scope, "global-wrapper-ran")
+  const nativeMarker = path.join(scope, "global-native-ran")
+  const installedMarker = path.join(scope, "installed-native-ran")
+  const installedWrapperMarker = path.join(scope, "installed-wrapper-ran")
+  const standaloneMarker = path.join(scope, "standalone-ran")
+  const overrideMarker = path.join(scope, "override-ran")
+  const pathMarker = path.join(scope, "path-candidate-ran")
+  const override = path.join(scope, "override")
+  const pathCandidate = path.join(tools, "openscience")
+  const calls = path.join(scope, "cli-calls.jsonl")
+  const npmCalls = path.join(scope, "npm-calls.jsonl")
+  const codesignCalls = path.join(scope, "codesign-calls.jsonl")
+  const mapFile = path.join(scope, "codesign-map.json")
+  const version = options.version ?? "1.3.0"
+  const globalSource = `#!/usr/bin/env node
+const fs = require("node:fs")
+fs.writeFileSync(process.env.FAKE_GLOBAL_MARKER, "executed\\n")
+if (process.argv[2] === "--version") console.log(${JSON.stringify(version)})
+`
+  const safeSource = `#!/usr/bin/env node
+const fs = require("node:fs")
+fs.appendFileSync(process.env.FAKE_CLI_CALLS, JSON.stringify(process.argv.slice(2)) + "\\n")
+if (process.argv[2] === "--version") console.log("2.0.66")
+`
+  const nativeSource = `#!/usr/bin/env node
+const fs = require("node:fs")
+fs.writeFileSync(process.env.FAKE_NATIVE_MARKER, "executed\\n")
+fs.appendFileSync(process.env.FAKE_CLI_CALLS, JSON.stringify(process.argv.slice(2)) + "\\n")
+if (process.argv[2] === "--version") console.log(${JSON.stringify(version)})
+`
+  const installedSource = `#!/usr/bin/env node
+const fs = require("node:fs")
+fs.writeFileSync(process.env.FAKE_INSTALLED_MARKER, "executed\\n")
+fs.appendFileSync(process.env.FAKE_CLI_CALLS, JSON.stringify(process.argv.slice(2)) + "\\n")
+if (process.argv[2] === "--version") console.log("2.0.66")
+`
+  const installedWrapperSource = `#!/usr/bin/env node
+const fs = require("node:fs")
+fs.writeFileSync(process.env.FAKE_INSTALLED_WRAPPER_MARKER, "executed\\n")
+fs.appendFileSync(process.env.FAKE_CLI_CALLS, JSON.stringify(process.argv.slice(2)) + "\\n")
+if (process.argv[2] === "--version") console.log("2.0.66")
+`
+  const rejectedSource = `#!/usr/bin/env node
+const fs = require("node:fs")
+fs.writeFileSync(process.env.FAKE_STANDALONE_MARKER, "executed\\n")
+if (process.argv[2] === "--version") console.log("2.0.66")
+`
+  const overrideSource = `#!/usr/bin/env node
+const fs = require("node:fs")
+fs.writeFileSync(process.env.FAKE_OVERRIDE_MARKER, "executed\\n")
+if (process.argv[2] === "--version") console.log("2.0.66")
+`
+  const pathSource = `#!/usr/bin/env node
+const fs = require("node:fs")
+fs.writeFileSync(process.env.FAKE_PATH_MARKER, "executed\\n")
+if (process.argv[2] === "--version") console.log("2.0.66")
+`
+  const npmSource = `#!/usr/bin/env node
+const fs = require("node:fs")
+const path = require("node:path")
+const args = process.argv.slice(2)
+fs.appendFileSync(process.env.FAKE_NPM_CALLS, JSON.stringify(args) + "\\n")
+if (args[0] === "prefix" && args[1] === "-g") {
+  console.log(process.env.FAKE_NPM_PREFIX)
+  process.exit(0)
+}
+if (args[0] === "root" && args[1] === "-g") {
+  console.log(process.env.FAKE_NPM_ROOT)
+  process.exit(0)
+}
+if (args[0] === "ls") {
+  console.log('{"dependencies":{}}')
+  process.exit(0)
+}
+if (args[0] === "view") {
+  console.log("2.0.66")
+  process.exit(0)
+}
+if (args[0] === "i" && args[1] === "-g") {
+  if (process.env.FAKE_NPM_INSTALL === "fail") process.exit(1)
+  fs.mkdirSync(path.dirname(process.env.FAKE_GLOBAL_MANIFEST), { recursive: true })
+  fs.mkdirSync(path.dirname(process.env.FAKE_GLOBAL_NATIVE), { recursive: true })
+  fs.writeFileSync(process.env.FAKE_GLOBAL_MANIFEST, JSON.stringify({
+    name: "@synsci/openscience",
+    version: "2.0.66",
+    optionalDependencies: { [process.env.FAKE_GLOBAL_NATIVE_NAME]: "2.0.66" },
+  }))
+  fs.writeFileSync(process.env.FAKE_GLOBAL_BIN, process.env.FAKE_INSTALLED_WRAPPER_SOURCE)
+  fs.writeFileSync(process.env.FAKE_GLOBAL_NATIVE, process.env.FAKE_INSTALLED_SOURCE)
+  fs.writeFileSync(process.env.FAKE_GLOBAL_NATIVE_MANIFEST, JSON.stringify({ name: process.env.FAKE_GLOBAL_NATIVE_NAME, version: "2.0.66" }))
+  fs.chmodSync(process.env.FAKE_GLOBAL_BIN, 0o755)
+  fs.chmodSync(process.env.FAKE_GLOBAL_NATIVE, 0o755)
+  const map = JSON.parse(fs.readFileSync(process.env.FAKE_CODESIGN_MAP, "utf8"))
+  if (process.env.FAKE_INSTALLED_ENTITLEMENTS) {
+    map[process.env.FAKE_GLOBAL_NATIVE] = process.env.FAKE_INSTALLED_ENTITLEMENTS
+  } else {
+    delete map[process.env.FAKE_GLOBAL_NATIVE]
+  }
+  fs.writeFileSync(process.env.FAKE_CODESIGN_MAP, JSON.stringify(map))
+  process.exit(0)
+}
+process.exit(1)
+`
+  const codesignSource = `#!/usr/bin/env node
+const fs = require("node:fs")
+const args = process.argv.slice(2)
+const file = args.at(-1)
+fs.appendFileSync(process.env.FAKE_CODESIGN_CALLS, JSON.stringify(args) + "\\n")
+const map = JSON.parse(fs.readFileSync(process.env.FAKE_CODESIGN_MAP, "utf8"))
+if (typeof map[file] !== "string") process.exit(1)
+process.stdout.write(map[file])
+`
+
+  await Promise.all([
+    fs.mkdir(path.dirname(manifest), { recursive: true }),
+    fs.mkdir(path.dirname(native), { recursive: true }),
+    fs.mkdir(path.dirname(bin), { recursive: true }),
+    fs.mkdir(path.dirname(local), { recursive: true }),
+    fs.mkdir(tools, { recursive: true }),
+    fs.mkdir(data, { recursive: true }),
+  ])
+  await Promise.all([
+    fs.writeFile(bin, globalSource),
+    fs.writeFile(native, nativeSource),
+    fs.writeFile(nativeManifest, JSON.stringify({ name: `@synsci/openscience-darwin-${process.arch}`, version })),
+    fs.writeFile(npm, npmSource),
+    fs.writeFile(codesign, codesignSource),
+    fs.writeFile(override, overrideSource),
+    options.pathCandidate ? fs.writeFile(pathCandidate, pathSource) : undefined,
+    fs.writeFile(path.join(data, "openscience-session.json"), JSON.stringify({ api_key: "thk_fixture.token" })),
+  ])
+  if ((options.manifest ?? "valid") === "valid") {
+    await fs.writeFile(
+      manifest,
+      JSON.stringify({
+        name: "@synsci/openscience",
+        version,
+        optionalDependencies: {
+          [`@synsci/openscience-darwin-${process.arch}`]: options.dependencyVersion ?? version,
+        },
+      }),
+    )
+  }
+  if (options.manifest === "malformed") await fs.writeFile(manifest, "{")
+  if (options.standalone) {
+    await fs.writeFile(local, options.standalone === "safe" ? safeSource : rejectedSource)
+  }
+
+  const map: Record<string, string> = {}
+  const globalEntitlements = Object.hasOwn(options, "globalEntitlements") ? options.globalEntitlements : entitled
+  if (typeof globalEntitlements === "string") map[native] = globalEntitlements
+  const standaloneEntitlements = Object.hasOwn(options, "standaloneEntitlements")
+    ? options.standaloneEntitlements
+    : options.standalone === "safe"
+      ? entitled
+      : false
+  if (typeof standaloneEntitlements === "string") map[local] = standaloneEntitlements
+  const installedEntitlements = Object.hasOwn(options, "installedEntitlements")
+    ? options.installedEntitlements
+    : entitled
+  await fs.writeFile(mapFile, JSON.stringify(map))
+  await Promise.all([
+    fs.chmod(bin, 0o755),
+    fs.chmod(native, 0o755),
+    fs.chmod(npm, 0o755),
+    fs.chmod(codesign, 0o755),
+    fs.chmod(override, 0o755),
+    options.pathCandidate ? fs.chmod(pathCandidate, 0o755) : undefined,
+    options.standalone ? fs.chmod(local, 0o755) : undefined,
+  ])
+
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    HOME: home,
+    OPENSCIENCE_TEST_HOME: home,
+    OPENSCIENCE_TEST_CODESIGN: codesign,
+    XDG_CONFIG_HOME: path.join(scope, "config"),
+    XDG_DATA_HOME: path.join(scope, "share"),
+    OPENSCIENCE_DATA_DIR: data,
+    PATH: `${tools}${path.delimiter}${process.env.PATH ?? ""}`,
+    FAKE_NPM_PREFIX: prefix,
+    FAKE_NPM_ROOT: root,
+    FAKE_NPM_CALLS: npmCalls,
+    FAKE_GLOBAL_MANIFEST: manifest,
+    FAKE_GLOBAL_BIN: bin,
+    FAKE_GLOBAL_NATIVE: native,
+    FAKE_GLOBAL_NATIVE_MANIFEST: nativeManifest,
+    FAKE_GLOBAL_NATIVE_NAME: `@synsci/openscience-darwin-${process.arch}`,
+    FAKE_INSTALLED_SOURCE: installedSource,
+    FAKE_INSTALLED_WRAPPER_SOURCE: installedWrapperSource,
+    FAKE_GLOBAL_MARKER: globalMarker,
+    FAKE_NATIVE_MARKER: nativeMarker,
+    FAKE_INSTALLED_MARKER: installedMarker,
+    FAKE_INSTALLED_WRAPPER_MARKER: installedWrapperMarker,
+    FAKE_STANDALONE_MARKER: standaloneMarker,
+    FAKE_OVERRIDE_MARKER: overrideMarker,
+    FAKE_PATH_MARKER: pathMarker,
+    FAKE_CLI_CALLS: calls,
+    FAKE_CODESIGN_MAP: mapFile,
+    FAKE_CODESIGN_CALLS: codesignCalls,
+    FAKE_INSTALLED_ENTITLEMENTS: typeof installedEntitlements === "string" ? installedEntitlements : "",
+    FAKE_NPM_INSTALL: options.npmInstall ?? "success",
+  }
+  if (options.override) env.OPENSCIENCE_BIN_PATH = override
+  delete env.__SYNSCI_LAUNCHER_PID
+  return {
+    scope,
+    globalMarker,
+    nativeMarker,
+    installedMarker,
+    installedWrapperMarker,
+    standaloneMarker,
+    overrideMarker,
+    pathMarker,
+    calls,
+    npmCalls,
+    codesignCalls,
+    native,
+    local,
+    env,
+  }
+}
+
+async function launch(env: NodeJS.ProcessEnv) {
+  const proc = Bun.spawn(["node", launcher], {
+    cwd: env.HOME,
+    env,
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+  return { stdout, stderr, code }
+}
+
+describe("synsci unsafe candidate recovery", () => {
+  posix("never probes a pre-2.0.2 global wrapper when a standalone binary is available", async () => {
+    const setup = await fixture({ standalone: "safe" })
+    const result = await launch(setup.env)
+
+    expect(result.code, result.stderr).toBe(0)
+    expect(await Bun.file(setup.globalMarker).exists()).toBe(false)
+    expect(await Bun.file(setup.calls).text()).toContain('["web"]')
+    expect(await Bun.file(setup.npmCalls).text()).not.toContain('["i","-g"')
+  })
+
+  posix("repairs npm before executing a pre-2.0.2 wrapper when no standalone binary exists", async () => {
+    const setup = await fixture({})
+    const result = await launch(setup.env)
+
+    expect(result.code, result.stderr).toBe(0)
+    expect(await Bun.file(setup.globalMarker).exists()).toBe(false)
+    expect(await Bun.file(setup.npmCalls).text()).toContain('["i","-g","@synsci/openscience@latest"]')
+    expect(await Bun.file(setup.calls).text()).toContain('["web"]')
+  })
+
+  for (const state of ["missing", "malformed"] as const) {
+    posix(`does not probe a global wrapper with ${state} ownership metadata`, async () => {
+      const setup = await fixture({ version: "2.0.66", manifest: state, standalone: "safe" })
+      const result = await launch(setup.env)
+
+      expect(result.code, result.stderr).toBe(0)
+      expect(await Bun.file(setup.globalMarker).exists()).toBe(false)
+      expect(await Bun.file(setup.npmCalls).text()).not.toContain('["i","-g"')
+      expect(await Bun.file(setup.calls).text()).toContain('["web"]')
+    })
+  }
+
+  for (const version of ["garbage", "2.0", "2.0.02", "2.0.2.5", "2.0.2-01", "2.0.2-beta.1", "9007199254740992.0.0"]) {
+    posix(`does not probe a global wrapper with unsafe version ${version}`, async () => {
+      const setup = await fixture({ version, standalone: "safe" })
+      const result = await launch(setup.env)
+
+      expect(result.code, result.stderr).toBe(0)
+      expect(await Bun.file(setup.globalMarker).exists()).toBe(false)
+      expect(await Bun.file(setup.calls).text()).toContain('["web"]')
+    })
+  }
+
+  mac("rejects a version-current global wrapper whose native binary lacks allow-jit", async () => {
+    const setup = await fixture({
+      version: "2.0.66",
+      standalone: "safe",
+      globalEntitlements: noJit,
+    })
+    const result = await launch(setup.env)
+
+    expect(result.code, result.stderr).toBe(0)
+    expect(await Bun.file(setup.globalMarker).exists()).toBe(false)
+    expect(await Bun.file(setup.nativeMarker).exists()).toBe(false)
+    expect(await Bun.file(setup.calls).text()).toContain('["web"]')
+    const calls = await Bun.file(setup.codesignCalls).text()
+    expect(calls).toContain(JSON.stringify(["--verify", "--strict", setup.native]))
+    expect(calls).toContain(setup.native)
+    expect(calls).toContain(setup.local)
+  })
+
+  mac("rejects a native package not bound to the wrapper's exact dependency version", async () => {
+    const setup = await fixture({
+      version: "2.0.66",
+      dependencyVersion: "2.0.65",
+      standalone: "safe",
+    })
+    const result = await launch(setup.env)
+
+    expect(result.code, result.stderr).toBe(0)
+    expect(await Bun.file(setup.globalMarker).exists()).toBe(false)
+    expect(await Bun.file(setup.nativeMarker).exists()).toBe(false)
+    expect(await Bun.file(setup.calls).text()).toContain('["web"]')
+  })
+
+  mac("repairs npm without probing a standalone binary missing the full entitlement set", async () => {
+    const setup = await fixture({
+      version: "2.0.66",
+      manifest: "missing",
+      standalone: "rejected",
+      standaloneEntitlements: jitOnly,
+    })
+    const result = await launch(setup.env)
+
+    expect(result.code, result.stderr).toBe(0)
+    expect(await Bun.file(setup.standaloneMarker).exists()).toBe(false)
+    expect(await Bun.file(setup.npmCalls).text()).toContain('["i","-g","@synsci/openscience@latest"]')
+    expect(await Bun.file(setup.codesignCalls).text()).toContain(setup.local)
+    expect(await Bun.file(setup.calls).text()).toContain('["web"]')
+  })
+
+  mac("executes the validated native package directly and ignores OPENSCIENCE_BIN_PATH", async () => {
+    const setup = await fixture({ version: "2.0.66", override: true })
+    const result = await launch(setup.env)
+
+    expect(result.code, result.stderr).toBe(0)
+    expect(await Bun.file(setup.globalMarker).exists()).toBe(false)
+    expect(await Bun.file(setup.overrideMarker).exists()).toBe(false)
+    expect(await Bun.file(setup.nativeMarker).exists()).toBe(true)
+    expect(await Bun.file(setup.codesignCalls).text()).toContain(setup.native)
+    expect(await Bun.file(setup.calls).text()).toContain('["web"]')
+  })
+
+  mac("revalidates a mac npm update and never executes a rejected replacement", async () => {
+    const setup = await fixture({
+      version: "2.0.65",
+      standalone: "safe",
+      installedEntitlements: false,
+      override: true,
+    })
+    const result = await launch(setup.env)
+
+    expect(result.code, result.stderr).toBe(0)
+    expect(await Bun.file(setup.globalMarker).exists()).toBe(false)
+    expect(await Bun.file(setup.installedWrapperMarker).exists()).toBe(false)
+    expect(await Bun.file(setup.installedMarker).exists()).toBe(false)
+    expect(await Bun.file(setup.overrideMarker).exists()).toBe(false)
+    expect(await Bun.file(setup.nativeMarker).exists()).toBe(true)
+    expect(await Bun.file(setup.npmCalls).text()).toContain('["i","-g","@synsci/openscience@2.0.66"]')
+    expect(await Bun.file(setup.codesignCalls).text()).toContain(setup.native)
+    expect(await Bun.file(setup.calls).text()).toContain('["web"]')
+  })
+
+  posix("does not let installer recovery execute a rejected command already on PATH", async () => {
+    const setup = await fixture({
+      manifest: "missing",
+      standalone: "rejected",
+      standaloneEntitlements: false,
+      npmInstall: "fail",
+      pathCandidate: true,
+    })
+    const result = await launch(setup.env)
+
+    expect(result.code).toBe(1)
+    expect(result.stdout).toContain("refusing to execute an existing unverified openscience command")
+    expect(await Bun.file(setup.globalMarker).exists()).toBe(false)
+    expect(await Bun.file(setup.standaloneMarker).exists()).toBe(false)
+    expect(await Bun.file(setup.pathMarker).exists()).toBe(false)
+    expect(await Bun.file(setup.npmCalls).text()).toContain('["i","-g","@synsci/openscience@latest"]')
+  })
+})

--- a/tooling/launcher/bin/synsci.mjs
+++ b/tooling/launcher/bin/synsci.mjs
@@ -43,6 +43,19 @@ if (process.argv.includes("--version") || process.argv.includes("-v")) {
 }
 const OPENSCIENCE_NPM_TAG = npmDistTag(LAUNCHER_VERSION)
 const OPENSCIENCE_NPM_SPEC = opensciencePackageSpec(LAUNCHER_VERSION)
+const SAFE_GLOBAL_WRAPPER_VERSION = [2, 0, 2]
+const MACOS_ENTITLEMENTS = [
+  "com.apple.security.cs.allow-jit",
+  "com.apple.security.cs.allow-unsigned-executable-memory",
+  "com.apple.security.cs.disable-library-validation",
+]
+const TEST_CODESIGN = process.env.OPENSCIENCE_TEST_CODESIGN
+const CODESIGN =
+  process.env.OPENSCIENCE_TEST_HOME &&
+  TEST_CODESIGN &&
+  resolve(TEST_CODESIGN).startsWith(`${resolve(process.env.OPENSCIENCE_TEST_HOME)}/`)
+    ? TEST_CODESIGN
+    : "/usr/bin/codesign"
 
 const BOLD = "\x1b[1m"
 const DIM = "\x1b[2m"
@@ -142,6 +155,104 @@ function isLauncherPath(p) {
   }
 }
 
+function unsafeGlobalVersion(version) {
+  const match = String(version || "").match(
+    /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/,
+  )
+  if (!match) return true
+  const parts = match.slice(1, 4).map(Number)
+  if (parts.some((part) => !Number.isSafeInteger(part))) return true
+  if (match[4]?.split(".").some((part) => /^\d+$/.test(part) && part.length > 1 && part.startsWith("0"))) return true
+  const index = parts.findIndex((part, i) => part !== SAFE_GLOBAL_WRAPPER_VERSION[i])
+  if (index !== -1) return parts[index] < SAFE_GLOBAL_WRAPPER_VERSION[index]
+  return Boolean(match[4])
+}
+
+function globalPackage(prefix) {
+  const detected = runQuiet("npm root -g")
+  const fallback = process.platform === "win32" ? join(prefix, "node_modules") : join(prefix, "lib", "node_modules")
+  const roots = [detected, fallback].filter((root, index, all) => root && all.indexOf(root) === index)
+  for (const root of roots) {
+    try {
+      const pkg = JSON.parse(readFileSync(join(root, "@synsci", "openscience", "package.json"), "utf-8"))
+      if (pkg.name === "@synsci/openscience" && typeof pkg.version === "string") {
+        return { root, version: pkg.version, dependencies: pkg.optionalDependencies }
+      }
+    } catch {
+      /* missing or malformed npm ownership metadata fails closed */
+    }
+  }
+  return null
+}
+
+function avx2() {
+  if (process.arch !== "x64") return undefined
+  try {
+    const value = execFileSync("/usr/sbin/sysctl", ["-n", "machdep.cpu.leaf7_features"], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 5000,
+    })
+    return value.toLowerCase().split(/\s+/).includes("avx2")
+  } catch {
+    return undefined
+  }
+}
+
+function globalMacBinary(root, version, dependencies) {
+  if (process.platform !== "darwin") return null
+  const base = `openscience-darwin-${process.arch}`
+  const names = process.arch === "x64" && avx2() === false ? [`${base}-baseline`, base] : [base, `${base}-baseline`]
+  const packageRoot = join(root, "@synsci", "openscience")
+  const modules = [join(packageRoot, "node_modules"), root]
+  for (const name of names) {
+    for (const dir of modules) {
+      for (const scoped of [true, false]) {
+        const packageDir = scoped ? join(dir, "@synsci", name) : join(dir, name)
+        const file = join(packageDir, "bin", "openscience")
+        if (!existsSync(file)) continue
+        try {
+          const pkg = JSON.parse(readFileSync(join(packageDir, "package.json"), "utf-8"))
+          const expected = scoped ? `@synsci/${name}` : name
+          if (pkg.name === expected && pkg.version === version && dependencies?.[expected] === version) return file
+        } catch {
+          /* native package ownership and version must be exact */
+        }
+      }
+    }
+  }
+  return null
+}
+
+function macEntitled(file) {
+  if (process.platform !== "darwin") return true
+  try {
+    execFileSync(CODESIGN, ["--verify", "--strict", file], {
+      stdio: ["ignore", "ignore", "ignore"],
+      timeout: 5000,
+    })
+    const plist = execFileSync(CODESIGN, ["-d", "--entitlements", ":-", file], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 5000,
+    })
+    return MACOS_ENTITLEMENTS.every((key) => {
+      const tag = `<key>${key}</key>`
+      const index = plist.indexOf(tag)
+      if (index === -1) return false
+      return /^\s*<true\s*\/>/.test(plist.slice(index + tag.length))
+    })
+  } catch {
+    return false
+  }
+}
+
+function macCandidateReady(binaries) {
+  if (process.platform !== "darwin") return true
+  if (binaries.length === 0) return false
+  return binaries.every(macEntitled)
+}
+
 // Returns the absolute path to the real @synsci/openscience binary (`openscience`).
 // Only trusts canonical install locations (no `$PATH` walk) to avoid picking
 // up dev shims or workspace symlinks. Each candidate is verified by invoking
@@ -153,21 +264,43 @@ function resolveCli() {
   // openscience.cmd shim; on POSIX it's <prefix>/bin/openscience.
   const prefix = runQuiet("npm prefix -g")
   if (prefix) {
-    if (process.platform === "win32") candidates.push(join(prefix, "openscience.cmd"))
-    else candidates.push(join(prefix, "bin", "openscience"))
+    const pkg = globalPackage(prefix)
+    // Versions before 2.0.2 recursively ran `xattr -rc ~/.openscience` even
+    // for `--version`. Never execute one as a health probe: use a safe
+    // standalone install, or let the normal install path repair npm first.
+    // Missing ownership metadata also fails closed: an arbitrary global bin
+    // must never be executed while attempting to repair OpenScience.
+    if (pkg && !unsafeGlobalVersion(pkg.version)) {
+      const wrapper =
+        process.platform === "win32" ? join(prefix, "openscience.cmd") : join(prefix, "bin", "openscience")
+      const native = globalMacBinary(pkg.root, pkg.version, pkg.dependencies)
+      // On macOS execute the exact version-bound native package directly.
+      // The npm wrapper honors OPENSCIENCE_BIN_PATH, so running it after
+      // validating a different binary would reintroduce an entitlement bypass.
+      const file = process.platform === "darwin" ? native : wrapper
+      if (file) candidates.push({ file, binaries: [file] })
+    }
   }
   // 2. ~/.openscience/bin/openscience (curl-installer location, POSIX only)
-  if (process.platform !== "win32") candidates.push(join(homedir(), ".openscience", "bin", "openscience"))
+  if (process.platform !== "win32") {
+    const file = join(homedir(), ".openscience", "bin", "openscience")
+    candidates.push({ file, binaries: [file] })
+  }
 
   for (const cand of candidates) {
-    if (!existsSync(cand) || isLauncherPath(cand)) continue
+    if (!existsSync(cand.file) || isLauncherPath(cand.file)) continue
+    // A malformed or JIT-incompatible macOS executable can enter an
+    // uninterruptible kernel wait before `--version` returns. Inspect the
+    // native executable's signature without running it; Node's timeout cannot
+    // recover a process once that wait begins.
+    if (!macCandidateReady(cand.binaries)) continue
     try {
-      const ver = execCli(cand, ["--version"], {
+      const ver = execCli(cand.file, ["--version"], {
         encoding: "utf-8",
         stdio: "pipe",
         timeout: 5000,
       }).trim()
-      if (/^\d/.test(ver)) return cand
+      if (/^\d/.test(ver)) return cand.file
     } catch {
       /* unrunnable candidate, try next */
     }
@@ -258,11 +391,39 @@ async function main() {
         s.ok(`openscience ${current} ${DIM}(up to date)${RESET}`)
       } else {
         s.update(`Upgrading ${current} → ${latest}...`)
-        try {
-          execCli(cliPath, ["upgrade", latest], { stdio: "pipe" })
-          s.ok(`Upgraded to ${latest}`)
-        } catch {
-          s.warn(`Upgrade failed, continuing with ${current}`)
+        if (process.platform !== "darwin") {
+          try {
+            execCli(cliPath, ["upgrade", latest], { stdio: "pipe" })
+            s.ok(`Upgraded to ${latest}`)
+          } catch {
+            s.warn(`Upgrade failed, continuing with ${current}`)
+          }
+        }
+        if (process.platform === "darwin") {
+          // A macOS CLI self-upgrade replaces its running native executable
+          // and immediately probes the replacement. A malformed signature can
+          // hang that probe in an uninterruptible kernel wait, so install with
+          // npm and resolve the new executable through the entitlement gate.
+          cliPath = null
+          try {
+            execFileSync("npm", ["i", "-g", `@synsci/openscience@${latest}`], { stdio: "pipe" })
+            cliPath = resolveCli()
+            if (!cliPath) throw new Error("updated OpenScience failed validation")
+            const upgraded = runFileQuiet(cliPath, ["--version"])
+            if (upgraded !== latest) throw new Error("updated OpenScience version mismatch")
+            s.ok(`Upgraded to ${latest}`)
+          } catch {
+            // npm may have replaced only part of the old package before
+            // failing. Never reuse the pre-install path; resolve and preflight
+            // every surviving candidate again.
+            cliPath = resolveCli()
+            if (!cliPath) {
+              s.fail("Upgrade failed and no safe OpenScience installation remains")
+              process.exit(1)
+            }
+            const fallback = runFileQuiet(cliPath, ["--version"]) || "a safe installed version"
+            s.warn(`Upgrade failed, continuing with ${fallback}`)
+          }
         }
       }
     }
@@ -287,9 +448,21 @@ async function main() {
       if (!cliPath) throw new Error("openscience not on PATH after install")
       s.ok("Installed OpenScience")
     } catch {
-      // The standalone installer is a bash script; on native Windows there's
-      // no bash to pipe it into, so don't suggest a fallback that can't run.
-      if (process.platform === "win32") {
+      // The remote installer performs its own unbounded `openscience
+      // --version` check. Discovering a command is harmless; running the
+      // installer while one is present is not, because it could be the stale
+      // or unentitled candidate that sent us into recovery.
+      const existing = process.platform === "win32" ? null : runQuiet("command -v openscience")
+      if (existing) {
+        s.fail("Install failed; refusing to execute an existing unverified openscience command")
+        console.log(`\n  Try manually: ${CYAN}npm i -g ${OPENSCIENCE_NPM_SPEC}${RESET}\n`)
+        process.exit(1)
+      }
+      // The current standalone installer probes any `openscience` already on
+      // PATH before replacing it. On macOS that can execute the same rejected
+      // binary whose signature sent us into recovery, so don't delegate to the
+      // remote installer until it can perform an equivalent preflight.
+      if (process.platform === "win32" || process.platform === "darwin" || process.env.OPENSCIENCE_TEST_HOME) {
         s.fail("Install failed")
         console.log(`\n  Try manually: ${CYAN}npm i -g ${OPENSCIENCE_NPM_SPEC}${RESET}\n`)
         process.exit(1)
@@ -299,14 +472,19 @@ async function main() {
       // (resolveCli already checks that location).
       s.update("npm -g failed, trying the standalone installer...")
       try {
-        execSync("curl -fsSL https://openscience.sh/install | bash", { stdio: "pipe" })
+        execSync("/usr/bin/curl -fsSL https://openscience.sh/install | /bin/bash", {
+          stdio: "pipe",
+          env: { ...process.env, PATH: "/usr/bin:/bin:/usr/sbin:/sbin" },
+        })
         cliPath = resolveCli()
         if (!cliPath) throw new Error("openscience not found after install")
         s.ok("Installed OpenScience")
       } catch (e2) {
         s.fail(`Install failed${e2 && e2.message ? ": " + e2.message : ""}`)
         console.log(`\n  Try manually: ${CYAN}npm i -g ${OPENSCIENCE_NPM_SPEC}${RESET}`)
-        console.log(`  or:           ${CYAN}curl -fsSL https://openscience.sh/install | bash${RESET}\n`)
+        console.log(
+          `  or:           ${CYAN}PATH=/usr/bin:/bin:/usr/sbin:/sbin /bin/bash -c '/usr/bin/curl -fsSL https://openscience.sh/install | /bin/bash'${RESET}\n`,
+        )
         process.exit(1)
       }
     }


### PR DESCRIPTION
## Root cause

The standalone macOS CLI was re-signed with hardened runtime but without Bun's required JIT entitlements. The Electron app re-signed its bundled sidecar with the correct entitlement plist, so the app worked while the byte-identical Terminal binary could hang in `pthread_jit_write_protect_np`.

## Changes

- sign every standalone macOS CLI artifact with the desktop entitlement plist
- verify Developer ID, Team ID, and all three JIT/runtime entitlements even on release cache hits
- smoke the native macOS sidecar without passing a GitHub token and invalidate pre-fix release caches
- preserve the contract that desktop and Terminal inherit the same OpenScience root selectors
- make the `synsci` launcher reject legacy, malformed, version-mismatched, unsigned, or incompletely entitled candidates before execution
- re-resolve and revalidate macOS npm upgrades and installer recovery paths
- prevent npm-visible launchers from reintroducing recursive `xattr` or data-root deletion behavior

## Validation

- 38 focused release/launcher/shared-root tests passed
- 120 installation tests passed
- 79/79 previously timing-sensitive npm-release and compute tests passed with a 30-second ceiling
- monorepo typecheck, formatting, workflow parse, release-entrypoint syntax, workspace production build, and diff checks passed
- live Terminal status and doctor passed; Terminal and app-sidecar debug paths are byte-identical
- live signature verification and all three JIT entitlements passed

The default 5-second repository-wide run completed 3,073 tests and timed out in eight unrelated long-running tests; all eight passed in the targeted 79-test rerun above.

This PR is intentionally left unmerged for review.
