### PR TITLE
Point the image viewer e2e at the PNG the workspace still ships

### DIFF
--- a/frontend/workspace/e2e/prompt-slash-open.spec.ts
+++ b/frontend/workspace/e2e/prompt-slash-open.spec.ts
@@ -2,12 +2,18 @@ import { test, expect } from "./fixtures"
 import { promptSelector } from "./utils"
 
 test("smoke slash menu exposes session actions", async ({ page, gotoSession, sdk }) => {
-  const created = await sdk.session.create({ title: `e2e slash menu ${Date.now()}` }).then((r) => r.data)
+  const title = `e2e slash menu ${Date.now()}`
+  const created = await sdk.session.create({ title }).then((r) => r.data)
   if (!created?.id) throw new Error("Failed to create a session fixture")
 
   try {
     await gotoSession(created.id)
 
+    // Type only once the workspace has hydrated the session list; on a slow
+    // runner the first keystrokes otherwise race the initial render.
+    await expect(
+      page.getByRole("navigation", { name: "Sessions" }).getByRole("button", { name: title, exact: true }),
+    ).toBeVisible()
     const prompt = page.locator(promptSelector)
     await expect(prompt).toBeVisible()
     await prompt.click()

--- a/frontend/workspace/e2e/science-file-viewers.spec.ts
+++ b/frontend/workspace/e2e/science-file-viewers.spec.ts
@@ -22,7 +22,7 @@ test("markdown files render and can toggle their editable source", async ({ page
 
 test("image files render their decoded dimensions", async ({ page, openSession }) => {
   await openSession()
-  await openWorkspaceFile(page, "frontend/ui/src/assets/images/social-share.png")
+  await openWorkspaceFile(page, "frontend/workspace/public/social-share.png")
 
   const image = page.getByRole("img", { name: "social-share.png", exact: true })
   await expect(image).toBeVisible()


### PR DESCRIPTION
The e2e opened `frontend/ui/src/assets/images/social-share.png`, which #513 removed as a dead ui asset; the app serves the copy under `frontend/workspace/public/`. Found by the release rehearsal's packaged e2e and the nightly E2E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)