### PR TITLE
Keep slash typing focused and verify detailed artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ tagged release also ships native binaries for Linux, macOS, and Windows.
 
 ### Changed
 
+- Keep the composer focused while slash-command suggestions refresh, so loading
+  skills cannot interrupt typing or drop part of a command.
 - Bound silent model connections and stalled streams, preserve partial output,
   and stop without automatically replaying an uncertain paid request. Detailed
   reasoning and tool activity are visible by default, with a saved Compact option;

--- a/frontend/workspace/e2e/prompt-slash-open.spec.ts
+++ b/frontend/workspace/e2e/prompt-slash-open.spec.ts
@@ -2,8 +2,7 @@ import type { Locator, Page } from "@playwright/test"
 import { test, expect } from "./fixtures"
 import { promptSelector } from "./utils"
 
-// A contenteditable that mounts a listbox on "/" can drop keys typed in the
-// same frame on a slow runner; open the menu first, then type the query.
+// Check opening separately from filtering so failures identify the interaction.
 async function slash(page: Page, prompt: Locator, query: string) {
   await prompt.pressSequentially("/", { delay: 10 })
   const listbox = page.locator("#composer-slash-listbox")
@@ -66,6 +65,71 @@ test("smoke slash menu exposes session actions", async ({ page, gotoSession, sdk
     await page.keyboard.press("Escape")
     await expect(command).toHaveCount(0)
   } finally {
+    await sdk.session.delete({ sessionID: created.id }).catch(() => undefined)
+  }
+})
+
+test("typing a slash query keeps focus when the skill catalog arrives", async ({ page, gotoSession, sdk }) => {
+  const created = await sdk.session.create({ title: `e2e slash refresh ${Date.now()}` }).then((r) => r.data)
+  if (!created?.id) throw new Error("Failed to create a slash refresh fixture")
+  let release!: () => void
+  const pending = new Promise<void>((resolve) => (release = resolve))
+  await page.route("**/skill", async (route) => {
+    const response = await route.fetch()
+    await pending
+    await route.fulfill({ response })
+  })
+
+  try {
+    await gotoSession(created.id)
+    const prompt = page.locator(promptSelector)
+    await prompt.click()
+    await prompt.pressSequentially("/c", { delay: 30 })
+    await expect(page.locator("#composer-slash-listbox")).toBeVisible()
+    const continuity = await prompt.evaluateHandle((editor) => {
+      const state = { blurred: false, detached: false }
+      const blur = () => (state.blurred = true)
+      editor.addEventListener("blur", blur)
+      const observer = new MutationObserver((records) => {
+        if (records.some((record) => Array.from(record.removedNodes).some((node) => node.contains(editor)))) {
+          state.detached = true
+        }
+      })
+      observer.observe(document.body, { childList: true, subtree: true })
+      return {
+        finish() {
+          observer.disconnect()
+          editor.removeEventListener("blur", blur)
+          return state
+        },
+      }
+    })
+    const refreshed = page.waitForResponse((response) => new URL(response.url()).pathname === "/skill")
+    release()
+    await refreshed
+    await page.keyboard.type("ompact", { delay: 30 })
+    expect(await continuity.evaluate((monitor) => monitor.finish())).toEqual({ blurred: false, detached: false })
+    await continuity.dispose()
+    await expect(prompt).toHaveText("/compact")
+    await expect(prompt).toBeFocused()
+    await expect(page.locator('[data-slash-id="session.compact"]')).toBeVisible()
+
+    const destination = page.getByRole("button", { name: "Search this project", exact: true })
+    const target = await destination.elementHandle()
+    if (!target) throw new Error("Missing focus destination")
+    await prompt.evaluate((editor, button) => {
+      editor.dispatchEvent(new InputEvent("input", { bubbles: true }))
+      button.focus()
+    }, target)
+    // Let post-input rendering finish; it must not reclaim deliberately moved focus.
+    await page.evaluate(
+      () => new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve()))),
+    )
+    await expect(destination).toBeFocused()
+    await expect(page.locator("#composer-slash-listbox")).toHaveCount(0)
+    await target.dispose()
+  } finally {
+    release()
     await sdk.session.delete({ sessionID: created.id }).catch(() => undefined)
   }
 })

--- a/frontend/workspace/e2e/science-artifact.spec.ts
+++ b/frontend/workspace/e2e/science-artifact.spec.ts
@@ -148,7 +148,10 @@ async function withArtifact(
 
     const steps = browser.page.locator('[data-slot="session-turn-collapsible-trigger-content"]')
     await expect(steps).toBeVisible()
-    await steps.click()
+    // Detailed mode already shows completed activity. Only expand a closed
+    // trace; an unconditional toggle would hide the artifact under test.
+    if ((await steps.getAttribute("aria-expanded")) !== "true") await steps.click()
+    await expect(steps).toHaveAttribute("aria-expanded", "true")
 
     const artifact = locate(browser.page)
     const metadata = browser.page
@@ -164,6 +167,53 @@ async function withArtifact(
     await browser.sdk.session.delete({ sessionID }).catch(() => undefined)
   }
 }
+
+test("artifacts remain inspectable across Detailed and Compact activity modes", async ({ page, sdk, gotoSession }) => {
+  const sessionID = await seedArtifact(sdk, {
+    kind: "sequence",
+    data: { id: "activity-mode-dna", sequence: "ACGTACGT", type: "dna", perRow: 8 },
+  })
+  try {
+    await gotoSession(sessionID)
+    const steps = page.locator('[data-slot="session-turn-collapsible-trigger-content"]')
+    const mode = page.getByRole("group", { name: "Activity view", exact: true })
+    const detailed = mode.getByRole("button", { name: "Detailed", exact: true })
+    const compact = mode.getByRole("button", { name: "Compact", exact: true })
+    const artifact = page.locator('[data-component="science-artifact"][data-kind="sequence"]')
+    const residues = artifact.locator('[data-slot="sequence-residues"]')
+
+    // The default is readable immediately, with no preliminary toggle.
+    await expect(detailed).toHaveAttribute("aria-pressed", "true")
+    await expect(steps).toHaveAttribute("aria-expanded", "true")
+    await expect(artifact).toBeVisible()
+    await expect(residues).toHaveText("ACGTACGT")
+
+    await compact.click()
+    await expect(compact).toHaveAttribute("aria-pressed", "true")
+    await expect(steps).toHaveAttribute("aria-expanded", "false")
+    await expect(artifact).toBeHidden()
+    await page.reload()
+    await expect(compact).toHaveAttribute("aria-pressed", "true")
+    await expect(steps).toHaveAttribute("aria-expanded", "false")
+
+    // Compact keeps the same artifact accessible through its disclosure.
+    await steps.click()
+    await expect(steps).toHaveAttribute("aria-expanded", "true")
+    await expect(artifact).toBeVisible()
+    await expect(residues).toHaveText("ACGTACGT")
+    await steps.click()
+    await detailed.click()
+    await expect(detailed).toHaveAttribute("aria-pressed", "true")
+    // Explicit reader collapse wins over a changed mode default.
+    await expect(steps).toHaveAttribute("aria-expanded", "false")
+    await expect(artifact).toBeHidden()
+    await steps.click()
+    await expect(artifact).toBeVisible()
+    await expect(residues).toHaveText("ACGTACGT")
+  } finally {
+    await sdk.session.delete({ sessionID }).catch(() => undefined)
+  }
+})
 
 test("notebook artifact metadata renders through the canonical kernel tool", async ({ page, sdk, gotoSession }) => {
   await withArtifact(

--- a/frontend/workspace/src/components/prompt-input.tsx
+++ b/frontend/workspace/src/components/prompt-input.tsx
@@ -1442,7 +1442,6 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
 
     const shellMode = store.mode === "shell"
     const slashMatch = shellMode ? undefined : slashTokenAt(rawText, cursorPosition)
-    const keepSlashFocus = !!slashMatch && document.activeElement === editorRef
 
     if (!shellMode) {
       const atMatch = rawText.substring(0, cursorPosition).match(/@(\S*)$/)
@@ -1477,15 +1476,6 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     mirror.input = true
     prompt.set([...rawParts, ...images], cursorPosition)
     queueScroll()
-    if (keepSlashFocus) {
-      requestAnimationFrame(() => {
-        if (document.activeElement !== editorRef) {
-          editorRef.focus({ preventScroll: true })
-          setCursorPosition(editorRef, cursorPosition)
-        }
-        if (slashTokenAt(editorRef.textContent ?? "", getCursorPosition(editorRef))) setStore("popover", "slash")
-      })
-    }
   }
 
   const setRangeEdge = (range: Range, edge: "start" | "end", offset: number) => {
@@ -2587,7 +2577,8 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                 when={slashFlat().length > 0}
                 fallback={<div class="text-text-weak px-2 py-1">{language.t("prompt.popover.emptyCommands")}</div>}
               >
-                <For each={slashGrouped()}>
+                {/* A suggestion refresh must not suspend the session and detach the focused editor. */}
+                <For each={slashGrouped.latest}>
                   {(group) => (
                     <section class="workspace-composer__slash-group" aria-label={group.category}>
                       <header class="workspace-composer__slash-heading">{group.category}</header>


### PR DESCRIPTION
## Summary
- Keep resolved slash suggestions visible during refresh so their async resource cannot suspend the session and detach the focused editor.
- Remove the delayed focus-recovery workaround that could restore a stale caret or steal intentional focus.
- Update artifact E2E interactions for the Detailed default without weakening renderer assertions; cover Detailed, Compact, preference persistence and explicit disclosure.

## Evidence and validation
Release rehearsal 33948339231 passed every native OS and all fifteen scientific capability gates but caught these browser issues. A deterministic delayed skill-catalog response reproduced the exact missing command suffix locally before the fix.

- All four slash browser cases repeated five times: 20 passed, no retries. Checks include no blur/detachment during refresh and preserving deliberate focus changes.
- All ten artifact browser cases passed, preserving every original semantic assertion.
- Workspace typecheck, formatting and diff checks passed.

This is a targeted recovery before stable publication; a fresh exact-commit release rehearsal remains required.