### PR TITLE
Refine homepage layout and model picker preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ tagged release also ships native binaries for Linux, macOS, and Windows.
   sections, a moving institution strip, interactive workflow previews, detailed
   research skills, expandable database tiles, and an oversized OpenScience footer.
   Center desktop downloads and command-line installation in a matching download
-  page. Alternate black and white homepage sections, simplify navigation and copy,
+  page. Alternate black and white homepage sections with a white workspace preview
+  and separate black research-tools section, simplify navigation and copy,
   and add a searchable model-picker preview. Introduce Ace’s pay-as-you-go
   Wallet billing on the home page.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ tagged release also ships native binaries for Linux, macOS, and Windows.
   sections, a moving institution strip, interactive workflow previews, detailed
   research skills, expandable database tiles, and an oversized OpenScience footer.
   Center desktop downloads and command-line installation in a matching download
-  page. Introduce Ace’s pay-as-you-go Wallet billing on the home page.
+  page. Alternate black and white homepage sections, simplify navigation and copy,
+  and add a searchable model-picker preview. Introduce Ace’s pay-as-you-go
+  Wallet billing on the home page.
 
 - Keep the saved model-access choice stable through delayed Wallet reads and
   account switches, without letting an old request overwrite the new account UI.

--- a/frontend/landing/README.md
+++ b/frontend/landing/README.md
@@ -11,7 +11,9 @@ additional download styles in `src/pages/download.css`. Shared branding,
 navigation, footer, and Ace offer live in `src/components/`.
 
 The home page includes an interactive workflow preview, detailed research
-categories, an expandable database grid, and an institution marquee. Motion
+categories, an expandable database grid, and an institution marquee. A searchable
+model-picker preview uses a curated set of identities from the client catalog;
+selection updates its illustrative composer without making inference requests. Motion
 respects reduced-motion preferences and can be paused. Ace appears on the home page and links to the
 Synthetic Sciences account billing page; its offer describes usage billing
 and the fixed Wallet reload, not a monthly subscription.

--- a/frontend/landing/src/components/Ace.tsx
+++ b/frontend/landing/src/components/Ace.tsx
@@ -2,13 +2,11 @@ import { DOCS } from "./Site"
 
 export default function Ace() {
   return (
-    <div id="ace" className="ace-offer">
+    <section id="ace" className="ace-offer paper section" aria-labelledby="ace-title">
       <div className="ace-copy">
-        <p className="eyebrow">Optional / Pay as you go</p>
-        <h3>OpenScience Ace.</h3>
+        <h2 id="ace-title">OpenScience Ace.</h2>
         <p>
-          Use managed models and research search with one Wallet. Sign in with Synthetic Sciences, choose a model, and
-          get to work. No individual provider keys to set up.
+          Managed models and research search, billed to one Wallet. Use Ace without setting up individual provider keys.
         </p>
         <div className="ace-actions">
           <a className="button button-dark" href="https://app.syntheticsciences.ai/billing">
@@ -51,6 +49,6 @@ export default function Ace() {
           separately before payment. Set a monthly usage limit or turn off future reloads in your account.
         </p>
       </div>
-    </div>
+    </section>
   )
 }

--- a/frontend/landing/src/components/Models.tsx
+++ b/frontend/landing/src/components/Models.tsx
@@ -1,0 +1,71 @@
+import { useState } from "react"
+import { MODELS } from "@/data/models"
+import { Mark } from "./Site"
+
+export default function Models() {
+  const [selected, setSelected] = useState(MODELS[0])
+  const [query, setQuery] = useState("")
+  const matches = MODELS.filter((model) =>
+    `${model.name} ${model.provider}`.toLowerCase().includes(query.trim().toLowerCase()),
+  )
+
+  return (
+    <figure className="model-preview" aria-label="OpenScience model picker preview">
+      <figcaption className="model-preview-header">
+        <span>
+          <Mark />
+          OpenScience
+        </span>
+        <span>Model picker preview</span>
+      </figcaption>
+      <div className="model-picker">
+        <div className="picker-heading">Choose a model</div>
+        <div className="picker-search">
+          <input
+            type="search"
+            aria-label="Search models in the preview"
+            placeholder="Search models…"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+          />
+        </div>
+        <fieldset className="picker-models">
+          <legend className="sr-only">Choose a model for this preview</legend>
+          {matches.map((model) => (
+            <label key={model.id} className="picker-row">
+              <input
+                type="radio"
+                name="preview-model"
+                value={model.id}
+                checked={selected.id === model.id}
+                onChange={() => setSelected(model)}
+              />
+              <span className="picker-option">
+                <span>
+                  <strong>{model.name}</strong>
+                  <small>{model.provider}</small>
+                </span>
+                <span className="picker-selected" aria-hidden="true" />
+              </span>
+            </label>
+          ))}
+          {matches.length === 0 && (
+            <p className="picker-empty" role="status">
+              No models found.
+            </p>
+          )}
+        </fieldset>
+      </div>
+      <div className="model-composer">
+        <p>Ask about your research…</p>
+        <div>
+          <span>Research</span>
+          <span className="composer-model" aria-live="polite">
+            {selected.name}
+          </span>
+        </div>
+      </div>
+      <p className="model-preview-note">Available models depend on your connections.</p>
+    </figure>
+  )
+}

--- a/frontend/landing/src/data/models.ts
+++ b/frontend/landing/src/data/models.ts
@@ -1,0 +1,18 @@
+// Model identities from the client's managed-catalog.ts and model-catalog.ts.
+// This is a curated UI preview, not a live availability or pricing feed.
+export const MODELS = [
+  { id: "openai/gpt-5.6-sol", name: "GPT-5.6 Sol", provider: "OpenAI" },
+  { id: "anthropic/claude-opus-5", name: "Claude Opus 5", provider: "Anthropic" },
+  { id: "google/gemini-3.1-pro-preview", name: "Gemini 3.1 Pro Preview", provider: "Google" },
+  { id: "moonshotai/kimi-k3", name: "Kimi K3", provider: "Moonshot AI" },
+  { id: "z-ai/glm-5.3", name: "GLM 5.3", provider: "Z.AI" },
+  { id: "deepseek/deepseek-v4-flash", name: "DeepSeek V4 Flash", provider: "DeepSeek" },
+  { id: "anthropic/claude-fable-5", name: "Claude Fable 5", provider: "Anthropic" },
+  { id: "google/gemini-3.7-flash", name: "Gemini 3.7 Flash", provider: "Google" },
+  { id: "openai/gpt-5.6-terra", name: "GPT-5.6 Terra", provider: "OpenAI" },
+  { id: "openai/gpt-5.6-luna", name: "GPT-5.6 Luna", provider: "OpenAI" },
+  { id: "qwen/qwen3.8-max", name: "Qwen 3.8 Max", provider: "Qwen" },
+  { id: "minimax/minimax-m3", name: "MiniMax M3", provider: "MiniMax" },
+  { id: "x-ai/grok-4.6", name: "Grok 4.6", provider: "xAI" },
+  { id: "local", name: "Your local model", provider: "Ollama / LM Studio" },
+]

--- a/frontend/landing/src/pages/Landing.tsx
+++ b/frontend/landing/src/pages/Landing.tsx
@@ -2,8 +2,9 @@ import { useState } from "react"
 import photograph from "@/assets/lunar-lab.jpg"
 import { RESEARCH } from "@/data/research"
 import { CONNECTORS } from "@/data/connectors"
-import { Header, Footer, Mark, GITHUB, DOCS, COMMAND } from "@/components/Site"
+import { Header, Footer, Mark, GITHUB } from "@/components/Site"
 import Ace from "@/components/Ace"
+import Models from "@/components/Models"
 import "./landing.css"
 
 const FEATURED = new Set([
@@ -98,21 +99,6 @@ const WORK = [
     ],
   },
 ] as const
-const PROVIDERS = [
-  { name: "OpenAI", note: "Use your OpenAI API key or a supported account connection.", mark: "01" },
-  { name: "Anthropic", note: "Connect Anthropic and use Claude for your research sessions.", mark: "02" },
-  { name: "Google", note: "Connect your Google provider credentials to work with Gemini.", mark: "03" },
-  {
-    name: "Open weights",
-    note: "Connect compatible providers for models from DeepSeek, Moonshot, Z.AI, and more.",
-    mark: "04",
-  },
-  {
-    name: "Your local model",
-    note: "Use Ollama or an OpenAI-compatible local endpoint. Keep model inference on your own hardware.",
-    mark: "05",
-  },
-] as const
 const QUESTIONS = [
   [
     "What is OpenScience?",
@@ -138,21 +124,10 @@ const QUESTIONS = [
 export default function Landing() {
   const [expanded, setExpanded] = useState(false)
   const [chapter, setChapter] = useState(0)
-  const [provider, setProvider] = useState(0)
   const [paused, setPaused] = useState(false)
-  const [copied, setCopied] = useState(false)
-  const [failed, setFailed] = useState(false)
   const work = WORK[chapter]
-  async function copy() {
-    const result = await navigator.clipboard?.writeText(COMMAND).then(
-      () => true,
-      () => false,
-    )
-    setCopied(Boolean(result))
-    setFailed(!result)
-  }
   return (
-    <div id="top" className={`landing${paused ? " motion-paused" : ""}`}>
+    <div id="top" className={`landing home-page${paused ? " motion-paused" : ""}`}>
       <a className="skip-link" href="#research">
         Skip to content
       </a>
@@ -160,19 +135,15 @@ export default function Landing() {
       <main>
         <section className="hero" aria-labelledby="hero-title">
           <div className="hero-copy">
-            <p className="eyebrow entrance">A workbench for scientific research</p>
             <h1 id="hero-title" className="entrance">
-              For the
+              A workbench
               <br />
-              beautifully
+              for scientific
               <br />
-              <span>unsolved.</span>
+              research.
             </h1>
             <div className="hero-intro entrance">
-              <p>
-                OpenScience is a research agent that works with your papers, code, and experiments. Open source, on your
-                computer.
-              </p>
+              <p>Open source, on your computer.</p>
               <a href="/download" className="button button-light">
                 Get OpenScience
               </a>
@@ -202,7 +173,7 @@ export default function Landing() {
             </figcaption>
           </figure>
         </section>
-        <section className="institutions" aria-label="Research community">
+        <section className="institutions paper" aria-label="Research community">
           <div className="marquee-heading">
             <p className="eyebrow">Used by researchers at</p>
             <button className="motion-control" type="button" aria-pressed={paused} onClick={() => setPaused(!paused)}>
@@ -230,20 +201,13 @@ export default function Landing() {
             </div>
           </div>
         </section>
-        <section id="research" className="research paper section">
-          <div className="section-heading">
-            <p className="eyebrow">01 / The workbench</p>
-          </div>
+        <section id="research" className="research section">
           <div className="research-heading">
             <h2>
-              Stay with
+              Your research
               <br />
-              the question.
+              workspace.
             </h2>
-            <p>
-              OpenScience works in your project: reading papers, writing code, and running experiments. You can inspect
-              the work as it happens and pick up where you left off.
-            </p>
           </div>
           <div className="workflow-layout">
             <div
@@ -279,7 +243,6 @@ export default function Landing() {
                     document.getElementById(`chapter-${next}`)?.focus()
                   }}
                 >
-                  <span className="chapter-number">0{index + 1}</span>
                   <span>
                     <strong>{item.title}</strong>
                     <span className="chapter-description">{item.description}</span>
@@ -336,111 +299,79 @@ export default function Landing() {
               <div className="workspace-document">
                 <div>
                   <span>{work.label}</span>
-                  <span>Saved in your project</span>
                 </div>
                 <pre>{work.lines.join("\n")}</pre>
               </div>
             </div>
           </div>
-          <div className="section-tail">
-            <span>Papers, notebooks, and results saved in your project.</span>
-            <a className="text-link" href={`${DOCS}/#/openscience/workspace`}>
-              Explore the workspace
-            </a>
-          </div>
-        </section>
-        <section id="skills" className="capabilities section">
-          <div className="section-heading">
-            <p className="eyebrow">02 / Research tools</p>
-            <a className="text-link" href={`${DOCS}/#/openscience/skills`}>
-              Browse the skills
-            </a>
-          </div>
-          <div className="capability-heading">
-            <h2>
-              Tools for
-              <br />
-              your kind of science.
-            </h2>
-            <p>
-              Run an analysis, work through a simulation, or prepare a paper. OpenScience has research skills for the
-              details of each field.
-            </p>
-          </div>
-          <div className="skill-index">
-            {RESEARCH.map((field, index) => (
-              <details key={field.title} name="research-fields" open={index === 0}>
-                <summary>
-                  <span className="index-number">0{index + 1}</span>
-                  <h3>{field.title}</h3>
-                  <span className="skill-detail">{field.detail}</span>
-                  <span className="detail-toggle" aria-hidden="true">
-                    +
-                  </span>
-                </summary>
-                <div className="field-content">
-                  <div className="field-tasks">
-                    {field.tasks.map((task) => (
-                      <div key={task[0]}>
-                        <h4>{task[0]}</h4>
-                        <p>{task[1]}</p>
-                      </div>
-                    ))}
-                  </div>
-                  <div className="field-skills">
-                    <span className="eyebrow">Included skills</span>
-                    <div>
-                      {field.skills.map((skill) => (
-                        <a key={skill[0]} href={`${GITHUB}/tree/main/backend/cli/skills/${skill[1]}`}>
-                          {skill[0]}
-                        </a>
+          <div id="skills" className="capabilities">
+            <div className="capability-heading">
+              <h2>Research tools.</h2>
+            </div>
+            <div className="skill-index">
+              {RESEARCH.map((field) => (
+                <details key={field.title} name="research-fields">
+                  <summary>
+                    <h3>{field.title}</h3>
+                    <span className="skill-detail">{field.detail}</span>
+                    <span className="detail-toggle" aria-hidden="true">
+                      +
+                    </span>
+                  </summary>
+                  <div className="field-content">
+                    <div className="field-tasks">
+                      {field.tasks.map((task) => (
+                        <div key={task[0]}>
+                          <h4>{task[0]}</h4>
+                          <p>{task[1]}</p>
+                        </div>
                       ))}
                     </div>
+                    <div className="field-skills">
+                      <span className="eyebrow">Included skills</span>
+                      <div>
+                        {field.skills.map((skill) => (
+                          <a key={skill[0]} href={`${GITHUB}/tree/main/backend/cli/skills/${skill[1]}`}>
+                            {skill[0]}
+                          </a>
+                        ))}
+                      </div>
+                    </div>
+                    <div className="field-example">
+                      <span className="eyebrow">Try asking</span>
+                      <p>“{field.example}”</p>
+                    </div>
                   </div>
-                  <div className="field-example">
-                    <span className="eyebrow">Try asking</span>
-                    <p>“{field.example}”</p>
-                  </div>
-                </div>
-              </details>
-            ))}
-          </div>
-          <div className="toolkit databases">
-            <div className="toolkit-heading">
-              <h3>Scientific databases</h3>
-              <button
-                className="database-more"
-                type="button"
-                aria-expanded={expanded}
-                aria-controls="database-grid"
-                onClick={() => setExpanded(!expanded)}
-              >
-                {expanded ? "Show fewer" : `+${DATABASES.length - FEATURED.size} more`}
-              </button>
-            </div>
-            <div className="database-grid" id="database-grid">
-              {DATABASES.slice(0, expanded ? DATABASES.length : FEATURED.size).map((connector) => (
-                <a key={connector.id} href={connector.home} target="_blank" rel="noreferrer">
-                  <span className="database-logo">
-                    <img src={connector.logo} alt="" width="24" height="24" loading="lazy" />
-                  </span>
-                  <span>{connector.name}</span>
-                </a>
+                </details>
               ))}
             </div>
           </div>
-          <div className="toolkit-note">
-            <p>Add your own lab’s tools through MCP servers, plugins, and custom skills.</p>
-            <a className="text-link" href={`${DOCS}/#/openscience/skills`}>
-              Extend OpenScience
-            </a>
+        </section>
+        <section id="databases" className="databases paper section" aria-labelledby="databases-title">
+          <div className="toolkit-heading">
+            <h2 id="databases-title">Scientific databases.</h2>
+            <button
+              className="database-more"
+              type="button"
+              aria-expanded={expanded}
+              aria-controls="database-grid"
+              onClick={() => setExpanded(!expanded)}
+            >
+              {expanded ? "Show fewer" : `+${DATABASES.length - FEATURED.size} more`}
+            </button>
+          </div>
+          <div className="database-grid" id="database-grid">
+            {DATABASES.slice(0, expanded ? DATABASES.length : FEATURED.size).map((connector) => (
+              <a key={connector.id} href={connector.home} target="_blank" rel="noreferrer">
+                <span className="database-logo">
+                  <img src={connector.logo} alt="" width="24" height="24" loading="lazy" />
+                </span>
+                <span>{connector.name}</span>
+              </a>
+            ))}
           </div>
         </section>
-        <section id="models" className="models paper section">
-          <div className="section-heading">
-            <p className="eyebrow">03 / Models</p>
-            <span className="small-note">Open source. Model agnostic.</span>
-          </div>
+        <section id="models" className="models section">
           <div className="model-layout">
             <div className="model-copy">
               <h2>
@@ -448,38 +379,15 @@ export default function Landing() {
                 <br />
                 agnostic.
               </h2>
-              <p>
-                Use the model you prefer. Connect your API keys or provider account, or run a model on your machine. You
-                can change models between sessions.
-              </p>
-              <a className="text-link" href={`${DOCS}/#/openscience/models`}>
-                Find your model
-              </a>
-              <div className="model-note" aria-live="polite">
-                <span className="eyebrow">{PROVIDERS[provider].name}</span>
-                <p>{PROVIDERS[provider].note}</p>
-              </div>
+              <p>Connect your API keys, use a supported provider account, or run a model on your own machine.</p>
             </div>
-            <div className="provider-list" aria-label="Model provider examples">
-              {PROVIDERS.map((item, index) => (
-                <button key={item.name} aria-pressed={provider === index} onClick={() => setProvider(index)}>
-                  <span className="provider-number">{item.mark}</span>
-                  <span>{item.name}</span>
-                  <span className="provider-select" data-selected={provider === index} aria-hidden="true" />
-                </button>
-              ))}
-              <p>Your choice of model, in the same workspace.</p>
-            </div>
+            <Models />
           </div>
-          <Ace />
         </section>
+        <Ace />
         <section id="faq" className="questions section">
           <div>
-            <p className="eyebrow">04 / Questions</p>
             <h2>Good to know.</h2>
-            <a className="text-link" href={DOCS}>
-              Read the docs
-            </a>
           </div>
           <div className="faq-list">
             {QUESTIONS.map((question) => (
@@ -496,31 +404,10 @@ export default function Landing() {
           </div>
         </section>
         <section className="closing paper">
-          <h2>
-            What are you
-            <br />
-            working on?
-          </h2>
+          <h2>Get OpenScience.</h2>
           <a className="button button-dark" href="/download">
-            Get OpenScience
+            Download <span className="button-dot" aria-hidden="true" />
           </a>
-          <div className="install">
-            <code>{COMMAND}</code>
-            <button
-              type="button"
-              onClick={copy}
-              aria-label={copied ? "Install command copied" : "Copy install command"}
-            >
-              {copied ? "Copied ✓" : "Copy"}
-            </button>
-          </div>
-          <p className="copy-feedback" role="status">
-            {failed
-              ? "Select the command above to copy it manually."
-              : copied
-                ? "Copied. Paste it into your terminal to install."
-                : "Free and open source."}
-          </p>
         </section>
       </main>
       <Footer />

--- a/frontend/landing/src/pages/Landing.tsx
+++ b/frontend/landing/src/pages/Landing.tsx
@@ -173,7 +173,7 @@ export default function Landing() {
             </figcaption>
           </figure>
         </section>
-        <section className="institutions paper" aria-label="Research community">
+        <section className="institutions" aria-label="Research community">
           <div className="marquee-heading">
             <p className="eyebrow">Used by researchers at</p>
             <button className="motion-control" type="button" aria-pressed={paused} onClick={() => setPaused(!paused)}>
@@ -201,9 +201,9 @@ export default function Landing() {
             </div>
           </div>
         </section>
-        <section id="research" className="research section">
+        <section id="research" className="research paper section" aria-labelledby="research-title">
           <div className="research-heading">
-            <h2>
+            <h2 id="research-title">
               Your research
               <br />
               workspace.
@@ -304,47 +304,47 @@ export default function Landing() {
               </div>
             </div>
           </div>
-          <div id="skills" className="capabilities">
-            <div className="capability-heading">
-              <h2>Research tools.</h2>
-            </div>
-            <div className="skill-index">
-              {RESEARCH.map((field) => (
-                <details key={field.title} name="research-fields">
-                  <summary>
-                    <h3>{field.title}</h3>
-                    <span className="skill-detail">{field.detail}</span>
-                    <span className="detail-toggle" aria-hidden="true">
-                      +
-                    </span>
-                  </summary>
-                  <div className="field-content">
-                    <div className="field-tasks">
-                      {field.tasks.map((task) => (
-                        <div key={task[0]}>
-                          <h4>{task[0]}</h4>
-                          <p>{task[1]}</p>
-                        </div>
+        </section>
+        <section id="skills" className="capabilities section" aria-labelledby="skills-title">
+          <div className="capability-heading">
+            <h2 id="skills-title">Research tools.</h2>
+          </div>
+          <div className="skill-index">
+            {RESEARCH.map((field) => (
+              <details key={field.title} name="research-fields">
+                <summary>
+                  <h3>{field.title}</h3>
+                  <span className="skill-detail">{field.detail}</span>
+                  <span className="detail-toggle" aria-hidden="true">
+                    +
+                  </span>
+                </summary>
+                <div className="field-content">
+                  <div className="field-tasks">
+                    {field.tasks.map((task) => (
+                      <div key={task[0]}>
+                        <h4>{task[0]}</h4>
+                        <p>{task[1]}</p>
+                      </div>
+                    ))}
+                  </div>
+                  <div className="field-skills">
+                    <span className="eyebrow">Included skills</span>
+                    <div>
+                      {field.skills.map((skill) => (
+                        <a key={skill[0]} href={`${GITHUB}/tree/main/backend/cli/skills/${skill[1]}`}>
+                          {skill[0]}
+                        </a>
                       ))}
                     </div>
-                    <div className="field-skills">
-                      <span className="eyebrow">Included skills</span>
-                      <div>
-                        {field.skills.map((skill) => (
-                          <a key={skill[0]} href={`${GITHUB}/tree/main/backend/cli/skills/${skill[1]}`}>
-                            {skill[0]}
-                          </a>
-                        ))}
-                      </div>
-                    </div>
-                    <div className="field-example">
-                      <span className="eyebrow">Try asking</span>
-                      <p>“{field.example}”</p>
-                    </div>
                   </div>
-                </details>
-              ))}
-            </div>
+                  <div className="field-example">
+                    <span className="eyebrow">Try asking</span>
+                    <p>“{field.example}”</p>
+                  </div>
+                </div>
+              </details>
+            ))}
           </div>
         </section>
         <section id="databases" className="databases paper section" aria-labelledby="databases-title">

--- a/frontend/landing/src/pages/landing.css
+++ b/frontend/landing/src/pages/landing.css
@@ -10,7 +10,7 @@
   line-height: 1.6;
 }
 .landing.home-page {
-  --paper: #f5f5f5;
+  --paper: #fff;
 }
 .landing * {
   box-sizing: border-box;
@@ -237,15 +237,16 @@
   opacity: 0.8;
 }
 .landing .institutions {
-  padding: 29px 0 37px;
+  padding: 35px 0 42px;
+  border-top: 1px solid var(--rule);
   border-bottom: 1px solid var(--rule);
 }
 .landing .marquee-heading {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin: 0 4.4% 29px;
-  color: #555;
+  margin: 0 6.25% 29px;
+  color: #aaa;
 }
 .landing .motion-control {
   display: inline-flex;
@@ -304,6 +305,9 @@
 .landing .section {
   padding: 67px 6.25% 75px;
 }
+.landing.home-page .section {
+  padding-block: clamp(56px, 6.8vw, 104px);
+}
 .landing .paper {
   background: var(--paper);
   color: var(--ink);
@@ -329,18 +333,17 @@
   grid-template-columns: 1fr 16px;
   gap: 16px;
   padding: 28px 0;
-  border-top: 1px solid #3a3a3a;
+  border-top: 1px solid var(--rule);
   text-align: left;
-  color: #aaa;
-  opacity: 1;
-  transition: opacity 0.25s;
+  color: #666;
+  transition: color 0.2s;
 }
 .landing .chapter:last-child {
-  border-bottom: 1px solid #3a3a3a;
+  border-bottom: 1px solid var(--rule);
 }
 .landing .chapter:hover,
 .landing .chapter.selected {
-  color: var(--paper);
+  color: var(--ink);
 }
 .landing .chapter strong {
   font-weight: 400;
@@ -350,16 +353,21 @@
 }
 .landing .chapter-description {
   font-size: 14px;
-  color: #aaa;
+  color: #606060;
   display: block;
   margin-top: 12px;
 }
 .landing .workspace {
-  background: #181818;
-  color: #c9c9c9;
-  border: 1px solid #404040;
-  font-size: 10px;
-  box-shadow: 0 24px 45px #00000012;
+  --rule: #dedede;
+  --quiet: #616161;
+  background: #fff;
+  color: #333;
+  border: 1px solid var(--rule);
+  font-size: 11px;
+}
+.landing .workspace .science-mark {
+  filter: brightness(0);
+  mix-blend-mode: normal;
 }
 .landing .workspace-chrome {
   min-height: 44px;
@@ -368,24 +376,24 @@
   justify-content: space-between;
   gap: 16px;
   padding: 0 17px;
-  border-bottom: 1px solid #363636;
-  font-size: 8px;
-  color: #949494;
+  border-bottom: 1px solid var(--rule);
+  font-size: 9px;
+  color: var(--quiet);
 }
 .landing .workspace-chrome > span:first-child {
   display: flex;
   align-items: center;
   gap: 6px;
-  color: #eee;
+  color: var(--ink);
   font-family: "CMU Concrete", Georgia, serif;
-  font-size: 11px;
+  font-size: 13px;
 }
 .landing .workspace-chrome .science-mark {
   width: 13px;
   height: 13px;
 }
 .landing .workspace-status {
-  border: 1px solid #494949;
+  border: 1px solid var(--rule);
   padding: 2px 6px;
 }
 .landing .workspace-body {
@@ -395,35 +403,35 @@
 }
 .landing .workspace-files {
   padding: 24px 12px;
-  border-right: 1px solid #333;
+  border-right: 1px solid var(--rule);
   display: flex;
   flex-direction: column;
   gap: 16px;
-  background: #141414;
+  background: #fafafa;
   overflow-wrap: anywhere;
-  font-size: 9px;
+  font-size: 10px;
 }
 .landing .workspace-files .eyebrow {
   margin-bottom: 8px;
-  color: #777;
-  font-size: 8px;
+  color: var(--quiet);
+  font-size: 9px;
 }
 .landing .workspace-files-bottom {
   margin-top: auto;
-  color: #888;
+  color: var(--quiet);
 }
 .landing .workspace-conversation {
   padding: 22px;
   animation: chapter-in 0.35s both;
 }
 .landing .example-label {
-  color: #888;
-  font-size: 8px;
+  color: var(--quiet);
+  font-size: 9px;
   letter-spacing: 0.05em;
 }
 .landing .example-prompt {
   margin-top: 12px !important;
-  background: #262626;
+  background: #f4f4f4;
   padding: 13px 15px;
   line-height: 1.6;
 }
@@ -439,15 +447,15 @@
   height: 13px;
 }
 .landing .example-response h3 {
-  font-size: 12px;
-  color: #eee;
+  font-size: 14px;
+  color: var(--ink);
   font-family: "CMU Concrete", Georgia, serif;
   letter-spacing: 0;
 }
 .landing .example-response > p {
   margin-top: 10px;
-  color: #aaa;
-  font-size: 10px;
+  color: var(--quiet);
+  font-size: 11px;
 }
 .landing .example-response ul {
   list-style: none;
@@ -455,7 +463,7 @@
   margin: 0;
   display: grid;
   gap: 8px;
-  font-size: 9px;
+  font-size: 10px;
 }
 .landing .example-response li span {
   display: inline-block;
@@ -467,9 +475,9 @@
   justify-content: space-between;
   align-items: center;
   padding: 10px 12px;
-  border: 1px solid #444;
-  color: #888;
-  font-size: 9px;
+  border: 1px solid #ccc;
+  color: var(--quiet);
+  font-size: 10px;
 }
 .landing .example-composer > span:last-child {
   background: #ddd;
@@ -480,24 +488,24 @@
   font-size: 13px;
 }
 .landing .workspace-document {
-  border-top: 1px solid #3a3a3a;
-  background: #202020;
+  border-top: 1px solid var(--rule);
+  background: #fafafa;
 }
 .landing .workspace-document > div {
   display: flex;
   justify-content: space-between;
   padding: 9px 17px;
-  border-bottom: 1px solid #373737;
-  font-size: 8px;
+  border-bottom: 1px solid var(--rule);
+  font-size: 9px;
 }
 .landing .workspace-document > div > span:last-child {
-  color: #939393;
+  color: var(--quiet);
 }
 .landing .workspace-document pre {
   margin: 0;
   padding: 17px 25px;
-  color: #aaa;
-  font-size: 9px;
+  color: #555;
+  font-size: 10px;
   line-height: 1.7;
   min-height: 160px;
   font-family: var(--font-terminal);
@@ -513,12 +521,6 @@
 }
 .landing .text-link:hover {
   border-bottom-color: currentColor;
-}
-.landing .capabilities {
-  padding-top: 45px;
-  margin-top: 70px;
-  border-top: 1px solid #333;
-  scroll-margin-top: 30px;
 }
 .landing .capability-heading {
   display: grid;
@@ -1282,7 +1284,7 @@
   }
 }
 .landing .institution-marquee img {
-  filter: grayscale(1) brightness(0);
+  filter: grayscale(1) brightness(0) invert(1);
 }
 .landing .institution-marquee img[data-institution="yale"],
 .landing .institution-marquee img[data-institution="oxford"],
@@ -1424,17 +1426,13 @@
   align-items: center;
   margin-bottom: 12px;
 }
-.landing .databases h2,
-.landing .capability-heading h2 {
-  font-size: clamp(36px, 4.2vw, 60px);
-}
 @media (max-width: 760px) {
   .landing .databases .toolkit-heading {
     align-items: start;
   }
   .landing .databases h2 {
     max-width: 220px;
-    font-size: 34px;
+    font-size: clamp(32px, 10vw, 44px);
   }
   .landing .database-more {
     margin-top: 4px;

--- a/frontend/landing/src/pages/landing.css
+++ b/frontend/landing/src/pages/landing.css
@@ -9,6 +9,9 @@
   font-size: 16px;
   line-height: 1.6;
 }
+.landing.home-page {
+  --paper: #f5f5f5;
+}
 .landing * {
   box-sizing: border-box;
 }
@@ -46,20 +49,13 @@
   scroll-margin-top: 30px;
 }
 .landing .eyebrow,
-.landing .small-note,
 .landing .motion-control,
 .landing .hero-scroll,
 .landing .hero-photograph figcaption,
-.landing .section-tail,
-.landing .index-number,
 .landing .skill-detail,
-.landing .provider-number,
-.landing .provider-list > p,
 .landing .footer-meta,
 .landing .example-label,
-.landing .workspace,
-.landing .install,
-.landing .copy-feedback {
+.landing .workspace {
   font-family: "Helvetica Neue", Helvetica, sans-serif;
 }
 .landing .eyebrow {
@@ -76,6 +72,10 @@
   align-items: center;
   padding: 0 4.4%;
   border-bottom: 1px solid var(--rule);
+}
+.landing .brand .science-mark {
+  width: 1.1em;
+  height: 1.1em;
 }
 .landing .brand {
   display: inline-flex;
@@ -123,10 +123,10 @@
   position: relative;
 }
 .landing .hero-copy h1 {
-  font-size: clamp(62px, 6.5vw, 102px);
+  font-size: clamp(46px, 5.6vw, 86px);
   line-height: 1.02;
   letter-spacing: -0.065em;
-  margin-top: 44px;
+  margin-top: 40px;
 }
 .landing .hero-copy h1 > span {
   color: #adadad;
@@ -178,9 +178,10 @@
   color: #a4a4a4 !important;
 }
 .landing .scroll-line {
-  width: 36px;
-  height: 1px;
-  background: #777;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: #999;
 }
 .landing .hero-photograph {
   min-width: 0;
@@ -205,7 +206,7 @@
 .landing .photograph-brand {
   display: flex;
   align-items: center;
-  gap: 17px;
+  gap: 0.2em;
   position: absolute;
   z-index: 1;
   left: 7%;
@@ -214,10 +215,6 @@
   line-height: 1;
   letter-spacing: -0.065em;
   color: #fff;
-}
-.landing .photograph-brand .science-mark {
-  width: 42px;
-  height: 42px;
 }
 .landing .hero-photograph figcaption {
   z-index: 1;
@@ -248,7 +245,7 @@
   align-items: center;
   justify-content: space-between;
   margin: 0 4.4% 29px;
-  color: #a9a9a9;
+  color: #555;
 }
 .landing .motion-control {
   display: inline-flex;
@@ -296,7 +293,7 @@
 }
 .landing .marquee:hover .marquee-track,
 .landing .marquee:focus-within .marquee-track,
-.landing .motion-paused .marquee-track {
+.landing.motion-paused .marquee-track {
   animation-play-state: paused;
 }
 @keyframes marquee {
@@ -312,31 +309,13 @@
   color: var(--ink);
   --rule: #d1d1ce;
 }
-.landing .section-heading {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 25px;
-  padding-bottom: 23px;
-  border-bottom: 1px solid var(--rule);
-}
 .landing .small-note {
   font-size: 11px;
   opacity: 0.6;
 }
 .landing .research-heading {
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  align-items: end;
-  gap: 8%;
-  padding: 58px 0;
-}
-.landing .research-heading > p {
-  max-width: 400px;
-  justify-self: end;
-  font-size: 17px;
-  line-height: 1.65;
-  color: #555;
+  padding-bottom: 45px;
 }
 .landing .workflow-layout {
   display: grid;
@@ -347,25 +326,21 @@
 .landing .chapter {
   width: 100%;
   display: grid;
-  grid-template-columns: 20px 1fr 16px;
+  grid-template-columns: 1fr 16px;
   gap: 16px;
   padding: 28px 0;
-  border-top: 1px solid #cececa;
+  border-top: 1px solid #3a3a3a;
   text-align: left;
-  opacity: 0.48;
+  color: #aaa;
+  opacity: 1;
   transition: opacity 0.25s;
 }
 .landing .chapter:last-child {
-  border-bottom: 1px solid #cececa;
+  border-bottom: 1px solid #3a3a3a;
 }
 .landing .chapter:hover,
 .landing .chapter.selected {
-  opacity: 1;
-}
-.landing .chapter-number {
-  font-family: "Helvetica Neue", Helvetica, sans-serif;
-  font-size: 10px;
-  margin-top: 7px;
+  color: var(--paper);
 }
 .landing .chapter strong {
   font-weight: 400;
@@ -375,7 +350,7 @@
 }
 .landing .chapter-description {
   font-size: 14px;
-  color: #595959;
+  color: #aaa;
   display: block;
   margin-top: 12px;
 }
@@ -527,14 +502,6 @@
   min-height: 160px;
   font-family: var(--font-terminal);
 }
-.landing .section-tail {
-  display: flex;
-  justify-content: space-between;
-  gap: 25px;
-  padding-top: 45px;
-  font-size: 11px;
-  color: #666;
-}
 .landing .text-link {
   font-family: "Helvetica Neue", Helvetica, sans-serif;
   display: inline-flex;
@@ -548,19 +515,14 @@
   border-bottom-color: currentColor;
 }
 .landing .capabilities {
-  padding-top: 70px;
+  padding-top: 45px;
+  margin-top: 70px;
+  border-top: 1px solid #333;
+  scroll-margin-top: 30px;
 }
 .landing .capability-heading {
   display: grid;
-  grid-template-columns: 1.4fr 1fr;
-  align-items: end;
-  gap: 10%;
-  margin-top: 58px;
-}
-.landing .capability-heading > p {
-  max-width: 330px;
-  font-size: 17px;
-  color: #a5a5a5;
+  margin: 0;
 }
 .landing .skill-index details {
   border-top: 1px solid #353535;
@@ -577,14 +539,10 @@
 }
 .landing .skill-index summary {
   display: grid;
-  grid-template-columns: 5% 40% 1fr 20px;
+  grid-template-columns: 42% 1fr 20px;
   align-items: center;
   gap: 20px;
   padding: 25px 0;
-}
-.landing .index-number {
-  font-size: 10px;
-  color: #848484;
 }
 .landing .skill-index h3 {
   font-size: 26px;
@@ -604,66 +562,16 @@
 }
 .landing .model-layout {
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 11%;
-  padding: 60px 0;
+  grid-template-columns: 0.85fr 1.15fr;
+  gap: 8%;
+  align-items: center;
+  padding: 0;
 }
 .landing .model-copy > p {
   max-width: 340px;
   font-size: 16px;
-  color: #5c5c5c;
+  color: #aaa;
   margin: 27px 0;
-}
-.landing .model-note {
-  border-left: 1px solid #bcbcb6;
-  padding: 2px 0 2px 18px;
-  margin-top: 35px;
-  max-width: 350px;
-  min-height: 100px;
-}
-.landing .model-note > p {
-  font-size: 13px;
-  color: #666;
-  margin-top: 8px;
-}
-.landing .provider-list {
-  align-self: start;
-  padding-top: 8px;
-}
-.landing .provider-list button {
-  display: grid;
-  grid-template-columns: 35px 1fr 30px;
-  align-items: center;
-  width: 100%;
-  text-align: left;
-  padding: 24px 14px;
-  border-top: 1px solid #c5c5c0;
-  transition: background 0.2s;
-}
-.landing .provider-list button[aria-pressed="true"] {
-  background: #e4e4de;
-}
-.landing .provider-list button:hover {
-  background: #eaeae5;
-}
-.landing .provider-list button > span:nth-child(2) {
-  font-size: clamp(23px, 2.65vw, 38px);
-  letter-spacing: -0.045em;
-}
-.landing .provider-number {
-  color: #777;
-  font-size: 9px;
-}
-.landing .provider-select {
-  font-family: "Helvetica Neue", Helvetica, sans-serif;
-  font-size: 23px;
-  text-align: right;
-}
-.landing .provider-list > p {
-  border-top: 1px solid #c5c5c0;
-  padding-top: 20px;
-  color: #777;
-  font-size: 10px;
 }
 .landing .questions {
   display: grid;
@@ -673,7 +581,7 @@
   padding-bottom: 88px;
 }
 .landing .questions h2 {
-  margin: 27px 0;
+  margin: 0;
 }
 .landing .faq-list {
   padding-top: 3px;
@@ -704,33 +612,6 @@
 .landing .closing h2 {
   font-size: clamp(62px, 7.5vw, 112px);
   margin: 34px 0;
-}
-.landing .install {
-  margin: 27px auto 0;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 18px;
-  width: fit-content;
-  border-bottom: 1px solid #c1c1bc;
-  padding: 9px 0;
-  font-size: 10px;
-}
-.landing .install code {
-  font-family: var(--font-terminal);
-  user-select: all;
-}
-.landing .install button {
-  border-left: 1px solid #bbb;
-  padding-left: 15px;
-  min-height: 30px;
-  font-size: 10px;
-}
-.landing .copy-feedback {
-  font-size: 10px;
-  color: #696969;
-  min-height: 17px;
-  margin-top: 14px !important;
 }
 .landing .site-footer {
   padding: 65px 4.4% 0;
@@ -844,7 +725,7 @@
     padding-top: 42px;
   }
   .landing .hero-copy h1 {
-    font-size: 7vw;
+    font-size: 5.6vw;
     margin-top: 38px;
   }
   .landing .hero-intro > p {
@@ -860,11 +741,7 @@
   }
   .landing .photograph-brand {
     font-size: 6vw;
-    gap: 10px;
-  }
-  .landing .photograph-brand .science-mark {
-    width: 27px;
-    height: 27px;
+    gap: 0.2em;
   }
   .landing .site-header nav {
     gap: 20px;
@@ -922,7 +799,7 @@
     padding: 37px 7% 35px;
   }
   .landing .hero-copy h1 {
-    font-size: clamp(68px, 12.5vw, 94px);
+    font-size: clamp(39px, 10.6vw, 76px);
     margin-top: 28px;
   }
   .landing .hero-intro {
@@ -933,7 +810,8 @@
     font-size: 16px;
   }
   .landing .hero-scroll {
-    display: none;
+    display: flex;
+    padding-top: 30px;
   }
   .landing .hero-photograph {
     height: 510px;
@@ -944,10 +822,6 @@
   .landing .photograph-brand {
     font-size: 12vw;
     bottom: 78px;
-  }
-  .landing .photograph-brand .science-mark {
-    width: 30px;
-    height: 30px;
   }
   .landing .hero-photograph figcaption {
     flex-direction: row;
@@ -981,36 +855,20 @@
   .landing .section {
     padding: 45px 7% 50px;
   }
-  .landing .section-heading {
-    align-items: start;
-    padding-bottom: 17px;
-  }
-  .landing .section-heading .small-note {
-    display: none;
-  }
-  .landing .section-heading .text-link {
-    font-size: 9px;
-    gap: 9px;
-  }
   .landing .eyebrow {
     font-size: 9px;
   }
   .landing .research-heading {
     grid-template-columns: 1fr;
     gap: 25px;
-    padding: 35px 0;
-  }
-  .landing .research-heading > p {
-    justify-self: start;
-    font-size: 16px;
-    max-width: 440px;
+    padding: 0 0 30px;
   }
   .landing .workflow-layout {
     grid-template-columns: 1fr;
     gap: 30px;
   }
   .landing .chapter {
-    grid-template-columns: 20px 1fr 20px;
+    grid-template-columns: 1fr 20px;
     padding: 18px 0;
   }
   .landing .chapter-description {
@@ -1048,23 +906,13 @@
     font-size: 9px;
     overflow-x: auto;
   }
-  .landing .section-tail {
-    flex-direction: column;
-    align-items: start;
-    padding-top: 30px;
-    gap: 15px;
-    font-size: 10px;
-  }
   .landing .capability-heading {
     grid-template-columns: 1fr;
     gap: 25px;
-    margin-top: 36px;
-  }
-  .landing .capability-heading > p {
-    font-size: 16px;
+    margin-top: 0;
   }
   .landing .skill-index summary {
-    grid-template-columns: 20px 1fr 20px;
+    grid-template-columns: 1fr 20px;
     gap: 12px;
     padding: 20px 0;
   }
@@ -1077,28 +925,18 @@
   .landing .model-layout {
     grid-template-columns: 1fr;
     gap: 20px;
-    padding: 36px 0;
+    padding: 0;
   }
   .landing .model-copy > p {
     max-width: 400px;
     font-size: 16px;
-  }
-  .landing .model-note {
-    margin-top: 28px;
-    min-height: 100px;
-  }
-  .landing .provider-list button {
-    padding: 19px 12px;
-  }
-  .landing .provider-list button > span:nth-child(2) {
-    font-size: 28px;
   }
   .landing .questions {
     grid-template-columns: 1fr;
     gap: 38px;
   }
   .landing .questions h2 {
-    margin: 23px 0;
+    margin: 0;
   }
   .landing .faq-list summary {
     font-size: 18px;
@@ -1113,17 +951,6 @@
   }
   .landing .closing h2 {
     font-size: clamp(55px, 11vw, 75px);
-  }
-  .landing .install {
-    font-size: 9px;
-    gap: 10px;
-  }
-  .landing .install button {
-    padding-left: 9px;
-    font-size: 9px;
-  }
-  .landing .copy-feedback {
-    font-size: 9px;
   }
   .landing .site-footer {
     padding: 42px 7% 0;
@@ -1190,16 +1017,11 @@
   letter-spacing: -0.03em;
 }
 .landing .site-header .brand .science-mark {
-  width: 32px;
-  height: 32px;
+  width: 1.1em;
+  height: 1.1em;
 }
 .landing .site-header nav {
   gap: 27px;
-}
-.landing .site-header nav > a:nth-child(2)::before {
-  content: "·";
-  color: #999;
-  margin-right: 20px;
 }
 .landing .site-header .nav-download {
   margin-left: 9px;
@@ -1224,14 +1046,14 @@
   padding-inline: 24px;
 }
 .landing .skill-index summary {
-  grid-template-columns: 5% 38% 1fr 20px;
+  grid-template-columns: 42% 1fr 20px;
 }
 .landing .skill-detail {
   max-width: 100%;
 }
 .landing .field-content {
   padding: 0 0 32px;
-  margin-left: calc(5% + 20px);
+  margin-left: 0;
 }
 .landing .field-tasks {
   display: grid;
@@ -1316,8 +1138,8 @@
 .landing .database-grid {
   display: grid;
   grid-template-columns: repeat(6, minmax(0, 1fr));
-  border-top: 1px solid #373737;
-  border-left: 1px solid #373737;
+  border-top: 1px solid #ccc;
+  border-left: 1px solid #ccc;
 }
 .landing .database-grid > a {
   display: flex;
@@ -1325,15 +1147,15 @@
   gap: 11px;
   min-height: 75px;
   padding: 13px;
-  border-right: 1px solid #373737;
-  border-bottom: 1px solid #373737;
+  border-right: 1px solid #ccc;
+  border-bottom: 1px solid #ccc;
   font-family: "Helvetica Neue", Helvetica, sans-serif;
   font-size: 10px;
   line-height: 1.5;
   transition: background 0.2s;
 }
 .landing .database-grid > a:hover {
-  background: #242424;
+  background: #e5e5e5;
 }
 .landing .database-logo {
   width: 31px;
@@ -1351,17 +1173,6 @@
   object-fit: contain;
   filter: grayscale(1);
 }
-.landing .toolkit-note {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 25px;
-  margin-top: 30px;
-}
-.landing .toolkit-note p {
-  color: #aaa;
-  font-size: 13px;
-}
 @media (max-width: 1100px) {
   .landing .database-grid {
     grid-template-columns: repeat(4, minmax(0, 1fr));
@@ -1370,7 +1181,7 @@
     gap: 20px;
   }
   .landing .skill-index summary {
-    grid-template-columns: 5% 38% 1fr 20px;
+    grid-template-columns: 42% 1fr 20px;
   }
 }
 @media (max-width: 760px) {
@@ -1383,15 +1194,12 @@
     font-size: 19px;
   }
   .landing .site-header .brand .science-mark {
-    width: 28px;
-    height: 28px;
+    width: 1.1em;
+    height: 1.1em;
   }
   .landing .site-header nav {
     margin-top: 13px;
     gap: 20px;
-  }
-  .landing .site-header nav > a:nth-child(2)::before {
-    margin-right: 12px;
   }
   .landing .site-header .nav-download {
     display: inline-flex;
@@ -1410,7 +1218,7 @@
     padding-inline: 13px;
   }
   .landing .skill-index summary {
-    grid-template-columns: 20px 1fr 20px;
+    grid-template-columns: 1fr 20px;
     gap: 12px;
   }
   .landing .field-content {
@@ -1472,30 +1280,9 @@
     width: 28px;
     height: 28px;
   }
-  .landing .toolkit-note {
-    flex-direction: column;
-    align-items: start;
-    gap: 15px;
-    margin-top: 23px;
-  }
-}
-.landing .provider-select {
-  display: flex;
-  justify-content: end;
-}
-.landing .provider-select::before {
-  content: "";
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  border: 1px solid #999;
-}
-.landing .provider-select[data-selected="true"]::before {
-  background: #111;
-  border-color: #111;
 }
 .landing .institution-marquee img {
-  filter: grayscale(1) brightness(0) invert(1);
+  filter: grayscale(1) brightness(0);
 }
 .landing .institution-marquee img[data-institution="yale"],
 .landing .institution-marquee img[data-institution="oxford"],
@@ -1508,14 +1295,14 @@
   white-space: nowrap;
   font-family: "Helvetica Neue", Helvetica, sans-serif;
   font-size: 13px;
-  color: #c6c6c6;
+  color: #555;
   text-decoration: underline;
   text-underline-offset: 5px;
   text-decoration-color: #656565;
 }
 .landing .database-more:hover {
-  color: #fff;
-  text-decoration-color: #fff;
+  color: #111;
+  text-decoration-color: #111;
 }
 .landing .button-dot {
   display: inline-block;
@@ -1529,15 +1316,14 @@
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 11%;
-  margin-top: 10px;
-  padding-top: 48px;
-  border-top: 1px solid #c5c5c0;
+  margin: 0;
+  border: 0;
 }
-.landing .ace-copy h3 {
+.landing .ace-copy h2 {
   font-size: clamp(38px, 4.2vw, 63px);
   line-height: 1.1;
   letter-spacing: -0.055em;
-  margin: 23px 0;
+  margin: 0 0 23px;
 }
 .landing .ace-copy > p:not(.eyebrow) {
   font-size: 16px;
@@ -1613,12 +1399,11 @@
   .landing .ace-offer {
     grid-template-columns: 1fr;
     gap: 36px;
-    margin-top: 5px;
-    padding-top: 35px;
+    margin: 0;
   }
-  .landing .ace-copy h3 {
+  .landing .ace-copy h2 {
     font-size: 43px;
-    margin: 18px 0;
+    margin: 0 0 18px;
   }
   .landing .ace-copy > p:not(.eyebrow) {
     font-size: 15px;
@@ -1628,5 +1413,221 @@
   }
   .landing .ace-terms dl > div {
     font-size: 11px;
+  }
+}
+
+.landing .photograph-brand .science-mark {
+  width: 0.78em;
+  height: 0.78em;
+}
+.landing .databases .toolkit-heading {
+  align-items: center;
+  margin-bottom: 12px;
+}
+.landing .databases h2,
+.landing .capability-heading h2 {
+  font-size: clamp(36px, 4.2vw, 60px);
+}
+@media (max-width: 760px) {
+  .landing .databases .toolkit-heading {
+    align-items: start;
+  }
+  .landing .databases h2 {
+    max-width: 220px;
+    font-size: 34px;
+  }
+  .landing .database-more {
+    margin-top: 4px;
+  }
+}
+.landing .model-preview {
+  min-width: 0;
+  border: 1px solid #414141;
+  background: #191919;
+  font-family: "Helvetica Neue", Helvetica, sans-serif;
+}
+.landing .model-preview-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 16px 20px;
+  border-bottom: 1px solid #363636;
+}
+.landing .model-preview-header > span:first-child {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+}
+.landing .model-preview-header .science-mark {
+  width: 16px;
+  height: 16px;
+}
+.landing .model-preview-header > span:last-child {
+  font-size: 9px;
+  color: #aaa;
+}
+.landing .model-picker {
+  margin: 24px 24px 0;
+  border: 1px solid #484848;
+  background: #222;
+}
+.landing .picker-heading {
+  padding: 15px 16px 0;
+  font-size: 13px;
+  font-weight: 500;
+}
+.landing .picker-search {
+  padding: 13px 16px;
+  border-bottom: 1px solid #444;
+}
+.landing .picker-search input {
+  width: 100%;
+  min-width: 0;
+  min-height: 35px;
+  border: 1px solid #555;
+  padding: 8px 10px;
+  background: #191919;
+  color: #eee;
+  font-size: 11px;
+}
+.landing .picker-search input::placeholder {
+  color: #aaa;
+}
+.landing .picker-models {
+  border: 0;
+  padding: 6px;
+  margin: 0;
+  min-width: 0;
+  height: 280px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: #777 #222;
+}
+.landing .picker-row {
+  position: relative;
+  display: block;
+  cursor: pointer;
+}
+.landing .picker-row > input {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+.landing .picker-option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  min-height: 45px;
+  padding: 9px 12px;
+  border: 1px solid transparent;
+}
+.landing .picker-option > span:first-child {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  flex: 1;
+  flex-wrap: wrap;
+  gap: 2px 14px;
+}
+.landing .picker-option strong {
+  font-size: 12px;
+  line-height: 1.4;
+  font-weight: 400;
+}
+.landing .picker-option small {
+  font-size: 9px;
+  color: #aaa;
+}
+.landing .picker-selected {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  border: 1px solid #888;
+  flex-shrink: 0;
+}
+.landing .picker-row input:checked + .picker-option {
+  background: #383838;
+}
+.landing .picker-row input:checked + .picker-option .picker-selected {
+  background: #eee;
+  border-color: #eee;
+}
+.landing .picker-row:hover .picker-option {
+  border-color: #555;
+}
+.landing .picker-row input:focus-visible + .picker-option {
+  outline: 2px solid #ddd;
+  outline-offset: -2px;
+}
+.landing .picker-empty {
+  padding: 25px 12px;
+  color: #bbb;
+  font-size: 12px;
+}
+.landing .model-composer {
+  margin: 18px 24px 0;
+  border: 1px solid #484848;
+  padding: 18px;
+}
+.landing .model-composer > p {
+  font-size: 12px;
+  color: #aaa;
+}
+.landing .model-composer > div {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-top: 28px;
+  font-size: 10px;
+  color: #aaa;
+}
+.landing .composer-model {
+  border: 1px solid #555;
+  padding: 5px 9px;
+  color: #eee;
+}
+.landing .model-preview-note {
+  font-size: 9px;
+  color: #aaa;
+  margin: 12px 24px 18px;
+}
+@media (max-width: 760px) {
+  .landing .model-picker {
+    margin: 18px 14px 0;
+  }
+  .landing .model-preview-header {
+    padding: 14px;
+    gap: 12px;
+  }
+  .landing .model-preview-header > span:first-child {
+    font-size: 12px;
+  }
+  .landing .model-preview-header > span:last-child {
+    font-size: 8px;
+  }
+  .landing .picker-option {
+    padding-inline: 9px;
+    min-height: 49px;
+  }
+  .landing .picker-option strong {
+    font-size: 11px;
+  }
+  .landing .picker-models {
+    height: 295px;
+  }
+  .landing .model-composer {
+    margin-inline: 14px;
+    padding: 15px;
+  }
+  .landing .model-preview-note {
+    margin-inline: 14px;
   }
 }


### PR DESCRIPTION
### What does this PR do, and why?

Refine the homepage after #530 with the headline “A workbench for scientific research.”, shorter copy, and alternating black and white sections. Remove the small hero caption, numbered section labels, and redundant links while keeping the navigation and “Explore OpenScience” on desktop and mobile. Align the photo logo with its wordmark and remove the separator between Docs and GitHub.

Replace the provider buttons with an OpenScience-style model picker preview. Search by model or provider, select from 13 entries in the shipped client catalog plus a local-model option, and see the selection in the composer. Native radio inputs provide full-row click targets and keyboard navigation. The preview makes no inference requests or account changes.

The researcher strip is black, the workspace and its app preview are white, and Research tools has a separate black section. Databases, models, Ace, the FAQ, and the download call to action continue that alternating sequence. Section spacing and main heading sizes are consistent, and the workspace preview uses larger text with dark marks and borders suited to its light theme. Research tools remain expandable and scientific databases use static tiles. Fix the institution strip’s pause selector so its control actually stops the animation. The approved download layout is preserved; shared branding and navigation receive the same consistency fixes.

### Linked issue

Follow-up to #530, requested during visual review.

### How did you verify it?

- `bun run build` in `frontend/landing` builds the documentation and landing site.
- `bunx tsc --noEmit -p tsconfig.app.json`, targeted Prettier checks, and `git diff --check` pass.
- Playwright browser checks cover all six research disclosures, workflow tabs and keyboard navigation, 12-to-42 database expansion and collapse, FAQ controls, and animation pause/resume.
- Model preview checks cover filtering by model/provider, empty results, clearing search, mouse and keyboard selection, local models, and composer updates. All 13 hosted-model names match the shipped client catalog.
- Desktop, 390px mobile, and 320px narrow layouts reviewed visually. No horizontal overflow, missing images, or browser console errors observed. The workspace preview and section transitions were rechecked after the color changes. Both download-page copy buttons and navigation back home work.

### Checklist

- [x] Build, TypeScript, formatting, and browser checks pass.
- [x] CHANGELOG.md and landing README updated.
- [x] No version bumps, installer changes, billing behavior changes, or production deployment.
- [ ] User visual review at http://127.0.0.1:8080/.

Keep this PR in draft for iteration. Do not merge.
