### PR TITLE
Repair accepted npm staging gaps once

### DIFF
--- a/backend/cli/test/installation/fixtures/fake-npm.ts
+++ b/backend/cli/test/installation/fixtures/fake-npm.ts
@@ -8,6 +8,8 @@ type State = {
   packages: Record<string, { integrity: string; visibilityReads?: number }>
   publishCalls: number
   publishFailures?: Record<string, number>
+  publishGhosts?: Record<string, number>
+  publishIntegrities?: string[]
   publishMode?: "already" | "ghost" | "permission" | "success"
   publishSpecs?: string[]
   publishVisibilityReads?: number
@@ -72,10 +74,20 @@ if (args[0] === "publish") {
   const spec = process.env.FAKE_NPM_SPEC ?? `${manifest.name}@${manifest.version}`
   state.publishSpecs ??= []
   state.publishSpecs.push(spec)
+  const bytes = await Bun.file(args[1]).arrayBuffer()
+  const digest = new Bun.CryptoHasher("sha512").update(bytes).digest("base64")
+  state.publishIntegrities ??= []
+  state.publishIntegrities.push(`sha512-${digest}`)
   if ((state.publishFailures?.[spec] ?? 0) > 0) {
     state.publishFailures![spec]--
     await save()
     fail("npm error code E500\ntransient publish failure")
+  }
+  if ((state.publishGhosts?.[spec] ?? 0) > 0) {
+    state.publishGhosts![spec]--
+    await save()
+    console.log(`+ ${spec}`)
+    process.exit(0)
   }
   if (state.publishMode === "ghost") {
     await save()
@@ -86,8 +98,6 @@ if (args[0] === "publish") {
     await save()
     fail("npm error code E403\nYou do not have permission to publish this package")
   }
-  const bytes = await Bun.file(args[1]).arrayBuffer()
-  const digest = new Bun.CryptoHasher("sha512").update(bytes).digest("base64")
   state.packages[spec] = {
     integrity: `sha512-${digest}`,
     visibilityReads: state.publishVisibilityReads ?? 0,

--- a/backend/cli/test/installation/npm-release.test.ts
+++ b/backend/cli/test/installation/npm-release.test.ts
@@ -38,6 +38,8 @@ type FakeState = {
   packages: Record<string, { integrity: string; visibilityReads?: number }>
   publishCalls: number
   publishFailures?: Record<string, number>
+  publishGhosts?: Record<string, number>
+  publishIntegrities?: string[]
   publishMode?: "already" | "ghost" | "permission" | "success"
   publishSpecs?: string[]
   publishVisibilityReads?: number
@@ -334,7 +336,7 @@ test("release artifacts persist exact packed bytes and reject a different source
   await expect(loadReleaseArtifacts({ directory, source, version: "2.0.32" })).rejects.toThrow("expected 2.0.32")
 })
 
-test("stage-only verifies the complete immutable release without promoting latest", async () => {
+test("stage-only repairs one accepted-but-absent package once without promoting latest", async () => {
   const artifacts: PackedPackage[] = []
   for (const name of releasePackageNames()) artifacts.push(await fixturePackage(name))
   const source = (await Bun.$`git rev-parse HEAD`.cwd(releaseRoot).text()).trim()
@@ -345,43 +347,51 @@ test("stage-only verifies the complete immutable release without promoting lates
     packages: Object.fromEntries(
       artifacts.slice(1).map((artifact) => [`${artifact.name}@${artifact.version}`, { integrity: artifact.integrity }]),
     ),
+    publishGhosts: { [`${artifacts[0].name}@2.0.32`]: 1 },
     tags: Object.fromEntries(artifacts.map((artifact) => [artifact.name, { latest: "2.0.31" }])),
   })
   const command = path.join(root, "npm-fixture")
   await Bun.write(command, `#!${process.execPath}\nawait import(${JSON.stringify(fake)})\n`)
   await chmod(command, 0o755)
-  const proc = Bun.spawn([process.execPath, path.join(releaseRoot, "tooling/repo/publish.ts"), "--stage-only"], {
-    cwd: releaseRoot,
-    env: {
-      ...Bun.env,
-      ...fastOptions(file).env,
-      OPENSCIENCE_CHANNEL: "latest",
-      OPENSCIENCE_VERSION: "2.0.32",
-      // Never authorize Git/GitHub writes, even if the stage-only exit regresses.
-      OPENSCIENCE_RELEASE: "",
-      OPENSCIENCE_RELEASE_SOURCE: source,
-      OPENSCIENCE_ARTIFACT_SOURCE: source,
-      OPENSCIENCE_NPM_ARTIFACT_DIR: directory,
-      OPENSCIENCE_NPM_COMMAND: command,
-    },
-    stdout: "pipe",
-    stderr: "pipe",
-  })
-  const [stdout, stderr, code] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-    proc.exited,
-  ])
-  expect({ code, stderr }).toEqual({ code: 0, stderr: "" })
-  expect(stdout).toContain("staging complete; latest tags and the GitHub draft are unchanged")
-  expect(stdout).not.toContain("promoting npm latest")
+  const run = async () => {
+    const proc = Bun.spawn([process.execPath, path.join(releaseRoot, "tooling/repo/publish.ts"), "--stage-only"], {
+      cwd: releaseRoot,
+      env: {
+        ...Bun.env,
+        ...fastOptions(file).env,
+        OPENSCIENCE_CHANNEL: "latest",
+        OPENSCIENCE_VERSION: "2.0.32",
+        // Never authorize Git/GitHub writes, even if the stage-only exit regresses.
+        OPENSCIENCE_RELEASE: "",
+        OPENSCIENCE_RELEASE_SOURCE: source,
+        OPENSCIENCE_ARTIFACT_SOURCE: source,
+        OPENSCIENCE_NPM_ARTIFACT_DIR: directory,
+        OPENSCIENCE_NPM_COMMAND: command,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    const [stdout, stderr, code] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ])
+    expect({ code, stderr }).toEqual({ code: 0, stderr: "" })
+    expect(stdout).toContain("staging complete; latest tags and the GitHub draft are unchanged")
+    expect(stdout).not.toContain("promoting npm latest")
+  }
+  await run()
   const state = await readState(file)
-  expect(state.publishCalls).toBe(1)
-  expect(state.publishSpecs).toEqual([`${artifacts[0].name}@2.0.32`])
+  expect(state.publishCalls).toBe(2)
+  expect(state.publishSpecs).toEqual([`${artifacts[0].name}@2.0.32`, `${artifacts[0].name}@2.0.32`])
+  expect(state.publishIntegrities).toEqual([artifacts[0].integrity, artifacts[0].integrity])
   for (const artifact of artifacts) {
     expect(state.packages[`${artifact.name}@2.0.32`].integrity).toBe(artifact.integrity)
     expect(state.tags[artifact.name]).toEqual({ latest: "2.0.31", [releaseStagingTag("2.0.32")]: "2.0.32" })
   }
+
+  await run()
+  expect((await readState(file)).publishCalls).toBe(2)
 }, 30_000)
 
 test("a missing artifact cache fails closed when any package version already exists", async () => {

--- a/tooling/repo/npm-release.ts
+++ b/tooling/repo/npm-release.ts
@@ -528,7 +528,7 @@ export async function verifyPublishedPackageIntegrities(inputs: PackedPackage[],
   }
 }
 
-async function submitCandidatePackageOnce(
+async function submitPackageOnce(
   input: PackedPackage,
   tag: string,
   options: NpmCommandOptions,
@@ -550,6 +550,23 @@ async function submitCandidatePackageOnce(
   // authoritative result and the only input to the single repair round.
   console.warn(`  ${phase} submission uncertain for ${input.name}@${input.version}: ${failure(result)}`)
   return false
+}
+
+async function repairSubmittedRelease(
+  artifacts: PackedPackage[],
+  tag: string,
+  label: "npm candidate" | "npm release",
+  options: NpmCommandOptions,
+) {
+  const repair = await waitForPublishedSet(artifacts, options)
+  for (const artifact of repair) await submitPackageOnce(artifact, tag, options, "repair")
+  const unresolved = repair.length > 0 ? await waitForPublishedSet(artifacts, options) : []
+  if (unresolved.length > 0) {
+    throw new Error(
+      `${label} remains incomplete after one repair round: ${unresolved.map((item) => item.name).join(", ")}`,
+    )
+  }
+  return repair
 }
 
 function exactReleaseArtifacts(inputs: PackedPackage[]) {
@@ -630,20 +647,25 @@ export async function stageCandidateRelease(artifacts: PackedPackage[], options:
   const inspected = await Promise.all(ordered.map((artifact) => inspectPublishedPackage(artifact, options)))
   const absent = ordered.filter((_, index) => !inspected[index])
 
-  for (const artifact of absent) await submitCandidatePackageOnce(artifact, tag, options, "initial")
-  const repair = await waitForPublishedSet(ordered, options)
-  for (const artifact of repair) await submitCandidatePackageOnce(artifact, tag, options, "repair")
-  const unresolved = repair.length > 0 ? await waitForPublishedSet(ordered, options) : []
-  if (unresolved.length > 0) {
-    throw new Error(
-      `npm candidate remains incomplete after one repair round: ${unresolved.map((item) => item.name).join(", ")}`,
-    )
-  }
+  for (const artifact of absent) await submitPackageOnce(artifact, tag, options, "initial")
+  await repairSubmittedRelease(ordered, tag, "npm candidate", options)
 
   await verifyPublishedPackageIntegrities(ordered, options)
   await verifyReleaseOptionalDependencies(ordered, options)
   await ensureReleaseStagingTags(ordered, tag, options)
   return { tag, version }
+}
+
+/** Stable staging may receive a successful npm response without the version
+ * becoming visible. After one complete registry visibility window, resubmit
+ * only genuinely absent packages from their already-validated cached tgz,
+ * once, under the isolated per-version tag. */
+export async function repairStagedRelease(artifacts: PackedPackage[], options: NpmCommandOptions = {}) {
+  const ordered = exactReleaseArtifacts(artifacts)
+  const version = ordered[0].version
+  const tag = releaseStagingTag(version)
+  const repaired = await repairSubmittedRelease(ordered, tag, "npm release", options)
+  return { repaired: repaired.map((artifact) => artifact.name), tag, version }
 }
 
 export async function publishPackage(

--- a/tooling/repo/publish.ts
+++ b/tooling/repo/publish.ts
@@ -8,6 +8,7 @@ import {
   preflightRelease,
   promoteRelease,
   publishPackage,
+  repairStagedRelease,
   releasePromotionNames,
   releaseStagingTag,
   verifyPublishedPackages,
@@ -54,6 +55,7 @@ if (Script.preview) {
         batch.map((artifact) => publishPackage({ ...artifact, deferVerification: true, tag: stagingTag })),
       )
     }
+    if (stageOnly) await repairStagedRelease(ordered)
   } else {
     console.log(`\n=== promotion-only resume from ${source}; no npm package writes are allowed ===\n`)
   }


### PR DESCRIPTION
## Summary

- recover when npm accepts a stable staging upload but the package remains temporarily absent after the full visibility window
- resubmit each genuinely absent package exactly once from the same validated cached tarball and release-specific tag
- run a second full visibility and integrity pass while keeping reruns idempotent and never moving latest

## Scope

- changes future stable stage-only runs only
- leaves promotion-only and final publication behavior unchanged
- does not issue or alter the already-published v2.0.67 release

## Verification

- 33 focused npm release and release-order tests passed
- backend typecheck passed
- Prettier and git diff checks passed
- regression coverage verifies identical SHA-512 bytes, one repair submission, unchanged latest, and no writes on a second stage-only run