### PR TITLE
Align packaged image-viewer acceptance with the branded asset

### DIFF
--- a/frontend/workspace/e2e/science-file-viewers.spec.ts
+++ b/frontend/workspace/e2e/science-file-viewers.spec.ts
@@ -28,7 +28,7 @@ test("image files render their decoded dimensions", async ({ page, openSession }
   await expect(image).toBeVisible()
   await expect
     .poll(() => image.evaluate((node: HTMLImageElement) => [node.naturalWidth, node.naturalHeight, node.src]))
-    .toEqual([1280, 721, expect.stringMatching(/^data:image\/png;base64,/)])
+    .toEqual([512, 512, expect.stringMatching(/^data:image\/png;base64,/)])
 })
 
 test("PDF files rasterize their pages without an error", async ({ page, openSession }) => {


### PR DESCRIPTION
The release rehearsal correctly loaded the newly branded 512x512 workspace social image, but the packaged browser assertion still expected the retired 1280x721 asset. Update the expected decoded dimensions while preserving the data-URL and visibility checks.\n\nVerification: targeted formatting, actual PNG dimensions, and git diff checks pass. The failed release rehearsal otherwise passed Deep CI, all OS smokes, and all 15 packaged scientific-capability canaries.