### PR TITLE
Update homepage closing copy and footer links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ tagged release also ships native binaries for Linux, macOS, and Windows.
 
 ### Changed
 
+- Update the homepage closing headline, simplify the photo wordmark, and add
+  LinkedIn with external-link arrows to the footer’s Connect links.
+
 - Keep all readable provider reasoning and individual tool calls visible in
   chronological order, without Detailed/Compact modes or a shared activity
   disclosure. Omit empty encrypted-only rows instead of repeating unavailable

--- a/frontend/landing/src/components/Site.tsx
+++ b/frontend/landing/src/components/Site.tsx
@@ -67,7 +67,7 @@ export function Footer() {
             links: [
               ["Synthetic Sciences", "https://syntheticsciences.ai"],
               ["X / Twitter", "https://x.com/SynScience"],
-              ["Contribute", `${GITHUB}/blob/main/CONTRIBUTING.md`],
+              ["LinkedIn", "https://www.linkedin.com/company/synsci/"],
               ["License", `${GITHUB}/blob/main/LICENSE`],
             ],
           },
@@ -77,6 +77,11 @@ export function Footer() {
             {group.links.map((link) => (
               <a key={link[0]} href={link[1]}>
                 {link[0]}
+                {group.title === "Connect" && link[0] !== "License" && (
+                  <span className="footer-arrow" aria-hidden="true">
+                    ↗
+                  </span>
+                )}
               </a>
             ))}
           </nav>

--- a/frontend/landing/src/pages/Landing.tsx
+++ b/frontend/landing/src/pages/Landing.tsx
@@ -162,7 +162,6 @@ export default function Landing() {
               {...{ fetchpriority: "high" }}
             />
             <div className="photograph-brand" aria-hidden="true">
-              <Mark />
               <span>OpenScience</span>
             </div>
             <figcaption>
@@ -404,7 +403,11 @@ export default function Landing() {
           </div>
         </section>
         <section className="closing paper">
-          <h2>Get OpenScience.</h2>
+          <h2>
+            A home for
+            <br />
+            your research.
+          </h2>
           <a className="button button-dark" href="/download">
             Download <span className="button-dot" aria-hidden="true" />
           </a>

--- a/frontend/landing/src/pages/landing.css
+++ b/frontend/landing/src/pages/landing.css
@@ -648,6 +648,10 @@
   color: #8b8b8b;
   margin-bottom: 9px;
 }
+.landing .footer-arrow {
+  margin-left: 8px;
+  font-family: "Helvetica Neue", Helvetica, sans-serif;
+}
 .landing .footer-meta {
   display: flex;
   justify-content: space-between;
@@ -1418,10 +1422,6 @@
   }
 }
 
-.landing .photograph-brand .science-mark {
-  width: 0.78em;
-  height: 0.78em;
-}
 .landing .databases .toolkit-heading {
   align-items: center;
   margin-bottom: 12px;


### PR DESCRIPTION
### What does this PR do, and why?

Change only the homepage’s large closing headline to “A home for your research.” Remove the logo mark from the NASA photo while keeping the OpenScience wordmark. In the shared footer, replace Contribute with LinkedIn and add external-link arrows to Synthetic Sciences, X / Twitter, and LinkedIn.

### Linked issue

Requested during homepage visual review, following #531.

### How did you verify it?

- Landing and documentation production build pass.
- Landing TypeScript, targeted Prettier, and git diff checks pass.
- Browser review confirms the new heading on desktop and mobile, the removed photo mark, and all three Connect destinations and arrows. No horizontal overflow observed at 390px.

### Checklist

- [x] CHANGELOG updated.
- [x] Download-page heading and primary download buttons preserved.
- [ ] Final user review. Keep this PR unmerged.
