### PR TITLE
Align settings E2E with Permissions panel

### DIFF
--- a/frontend/workspace/e2e/settings-panels.spec.ts
+++ b/frontend/workspace/e2e/settings-panels.spec.ts
@@ -8,7 +8,7 @@ const panels = [
   "Tools",
   "Connectors",
   "Compute",
-  "Security & access",
+  "Permissions",
   "Network",
   "Sandbox",
   "Credentials",

--- a/frontend/workspace/e2e/workspace-consistency.spec.ts
+++ b/frontend/workspace/e2e/workspace-consistency.spec.ts
@@ -21,7 +21,7 @@ test("keeps Files and Customize labels visually consistent", async ({ page, goto
     ["Tools"],
     ["Connectors", "Add connector"],
     ["Compute", "Add host"],
-    ["Security & access"],
+    ["Permissions"],
     ["Network", "Add domain"],
     ["Sandbox"],
     ["Credentials"],


### PR DESCRIPTION
## Summary
- update packaged settings navigation checks for the shipped Permissions label
- keep the stable `permissions` route and product copy unchanged

## Verification
- `bun test src/components/settings/registry-contract.test.ts src/components/settings/panel-layout.test.ts src/components/settings/preference-panels.test.ts` (19 passed)
- `bun test src/components/settings-permissions.test.ts` (5 passed)
- `bun run test:e2e -- e2e/settings-panels.spec.ts e2e/workspace-consistency.spec.ts` (3 passed)
- `git diff --check`