### PR TITLE
Install the whole workspace for desktop packaging

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -527,7 +527,6 @@ jobs:
         if: steps.existing.outputs.found != 'true' || matrix.arch == 'x64'
         with:
           install: ${{ steps.existing.outputs.found != 'true' }}
-          filter: "@synsci/desktop"
 
       - name: Verify resumed macOS assets
         if: steps.existing.outputs.found == 'true'
@@ -790,8 +789,6 @@ jobs:
           ref: ${{ needs.version.outputs.source }}
       - uses: ./.github/actions/setup-bun
         if: steps.existing.outputs.found != 'true'
-        with:
-          filter: "@synsci/desktop"
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         if: steps.existing.outputs.found != 'true'

--- a/backend/cli/test/installation/release-order.test.ts
+++ b/backend/cli/test/installation/release-order.test.ts
@@ -338,10 +338,13 @@ test("shared dependency cache is architecture-specific and excludes the Bun runt
   expect(parsed.runs.steps.find((step) => step.name === "Setup Bun")?.if).toBeUndefined()
 })
 
-test("desktop packaging installs only the desktop workspace and caches Electron downloads", async () => {
+test("desktop packaging installs the whole workspace and caches Electron downloads", async () => {
   const workflow = await read(".github/workflows/publish.yml")
 
-  expect(workflow).toContain('filter: "@synsci/desktop"')
+  // electron-builder validates the root package's production dependencies, so
+  // a --filter install fails with "Production dependency @synsci/plugin not
+  // found for package @synsci/monorepo". Desktop jobs install everything.
+  expect(workflow).not.toContain('filter: "@synsci/desktop"')
   expect(workflow).toContain("name: Cache Electron downloads")
   expect(workflow).toContain("electron-${{ hashFiles('frontend/desktop/package.json') }}")
   expect(workflow).not.toContain("Smoke packaged signed macOS app")


### PR DESCRIPTION
## Summary

The v2.0.70 publish run failed all five desktop jobs with `Production dependency @synsci/plugin not found for package @synsci/monorepo`. electron-builder validates the root package's production dependencies, which a `bun install --filter @synsci/desktop` never installs, so the filter optimization from #500 cannot work. Removed from both desktop job families; the Electron download cache and the mac/non-mac split keep their savings.

The CLI half of that release is unaffected: the draft carries all 12 signed, checksummed CLI archives, so the release resumes from this fix.

## Verification
actionlint, format, and the release-order contract suite (16 pass) with the pin inverted and the reason recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)