### PR TITLE
fix: retry a turn still oversized after its one compaction attempt

### DIFF
--- a/backend/cli/src/session/prompt.ts
+++ b/backend/cli/src/session/prompt.ts
@@ -1588,9 +1588,34 @@ export namespace SessionPrompt {
         if (await armedCompact()) continue
       }
       if (preflight.total > preflight.hard) {
+        // Same recovery as the newest-alone-too-big case above: the failed
+        // reply failTooLarge is about to record makes this turn terminal,
+        // un-protecting it from the tail floor on the *next* attempt — so a
+        // retry can genuinely reclaim content this pass could not. But unlike
+        // that case, we only reach here after armedCompact() already fired
+        // and spent its one-shot latch (or never had anything to reclaim) —
+        // a retry that doesn't re-arm it just repeats the identical failed
+        // preflight against the identical un-compactable context. Re-arm so
+        // the retry gets a real second compaction attempt against the newly
+        // unprotected history, not just a second look at the same numbers.
+        const recoverable =
+          config.compaction?.auto !== false && SessionLoopState.preflightRecovery({ attempts: preflightRecoveries })
         await failTooLarge(
           `The assembled request is still estimated at ${preflight.total.toLocaleString()} tokens after context reduction, above ${window.name}'s safe input budget of ${preflight.hard.toLocaleString()}. Shorten the request or start a new session. No provider request was sent for this oversized attempt.`,
+          recoverable,
         )
+        if (recoverable) {
+          preflightRecoveries++
+          compactionArmed = true
+          await enqueue({
+            user: lastUser,
+            kind: "context",
+            epoch: turn,
+            text: PREFLIGHT_CONTINUATION,
+            routing: routingExcerpt(msgs, lastUser.id),
+          })
+          continue
+        }
         break
       }
 

--- a/backend/cli/test/session/context-preflight.test.ts
+++ b/backend/cli/test/session/context-preflight.test.ts
@@ -297,6 +297,108 @@ describe("current-turn context preflight", () => {
     }
   }, 30_000)
 
+  test("automatically retries a turn still oversized after its one compaction attempt", async () => {
+    const provider = startStressProvider([scenario])
+    try {
+      const base = stressProviderConfig(`http://127.0.0.1:${provider.server.port}/v1`)
+      base.provider[STRESS_PROVIDER_ID].models[STRESS_PROVIDER_COMPACT_MODEL].limit.context = 20_000
+      await using tmp = await tmpdir({
+        git: true,
+        config: { ...base, compaction: { tailTurns: 2, tailTokens: 50_000 } },
+      })
+      await Instance.provide({
+        directory: tmp.path,
+        init: async () => {
+          await trustProject()
+          await Provider.invalidate()
+        },
+        fn: async () => {
+          const session = await Session.create({ title: "Post-compaction preflight retry" })
+          const model = { providerID: STRESS_PROVIDER_ID, modelID: STRESS_PROVIDER_COMPACT_MODEL }
+          const t1 = await SessionPrompt.prompt({
+            sessionID: session.id,
+            model,
+            agent: "research",
+            tools: { "*": false },
+            system: `${STRESS_SCENARIO_MARKER}${scenario.id}`,
+            parts: [{ type: "text", text: "trivial prior turn" }],
+          })
+          expect(t1.info.role).toBe("assistant")
+          await provider.quiet()
+
+          // A second, heavier turn old enough to be eligible for the tail floor
+          // (kept verbatim by tailTurns/tailTokens, not summarized) once a later
+          // turn arrives — the fixture's real usage, not the fixture's flat
+          // 12-token mock reply, so the session's own "last real turn was
+          // comfortably under threshold" re-arm cannot mask the stall below.
+          const t2 = await SessionPrompt.prompt({
+            sessionID: session.id,
+            model,
+            agent: "research",
+            tools: { "*": false },
+            noReply: true,
+            system: `${STRESS_SCENARIO_MARKER}${scenario.id}`,
+            parts: [{ type: "text", text: `Kept-tail turn:\n${"k".repeat(48_000)}` }],
+          })
+          if (t2.info.role !== "user") throw new Error("Expected queued user message")
+          await Session.updateMessage({
+            id: await MessageV2.nextMessageID(session.id),
+            sessionID: session.id,
+            parentID: t2.info.id,
+            role: "assistant",
+            mode: "research",
+            agent: "research",
+            path: { cwd: tmp.path, root: tmp.path },
+            modelID: model.modelID,
+            providerID: model.providerID,
+            cost: 0,
+            tokens: { input: 12_000, output: 12, reasoning: 0, cache: { read: 0, write: 0 } },
+            finish: "stop",
+            time: { created: Date.now(), completed: Date.now() },
+          })
+          await provider.quiet()
+          const before = provider.requests.length
+
+          const result = await SessionPrompt.prompt({
+            sessionID: session.id,
+            model,
+            agent: "research",
+            tools: { "*": false },
+            system: `${STRESS_SCENARIO_MARKER}${scenario.id}`,
+            parts: [{ type: "text", text: `Small current turn:\n${"c".repeat(8_000)}` }],
+          })
+          await provider.quiet()
+
+          expect(result.info.role).toBe("assistant")
+          if (result.info.role !== "assistant") throw new Error("Expected recovered assistant response")
+          expect(result.info.error).toBeUndefined()
+
+          const requests = provider.requests.slice(before)
+          const summaries = requests.filter((request) => request.kind === "summary")
+          // One compaction pass alone could not clear the tail-floor-protected
+          // turn; a second, freshly re-armed pass (after the retry un-protects
+          // it) is what actually gets this turn under budget.
+          expect(summaries.length).toBeGreaterThanOrEqual(2)
+
+          const history = await Session.messages({ sessionID: session.id })
+          const rejections = history.filter((message) => message.info.role === "assistant" && message.info.error)
+          const recoveries = history.filter(
+            (message) => message.info.role === "user" && SessionLoopState.messageKind(message.info) === "context",
+          )
+          expect(rejections).toHaveLength(1)
+          expect(
+            rejections.some(
+              (r) => r.info.role === "assistant" && r.info.error?.data.message.includes("after context reduction"),
+            ),
+          ).toBe(true)
+          expect(recoveries).toHaveLength(1)
+        },
+      })
+    } finally {
+      provider.stop()
+    }
+  }, 30_000)
+
   test("does not mistake a delayed prior-turn assistant for an answer to a queued prompt", async () => {
     const provider = startStressProvider([scenario])
     try {


### PR DESCRIPTION
## Summary

- Extends the auto-retry #483 added for the `preflight.newest > preflight.hard` preflight rejection to the second, structurally identical stall later in the same function: `preflight.total > preflight.hard` after an auto-compaction pass already ran and still couldn't clear the budget. That branch had no retry at all.
- Re-arms `compactionArmed` on this retry specifically. Unlike the existing branch (which fires before any compaction attempt), this one is only reached *after* `armedCompact()` has already spent its one-shot latch for the request — a retry that doesn't re-arm it just repeats the identical failed preflight against the identical un-compactable context, since making the turn terminal frees the tail floor but doesn't itself trigger a new compaction pass.

Closes #488

## Real-world motivation

Confirmed against an actual overnight session failure, not a hypothetical: a live benchmark session ran normally for 5+ hours (158 messages, several successful compactions), then hit `preflight.total > preflight.hard` exactly once and stalled — no retry, no synthetic continuation, session idle until a human noticed the next morning. Full details in #488.

## Validation

- New integration test in `context-preflight.test.ts` reproduces the exact interaction: a turn old enough to sit in the tail floor (kept verbatim by `tailTurns`/`tailTokens`, not summarized) combined with a new turn that pushes `total` over `hard` while `newest` alone stays under it. Without the re-arm fix, the test fails with 2 rejections (the retry repeats the identical stall); with it, exactly 1 rejection + 1 recovery + a second, successful compaction pass.
- `bun test test/session/` — 506 passed, 2 pre-existing failures unrelated to this change (confirmed identical on unmodified `main`: a local Python/conda environment issue in `managed-scratch.test.ts`'s notebook-kernel test, nothing to do with session/prompt code).
- `bun test test/session/context-preflight.test.ts` — 7 passed (6 existing + the new one), 0 failed.
- `tsc --noEmit` — clean.

## Scope notes

- Only the second `failTooLarge` call site in `prompt.ts` is touched, reusing the existing `PREFLIGHT_CONTINUATION`, `routingExcerpt`, `preflightRecoveries` counter, and `SessionLoopState.preflightRecovery` gate #483 already introduced for the sibling case — no new state or counters added.
