### PR TITLE
fix(skill): restore BRENDA query helper imports

### DIFF
--- a/backend/cli/skills/databases/brenda-database/scripts/brenda_queries.py
+++ b/backend/cli/skills/databases/brenda-database/scripts/brenda_queries.py
@@ -556,7 +556,7 @@ def get_activators(ec_number: str) -> List[Dict[str, Any]]:
                         activators.append({
                             'name': activator,
                             'type': 'metal ion' if '+' in activator else 'reducing agent' if 'dtt' in activator.lower() or 'mercapto' in activator.lower() else 'other',
-                            'mechanism': 'allosteric' if 'allosteric' in commentary else 'cofactor' else 'unknown',
+                            'mechanism': 'allosteric' if 'allosteric' in commentary else ('cofactor' if 'cofactor' in commentary else 'unknown'),
                             'organism': parsed.get('organism', ''),
                             'ec_number': ec_number,
                             'commentary': parsed.get('commentary', '')

--- a/backend/cli/test/skill/brenda-database.test.ts
+++ b/backend/cli/test/skill/brenda-database.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "bun:test"
+import path from "path"
+
+const python = Bun.which("python3") ?? Bun.which("python")
+const script = path.resolve(import.meta.dir, "../../skills/databases/brenda-database/scripts/brenda_queries.py")
+
+test("BRENDA query helpers compile before they are offered to agents (#485)", () => {
+  if (!python) return
+
+  const proc = Bun.spawnSync([python, "-m", "py_compile", script], { stderr: "pipe" })
+
+  expect(proc.exitCode, proc.stderr.toString()).toBe(0)
+})


### PR DESCRIPTION
Fixes #485

The BRENDA query helper contained an invalid chained conditional expression, preventing the module from compiling or importing. This fixes the conditional so activators are classified as allosteric, cofactor, or unknown.

A Bun test now compiles the bundled helper with Python so a syntax regression fails CI.

Verified with:
- `bun test test/skill/brenda-database.test.ts`
- `bun run typecheck`
- `python3 -m py_compile skills/databases/brenda-database/scripts/brenda_queries.py`

I also ran the full CLI test suite locally. It reached two pre-existing mounted-parent snapshot tests that timed out; the new targeted test passed.