### PR TITLE
Fix context continuity, cancellation and callback ownership races

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ tagged release also ships native binaries for Linux, macOS, and Windows.
 
 ### Changed
 
+- Honor Stop even when it arrives just before retry backoff. Preserve the
+  selected model context window through compaction and continuation, and include
+  cached writes when assessing whether pruning made enough room.
+- Recheck the current OAuth callback listener when two local processes connect
+  simultaneously. Avoid stale pooled connections to a stopped runtime without
+  accepting a different data profile or taking over another service's port.
+- Make the reasoning setting keyboard- and screen-reader-accessible, and verify
+  that Show/Hide survives reloads without hiding tool results or shortening prose.
 - Restore a saved Show/Hide reasoning control without Detailed/Compact modes.
   Display reasoning as plain prose, omit routine provider phase headings, and
   remove per-part thinking clocks that counted silence as reasoning. Keep the

--- a/backend/cli/src/mcp/oauth-callback.ts
+++ b/backend/cli/src/mcp/oauth-callback.ts
@@ -93,9 +93,10 @@ export namespace McpOAuthCallback {
         `OAuth callback port ${OAUTH_CALLBACK_PORT} belongs to another OpenScience data profile; close that profile or finish its authentication first`,
       )
     }
-    if (await isPortInUse()) throw new Error(`OAuth callback port ${OAUTH_CALLBACK_PORT} is owned by another service`)
-
     try {
+      // Ownership can change between the health and TCP probes. Apply the same
+      // profile-verified recovery as a bind collision instead of failing early.
+      if (await isPortInUse()) throw new Error(`OAuth callback port ${OAUTH_CALLBACK_PORT} is owned by another service`)
       server = Bun.serve({
         port: OAUTH_CALLBACK_PORT,
         hostname: "127.0.0.1",
@@ -157,9 +158,9 @@ export namespace McpOAuthCallback {
         },
       })
     } catch (error) {
-      // Two compatible processes can both observe the port as free. If the
-      // winner belongs to this exact physical data root, share it; never turn
-      // that harmless bind race into a failed OAuth flow.
+      // A compatible process can bind after either probe. If the winner belongs
+      // to this exact physical data root, share it; never accept another profile
+      // or stop the existing listener while recovering the race.
       for (let attempt = 0; attempt < 20; attempt++) {
         const raced = await callbackServerOwner(expectedRoot)
         if (raced === "same") return
@@ -255,6 +256,9 @@ export namespace McpOAuthCallback {
   async function callbackServerOwner(expectedRoot: string): Promise<"same" | "different" | "none"> {
     const response = await fetch(`http://127.0.0.1:${OAUTH_CALLBACK_PORT}${OAUTH_CALLBACK_PATH}/health`, {
       signal: AbortSignal.timeout(500),
+      // Inspect the listener that currently owns the port, not a pooled socket
+      // to a previous owner that is still draining after graceful shutdown.
+      keepalive: false,
     }).catch(() => undefined)
     if (!response?.ok) return "none"
     const body = (await response.json().catch(() => undefined)) as

--- a/backend/cli/src/session/compaction.ts
+++ b/backend/cli/src/session/compaction.ts
@@ -57,23 +57,39 @@ export namespace SessionCompaction {
   // OpenCode's automatic budget: leave a response reserve, or a 20k buffer below
   // an explicit input cap. Unknown/small local model windows retain their fallback
   // and half-window clamp so missing metadata cannot cause compaction every turn.
-  export function usableContext(model: Provider.Model, config: Config.Info): { context: number; usable: number } {
-    const context = model.limit.context || config.compaction?.fallbackContext || FALLBACK_CONTEXT
-    const cap = Math.min(model.limit.output, SessionPrompt.OUTPUT_TOKEN_MAX) || SessionPrompt.OUTPUT_TOKEN_MAX
+  export function usableContext(
+    model: Provider.Model,
+    config: Config.Info,
+    requestedContext?: number,
+  ): { context: number; usable: number } {
+    const positive = (value: number | undefined) =>
+      value !== undefined && Number.isSafeInteger(value) && value > 0 ? value : undefined
+    if (requestedContext !== undefined && positive(requestedContext) === undefined) {
+      throw new Error("The selected context size must be a positive whole number of tokens.")
+    }
+    // Custom/OpenAI-compatible model metadata is less strict than per-turn
+    // context input. Invalid limits must not enlarge a budget or make it zero.
+    const capacity = positive(model.limit.context) ?? positive(config.compaction?.fallbackContext) ?? FALLBACK_CONTEXT
+    const context = Math.min(capacity, requestedContext ?? capacity)
+    const maximum = positive(SessionPrompt.OUTPUT_TOKEN_MAX) ?? 32_000
+    const cap = Math.min(positive(model.limit.output) ?? maximum, maximum)
     const output = Math.min(cap, Math.floor(context / 2))
-    const usable = model.limit.input
-      ? Math.min(
-          model.limit.input - Math.min(COMPACTION_BUFFER, output, Math.floor(model.limit.input / 2)),
-          context - output,
-        )
+    const inputLimit = positive(model.limit.input)
+    const input = inputLimit ? Math.min(inputLimit, context) : undefined
+    const usable = input
+      ? Math.min(input - Math.min(COMPACTION_BUFFER, output, Math.floor(input / 2)), context - output)
       : context - output
     return { context, usable }
   }
 
-  export async function isOverflow(input: { tokens: MessageV2.Assistant["tokens"]; model: Provider.Model }) {
+  export async function isOverflow(input: {
+    tokens: MessageV2.Assistant["tokens"]
+    model: Provider.Model
+    context?: number
+  }) {
     const config = await Config.get()
     if (config.compaction?.auto === false) return false
-    const { usable } = usableContext(input.model, config)
+    const { usable } = usableContext(input.model, config, input.context)
     return TokenUsage.total(input.tokens) >= usable
   }
 
@@ -597,7 +613,7 @@ Output exactly this Markdown structure, keeping every section (write "(none)" wh
     const convModel = agent.model
       ? await Provider.getModel(userMessage.model.providerID, userMessage.model.modelID)
       : model
-    const { usable } = usableContext(convModel, cfg)
+    const { usable } = usableContext(convModel, cfg, userMessage.context)
     const tailTurns = cfg.compaction?.tailTurns ?? TAIL_TURNS
     const tailTokens =
       cfg.compaction?.tailTokens ?? Math.min(TAIL_TOKENS_MAX, Math.max(TAIL_TOKENS_MIN, Math.floor(usable * 0.2)))

--- a/backend/cli/src/session/loop-state.ts
+++ b/backend/cli/src/session/loop-state.ts
@@ -81,6 +81,7 @@ export namespace SessionLoopState {
       delegationSettings: message.delegationSettings,
       variant: message.variant,
       tier: message.tier,
+      context: message.context,
       inference: message.inference,
     }
   }

--- a/backend/cli/src/session/prompt.ts
+++ b/backend/cli/src/session/prompt.ts
@@ -11,6 +11,7 @@ import { Agent } from "../agent/agent"
 import { Provider } from "../provider/provider"
 import { asSchema, type Tool as AITool, tool, jsonSchema, type ToolCallOptions } from "ai"
 import { SessionCompaction } from "./compaction"
+import { TokenUsage } from "@synsci/util/token-usage"
 import { SessionTelemetry } from "./telemetry"
 import { Instance } from "../project/instance"
 import { Bus } from "../bus"
@@ -190,7 +191,7 @@ export namespace SessionPrompt {
     extra?: string
   }) {
     const config = await Config.get()
-    const usable = SessionCompaction.usableContext(input.model, config).usable
+    const usable = SessionCompaction.usableContext(input.model, config, input.current.context).usable
     const hard = Math.max(1, Math.floor(usable * CONTEXT_PREFLIGHT_MARGIN))
     const tools = await toolTokens(input.tools)
     const extra = input.extra ? Token.estimate(input.extra) : 0
@@ -1359,7 +1360,7 @@ export namespace SessionPrompt {
       const overThreshold =
         !!lastFinished &&
         lastFinished.summary !== true &&
-        (await SessionCompaction.isOverflow({ tokens: lastFinished.tokens, model }))
+        (await SessionCompaction.isOverflow({ tokens: lastFinished.tokens, model, context: lastUser.context }))
       // Circuit breaker: once repeated compactions have proven ineffective for this
       // session (fixed overhead already exceeds the threshold), stop proactively
       // compacting — it only burns tokens/latency. The reactive overflow-error path is
@@ -1380,7 +1381,7 @@ export namespace SessionPrompt {
           msgs = await readMessages()
           // `before` is the last finished turn's real token usage (the reason we tripped
           // the threshold); prune's return value is the estimated reclaim.
-          const before = lastFinished!.tokens.input + lastFinished!.tokens.cache.read + lastFinished!.tokens.output
+          const before = TokenUsage.total(lastFinished!.tokens)
           SessionTelemetry.recordCompaction({ sessionID, trigger: "proactive", mechanism: "prune", before, reclaimed })
           await SessionCompaction.persistBreaker({
             sessionID,

--- a/backend/cli/src/session/retry.ts
+++ b/backend/cli/src/session/retry.ts
@@ -10,6 +10,9 @@ export namespace SessionRetry {
 
   export async function sleep(ms: number, signal: AbortSignal): Promise<void> {
     return new Promise((resolve, reject) => {
+      // Stop can arrive while the caller records retry telemetry. An abort
+      // listener added afterwards will never fire for that completed event.
+      if (signal.aborted) return reject(new DOMException("Aborted", "AbortError"))
       const abortHandler = () => {
         clearTimeout(timeout)
         reject(new DOMException("Aborted", "AbortError"))

--- a/backend/cli/test/mcp/oauth-callback-durable.test.ts
+++ b/backend/cli/test/mcp/oauth-callback-durable.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, expect, test } from "bun:test"
+import { afterEach, expect, spyOn, test } from "bun:test"
+import { createHash } from "node:crypto"
 import path from "node:path"
 import os from "node:os"
 import fs from "node:fs/promises"
@@ -191,5 +192,87 @@ test("simultaneous same-profile processes share the callback owner bind race", a
     children.forEach((child) => child.kill("SIGTERM"))
     await Promise.all(children.map((child) => child.exited))
     await Promise.all(files.map((file) => fs.rm(file, { force: true })))
+  }
+})
+
+test.each(["same", "different", "unrelated"] as const)(
+  "rechecks a %s owner appearing between the health probe and port probe",
+  async (owner) => {
+    const root = createHash("sha256")
+      .update(await fs.realpath(Global.Path.data))
+      .digest("hex")
+    let listener: ReturnType<typeof Bun.serve> | undefined
+    const request = globalThis.fetch
+    let first = true
+    // The first health probe sees an empty port. Another process binds before
+    // the subsequent TCP probe; use a real listener to force that ordering.
+    const probe = spyOn(globalThis, "fetch").mockImplementation(
+      Object.assign(
+        async (...args: Parameters<typeof fetch>) => {
+          if (!first) return request(...args)
+          first = false
+          listener = Bun.serve({
+            hostname: "127.0.0.1",
+            port: OAUTH_CALLBACK_PORT,
+            fetch: () =>
+              Response.json({
+                service: owner === "unrelated" ? "another-service" : "openscience-mcp-oauth-callback",
+                version: 1,
+                root: owner === "different" ? "another-profile" : root,
+              }),
+          })
+          throw new TypeError("Connection refused before the other process bound")
+        },
+        { preconnect: request.preconnect },
+      ),
+    )
+    try {
+      if (owner === "same") await expect(McpOAuthCallback.ensureRunning()).resolves.toBeUndefined()
+      else
+        await expect(McpOAuthCallback.ensureRunning()).rejects.toThrow(
+          owner === "different" ? "another OpenScience data profile" : "owned by another service",
+        )
+      // Sharing or rejecting an existing owner must never stop its listener.
+      const response = await fetch(`http://127.0.0.1:${OAUTH_CALLBACK_PORT}${OAUTH_CALLBACK_PATH}/health`, {
+        keepalive: false,
+      })
+      expect(response.ok).toBe(true)
+      await response.arrayBuffer()
+    } finally {
+      probe.mockRestore()
+      await listener?.stop(true)
+    }
+  },
+)
+
+test("ownership verification ignores a pooled connection to a gracefully stopped owner", async () => {
+  const root = createHash("sha256")
+    .update(await fs.realpath(Global.Path.data))
+    .digest("hex")
+  const health = `http://127.0.0.1:${OAUTH_CALLBACK_PORT}${OAUTH_CALLBACK_PATH}/health`
+  const previous = Bun.serve({
+    hostname: "127.0.0.1",
+    port: OAUTH_CALLBACK_PORT,
+    fetch: () => Response.json({ service: "openscience-mcp-oauth-callback", version: 1, root }),
+  })
+  let replacement: ReturnType<typeof Bun.serve> | undefined
+  try {
+    // A fully consumed health response leaves an HTTP keepalive socket in the
+    // client pool. Graceful stop releases the listening port, not that socket.
+    expect(await (await fetch(health)).json()).toMatchObject({ root })
+    previous.stop()
+    replacement = Bun.serve({
+      hostname: "127.0.0.1",
+      port: OAUTH_CALLBACK_PORT,
+      fetch: () =>
+        Response.json({ service: "openscience-mcp-oauth-callback", version: 1, root: "replacement-profile" }),
+    })
+    await expect(McpOAuthCallback.ensureRunning()).rejects.toThrow("another OpenScience data profile")
+    expect(McpOAuthCallback.isRunning()).toBe(false)
+    const response = await fetch(health, { keepalive: false })
+    expect(await response.json()).toMatchObject({ root: "replacement-profile" })
+  } finally {
+    await replacement?.stop(true)
+    await previous.stop(true)
   }
 })

--- a/backend/cli/test/session/compaction.test.ts
+++ b/backend/cli/test/session/compaction.test.ts
@@ -264,6 +264,54 @@ describe("session.compaction.isOverflow", () => {
     })
   })
 
+  test("a caller-selected smaller context remains the automatic compaction boundary", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const model = createModel({ context: 200_000, output: 32_000 })
+        const tokens = { input: 63_000, output: 5_000, reasoning: 0, cache: { read: 0, write: 0 } }
+        expect(await SessionCompaction.isOverflow({ tokens, model })).toBe(false)
+        expect(await SessionCompaction.isOverflow({ tokens, model, context: 100_000 })).toBe(true)
+        expect(SessionCompaction.usableContext(model, {}, 100_000)).toEqual({ context: 100_000, usable: 68_000 })
+        expect(SessionCompaction.usableContext(model, {}, 400_000)).toEqual({ context: 200_000, usable: 168_000 })
+      },
+    })
+  })
+
+  test("usable capacity stays positive and within known and selected limits", () => {
+    for (const context of [1, 2, 8_000, 128_000, 1_000_000]) {
+      for (const output of [0, 1, 4_096, 32_000, 128_000]) {
+        for (const input of [undefined, 1, 4_000, context, context * 2]) {
+          for (const requested of [undefined, 1, 8_000, context * 2]) {
+            const budget = SessionCompaction.usableContext(createModel({ context, input, output }), {}, requested)
+            expect(budget.usable).toBeGreaterThan(0)
+            expect(budget.usable).toBeLessThanOrEqual(Math.min(context, input ?? context, requested ?? context))
+          }
+        }
+      }
+    }
+  })
+
+  test("invalid provider limits use safe defaults and invalid caller context is rejected", () => {
+    for (const invalid of [-1, 0, 0.5, NaN, Infinity]) {
+      expect(SessionCompaction.usableContext(createModel({ context: 128_000, output: invalid }), {})).toEqual({
+        context: 128_000,
+        usable: 96_000,
+      })
+      expect(SessionCompaction.usableContext(createModel({ context: invalid, output: 32_000 }), {})).toEqual({
+        context: 128_000,
+        usable: 96_000,
+      })
+      expect(
+        SessionCompaction.usableContext(createModel({ context: 128_000, input: invalid, output: 32_000 }), {}),
+      ).toEqual({ context: 128_000, usable: 96_000 })
+      expect(() =>
+        SessionCompaction.usableContext(createModel({ context: 128_000, output: 32_000 }), {}, invalid),
+      ).toThrow("positive whole number")
+    }
+  })
+
   test("a stale config.compaction.warn_tokens is ignored and never changes the overflow trigger", async () => {
     await using tmp = await tmpdir({
       init: async (dir) => {
@@ -649,6 +697,7 @@ describe("session.compaction.persistHandoff", () => {
         tools: { task: false },
         delegation: false,
         variant: "careful",
+        context: 128_000,
       })
       await Session.updatePart({
         id: Identifier.ascending("part"),
@@ -685,6 +734,7 @@ describe("session.compaction.persistHandoff", () => {
       expect(carrier.info.effort).toBe("ultra")
       expect(carrier.info.delegation).toBe(true)
       expect(carrier.info.variant).toBe("careful")
+      expect(carrier.info.context).toBe(128_000)
     })
   })
 
@@ -805,6 +855,7 @@ describe("session.compaction durable finalization", () => {
         agent: "research",
         model,
         effort: "normal",
+        context: 128_000,
         internal: SessionLoopState.prompt(sourceID),
       })
       await Session.updatePart({
@@ -906,6 +957,7 @@ describe("session.compaction durable finalization", () => {
           message.info.internal.kind === "compaction",
       )
       expect(continuations).toHaveLength(1)
+      expect(continuations[0]?.info.role === "user" && continuations[0].info.context).toBe(128_000)
       expect(continuations[0]?.parts).toEqual([
         expect.objectContaining({
           id: SessionLoopState.partID(continuations[0]!.info.id, "continuation"),

--- a/backend/cli/test/session/context-preflight.test.ts
+++ b/backend/cli/test/session/context-preflight.test.ts
@@ -66,6 +66,7 @@ describe("current-turn context preflight", () => {
           const oversized = await SessionPrompt.prompt({
             sessionID: session.id,
             model,
+            context: 64_000,
             agent: "research",
             system: `${STRESS_SCENARIO_MARKER}${scenario.id}`,
             parts: [
@@ -104,6 +105,11 @@ describe("current-turn context preflight", () => {
           )
           expect(recoveries).toHaveLength(1)
           expect(carriers).toHaveLength(1)
+          expect(recoveries[0]?.info.role === "user" && recoveries[0].info.context).toBe(64_000)
+          expect(carriers[0]?.info.role === "user" && carriers[0].info.context).toBe(64_000)
+          const parentID = oversized.info.parentID
+          const resumed = history.find((message) => message.info.id === parentID)
+          expect(resumed?.info.role === "user" && resumed.info.context).toBe(64_000)
           expect(rejections).toHaveLength(1)
           expect(SessionLoopState.routing(history)).toContain("genome index")
           expect(requests[main]?.text).toContain("MATRIX_OBJECTIVE")

--- a/backend/cli/test/session/loop-state.test.ts
+++ b/backend/cli/test/session/loop-state.test.ts
@@ -455,6 +455,7 @@ describe("session loop restart state", () => {
     source.info.system = "stay local"
     source.info.variant = "careful"
     source.info.tier = "priority"
+    source.info.context = 128_000
     expect(SessionLoopState.controls(source.info)).toEqual({
       tools: { task: false, bash: false },
       delegation: false,
@@ -465,6 +466,7 @@ describe("session loop restart state", () => {
       system: "stay local",
       variant: "careful",
       tier: "priority",
+      context: 128_000,
       inference: undefined,
     })
   })

--- a/backend/cli/test/session/retry.test.ts
+++ b/backend/cli/test/session/retry.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test"
+import { describe, expect, spyOn, test } from "bun:test"
 import { APICallError } from "ai"
 import { SessionRetry } from "../../src/session/retry"
 import { MessageV2 } from "../../src/session/message-v2"
@@ -85,6 +85,54 @@ describe("session.retry.delay", () => {
 
     process.emitWarning = originalWarn
     expect(warnings.some((w) => w.includes("TimeoutOverflowWarning"))).toBe(false)
+  })
+
+  test("sleep rejects an already-stopped turn without waiting for Retry-After", async () => {
+    const controller = new AbortController()
+    controller.abort()
+    const listener = spyOn(controller.signal, "addEventListener")
+    try {
+      const result = await Promise.race([
+        SessionRetry.sleep(100, controller.signal).then(
+          () => "completed",
+          (error: unknown) => error,
+        ),
+        Bun.sleep(30).then(() => "still waiting"),
+      ])
+      expect(result).toBeInstanceOf(DOMException)
+      expect(result).toMatchObject({ name: "AbortError" })
+      expect(listener).not.toHaveBeenCalled()
+    } finally {
+      listener.mockRestore()
+    }
+  })
+
+  test("sleep removes its abort listener after normal completion", async () => {
+    const controller = new AbortController()
+    const added = spyOn(controller.signal, "addEventListener")
+    const removed = spyOn(controller.signal, "removeEventListener")
+    try {
+      await SessionRetry.sleep(1, controller.signal)
+      expect(added).toHaveBeenCalledTimes(1)
+      expect(removed).toHaveBeenCalledWith("abort", added.mock.calls[0][1])
+      controller.abort()
+    } finally {
+      added.mockRestore()
+      removed.mockRestore()
+    }
+  })
+
+  test("sleep clears its pending timer when Stop interrupts backoff", async () => {
+    const controller = new AbortController()
+    const cleared = spyOn(globalThis, "clearTimeout")
+    try {
+      const pending = SessionRetry.sleep(10_000, controller.signal)
+      controller.abort()
+      await expect(pending).rejects.toMatchObject({ name: "AbortError" })
+      expect(cleared).toHaveBeenCalledTimes(1)
+    } finally {
+      cleared.mockRestore()
+    }
   })
 })
 

--- a/backend/cli/test/session/stream-stop.test.ts
+++ b/backend/cli/test/session/stream-stop.test.ts
@@ -1,0 +1,155 @@
+import { expect, test } from "bun:test"
+import z from "zod"
+import { Instance } from "../../src/project/instance"
+import { Provider } from "../../src/provider/provider"
+import { SessionRoutes } from "../../src/server/routes/session"
+import { Session } from "../../src/session"
+import { SessionPrompt } from "../../src/session/prompt"
+import { SessionStatus } from "../../src/session/status"
+import { Tool } from "../../src/tool/tool"
+import { ToolRegistry } from "../../src/tool/registry"
+import { tmpdir, trustProject } from "../fixture/fixture"
+import { STRESS_PROVIDER_ID, STRESS_PROVIDER_MODEL, stressProviderConfig } from "../fixture/stress-provider"
+
+const marker = "STOP_DEFAULT_STREAM_FIXTURE"
+const encoder = new TextEncoder()
+
+function chunk(delta: Record<string, unknown>, finish: string | null = null) {
+  return `data: ${JSON.stringify({ id: "chatcmpl-stop", object: "chat.completion.chunk", created: 1, model: STRESS_PROVIDER_MODEL, choices: [{ index: 0, delta, finish_reason: finish }] })}\n\n`
+}
+
+async function until(check: () => boolean | Promise<boolean>) {
+  const deadline = Date.now() + 2_000
+  while (!(await check())) {
+    if (Date.now() > deadline) throw new Error("The isolated Stop fixture did not settle")
+    await Bun.sleep(5)
+  }
+}
+
+test.each(["quiet-response", "active-tool"])(
+  "the actual Stop route cancels a %s with default response deadlines",
+  async (mode) => {
+    let requests = 0
+    let cancelled = false
+    let toolStarted = false
+    let toolStopped = false
+    using server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      async fetch(request) {
+        if (!JSON.stringify(await request.json()).includes(marker)) {
+          return new Response(`${chunk({ content: "Fixture title" })}${chunk({}, "stop")}data: [DONE]\n\n`, {
+            headers: { "content-type": "text/event-stream" },
+          })
+        }
+        requests++
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(encoder.encode(chunk({ role: "assistant", content: "Keep this partial answer." })))
+              if (mode === "quiet-response") return
+              controller.enqueue(
+                encoder.encode(
+                  chunk({
+                    tool_calls: [
+                      {
+                        index: 0,
+                        id: "stop_tool",
+                        type: "function",
+                        function: { name: "stop_fixture", arguments: "{}" },
+                      },
+                    ],
+                  }) + chunk({}, "tool_calls"),
+                ),
+              )
+            },
+            cancel() {
+              cancelled = true
+            },
+          }),
+          { headers: { "content-type": "text/event-stream" } },
+        )
+      },
+    })
+    await using tmp = await tmpdir({ git: true, config: stressProviderConfig(`${server.url.origin}/v1`) })
+    await Instance.provide({
+      directory: tmp.path,
+      init: async () => {
+        await trustProject()
+        await Provider.invalidate()
+      },
+      fn: async () => {
+        await ToolRegistry.register(
+          Tool.define("stop_fixture", {
+            description: "Wait for explicit cancellation",
+            parameters: z.object({}),
+            async execute(_args, context) {
+              try {
+                await new Promise<never>((_resolve, reject) => {
+                  context.abort.throwIfAborted()
+                  context.abort.addEventListener("abort", () => reject(context.abort.reason), { once: true })
+                  toolStarted = true
+                })
+                throw new Error("The cancellation fixture must not succeed")
+              } finally {
+                toolStopped = true
+              }
+            },
+          }),
+        )
+        const session = await Session.create({
+          title: "Stop fixture",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+        const running = SessionPrompt.prompt({
+          sessionID: session.id,
+          model: { providerID: STRESS_PROVIDER_ID, modelID: STRESS_PROVIDER_MODEL },
+          agent: "research",
+          delegation: false,
+          system: marker,
+          tools: mode === "active-tool" ? { stop_fixture: true } : {},
+          parts: [{ type: "text", text: "Run the local fixture once." }],
+        })
+        let settled = false
+        void running.then(
+          () => (settled = true),
+          () => (settled = true),
+        )
+        try {
+          // The SDK can start execute() before the processor consumes earlier
+          // text events. Stop only after the transcript owns the partial text.
+          await until(async () => {
+            if (mode === "active-tool" && !toolStarted) return false
+            const messages = await Session.messages({ sessionID: session.id })
+            return messages.some((message) =>
+              message.parts.some((part) => part.type === "text" && part.text === "Keep this partial answer."),
+            )
+          })
+          const response = await SessionRoutes().request(`/${session.id}/abort`, { method: "POST" })
+          expect(response.status).toBe(200)
+          expect(await response.json()).toBe(true)
+          await until(() => settled && cancelled && (mode !== "active-tool" || toolStopped))
+          const result = await running
+          expect(result.info).toMatchObject({ role: "assistant", error: { name: "MessageAbortedError" } })
+          expect(result.parts.find((part) => part.type === "text")).toMatchObject({
+            text: "Keep this partial answer.",
+            time: { end: expect.any(Number) },
+          })
+          expect(requests).toBe(1)
+          expect(SessionStatus.get(session.id)).toEqual({ type: "idle" })
+          expect(SessionPrompt.activeController(session.id)).toBeUndefined()
+          if (mode === "active-tool") {
+            const messages = await Session.messages({ sessionID: session.id })
+            expect(messages.flatMap((message) => message.parts).filter((part) => part.type === "tool")).toEqual([
+              expect.objectContaining({ callID: "stop_tool", state: expect.objectContaining({ status: "error" }) }),
+            ])
+          }
+        } finally {
+          SessionPrompt.cancel(session.id)
+          await running.catch(() => {})
+        }
+      },
+    })
+  },
+  15_000,
+)

--- a/docs/notes/request-timing.md
+++ b/docs/notes/request-timing.md
@@ -71,12 +71,14 @@ An opened response remains open by default until it completes, fails upstream, o
 
 The output watchdog cancels the provider HTTP request through `RequestContext.abort`, not the session's tool-authority signal. Already-started tools retain their separate lifecycle; an HTTP timeout is not proof that a remote tool or provider computation was rolled back. The transport's own deadlines also abort the underlying fetch, not only the consumer's wait.
 
+User Stop cancels the session as well as its model wait, including an already-aborted signal entering retry backoff. A quiet stream or active tool must settle without automatically starting another model request. Completed tool results and partial transcript output remain saved; cancellation does not undo external work.
+
 ## Focused verification
 
 From `backend/cli`, these tests exercise the actual parser, dispatch observation, phase transitions, split private placeholders, keepalive handling, and activity throttling without paid model calls:
 
 ```bash
-bun test --timeout 15000 ./test/provider/gateway-timing.test.ts ./test/provider/idle-watchdog.test.ts ./test/session/request-progress.test.ts ./test/session/telemetry.test.ts ./test/session/output-watchdog.test.ts ./test/session/stall-recovery.test.ts
+bun test --timeout 15000 ./test/provider/gateway-timing.test.ts ./test/provider/idle-watchdog.test.ts ./test/session/request-progress.test.ts ./test/session/telemetry.test.ts ./test/session/output-watchdog.test.ts ./test/session/stall-recovery.test.ts ./test/session/retry.test.ts ./test/session/stream-stop.test.ts
 ```
 
 When changing the progress schema, regenerate the SDK with `./tooling/repo/generate.ts` from the repository root and update the workspace's phase handling in the same change.

--- a/frontend/docs/src/content/openscience/context.mdx
+++ b/frontend/docs/src/content/openscience/context.mdx
@@ -30,6 +30,8 @@ Compaction summarizes earlier context. Keep exact parameter values, code, source
 
 OpenScience automatically compacts a conversation as it approaches the model's usable input capacity, reserving room for the response. You do not need to choose a percentage in settings. The context indicator still shows how much of the window is in use, and `/compact` remains available whenever you want to summarize earlier work sooner.
 
+If the model offers a smaller context-window choice, that choice is retained through compaction and continuation. Automatic compaction uses that selected capacity, bounded by the model's supported limits, rather than silently expanding back to the full window.
+
 Old `compaction.threshold` and warning-level preferences are ignored. If you explicitly set `compaction.auto` to `false` in configuration, use `/compact` before the conversation becomes too large.
 
 ## Save a checkpoint

--- a/frontend/docs/src/content/openscience/preferences.mdx
+++ b/frontend/docs/src/content/openscience/preferences.mdx
@@ -3,7 +3,7 @@ title: "Appearance, notifications, and updates"
 description: "Set up the workspace for how you read, monitor work, and keep the app current."
 ---
 
-Open **Customize → General** for appearance, language, notification, sound, context, account, and update preferences.
+Open **Customize → General** for appearance, reasoning visibility, language, notification, sound, account, and update preferences.
 
 ## Appearance and language
 
@@ -26,9 +26,13 @@ Enable or disable sounds, adjust volume, and choose the available sound for comp
 
 ## Context and account
 
-Use the Context section to adjust the available automatic-compaction threshold. See [Context and handoffs](/openscience/context) for how to preserve important work as a conversation grows.
+Context compaction is automatic; there is no percentage selector in General. See [Context and handoffs](/openscience/context) for capacity, manual compaction, and preserving important work as a conversation grows.
 
 Check the account and funding workspace before paid work. [Ace](/openscience/ace) explains account connection, Wallet access, and switching workspaces.
+
+## Reasoning visibility
+
+Use **Show reasoning** in General, or **Show reasoning / Hide reasoning** above a turn's activity. Both controls use the same saved preference. Hiding reasoning leaves tool calls and results visible. There are no Detailed/Compact modes; readable provider text is shown as prose, with routine action headings omitted. Providers may supply summaries or no readable reasoning; OpenScience cannot reveal private reasoning the provider did not send.
 
 ## Updates and release notes
 

--- a/frontend/ui/src/components/tool-display.test.ts
+++ b/frontend/ui/src/components/tool-display.test.ts
@@ -314,6 +314,14 @@ describe("provider reasoning presentation", () => {
     expect(reasoningDisplayText(text)).toBe(passages.join("\n\n"))
   })
 
+  test("normalizes the comparison phase without deleting an inline scientific comparison", () => {
+    expect(reasoningDisplayText("**Comparing the assay controls**\n\nThe **same evaluation conditions** apply.")).toBe(
+      "The **same evaluation conditions** apply.",
+    )
+    const prose = "**Comparing the assays revealed a confound.**\nThe conditions differed."
+    expect(reasoningDisplayText(prose)).toBe(prose)
+  })
+
   test("preserves ordinary bold reasoning prose", () => {
     const prose =
       "Let me also make sure about **featureCounts GTF requirement**: featureCounts works best with a GFF/GTF."

--- a/frontend/ui/src/components/tool-display.ts
+++ b/frontend/ui/src/components/tool-display.ts
@@ -30,7 +30,7 @@ export function stripRedactedReasoning(text: string): string {
 }
 
 const reasoningPhase =
-  /^(?:planning|preparing|retrieving|exploring|inspecting|testing|verifying|checking|reviewing|analyzing|evaluating|designing|building|running|confirming|adjusting|patching|restarting|summarizing|finalizing|considering|choosing|simplifying|determining|revising|parsing|researching|optimizing|streamlining|refining|rethinking)\b[\p{L}\p{N} ,'/()_-]*$/iu
+  /^(?:planning|preparing|retrieving|exploring|inspecting|testing|verifying|checking|reviewing|analyzing|evaluating|designing|building|running|confirming|adjusting|patching|restarting|summarizing|finalizing|considering|choosing|simplifying|determining|revising|parsing|researching|optimizing|streamlining|refining|rethinking|comparing)\b[\p{L}\p{N} ,'/()_-]*$/iu
 const reasoningStatus =
   /^(?:planning|preparing|retrieving|exploring|inspecting|testing|verifying|checking|reviewing|analyzing|evaluating|designing|building|running|confirming|adjusting|patching|restarting|summarizing|finalizing|thinking|considering next steps)$/i
 

--- a/frontend/workspace/e2e/science-artifact.spec.ts
+++ b/frontend/workspace/e2e/science-artifact.spec.ts
@@ -5,7 +5,7 @@ import { promisify } from "node:util"
 import type { Locator, Page } from "@playwright/test"
 import type { ReasoningPart } from "@synsci/sdk/v2"
 import { test, expect } from "./fixtures"
-import { createSdk } from "./utils"
+import { createSdk, openSettings } from "./utils"
 
 test.skip(
   process.env.OPENSCIENCE_E2E_FAKE_MODEL !== "1",
@@ -162,7 +162,7 @@ async function withArtifact(
   }
 }
 
-test("literal reasoning and artifacts remain visible despite obsolete compact and collapse preferences", async ({
+test("reasoning prose and artifacts respect Show reasoning but ignore obsolete activity preferences", async ({
   page,
   sdk,
   gotoSession,
@@ -177,9 +177,15 @@ test("literal reasoning and artifacts remain visible despite obsolete compact an
     if (!userID) throw new Error("Seeded artifact has no user message")
     const assistant = messages.find((message) => message.info.role === "assistant")
     if (!assistant) throw new Error("Seeded artifact has no assistant message")
+    // Expected prose is independent of the production display normalizer: a
+    // regression that shortens either passage must still fail this test.
+    const prose = [
+      "The recorded control and treatment observations need the same evaluation conditions. I will retain the measured values, the failed observations, and the uncertainty instead of replacing the source with a shorter description. This whole passage should remain readable before the sequence result, including this final sentence.",
+      "The second passage belongs after the first one. The saved sequence is a separate tool result, not a replacement for either passage. A reader should be able to inspect both explanations and the actual sequence without changing an activity mode; hiding reasoning must leave the sequence accessible.",
+    ]
     const passages = [
-      "**Comparing the assay controls**\n\nThe recorded control and treatment observations need the same evaluation conditions. I will retain the measured values, the failed observations, and the uncertainty instead of replacing the source with a shorter description. This whole passage should remain readable before the sequence result, including this final sentence.",
-      "**Checking the transfer condition**\n\nThe second passage belongs after the first one. The saved sequence is a separate tool result, not a replacement for either passage. A reader should be able to inspect both explanations and the actual sequence without changing an activity mode or opening a reasoning disclosure.",
+      `**Comparing the assay controls**\n\n${prose[0].replace("same evaluation conditions", "**same evaluation conditions**")}`,
+      `**Checking the transfer condition**\n\n${prose[1]}`,
     ]
     const reasoning = (id: string, text: string): ReasoningPart => ({
       id,
@@ -220,20 +226,20 @@ test("literal reasoning and artifacts remain visible despite obsolete compact an
     await gotoSession(sessionID)
     const artifact = page.locator('[data-component="science-artifact"][data-kind="sequence"]')
     const reasoningRows = page.locator('[data-component="reasoning-part"]')
+    const toggle = page.locator('[data-slot="session-turn-reasoning-toggle"]')
     await expect(page.getByRole("group", { name: "Activity view", exact: true })).toHaveCount(0)
     await expect(page.locator('[data-slot="session-turn-collapsible-trigger-content"]')).toHaveCount(0)
     await expect(reasoningRows).toHaveCount(2)
     await expect(reasoningRows.locator("button")).toHaveCount(0)
-    await expect(reasoningRows.locator('[data-slot="reasoning-part-body"]')).toHaveText(
-      passages.map((passage) => passage.replaceAll("**", "")),
-    )
+    await expect(reasoningRows.locator('[data-slot="reasoning-part-body"]')).toHaveText(prose)
+    await expect(reasoningRows.locator("strong")).toHaveText("same evaluation conditions")
+    await expect(toggle).toHaveText("Hide reasoning")
+    await expect(toggle).toHaveAttribute("aria-expanded", "true")
     await expect(artifact).toBeVisible()
     await expect(artifact.locator('[data-slot="sequence-residues"]')).toHaveText("ACGTACGT")
     await page.reload()
     await expect(reasoningRows).toHaveCount(2)
-    await expect(reasoningRows.locator('[data-slot="reasoning-part-body"]')).toHaveText(
-      passages.map((passage) => passage.replaceAll("**", "")),
-    )
+    await expect(reasoningRows.locator('[data-slot="reasoning-part-body"]')).toHaveText(prose)
     await expect(page.locator('[data-component="reasoning-part"], [data-component="science-artifact"]')).toHaveCount(3)
     expect(
       await page
@@ -242,8 +248,39 @@ test("literal reasoning and artifacts remain visible despite obsolete compact an
     ).toEqual(["reasoning-part", "reasoning-part", "science-artifact"])
     await expect(artifact).toBeVisible()
     await expect(artifact.locator('[data-slot="sequence-residues"]')).toHaveText("ACGTACGT")
+
+    await toggle.click()
+    await expect(reasoningRows).toHaveCount(0)
+    await expect(toggle).toHaveText("Show reasoning")
+    await expect(toggle).toHaveAttribute("aria-expanded", "false")
+    await expect(artifact).toBeVisible()
+    await expect(artifact.locator('[data-slot="sequence-residues"]')).toHaveText("ACGTACGT")
+    await page.reload()
+    await expect(toggle).toHaveText("Show reasoning")
+    await expect(reasoningRows).toHaveCount(0)
+    await expect(artifact).toBeVisible()
+
+    const dialog = await openSettings(page)
+    await dialog.getByRole("button", { name: "General", exact: true }).click()
+    const setting = dialog.getByRole("switch", { name: "Show reasoning", exact: true })
+    await expect(setting).not.toBeChecked()
+    await setting.locator("..").locator('[data-slot="switch-control"]').click()
+    await expect(setting).toBeChecked()
+    await setting.focus()
+    await expect(setting).toBeFocused()
+    await setting.press("Space")
+    await expect(setting).not.toBeChecked()
+    await setting.press("Space")
+    await expect(setting).toBeChecked()
+    await dialog.getByRole("button", { name: "Close", exact: true }).click()
+    await expect(reasoningRows.locator('[data-slot="reasoning-part-body"]')).toHaveText(prose)
+    await expect(toggle).toHaveText("Hide reasoning")
+    await page.reload()
+    await expect(reasoningRows.locator('[data-slot="reasoning-part-body"]')).toHaveText(prose)
+    await expect(artifact).toBeVisible()
+    await expect(artifact.locator('[data-slot="sequence-residues"]')).toHaveText("ACGTACGT")
     await reasoningRows.first().scrollIntoViewIfNeeded()
-    await page.screenshot({ path: test.info().outputPath("literal-trace.png") })
+    await page.screenshot({ path: test.info().outputPath("reasoning-controls.png") })
   } finally {
     await sdk.session.delete({ sessionID }).catch(() => undefined)
   }

--- a/frontend/workspace/src/components/settings-general.tsx
+++ b/frontend/workspace/src/components/settings-general.tsx
@@ -194,11 +194,9 @@ export const AppearanceSections: Component = () => {
             title={language.t("settings.general.reasoning.title")}
             description={language.t("settings.general.reasoning.description")}
           >
-            <Switch
-              checked={settings.general.showReasoning()}
-              onChange={settings.general.setShowReasoning}
-              aria-label={language.t("settings.general.reasoning.title")}
-            />
+            <Switch hideLabel checked={settings.general.showReasoning()} onChange={settings.general.setShowReasoning}>
+              {language.t("settings.general.reasoning.title")}
+            </Switch>
           </SettingsRow>
         </div>
       </SettingsSection>


### PR DESCRIPTION
## Summary

- Keep selected context capacity through compaction/continuation, account for cache writes, and reject invalid limits safely.
- Honor Stop before retry backoff; verify the actual abort route cancels quiet streams and tools without redispatch or losing partial output.
- Fix concurrent OAuth callback ownership detection, including a pooled connection to a gracefully stopped owner. Preserve profile isolation and existing listener ownership.
- Correct the reasoning switch accessibility and stale browser/documentation expectations for the restored prose and saved Show/Hide control.

This builds on #536, which restores default uninterrupted response waits and removes the percentage selector and Detailed/Compact modes. No billing policy, provider retry classification, stored reasoning, or release gates are weakened.

## Verification

- 134 stream/retry tests, 93 context tests, and 10 OAuth tests passed locally.
- 210 shared-UI tests, 871 workspace tests, and 10 real isolated Chromium science-artifact tests passed.
- Monorepo typecheck, documentation checks, formatting and diff checks passed.
- No paid inference, customer account mutation, or running-app restart.

Fast CI, full Deep CI and browser E2E will gate merge. Stable publication will follow an exact-main full packaged release rehearsal, including native scientific canaries and operating-system smokes.
