### PR TITLE
Restore classic per-turn chat traces and stable scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,18 +10,23 @@ tagged release also ships native binaries for Linux, macOS, and Windows.
 
 ### Changed
 
+- Restore the classic 2.0.61–2.0.63 chat presentation: one saved reasoning/activity
+  disclosure per turn, inline reasoning, and quiet tool rows without repeated
+  timers or status rails. Keep live turns open on completion, anchor disclosure
+  clicks in place, and preserve pending answers, approvals, failures, and final
+  responses while activity is collapsed. Streaming and billing safeguards remain
+  unchanged.
 - Honor Stop even when it arrives just before retry backoff. Preserve the
   selected model context window through compaction and continuation, and include
   cached writes when assessing whether pruning made enough room.
 - Recheck the current OAuth callback listener when two local processes connect
   simultaneously. Avoid stale pooled connections to a stopped runtime without
   accepting a different data profile or taking over another service's port.
-- Make the reasoning setting keyboard- and screen-reader-accessible, and verify
-  that Show/Hide survives reloads without hiding tool results or shortening prose.
-- Restore a saved Show/Hide reasoning control without Detailed/Compact modes.
-  Display reasoning as plain prose, omit routine provider phase headings, and
-  remove per-part thinking clocks that counted silence as reasoning. Keep the
-  original provider text and tool results intact.
+- Keep the per-turn disclosure keyboard- and screen-reader-accessible, and retain
+  its open or closed state across reloads. Ignore the obsolete global reasoning
+  preference without resetting other settings. Display reasoning as plain prose,
+  omit routine provider phase headings, and remove per-part thinking clocks that
+  counted silence as reasoning. Keep original provider text and tool results intact.
 - Remove the Context percentage selector and automatically compact at the usable
   model capacity with output headroom, following OpenCode's default. Legacy
   percentage preferences no longer override automatic context management.
@@ -41,9 +46,9 @@ tagged release also ships native binaries for Linux, macOS, and Windows.
 - Update the homepage closing headline, simplify the photo wordmark, and add
   LinkedIn with external-link arrows to the footer’s Connect links.
 
-- Keep all readable provider reasoning and individual tool calls visible in
-  chronological order, without Detailed/Compact modes or a shared activity
-  disclosure. Omit empty encrypted-only rows instead of repeating unavailable
+- Keep readable provider reasoning and individual tool calls in chronological
+  order when a turn is expanded, without Detailed/Compact modes or a global
+  visibility toggle. Omit empty encrypted-only rows instead of repeating unavailable
   reasoning notices. Preserve readable OpenRouter reasoning when encrypted
   continuation metadata arrives in the same response.
 - Open chat-linked documents already saved in a managed project's Project files

--- a/docs/notes/classic-chat.md
+++ b/docs/notes/classic-chat.md
@@ -1,0 +1,63 @@
+# Classic chat presentation
+
+The reference is OpenScience 2.0.61–2.0.63. The turn, reasoning and tool
+presentation in these tags is identical; 2.0.64 uses the same tool components.
+This restoration is based on that implementation, not a rollback of the runtime.
+
+## One disclosure per turn
+
+The turn's **Show reasoning and activity** control expands inline reasoning and
+individual tool rows in their original order. It does not rewrite a global
+preference. Completed history starts collapsed unless the reader previously
+expanded it. A live turn opens once and stays open after completion; an explicit
+collapse is not overridden by the next stream update.
+
+`session-trace.ts` reads the historical `openscience-trace-expansion-v1` storage
+key, retaining explicit false values and bounding saved choices to 200 turns.
+The obsolete global `showReasoning` field is ignored, not deleted, and no other
+settings are reset.
+
+Answers and scientific results remain available when steps are collapsed.
+Pending approvals/questions and failed operations remain at the same keyed
+location, so toggling does not destroy an unsent answer or conceal a failure.
+
+## Streaming and scrolling
+
+Readable reasoning remains inline prose, without per-part clocks, repeated
+phase headings or Detailed/Compact modes. Tool rows use their original icon,
+title and description, with one accessible lifecycle indicator. Full command
+output and error details remain inspectable.
+
+The new global toggle changed the heights of earlier turns. In a long-chat
+Chromium reproduction this displaced the clicked control by 4,400 pixels.
+The restored per-turn control avoids that global mutation. The scroll hook also
+captures a disclosure's viewport position before layout changes and corrects
+only its residual displacement after native scroll anchoring. Corrections are
+immediate, not animated; manual scrolling and Jump to latest release the anchor.
+
+The 2.0.61–2.0.64 runtime used the same streaming SDK versions as 2.0.75 and
+appended reasoning deltas as they arrived. Keep that path, the readable-reasoning
+SDK fixes, model-specific controls, title single-flight, Stop, partial-output
+preservation and protections against retrying unknown paid outcomes. Stored
+reasoning/signatures are not changed by presentation. This UI restoration does
+not claim to eliminate provider latency or reveal reasoning a provider withholds.
+
+## Regression checks
+
+- `frontend/ui/src/components/session-turn-trajectory.test.ts`: incremental prose,
+  stable pending question drafts, failed tools, terminal errors and disclosure.
+- `frontend/ui/src/components/basic-tool.test.ts`: compact lifecycle rows and
+  complete error/cancellation details.
+- `frontend/ui/src/hooks/create-auto-scroll.test.ts`: disclosure anchoring,
+  native compensation, manual scrolling and viewport resize.
+- `frontend/workspace/src/pages/session-trace.test.ts`: per-turn persistence,
+  malformed storage and active-turn expansion.
+- `frontend/workspace/src/context/settings-reasoning.test.tsx`: legacy global
+  preference compatibility without resetting unrelated settings.
+- `frontend/workspace/e2e/science-artifact.spec.ts`: real workspace reloads,
+  reasoning prose and scientific results with obsolete preferences present.
+- `frontend/workspace/e2e/classic-chat.spec.ts`: twelve long turns with independent
+  disclosures, stable mouse/keyboard viewport positions, and persisted choices.
+
+Use the isolated fake-model browser harness; these checks do not require paid
+inference or interacting with a running user's session.

--- a/frontend/docs/src/content/openscience/models.mdx
+++ b/frontend/docs/src/content/openscience/models.mdx
@@ -87,7 +87,7 @@ Open a model's options to see its supported reasoning tiers, context capacity, a
 
 The conversation displays readable reasoning and tool activity when the model supplies them. Some models return only a final answer or a reasoning summary. The visible activity is useful for following progress, but the saved outputs and cited evidence are what you should verify.
 
-Use **Show reasoning / Hide reasoning** above a turn, or **Customize → General → Show reasoning**, to change visibility. The choice is saved across sessions. Hiding reasoning does not hide tool calls, stop the model, or change the conversation sent to it. There is no Detailed/Compact mode.
+Use **Show reasoning and activity / Hide reasoning and activity** above a turn to inspect its steps. Expansion is saved per turn, not applied to every earlier response. Live turns open once and stay open when they finish; answers and pending approvals remain accessible when steps are collapsed. The control does not stop the model or change the conversation sent to it. There is no global reasoning toggle or Detailed/Compact mode.
 
 Readable passages appear as plain prose, with routine provider phase headings removed from the display. OpenScience does not generate another summary or modify the stored provider response. A model that exposes only a reasoning summary cannot be made to expose private internal reasoning through this setting.
 

--- a/frontend/docs/src/content/openscience/preferences.mdx
+++ b/frontend/docs/src/content/openscience/preferences.mdx
@@ -3,7 +3,7 @@ title: "Appearance, notifications, and updates"
 description: "Set up the workspace for how you read, monitor work, and keep the app current."
 ---
 
-Open **Customize → General** for appearance, reasoning visibility, language, notification, sound, account, and update preferences.
+Open **Customize → General** for appearance, language, notification, sound, account, and update preferences. Reasoning visibility is controlled within each conversation turn.
 
 ## Appearance and language
 
@@ -32,7 +32,9 @@ Check the account and funding workspace before paid work. [Ace](/openscience/ace
 
 ## Reasoning visibility
 
-Use **Show reasoning** in General, or **Show reasoning / Hide reasoning** above a turn's activity. Both controls use the same saved preference. Hiding reasoning leaves tool calls and results visible. There are no Detailed/Compact modes; readable provider text is shown as prose, with routine action headings omitted. Providers may supply summaries or no readable reasoning; OpenScience cannot reveal private reasoning the provider did not send.
+Use **Show reasoning and activity / Hide reasoning and activity** above a turn to expand or collapse its steps. Each turn remembers its own choice; changing one does not move or hide the history in other turns. New live turns open automatically and stay open when they finish; a turn you explicitly collapse stays collapsed. Answers, scientific results, pending approvals/questions, and failed tool calls remain visible when steps are collapsed.
+
+There is no separate global reasoning toggle or Detailed/Compact mode. Readable provider text is shown inline, with routine action headings omitted. Providers may supply summaries or no readable reasoning; OpenScience cannot reveal private reasoning the provider did not send.
 
 ## Updates and release notes
 

--- a/frontend/ui/src/components/basic-tool.css
+++ b/frontend/ui/src/components/basic-tool.css
@@ -16,38 +16,8 @@
     gap: 20px;
   }
 
-  /* One fixed-width status rail per row: receipt or first error line, one
-     glyph, one clock. Tabular digits and a reserved clock width keep a ticking
-     counter from nudging the title while a call runs. */
+  /* Reuse the classic tool icon position for lifecycle state. */
   [data-slot="basic-tool-tool-status"] {
-    flex-shrink: 0;
-    min-width: 0;
-    max-width: 50%;
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    color: var(--text-weaker);
-    font-family: var(--font-family-sans);
-    font-size: var(--font-size-x-small);
-    font-weight: var(--font-weight-regular);
-    line-height: var(--line-height-large);
-    letter-spacing: var(--letter-spacing-normal);
-    font-variant-numeric: tabular-nums;
-    white-space: nowrap;
-  }
-
-  [data-slot="basic-tool-tool-detail"] {
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  [data-slot="basic-tool-tool-detail"][data-error="true"] {
-    color: var(--text-critical-base);
-  }
-
-  [data-slot="basic-tool-tool-glyph"] {
     flex-shrink: 0;
     width: 16px;
     height: 16px;
@@ -62,26 +32,23 @@
     }
   }
 
-  [data-slot="basic-tool-tool-status"][data-outcome="done"] [data-slot="basic-tool-tool-glyph"] {
-    color: var(--icon-success-base);
-  }
-
-  [data-slot="basic-tool-tool-status"][data-outcome="error"] [data-slot="basic-tool-tool-glyph"] {
+  [data-slot="basic-tool-tool-status"][data-outcome="error"] {
     color: var(--icon-critical-base);
   }
 
-  [data-slot="basic-tool-tool-status"][data-outcome="cancelled"] [data-slot="basic-tool-tool-glyph"] {
+  [data-slot="basic-tool-tool-status"][data-outcome="cancelled"] {
     color: var(--icon-warning-base);
   }
 
-  [data-slot="basic-tool-tool-time"] {
+  [data-slot="basic-tool-tool-failure-label"] {
     flex-shrink: 0;
-    min-width: 3.5ch;
-    text-align: right;
+    color: var(--text-critical-base);
+    font-size: var(--font-size-small);
+    font-weight: var(--font-weight-regular);
   }
 
-  [data-slot="basic-tool-tool-time"]:empty {
-    min-width: 0;
+  &[data-outcome="cancelled"] [data-slot="basic-tool-tool-failure-label"] {
+    color: var(--text-weak);
   }
 
   [data-slot="icon-svg"] {

--- a/frontend/ui/src/components/basic-tool.test.ts
+++ b/frontend/ui/src/components/basic-tool.test.ts
@@ -7,8 +7,7 @@ import solid from "vite-plugin-solid"
 import { dict as en } from "../i18n/en"
 import { resolveBasicToolChildren, type BasicToolProps } from "./basic-tool"
 
-// Render the real BasicTool row in jsdom so the status rail, the running verb,
-// and the disclosure state are checked against live DOM rather than source.
+// Check the classic compact row and lifecycle semantics against live DOM.
 const vite = await createServer({
   root: fileURLToPath(new URL("../../../workspace", import.meta.url)),
   mode: "production",
@@ -60,20 +59,29 @@ describe("BasicTool children", () => {
 })
 
 describe("tool row lifecycle", () => {
-  test("a live call reads as one verb line with a spinner and a ticking clock", async () => {
+  test("preparing, running and completed calls share one stable compact row", async () => {
     const { host, setProps, trigger, status } = mount({
       icon: "glasses",
       tool: "read",
-      status: "running",
+      status: "pending",
       time: { start: Date.now() - 12_400 },
       trigger: { title: "Read", subtitle: "paper.tex" },
     })
     await settle()
-    expect(host.querySelector('[data-slot="basic-tool-tool-title"]')?.textContent).toBe("Reading")
+    const row = trigger()
+    expect(host.querySelector('[data-slot="basic-tool-tool-title"]')?.textContent).toBe("Read")
+    expect(status()?.getAttribute("data-outcome")).toBe("pending")
+    expect(status()?.getAttribute("aria-label")).toBe("Preparing")
+    expect(status()?.querySelector('[data-component="spinner"]')).toBeNull()
+    expect(status()?.querySelector('[data-icon="clock"]')).not.toBeNull()
+
+    setProps("status", "running")
+    await settle()
     expect(status()?.getAttribute("data-outcome")).toBe("running")
     expect(status()?.querySelector('[data-component="spinner"]')).not.toBeNull()
-    expect(status()?.querySelector('[data-slot="basic-tool-tool-time"]')?.textContent).toBe("12s")
-    expect(status()?.querySelector('[data-slot="basic-tool-tool-glyph"]')?.getAttribute("aria-label")).toBe("Running")
+    expect(status()?.getAttribute("aria-label")).toBe("Running")
+    expect(host.querySelector('[data-slot="basic-tool-tool-time"]')).toBeNull()
+    expect(host.textContent?.trim()).toBe("Readpaper.tex")
     // No body yet, so the row is a button that has nothing to expand.
     expect(trigger().tagName).toBe("BUTTON")
     expect(host.querySelector('[data-slot="collapsible-arrow"]')).toBeNull()
@@ -83,11 +91,13 @@ describe("tool row lifecycle", () => {
     expect(host.querySelector('[data-slot="basic-tool-tool-title"]')?.textContent).toBe("Read")
     expect(status()?.getAttribute("data-outcome")).toBe("done")
     expect(status()?.querySelector('[data-component="spinner"]')).toBeNull()
-    expect(status()?.querySelector('[data-slot="basic-tool-tool-glyph"]')?.getAttribute("aria-label")).toBe("Done")
-    expect(status()?.querySelector('[data-slot="basic-tool-tool-time"]')?.textContent).toBe("3.4s")
+    expect(status()?.getAttribute("aria-label")).toBe("Done")
+    expect(status()?.querySelector('[data-icon="glasses"]')).not.toBeNull()
+    expect(host.textContent?.trim()).toBe("Readpaper.tex")
+    expect(trigger()).toBe(row)
   })
 
-  test("output stays collapsed behind a one-line receipt until the reader opens it", async () => {
+  test("output and receipt counts stay out of the compact row until opened or inspected", async () => {
     const { host, trigger } = mount({
       icon: "console",
       tool: "bash",
@@ -106,9 +116,10 @@ describe("tool row lifecycle", () => {
       },
     })
     await settle()
-    expect(host.querySelector('[data-slot="basic-tool-tool-detail"]')?.textContent).toBe("exit 2 · 12 lines")
-    // Sub-second durations stay quiet; the reserved clock slot keeps its place.
-    expect(host.querySelector('[data-slot="basic-tool-tool-time"]')?.textContent).toBe("")
+    expect(host.querySelector('[data-slot="basic-tool-tool-detail"]')).toBeNull()
+    expect(host.querySelector('[data-slot="basic-tool-tool-time"]')).toBeNull()
+    expect(host.querySelector('[data-slot="basic-tool-tool-status"]')?.getAttribute("title")).toContain("12 lines")
+    expect(host.textContent?.trim()).toBe("ShellRun the checks")
     expect(trigger().getAttribute("aria-expanded")).toBe("false")
     expect(host.querySelector('[data-slot="test-output"]')).toBeNull()
     expect(host.querySelector('[data-slot="collapsible-arrow"]')).not.toBeNull()
@@ -124,7 +135,7 @@ describe("tool row lifecycle", () => {
     expect(host.querySelector('[data-slot="test-output"]')).toBeNull()
   })
 
-  test("a failure keeps the tool's own row, shows the first error line inline, and folds the detail", async () => {
+  test("a failure keeps the tool and filename visible with an explicit label and expandable error", async () => {
     const { host, trigger, status } = mount({
       icon: "glasses",
       tool: "read",
@@ -136,10 +147,11 @@ describe("tool row lifecycle", () => {
     await settle()
     expect(host.querySelector('[data-slot="basic-tool-tool-title"]')?.textContent).toBe("Read")
     expect(status()?.getAttribute("data-outcome")).toBe("error")
-    expect(status()?.querySelector('[data-slot="basic-tool-tool-glyph"]')?.getAttribute("aria-label")).toBe("Failed")
-    const detail = host.querySelector('[data-slot="basic-tool-tool-detail"]')
-    expect(detail?.textContent).toBe("File not found: paper.pdf")
-    expect(detail?.getAttribute("data-error")).toBe("true")
+    expect(status()?.getAttribute("aria-label")).toBe("Failed")
+    const label = host.querySelector('[data-slot="basic-tool-tool-failure-label"]')
+    expect(label?.textContent).toBe("Failed")
+    expect(label?.getAttribute("title")).toBe("File not found: paper.pdf")
+    expect(host.querySelector('[data-slot="basic-tool-tool-subtitle"]')?.textContent).toBe("paper.pdf")
     expect(host.querySelector('[data-slot="basic-tool-failure"]')).toBeNull()
 
     trigger().click()
@@ -158,15 +170,22 @@ describe("tool row lifecycle", () => {
       status: "error",
       error: "Tool execution aborted",
       trigger: { title: "Shell" },
+      get children() {
+        const command = document.createElement("pre")
+        command.textContent = "$ python optional_check.py\nPartial output remains available"
+        return command
+      },
     })
     await settle()
     expect(status()?.getAttribute("data-outcome")).toBe("cancelled")
-    expect(status()?.querySelector('[data-slot="basic-tool-tool-glyph"]')?.getAttribute("aria-label")).toBe("Cancelled")
-    expect(status()?.querySelector('[data-slot="basic-tool-tool-detail"]')?.textContent).toBe("Tool execution aborted")
+    expect(status()?.getAttribute("aria-label")).toBe("Cancelled")
+    expect(status()?.getAttribute("title")).toContain("Tool execution aborted")
+    expect(host.querySelector('[data-slot="basic-tool-tool-failure-label"]')?.textContent).toBe("Cancelled")
     trigger().click()
     await settle()
     expect(host.querySelector('[data-slot="message-part-tool-error-title"]')?.textContent).toBe("Bash cancelled")
     expect(host.querySelector('[data-slot="basic-tool-failure"]')?.getAttribute("data-variant")).toBe("normal")
+    expect(host.querySelector("pre")?.textContent).toBe("$ python optional_check.py\nPartial output remains available")
   })
 
   test("a nonzero command exit is visibly unsuccessful while retaining its output receipt", async () => {
@@ -180,14 +199,17 @@ describe("tool row lifecycle", () => {
     })
     await settle()
     expect(status()?.getAttribute("data-outcome")).toBe("error")
-    expect(status()?.querySelector('[data-slot="basic-tool-tool-glyph"]')?.getAttribute("aria-label")).toBe("Failed")
-    expect(host.querySelector('[data-slot="basic-tool-tool-detail"]')?.textContent).toBe("exit 2")
+    expect(status()?.getAttribute("aria-label")).toBe("Failed")
+    expect(host.querySelector('[data-slot="basic-tool-tool-failure-label"]')?.textContent).toBe("Failed")
+    expect(status()?.getAttribute("title")).toContain("exit 2")
   })
 
-  test("rows without lifecycle props render no status rail", async () => {
+  test("rows without lifecycle props keep their icon without inventing a status", async () => {
     const { host, status } = mount({ icon: "console", trigger: { title: "Checked environment · 2 steps" } })
     await settle()
-    expect(status()).toBeNull()
+    expect(status()?.hasAttribute("data-outcome")).toBe(false)
+    expect(status()?.hasAttribute("aria-label")).toBe(false)
+    expect(status()?.querySelector('[data-icon="console"]')).not.toBeNull()
     expect(host.querySelector('[data-slot="basic-tool-tool-title"]')?.textContent).toBe("Checked environment · 2 steps")
   })
 })
@@ -202,7 +224,7 @@ describe("trajectory strings", () => {
         key.startsWith("ui.tool.calls.") ||
         key === "ui.messagePart.reasoning.thinking",
     )
-    expect(keys.length).toBe(25)
+    expect(keys.length).toBe(26)
     const dir = fileURLToPath(new URL("../i18n/", import.meta.url))
     const locales = readdirSync(dir).filter((file) => file.endsWith(".ts"))
     expect(locales.length).toBe(15)

--- a/frontend/ui/src/components/basic-tool.tsx
+++ b/frontend/ui/src/components/basic-tool.tsx
@@ -1,15 +1,12 @@
 import { children, createEffect, createMemo, createSignal, For, Match, Show, Switch, type JSX } from "solid-js"
 import { type UiI18nKey, useI18n } from "../context/i18n"
 import { Card } from "./card"
-import { useClock } from "./clock"
 import { Collapsible } from "./collapsible"
 import { Icon, IconProps } from "./icon"
 import { Spinner } from "./spinner"
-import { elapsedLabel, formatTaskDuration } from "./research-trace"
 import {
   errorLine,
   humanizeToolName,
-  runningLabel,
   toolErrorDisplay,
   toolOutcome,
   type ToolOutcome,
@@ -41,10 +38,7 @@ export interface BasicToolProps {
   forceOpen?: boolean
   locked?: boolean
   onSubtitleClick?: () => void
-  /** Lifecycle of the underlying call. Renderers spread their ToolProps, so
-   * these arrive without each renderer wiring them, and the row shows one
-   * status glyph, the live elapsed time or final duration, and a one-line
-   * receipt or the first error line. */
+  /** Preserve call state without adding another status rail to the transcript. */
   tool?: string
   status?: string
   time?: { start: number; end?: number }
@@ -59,7 +53,7 @@ export function resolveBasicToolChildren(getChildren: () => JSX.Element) {
 }
 
 const glyphLabel: Record<ToolOutcome, UiI18nKey> = {
-  pending: "ui.tool.status.running",
+  pending: "ui.tool.status.pending",
   running: "ui.tool.status.running",
   done: "ui.tool.status.done",
   error: "ui.tool.status.error",
@@ -110,24 +104,12 @@ export function BasicTool(props: BasicToolProps) {
   const outcome = createMemo(() =>
     toolOutcome(props.status, props.error, props.tool === "bash" ? props.metadata?.exit : undefined),
   )
-  const live = () => outcome() === "running" || outcome() === "pending"
-  const now = useClock(() => live() && !!props.time?.start)
-  const clock = createMemo(() => {
-    const time = props.time
-    if (!time?.start) return ""
-    if (live()) return elapsedLabel(now() - time.start)
-    const total = (time.end ?? time.start) - time.start
-    return total >= 1000 ? formatTaskDuration(total) : ""
-  })
   const detail = createMemo(() => {
     if (props.error) return errorLine(props.error)
     return (props.summary ?? []).map((item) => i18n.t(item.key, item.params)).join(" · ")
   })
   const detailed = () => !props.hideDetails && (!!props.error || !!content())
-  const title = (trigger: TriggerTitle) => {
-    const key = live() && props.tool ? runningLabel(props.tool) : undefined
-    return key ? i18n.t(key) : trigger.title
-  }
+  const failed = () => outcome() === "error" || outcome() === "cancelled"
 
   createEffect(() => {
     if (props.forceOpen) setOpen(true)
@@ -141,9 +123,33 @@ export function BasicTool(props: BasicToolProps) {
   return (
     <Collapsible open={open()} onOpenChange={handleOpenChange}>
       <Collapsible.Trigger>
-        <div data-component="tool-trigger">
+        <div data-component="tool-trigger" data-outcome={props.status ? outcome() : undefined}>
           <div data-slot="basic-tool-tool-trigger-content">
-            <Icon name={props.icon} size="small" />
+            <span
+              data-slot="basic-tool-tool-status"
+              data-outcome={props.status ? outcome() : undefined}
+              role={props.status ? "img" : undefined}
+              aria-label={props.status ? i18n.t(glyphLabel[outcome()]) : undefined}
+              title={props.status ? [i18n.t(glyphLabel[outcome()]), detail()].filter(Boolean).join(" · ") : undefined}
+            >
+              <Switch>
+                <Match when={props.status && outcome() === "pending"}>
+                  <Icon name="clock" size="small" />
+                </Match>
+                <Match when={props.status && outcome() === "running"}>
+                  <Spinner />
+                </Match>
+                <Match when={props.status && outcome() === "cancelled"}>
+                  <Icon name="circle-ban-sign" size="small" />
+                </Match>
+                <Match when={props.status && outcome() === "error"}>
+                  <Icon name="circle-x" size="small" />
+                </Match>
+                <Match when={true}>
+                  <Icon name={props.icon} size="small" />
+                </Match>
+              </Switch>
+            </span>
             <div data-slot="basic-tool-tool-info">
               <Switch>
                 <Match when={isTriggerTitle(props.trigger) && props.trigger}>
@@ -156,8 +162,13 @@ export function BasicTool(props: BasicToolProps) {
                             [trigger().titleClass ?? ""]: !!trigger().titleClass,
                           }}
                         >
-                          {title(trigger())}
+                          {trigger().title}
                         </span>
+                        <Show when={props.status && failed()}>
+                          <span data-slot="basic-tool-tool-failure-label" title={detail()}>
+                            {i18n.t(glyphLabel[outcome()])}
+                          </span>
+                        </Show>
                         <Show when={trigger().subtitle}>
                           <span
                             data-slot="basic-tool-tool-subtitle"
@@ -198,38 +209,6 @@ export function BasicTool(props: BasicToolProps) {
               </Switch>
             </div>
           </div>
-          <Show when={props.status}>
-            <span data-slot="basic-tool-tool-status" data-outcome={outcome()}>
-              <Show when={detail()}>
-                <span
-                  data-slot="basic-tool-tool-detail"
-                  data-error={outcome() === "error" ? "true" : undefined}
-                  title={detail()}
-                >
-                  {detail()}
-                </span>
-              </Show>
-              <span data-slot="basic-tool-tool-glyph" role="img" aria-label={i18n.t(glyphLabel[outcome()])}>
-                <Switch>
-                  <Match when={live()}>
-                    <Spinner />
-                  </Match>
-                  <Match when={outcome() === "done"}>
-                    <Icon name="check" size="small" />
-                  </Match>
-                  <Match when={outcome() === "cancelled"}>
-                    <Icon name="circle-ban-sign" size="small" />
-                  </Match>
-                  <Match when={true}>
-                    <Icon name="circle-x" size="small" />
-                  </Match>
-                </Switch>
-              </span>
-              <span data-slot="basic-tool-tool-time" aria-live="off">
-                {clock()}
-              </span>
-            </span>
-          </Show>
           <Show when={detailed() && !props.locked}>
             <Collapsible.Arrow />
           </Show>

--- a/frontend/ui/src/components/message-part.css
+++ b/frontend/ui/src/components/message-part.css
@@ -261,18 +261,28 @@
 [data-component="shell-output"] {
   position: relative;
   min-width: 0;
-  border-radius: var(--radius-sm);
-  background: var(--surface-inset-base, var(--surface-base));
 
   [data-slot="shell-output-actions"] {
-    display: flex;
-    justify-content: flex-end;
-    padding: 2px 4px 0;
+    position: absolute;
+    top: 0;
+    right: 4px;
+    opacity: 0;
+  }
+
+  &:hover [data-slot="shell-output-actions"],
+  &:focus-within [data-slot="shell-output-actions"] {
+    opacity: 1;
+  }
+
+  @media (hover: none) {
+    [data-slot="shell-output-actions"] {
+      opacity: 1;
+    }
   }
 
   [data-component="tool-output"] {
     min-width: 0;
-    padding: 0 12px 12px;
+    padding: 4px 40px 10px 10px;
     scrollbar-width: thin;
     overscroll-behavior: contain;
 
@@ -291,8 +301,8 @@
       white-space: pre-wrap;
       overflow-wrap: anywhere;
       font-family: var(--font-family-mono);
-      font-size: var(--font-size-small);
-      line-height: 1.6;
+      font-size: var(--font-size-medium);
+      line-height: 20px;
     }
   }
 

--- a/frontend/ui/src/components/research-trace.test.ts
+++ b/frontend/ui/src/components/research-trace.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import {
+  collapsibleTracePart,
   elapsedLabel,
   formatTaskDuration,
   stripTaskMetadata,
@@ -65,6 +66,57 @@ const lifecycle = (id: string, type: "step-start" | "step-finish", message = "ms
 }
 
 describe("literal research trace", () => {
+  test("collapses routine activity but retains answers, requests, failures, and scientific results", () => {
+    expect(collapsibleTracePart(narrative("reason", "reasoning", "Full reasoning").part)).toBe(true)
+    expect(collapsibleTracePart(narrative("answer", "text", "Final response").part)).toBe(false)
+    expect(collapsibleTracePart(entry("read", "read", "Read source").part)).toBe(true)
+    expect(collapsibleTracePart(entry("pending", "question", "Approval", "running").part, "pending")).toBe(false)
+    expect(collapsibleTracePart(entry("error", "read", "Missing file", "error").part)).toBe(false)
+    const command = entry("command", "bash", "Run calculation").part
+    if (command.type !== "tool" || command.state.status !== "completed") throw new Error("Invalid fixture")
+    command.state.metadata = { exit: 2 }
+    expect(collapsibleTracePart(command)).toBe(false)
+    command.state.metadata = { exit: 0 }
+    expect(collapsibleTracePart(command)).toBe(true)
+    command.state.metadata = { artifact: { kind: "sequence", data: { sequence: "ACGT" } } }
+    expect(collapsibleTracePart(command)).toBe(false)
+  })
+
+  test("keeps only tasks with a pending request in their bound child session outside collapse", () => {
+    const task = entry("task", "task", "Review protocol", "running").part
+    if (task.type !== "tool" || task.state.status !== "running") throw new Error("Invalid fixture")
+    task.state.metadata = { sessionId: "child" }
+    expect(collapsibleTracePart(task)).toBe(true)
+    expect(collapsibleTracePart(task, undefined, (id) => id === "unrelated")).toBe(true)
+    expect(collapsibleTracePart(task, undefined, (id) => id === "child")).toBe(false)
+    task.state.metadata = { sessionId: 12 }
+    expect(collapsibleTracePart(task, undefined, () => true)).toBe(true)
+    task.state.metadata = {}
+    expect(collapsibleTracePart(task, undefined, () => true)).toBe(true)
+  })
+
+  test("does not bury an explicitly failed kernel behind a completed tool transport", () => {
+    const kernel = entry("kernel", "python", "Evaluate control").part
+    if (kernel.type !== "tool" || kernel.state.status !== "completed") throw new Error("Invalid fixture")
+    kernel.state.metadata = { ok: false }
+    expect(collapsibleTracePart(kernel)).toBe(false)
+    kernel.state.metadata = { ok: true }
+    expect(collapsibleTracePart(kernel)).toBe(true)
+    kernel.state.metadata = { ok: "false" }
+    expect(collapsibleTracePart(kernel)).toBe(true)
+  })
+
+  test.each(["error", "timed_out", "partial"])("keeps a completed delegated %s outcome visible", (outcome) => {
+    const task = entry("task", "task", "Review protocol").part
+    if (task.type !== "tool" || task.state.status !== "completed") throw new Error("Invalid fixture")
+    task.state.metadata = { outcome }
+    expect(collapsibleTracePart(task)).toBe(false)
+    task.state.metadata = { outcome: "completed" }
+    expect(collapsibleTracePart(task)).toBe(true)
+    task.state.metadata = { outcome: "unknown" }
+    expect(collapsibleTracePart(task)).toBe(true)
+  })
+
   test("preserves prose and tool calls in their recorded order across assistant steps", () => {
     const first = narrative("reason-1", "reasoning", "First provider explanation", "msg-1")
     const read = entry("read", "read", "Read paper.tex", "completed", "msg-1")

--- a/frontend/ui/src/components/research-trace.ts
+++ b/frontend/ui/src/components/research-trace.ts
@@ -65,6 +65,28 @@ function lifecycle(part: Part) {
   return part.type === "step-start" || part.type === "step-finish" || part.type === "snapshot" || part.type === "patch"
 }
 
+/** Collapsing activity must not bury deliverables, failures, or a question the
+ * user is still answering. Keep those entries mounted at their original IDs. */
+export function collapsibleTracePart(
+  part: Part,
+  pendingRequestCallID?: string,
+  pendingChildRequest?: (sessionID: string) => boolean,
+) {
+  if (part.type === "reasoning") return true
+  if (part.type !== "tool") return false
+  if (part.callID === pendingRequestCallID || part.state.status === "error") return false
+  const child = part.tool === "task" && "metadata" in part.state ? part.state.metadata?.sessionId : undefined
+  if (typeof child === "string" && pendingChildRequest?.(child)) return false
+  if (part.state.status !== "completed") return true
+  if (part.state.metadata?.ok === false) return false
+  const outcome = part.tool === "task" ? part.state.metadata?.outcome : undefined
+  if (outcome === "error" || outcome === "timed_out" || outcome === "partial") return false
+  if (part.state.metadata?.artifact) return false
+  if (part.tool === "bash" && typeof part.state.metadata?.exit === "number" && part.state.metadata.exit !== 0)
+    return false
+  return true
+}
+
 /**
  * Keep received prose and tool calls unchanged and chronological. Only
  * lifecycle markers, unreadable reasoning, and entries presented elsewhere are omitted; streaming

--- a/frontend/ui/src/components/session-turn-trajectory.test.ts
+++ b/frontend/ui/src/components/session-turn-trajectory.test.ts
@@ -207,7 +207,7 @@ describe("reasoning rows", () => {
     expect(host.querySelector('[data-component="reasoning-part"]')).toBeNull()
   })
 
-  test("show/hide reasoning preserves live text, tool disclosure, and the saved visibility choice", async () => {
+  test("one turn's classic disclosure preserves streamed prose and its saved expansion choice", async () => {
     const message = assistant()
     const reason = reasoning("prt_reason", { start: Date.now() })
     const command = read("prt_read", "/research/protocol.md", 1_000)
@@ -224,35 +224,29 @@ describe("reasoning rows", () => {
       message: { [sessionID]: [user, message] },
       part: { [user.id]: [], [message.id]: [reason, command, answer] },
     })
-    const [preference, setPreference] = reactive.createStore({ show: true })
+    const [preference, setPreference] = reactive.createStore({ expanded: true })
     const view = () =>
       turn.SessionTurn({
         sessionID,
         messageID: user.id,
         lastUserMessageID: user.id,
-        get showReasoning() {
-          return preference.show
+        get stepsExpanded() {
+          return preference.expanded
         },
-        onShowReasoningChange: (show) => setPreference("show", show),
+        onStepsExpandedToggle: () => setPreference("expanded", !preference.expanded),
       })
     const host = mount(view, store)
     await ready(() => host.querySelector('[data-slot="reasoning-part-body"] p') !== null)
-    const toggle = host.querySelector<HTMLButtonElement>('[data-slot="session-turn-reasoning-toggle"]')!
-    expect(toggle.textContent).toContain("Hide reasoning")
+    const toggle = host.querySelector<HTMLButtonElement>('[data-slot="session-turn-collapsible-trigger-content"]')!
     expect(toggle.getAttribute("aria-expanded")).toBe("true")
-    const tool = host.querySelector('[data-component="tool-part-wrapper"]')!
-    const disclosure = tool.querySelector<HTMLButtonElement>('[data-slot="collapsible-trigger"]')!
-    disclosure.click()
-    await ready(() => disclosure.getAttribute("aria-expanded") === "true")
 
     toggle.click()
     await ready(() => host.querySelector('[data-component="reasoning-part"]') === null)
-    expect(preference.show).toBe(false)
-    expect(toggle.textContent).toContain("Show reasoning")
+    expect(preference.expanded).toBe(false)
     expect(toggle.getAttribute("aria-expanded")).toBe("false")
     expect(host.textContent).toContain(answer.text)
-    expect(host.querySelector('[data-component="tool-part-wrapper"]')).toBe(tool)
-    expect(disclosure.getAttribute("aria-expanded")).toBe("true")
+    expect(host.querySelector('[data-component="tool-part-wrapper"]')).toBeNull()
+    const prose = host.querySelector('[data-component="text-part"]')
     const continued = reason.text + "\n\nNew streamed evidence."
     setStore("part", message.id, 0, { ...reason, text: continued })
     await settle()
@@ -263,23 +257,28 @@ describe("reasoning rows", () => {
         host.querySelector('[data-slot="reasoning-part-body"]')?.textContent?.includes("New streamed evidence.") ===
         true,
     )
-    expect(host.querySelector('[data-component="tool-part-wrapper"]')).toBe(tool)
+    expect(host.querySelector('[data-component="tool-part-wrapper"]')).not.toBeNull()
+    expect(host.querySelector('[data-component="text-part"]')).toBe(prose)
 
     toggle.click()
     setStore("message", sessionID, 1, { ...message, time: { ...message.time, completed: Date.now() } })
+    setStore("session_status", sessionID, { type: "idle" })
     cleanups.splice(0).forEach((cleanup) => cleanup())
     document.body.replaceChildren()
     const again = mount(view, store)
-    await ready(() => again.querySelector('[data-slot="session-turn-reasoning-toggle"]') !== null)
+    await ready(() => again.querySelector('[data-slot="session-turn-collapsible-trigger-content"]') !== null)
     expect(again.querySelector('[data-component="reasoning-part"]')).toBeNull()
-    again.querySelector<HTMLButtonElement>('[data-slot="session-turn-reasoning-toggle"]')!.click()
+    const restored = again.querySelector<HTMLButtonElement>('[data-slot="session-turn-collapsible-trigger-content"]')!
+    expect(restored.textContent).toContain("Show reasoning and activity")
+    restored.click()
     await ready(() => again.textContent?.includes("New streamed evidence.") === true)
+    expect(restored.textContent).toContain("Hide reasoning and activity")
     expect(store.part[message.id][0]).toMatchObject({ text: continued })
     expect(again.textContent).not.toContain("Detailed")
     expect(again.textContent).not.toContain("Compact")
   })
 
-  test("visibility works for consumers without a settings callback", async () => {
+  test("completed turns start quietly collapsed and can open without a settings callback", async () => {
     const message = assistant(2_000)
     const store: Store = {
       ...empty(),
@@ -287,12 +286,13 @@ describe("reasoning rows", () => {
       part: { [user.id]: [], [message.id]: [reasoning("prt_reason", { start: 1_000, end: 2_000 })] },
     }
     const host = mount(() => turn.SessionTurn({ sessionID, messageID: user.id }), store)
+    expect(host.querySelector('[data-component="reasoning-part"]')).toBeNull()
+    const toggle = host.querySelector<HTMLButtonElement>('[data-slot="session-turn-collapsible-trigger-content"]')!
+    expect(toggle.textContent).toContain("Show reasoning and activity")
+    toggle.click()
     await ready(() => host.querySelector('[data-component="reasoning-part"]') !== null)
-    const toggle = host.querySelector<HTMLButtonElement>('[data-slot="session-turn-reasoning-toggle"]')!
     toggle.click()
     await ready(() => host.querySelector('[data-component="reasoning-part"]') === null)
-    toggle.click()
-    await ready(() => host.querySelector('[data-component="reasoning-part"]') !== null)
   })
 
   test("interleaved encrypted parts do not add blank rows or repeated notices to a completed turn", async () => {
@@ -313,9 +313,12 @@ describe("reasoning rows", () => {
         ],
       },
     }
-    const host = mount(() => turn.SessionTurn({ sessionID, messageID: user.id, lastUserMessageID: user.id }), store)
+    const host = mount(
+      () => turn.SessionTurn({ sessionID, messageID: user.id, lastUserMessageID: user.id, stepsExpanded: true }),
+      store,
+    )
     await ready(() => host.textContent?.includes(answer.text) === true)
-    expect(host.querySelector('[data-slot="session-turn-status"]')).not.toBeNull()
+    expect(host.querySelector('[data-slot="session-turn-collapsible-trigger-content"]')).not.toBeNull()
     expect(host.querySelectorAll('[data-component="reasoning-part"]')).toHaveLength(1)
     expect(host.querySelector('[data-slot="reasoning-part-body"]')?.textContent).toContain(visible.text)
     expect(host.querySelector('[data-origin="provider-reasoning-unavailable"]')).toBeNull()
@@ -347,7 +350,7 @@ describe("streaming prose", () => {
 })
 
 describe("chronological activity in a turn", () => {
-  test("completed operations stay individually visible without an outer disclosure or mode selector", async () => {
+  test("completed operations expand into individual chronological rows without a mode selector", async () => {
     const message = assistant(5_000)
     const store: Store = {
       ...empty(),
@@ -358,13 +361,15 @@ describe("chronological activity in a turn", () => {
       },
     }
     const host = mount(() => turn.SessionTurn({ sessionID, messageID: user.id }), store)
+    const status = host.querySelector<HTMLButtonElement>('[data-slot="session-turn-collapsible-trigger-content"]')!
+    expect(status.getAttribute("aria-expanded")).toBe("false")
+    status.click()
     await ready(() => host.querySelectorAll('[data-component="tool-part-wrapper"]').length === 2)
     expect(host.querySelector('[data-component="trace-run-group"]')).toBeNull()
     expect(host.textContent).toContain("paper.tex")
     expect(host.textContent).toContain("analysis.py")
-    const status = host.querySelector('[data-slot="session-turn-status"]')!
-    expect(status.tagName).not.toBe("BUTTON")
-    expect(status.hasAttribute("aria-expanded")).toBe(false)
+    expect(status.tagName).toBe("BUTTON")
+    expect(status.getAttribute("aria-expanded")).toBe("true")
     expect(host.querySelector('[data-slot="session-turn-activity-mode"]')).toBeNull()
   })
 
@@ -401,13 +406,13 @@ describe("chronological activity in a turn", () => {
     expect(
       [...rows].slice(0, 3).map((row) => row.querySelector('[data-slot="basic-tool-tool-subtitle"]')?.textContent),
     ).toEqual(["paper.tex", "analysis.py", "results.csv"])
-    expect(rows[1]?.querySelector('[data-slot="basic-tool-tool-detail"]')?.textContent).toBe("2 lines")
+    expect(rows[1]?.querySelector('[data-slot="basic-tool-tool-detail"]')).toBeNull()
 
     const live = host.querySelector('[data-component="tool-part-wrapper"][data-tool-status="running"]')!
     expect(live.closest('[data-component="trace-run-group"]')).toBeNull()
-    expect(live.querySelector('[data-slot="basic-tool-tool-title"]')?.textContent).toBe("Searching")
+    expect(live.querySelector('[data-slot="basic-tool-tool-title"]')?.textContent).toBe("Grep")
     expect(live.querySelector('[data-slot="basic-tool-tool-status"]')?.getAttribute("data-outcome")).toBe("running")
-    expect(live.querySelector('[data-slot="basic-tool-tool-time"]')?.textContent).toBe("2s")
+    expect(live.querySelector('[data-slot="basic-tool-tool-time"]')).toBeNull()
   })
 
   test("a call that just finished keeps its own row and receipt while the turn works", async () => {
@@ -449,7 +454,7 @@ describe("chronological activity in a turn", () => {
     const second = row("analysis.py")
     expect(second.getAttribute("data-tool-status")).toBe("completed")
     expect(second.querySelector('[data-slot="basic-tool-tool-status"]')?.getAttribute("data-outcome")).toBe("done")
-    expect(second.querySelector('[data-slot="basic-tool-tool-detail"]')?.textContent).toBe("2 lines")
+    expect(second.querySelector('[data-slot="basic-tool-tool-detail"]')).toBeNull()
     expect(row("paper.tex").querySelector('[data-slot="collapsible-trigger"]')?.getAttribute("aria-expanded")).toBe(
       "true",
     )
@@ -870,7 +875,9 @@ describe("timeout recovery", () => {
       expect(host.querySelector('[data-slot="reasoning-part-body"]')?.textContent).toContain(reason.text)
       expect(host.textContent).toContain(partial.text)
       expect(host.querySelector('[data-component="reasoning-part"]')?.getAttribute("data-live")).toBeNull()
-      expect(host.querySelector('[data-slot="session-turn-status"] [data-component="spinner"]')).toBeNull()
+      expect(
+        host.querySelector('[data-slot="session-turn-collapsible-trigger-content"] [data-component="spinner"]'),
+      ).toBeNull()
       expect(host.querySelector('[data-slot="session-turn-retry-message"]')).toBeNull()
       expect(host.querySelector('[data-slot="session-turn-progress-hint"]')).toBeNull()
 
@@ -896,7 +903,245 @@ describe("timeout recovery", () => {
           "Waiting for output from openai/gpt-5.6-sol",
         ),
       )
-      expect(host.querySelector('[data-slot="session-turn-status"] [data-component="spinner"]')).not.toBeNull()
+      expect(
+        host.querySelector('[data-slot="session-turn-collapsible-trigger-content"] [data-component="spinner"]'),
+      ).not.toBeNull()
     },
   )
+})
+
+describe("collapsed activity safeguards", () => {
+  test("keeps a pending question and its unsent selections and custom draft mounted across activity toggles", async () => {
+    const message = assistant()
+    const question: ToolPart = {
+      id: "prt_pending_question",
+      sessionID,
+      messageID: message.id,
+      type: "tool",
+      tool: "question",
+      callID: "call_pending_question",
+      state: {
+        status: "running",
+        input: {},
+        title: "Choose evaluation conditions",
+        metadata: {},
+        time: { start: Date.now() },
+      },
+    }
+    const store: Store = {
+      ...empty(),
+      session_status: { [sessionID]: { type: "busy" } },
+      message: { [sessionID]: [user, message] },
+      part: { [user.id]: [], [message.id]: [read("prt_before_question", "/research/protocol.md", 1_000), question] },
+      question: {
+        [sessionID]: [
+          {
+            id: "que_pending_draft",
+            sessionID,
+            tool: { messageID: message.id, callID: question.callID },
+            questions: [
+              {
+                header: "Conditions",
+                question: "Which evaluation conditions should be included?",
+                multiple: true,
+                options: [
+                  { label: "Stock", description: "Include the unchanged baseline." },
+                  { label: "Sham", description: "Include the procedural control." },
+                ],
+              },
+              {
+                header: "Confirmation",
+                question: "When should confirmation run?",
+                options: [{ label: "After review", description: "Wait for protocol review." }],
+              },
+            ],
+          },
+        ],
+      },
+    }
+    const host = mount(() => turn.SessionTurn({ sessionID, messageID: user.id }), store)
+    await ready(() => host.querySelector('[data-component="question-prompt"]') !== null)
+    const prompt = host.querySelector('[data-component="question-prompt"]')!
+    const options = prompt.querySelectorAll<HTMLButtonElement>('[data-slot="question-option"]')
+    options[0].click()
+    options[options.length - 1].click()
+    await ready(() => prompt.querySelector('[data-slot="custom-input"]') !== null)
+    const input = prompt.querySelector<HTMLInputElement>('[data-slot="custom-input"]')!
+    input.value = "A matched held-out control"
+    input.dispatchEvent(new window.Event("input", { bubbles: true }))
+    const toggle = host.querySelector<HTMLButtonElement>('[data-slot="session-turn-collapsible-trigger-content"]')!
+    expect(toggle.getAttribute("aria-expanded")).toBe("true")
+    const tool = prompt.closest('[data-component="tool-part-wrapper"]')!
+
+    for (const expanded of [false, true, false]) {
+      toggle.click()
+      await ready(() => toggle.getAttribute("aria-expanded") === String(expanded))
+      expect(host.querySelectorAll('[data-component="question-prompt"]')).toHaveLength(1)
+      expect(host.querySelector('[data-component="question-prompt"]')).toBe(prompt)
+      expect(prompt.closest('[data-component="tool-part-wrapper"]')).toBe(tool)
+      expect(input.isConnected).toBe(true)
+      expect(prompt.querySelector('[data-slot="custom-input"]')).toBe(input)
+      expect(input.value).toBe("A matched held-out control")
+      expect(options[0].getAttribute("data-picked")).toBe("true")
+      expect(prompt.querySelector('[data-slot="question-tab"][data-active="true"]')?.textContent).toBe("Conditions")
+      expect(host.querySelectorAll('[data-component="tool-part-wrapper"]')).toHaveLength(expanded ? 2 : 1)
+    }
+    expect(store.part[message.id][1]).toBe(question)
+    expect(store.question?.[sessionID]).toHaveLength(1)
+  })
+
+  test("keeps a completed turn's tool error visible while ordinary activity is collapsed", async () => {
+    const message = assistant(3_000)
+    const error = "Measurement file was not found. No result was produced."
+    const failed: ToolPart = {
+      id: "prt_failed_command",
+      sessionID,
+      messageID: message.id,
+      type: "tool",
+      tool: "bash",
+      callID: "call_failed_command",
+      state: {
+        status: "error",
+        input: { command: "inspect measurements" },
+        error,
+        time: { start: 2_000, end: 3_000 },
+      },
+    }
+    const store: Store = {
+      ...empty(),
+      message: { [sessionID]: [user, message] },
+      part: { [user.id]: [], [message.id]: [read("prt_successful_read", "/research/protocol.md", 1_000), failed] },
+    }
+    const host = mount(() => turn.SessionTurn({ sessionID, messageID: user.id }), store)
+    await ready(() => host.querySelector('[data-slot="basic-tool-tool-failure-label"]') !== null)
+    const toggle = host.querySelector<HTMLButtonElement>('[data-slot="session-turn-collapsible-trigger-content"]')!
+    const failure = host.querySelector('[data-component="tool-part-wrapper"][data-tool-status="error"]')!
+    expect(toggle.getAttribute("aria-expanded")).toBe("false")
+    expect(host.querySelectorAll('[data-component="tool-part-wrapper"]')).toHaveLength(1)
+    expect(failure.querySelector('[data-slot="basic-tool-tool-failure-label"]')?.textContent).toBe("Failed")
+    expect(failure.querySelector('[data-slot="basic-tool-tool-failure-label"]')?.getAttribute("title")).toBe(error)
+    expect(message.error).toBeUndefined()
+    failure.querySelector<HTMLButtonElement>('[data-slot="collapsible-trigger"]')!.click()
+    await ready(() => failure.querySelector('[data-component="tool-error"]') !== null)
+    expect(failure.textContent).toContain(error)
+
+    for (const expanded of [true, false]) {
+      toggle.click()
+      await ready(() => toggle.getAttribute("aria-expanded") === String(expanded))
+      expect(host.querySelector('[data-component="tool-part-wrapper"][data-tool-status="error"]')).toBe(failure)
+      expect(failure.querySelector('[data-component="tool-error"]')).not.toBeNull()
+      expect(failure.textContent).toContain(error)
+      expect(host.querySelectorAll('[data-component="tool-part-wrapper"]')).toHaveLength(expanded ? 2 : 1)
+    }
+    expect(store.part[message.id][1]).toBe(failed)
+  })
+})
+
+describe("delegated request visibility", () => {
+  const childID = "ses_child_request"
+  const task = (messageID: string): ToolPart => ({
+    id: "prt_child_task",
+    sessionID,
+    messageID,
+    type: "tool",
+    tool: "task",
+    callID: "call_child_task",
+    state: {
+      status: "running",
+      input: { description: "Review the evaluation protocol", subagent_type: "research" },
+      title: "Review the evaluation protocol",
+      metadata: { sessionId: childID },
+      time: { start: Date.now() },
+    },
+  })
+
+  test("preserves a child question draft when its parent's activity is collapsed", async () => {
+    const message = assistant()
+    const store: Store = {
+      ...empty(),
+      session_status: { [sessionID]: { type: "busy" } },
+      message: { [sessionID]: [user, message] },
+      part: { [user.id]: [], [message.id]: [task(message.id)] },
+      question: {
+        [childID]: [
+          {
+            id: "que_child_draft",
+            sessionID: childID,
+            tool: { messageID: "msg_child_question", callID: "call_child_question" },
+            questions: [
+              {
+                header: "Controls",
+                question: "Which controls should the delegated review include?",
+                multiple: true,
+                options: [{ label: "Sham", description: "Include a procedural control." }],
+              },
+            ],
+          },
+        ],
+      },
+    }
+    const host = mount(() => turn.SessionTurn({ sessionID, messageID: user.id }), store)
+    await ready(() => host.querySelector('[data-component="question-prompt"]') !== null)
+    const prompt = host.querySelector('[data-component="question-prompt"]')!
+    const options = prompt.querySelectorAll<HTMLButtonElement>('[data-slot="question-option"]')
+    options[0].click()
+    options[options.length - 1].click()
+    await ready(() => prompt.querySelector('[data-slot="custom-input"]') !== null)
+    const input = prompt.querySelector<HTMLInputElement>('[data-slot="custom-input"]')!
+    input.value = "Match the instrument calibration"
+    input.dispatchEvent(new window.Event("input", { bubbles: true }))
+    const toggle = host.querySelector<HTMLButtonElement>('[data-slot="session-turn-collapsible-trigger-content"]')!
+
+    for (const expanded of [false, true, false]) {
+      toggle.click()
+      await ready(() => toggle.getAttribute("aria-expanded") === String(expanded))
+      expect(host.querySelectorAll('[data-component="question-prompt"]')).toHaveLength(1)
+      expect(host.querySelector('[data-component="question-prompt"]')).toBe(prompt)
+      expect(prompt.querySelector('[data-slot="custom-input"]')).toBe(input)
+      expect(input.isConnected).toBe(true)
+      expect(input.value).toBe("Match the instrument calibration")
+      expect(options[0].getAttribute("data-picked")).toBe("true")
+    }
+    expect(store.question?.[sessionID]).toBeUndefined()
+    expect(store.question?.[childID]).toHaveLength(1)
+  })
+
+  test("reveals a new child permission in collapsed activity and restores ordinary task collapse after resolution", async () => {
+    const message = assistant()
+    const [store, setStore] = reactive.createStore<Store>({
+      ...empty(),
+      session_status: { [sessionID]: { type: "busy" } },
+      message: { [sessionID]: [user, message] },
+      part: { [user.id]: [], [message.id]: [task(message.id)] },
+      permission: { [childID]: [] },
+    })
+    const host = mount(() => turn.SessionTurn({ sessionID, messageID: user.id, stepsExpanded: false }), store)
+    await settle()
+    expect(host.querySelector('[data-component="tool-part-wrapper"]')).toBeNull()
+    setStore("permission", childID, [
+      {
+        id: "per_child_read",
+        sessionID: childID,
+        permission: "read",
+        patterns: ["/research/control.csv"],
+        always: [],
+        metadata: { query: "Read /research/control.csv" },
+        tool: { messageID: "msg_child_read", callID: "call_child_read" },
+      },
+    ])
+    await ready(() => host.querySelector('[data-component="permission-prompt"]') !== null)
+    const permission = host.querySelector('[data-component="permission-prompt"]')!
+    expect(host.querySelectorAll('[data-component="permission-prompt"]')).toHaveLength(1)
+    expect(permission.textContent).toContain("/research/control.csv")
+    expect(permission.querySelectorAll("button").length).toBeGreaterThan(0)
+    expect(
+      host.querySelector('[data-slot="session-turn-collapsible-trigger-content"]')?.getAttribute("aria-expanded"),
+    ).toBe("false")
+    expect(store.permission?.[sessionID]).toBeUndefined()
+
+    setStore("permission", childID, [])
+    await ready(() => host.querySelector('[data-component="permission-prompt"]') === null)
+    expect(host.querySelector('[data-component="tool-part-wrapper"]')).toBeNull()
+    expect(store.part[message.id][0].type).toBe("tool")
+  })
 })

--- a/frontend/ui/src/components/session-turn.css
+++ b/frontend/ui/src/components/session-turn.css
@@ -30,40 +30,6 @@
     min-width: 0;
   }
 
-  [data-slot="session-turn-reasoning-toggle"] {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-    min-height: 32px;
-    padding: 4px 8px;
-    border: 0;
-    border-radius: var(--radius-xs);
-    background: transparent;
-    color: var(--text-weak);
-    font-size: var(--font-size-small);
-    cursor: pointer;
-
-    &[aria-expanded="true"] [data-slot="icon-svg"] {
-      transform: rotate(180deg);
-    }
-
-    &:hover {
-      background: var(--surface-raised-base);
-      color: var(--text-base);
-    }
-
-    &:focus-visible {
-      outline: 2px solid var(--color-focus);
-      outline-offset: 1px;
-    }
-  }
-
-  [data-slot="session-turn-progress-hint"] {
-    flex-basis: 100%;
-    color: var(--text-weak);
-    font-size: var(--font-size-small);
-  }
-
   [data-slot="session-turn-message-container"] {
     display: flex;
     flex-direction: column;
@@ -594,14 +560,27 @@
     }
   }
 
-  [data-slot="session-turn-status"] {
+  [data-slot="session-turn-collapsible-trigger-content"] {
     max-width: 100%;
-    min-height: 24px;
+    min-height: 32px;
     display: flex;
     align-items: center;
     gap: 8px;
+    padding: 6px 10px;
+    margin: -6px -10px;
+    border-radius: var(--radius-xs);
     color: var(--text-weak);
     font-size: var(--font-size-small);
+    cursor: pointer;
+
+    [data-slot="session-turn-trigger-icon"] {
+      flex-shrink: 0;
+      transform: rotate(-90deg);
+    }
+
+    &[aria-expanded="true"] [data-slot="session-turn-trigger-icon"] {
+      transform: none;
+    }
 
     [data-component="spinner"] {
       width: 12px;
@@ -629,13 +608,6 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-  }
-
-  [data-slot="session-turn-progress-hint"] {
-    margin-top: 6px;
-    font-size: var(--font-size-small);
-    line-height: var(--line-height-large);
-    color: var(--text-weak);
   }
 
   [data-slot="session-turn-details-text"] {

--- a/frontend/ui/src/components/session-turn.tsx
+++ b/frontend/ui/src/components/session-turn.tsx
@@ -41,7 +41,7 @@ import { createAutoScroll } from "../hooks"
 import { createResizeObserver } from "@solid-primitives/resize-observer"
 import { responseText } from "./session-turn-response"
 import { progressStatus } from "./session-turn-progress"
-import { visibleResearchTrace } from "./research-trace"
+import { collapsibleTracePart, visibleResearchTrace } from "./research-trace"
 import { MarkdownFileScope } from "./markdown"
 
 type Translator = (key: UiI18nKey, params?: UiI18nParams) => string
@@ -126,9 +126,11 @@ function isGeneratedTool(part: PartType | undefined): part is ToolPart {
   return part?.type === "tool" && part.tool === "artifact" && part.state.status === "completed"
 }
 
-function AssistantTrace(props: { messages: AssistantMessage[]; showReasoning: boolean }) {
+function AssistantTrace(props: { messages: AssistantMessage[]; expanded: boolean; pendingRequestCallID?: string }) {
   const data = useData()
   const emptyParts: PartType[] = []
+  const pendingChildRequest = (sessionID: string) =>
+    !!(data.store.permission?.[sessionID]?.[0] || data.store.question?.[sessionID]?.[0])
   const trace = createMemo(() =>
     visibleResearchTrace(
       props.messages.flatMap((message) =>
@@ -136,7 +138,7 @@ function AssistantTrace(props: { messages: AssistantMessage[]; showReasoning: bo
           message,
           part,
           hidden:
-            (!props.showReasoning && part.type === "reasoning") ||
+            (!props.expanded && collapsibleTracePart(part, props.pendingRequestCallID, pendingChildRequest)) ||
             (part.type === "tool" && part.tool === "todoread") ||
             isGeneratedTool(part),
         })),
@@ -188,8 +190,8 @@ export function SessionTurn(
     sessionTitle?: string
     messageID: string
     lastUserMessageID?: string
-    showReasoning?: boolean
-    onShowReasoningChange?: (show: boolean) => void
+    stepsExpanded?: boolean
+    onStepsExpandedToggle?: () => void
     onUserInteracted?: () => void
     classes?: {
       root?: string
@@ -293,14 +295,6 @@ export function SessionTurn(
   const lastAssistantMessage = createMemo(() => assistantMessages().at(-1))
 
   const error = createMemo(() => assistantMessages().find((m) => m.error)?.error)
-
-  const hasReasoning = createMemo(() =>
-    assistantMessages().some((message) =>
-      (data.store.part[message.id] ?? emptyParts).some(
-        (part) => part.type === "reasoning" && !!reasoningDisplayText(part.text),
-      ),
-    ),
-  )
 
   const hasSteps = createMemo(() => {
     for (const m of assistantMessages()) {
@@ -547,7 +541,7 @@ export function SessionTurn(
   const diffBatch = 20
 
   const [store, setStore] = createStore({
-    showReasoning: true,
+    stepsExpanded: undefined as boolean | undefined,
     retrySeconds: 0,
     now: Date.now(),
     diffsOpen: [] as string[],
@@ -557,13 +551,18 @@ export function SessionTurn(
     duration: duration(),
   })
 
-  const showReasoning = () => props.showReasoning ?? store.showReasoning
-  const toggleReasoning = () => {
-    const show = !showReasoning()
-    setStore("showReasoning", show)
-    props.onShowReasoningChange?.(show)
+  const expanded = () => props.stepsExpanded ?? store.stepsExpanded ?? false
+  const toggleSteps = () => {
     props.onUserInteracted?.()
+    if (props.onStepsExpandedToggle) return props.onStepsExpandedToggle()
+    setStore("stepsExpanded", !expanded())
   }
+
+  // Open a live turn once. Finishing a response must not collapse the text
+  // underneath someone reading it, and an explicit collapse must stay put.
+  createEffect(() => {
+    if (working() && store.stepsExpanded === undefined) setStore("stepsExpanded", true)
+  })
 
   createEffect(
     on(
@@ -676,12 +675,24 @@ export function SessionTurn(
                         <Message message={msg()} parts={stickyParts()} />
                       </div>
 
-                      {/* Keep request state beside its originating user message. */}
+                      {/* One disclosure owns this turn's trace, never the whole conversation. */}
                       <Show when={working() || hasSteps()}>
                         <div data-slot="session-turn-response-trigger">
-                          <div data-slot="session-turn-status">
+                          <Button
+                            type="button"
+                            data-slot="session-turn-collapsible-trigger-content"
+                            data-expandable={hasSteps()}
+                            variant="ghost"
+                            size="small"
+                            aria-expanded={expanded()}
+                            onClick={toggleSteps}
+                            title={working() ? statusText() : undefined}
+                          >
                             <Show when={working()}>
                               <Spinner />
+                            </Show>
+                            <Show when={!working()}>
+                              <Icon name="chevron-down" size="small" data-slot="session-turn-trigger-icon" />
                             </Show>
                             <Switch>
                               <Match when={retry()}>
@@ -697,8 +708,10 @@ export function SessionTurn(
                               <Match when={working()}>
                                 <span data-slot="session-turn-status-text">{statusText()}</span>
                               </Match>
-                              <Match when={true}>
-                                <span data-slot="session-turn-status-text">{i18n.t("ui.sessionTurn.trace.title")}</span>
+                              <Match when={!working()}>
+                                <span data-slot="session-turn-status-text">
+                                  {i18n.t(expanded() ? "ui.sessionTurn.steps.hide" : "ui.sessionTurn.steps.show")}
+                                </span>
                               </Match>
                             </Switch>
                             <Show when={!working() || !phase()}>
@@ -707,34 +720,18 @@ export function SessionTurn(
                                 {store.duration}
                               </span>
                             </Show>
-                          </div>
-                          <Show when={hasReasoning()}>
-                            <button
-                              type="button"
-                              data-slot="session-turn-reasoning-toggle"
-                              aria-expanded={showReasoning()}
-                              onClick={toggleReasoning}
-                            >
-                              <Icon name="chevron-down" size="small" />
-                              {i18n.t(
-                                showReasoning() ? "ui.sessionTurn.reasoning.hide" : "ui.sessionTurn.reasoning.show",
-                              )}
-                            </button>
-                          </Show>
-                          <Show when={working() && phase()?.hint}>
-                            {(hint) => (
-                              <div data-slot="session-turn-progress-hint" role="status" aria-live="polite">
-                                {i18n.t(hint())}
-                              </div>
-                            )}
-                          </Show>
+                          </Button>
                         </div>
                       </Show>
                     </div>
                     <Show when={assistantMessages().length > 0}>
-                      <div data-slot="session-turn-response-section">
+                      <div data-slot="session-turn-response-section" data-expanded={expanded() ? "true" : undefined}>
                         <MarkdownFileScope paths={linkedFiles()}>
-                          <AssistantTrace messages={assistantMessages()} showReasoning={showReasoning()} />
+                          <AssistantTrace
+                            messages={assistantMessages()}
+                            expanded={expanded()}
+                            pendingRequestCallID={requestTool()?.callID}
+                          />
                         </MarkdownFileScope>
                         <Show when={response()}>
                           <div

--- a/frontend/ui/src/hooks/create-auto-scroll.test.ts
+++ b/frontend/ui/src/hooks/create-auto-scroll.test.ts
@@ -1,0 +1,177 @@
+import { afterAll, afterEach, describe, expect, test } from "bun:test"
+import { fileURLToPath } from "node:url"
+import { createServer } from "vite"
+import solid from "vite-plugin-solid"
+
+const observers = new Set<Observer>()
+const previousObserver = globalThis.ResizeObserver
+class Observer {
+  targets = new Set<Element>()
+  constructor(readonly callback: ResizeObserverCallback) {
+    observers.add(this)
+  }
+  observe(target: Element) {
+    this.targets.add(target)
+  }
+  unobserve(target: Element) {
+    this.targets.delete(target)
+  }
+  disconnect() {
+    this.targets.clear()
+    observers.delete(this)
+  }
+}
+Object.assign(globalThis, { ResizeObserver: Observer })
+const vite = await createServer({
+  configFile: false,
+  root: fileURLToPath(new URL("../../", import.meta.url)),
+  logLevel: "silent",
+  plugins: [solid({ ssr: false, dev: false })],
+  server: { middlewareMode: true, watch: null },
+  appType: "custom",
+  resolve: { conditions: ["browser", "production"], dedupe: ["solid-js"] },
+  ssr: { noExternal: true, resolve: { conditions: ["browser", "production"] } },
+})
+const reactive = (await vite.ssrLoadModule("solid-js")) as typeof import("solid-js")
+const hooks = (await vite.ssrLoadModule("/src/hooks/create-auto-scroll.tsx")) as typeof import("./create-auto-scroll")
+const cleanups: Array<() => void> = []
+const settle = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+const fixture = async (working = false) => {
+  const scroll = document.createElement("div")
+  const content = document.createElement("div")
+  const button = document.createElement("button")
+  button.setAttribute("aria-expanded", "false")
+  content.append(button)
+  scroll.append(content)
+  document.body.append(scroll)
+  const size = { height: 3000, viewport: 500, button: 2750, top: 2500 }
+  Object.defineProperties(scroll, {
+    scrollHeight: { get: () => size.height },
+    clientHeight: { get: () => size.viewport },
+    scrollTop: {
+      get: () => size.top,
+      set: (value: number) => (size.top = Math.max(0, Math.min(value, size.height - size.viewport))),
+    },
+  })
+  content.getBoundingClientRect = () => new DOMRect(0, -size.top, 700, size.height)
+  button.getBoundingClientRect = () => new DOMRect(0, size.button - size.top, 100, 24)
+  const follow = reactive.createRoot((dispose) => {
+    cleanups.push(dispose)
+    const follow = hooks.createAutoScroll({ working: () => working })
+    follow.scrollRef(scroll)
+    follow.contentRef(content)
+    return follow
+  })
+  await settle()
+  const resize = (target = content) => {
+    for (const observer of [...observers]) {
+      if (!observer.targets.has(target)) continue
+      const rect = target === content ? content.getBoundingClientRect() : new DOMRect(0, 0, 700, size.viewport)
+      const box = [{ inlineSize: rect.width, blockSize: rect.height }]
+      observer.callback(
+        [{ target, contentRect: rect, borderBoxSize: box, contentBoxSize: box, devicePixelContentBoxSize: box }],
+        observer,
+      )
+    }
+  }
+  resize()
+  return { scroll, content, button, size, follow, resize }
+}
+
+afterEach(() => {
+  cleanups.splice(0).forEach((dispose) => dispose())
+  document.body.replaceChildren()
+})
+afterAll(async () => {
+  Object.assign(globalThis, { ResizeObserver: previousObserver })
+  await vite.close()
+})
+
+describe("conversation scroll anchoring", () => {
+  test.each([false, true])(
+    "disclosure keeps its viewport position during earlier-content expansion (working=%s)",
+    async (working) => {
+      const view = await fixture(working)
+      const before = view.button.getBoundingClientRect().top
+      view.button.addEventListener("click", () => {
+        view.size.height += 4000
+        view.size.button += 4000
+      })
+      view.button.click()
+      view.resize()
+      expect(view.button.getBoundingClientRect().top).toBe(before)
+      expect(view.follow.userScrolled()).toBe(true)
+    },
+  )
+
+  test("native anchor correction is not counted twice, including keyboard-generated clicks", async () => {
+    const view = await fixture()
+    const before = view.button.getBoundingClientRect().top
+    view.button.dispatchEvent(new MouseEvent("click", { bubbles: true, detail: 0 }))
+    view.size.height += 1000
+    view.size.button += 1000
+    view.size.top += 1000
+    view.resize()
+    expect(view.button.getBoundingClientRect().top).toBe(before)
+    expect(view.size.top).toBe(3500)
+  })
+
+  test("manual scrolling cancels disclosure restoration and resume releases the old anchor", async () => {
+    const view = await fixture(true)
+    view.button.click()
+    view.scroll.dispatchEvent(new WheelEvent("wheel", { deltaY: -40 }))
+    view.size.top -= 40
+    view.size.height += 500
+    view.size.button += 500
+    view.resize()
+    expect(view.size.top).toBe(2460)
+    view.button.click()
+    view.follow.resume()
+    view.size.height += 200
+    view.resize()
+    expect(view.size.top).toBe(view.size.height - view.size.viewport)
+  })
+
+  test("viewport resizing keeps live bottom-follow without recapturing a detached reader", async () => {
+    const view = await fixture(true)
+    view.size.viewport = 300
+    view.resize(view.scroll)
+    expect(view.size.top).toBe(2700)
+    view.size.top = 1000
+    view.follow.handleScroll()
+    view.size.viewport = 200
+    view.resize(view.scroll)
+    expect(view.size.top).toBe(1000)
+  })
+
+  test.each(["PageUp", "PageDown", "ArrowUp", "ArrowDown", "Home", "End", " "])(
+    "manual %s scrolling releases a disclosure anchor before the next resize",
+    async (key) => {
+      const view = await fixture(true)
+      view.button.click()
+      view.scroll.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }))
+      view.size.top -= 40
+      view.size.height += 500
+      view.size.button += 500
+      view.resize()
+      expect(view.size.top).toBe(2460)
+    },
+  )
+
+  test.each(["Enter", " "])("%s disclosure activation keeps its viewport anchor", async (key) => {
+    const view = await fixture()
+    const before = view.button.getBoundingClientRect().top
+    view.button.click()
+    view.button.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }))
+    view.size.height += 500
+    view.size.button += 500
+    view.resize()
+    expect(view.button.getBoundingClientRect().top).toBe(before)
+    view.button.dispatchEvent(new MouseEvent("click", { bubbles: true, detail: 0 }))
+    view.size.height -= 500
+    view.size.button -= 500
+    view.resize()
+    expect(view.button.getBoundingClientRect().top).toBe(before)
+  })
+})

--- a/frontend/ui/src/hooks/create-auto-scroll.tsx
+++ b/frontend/ui/src/hooks/create-auto-scroll.tsx
@@ -17,10 +17,13 @@ export function createAutoScroll(options: AutoScrollOptions) {
   let cleanup: (() => void) | undefined
   let auto: { top: number; time: number } | undefined
   let height = 0
+  let anchor: { element: HTMLElement; top: number; until: number } | undefined
+  let anchorFrame: number | undefined
 
   const threshold = () => options.bottomThreshold ?? 10
 
   const [store, setStore] = createStore({
+    scrollRef: undefined as HTMLElement | undefined,
     contentRef: undefined as HTMLElement | undefined,
     userScrolled: false,
   })
@@ -78,6 +81,7 @@ export function createAutoScroll(options: AutoScrollOptions) {
   }
 
   const scrollToBottom = (force: boolean) => {
+    if (force) anchor = undefined
     if (!force && !active()) return
     const el = scroll
     if (!el) return
@@ -106,6 +110,7 @@ export function createAutoScroll(options: AutoScrollOptions) {
   }
 
   const handleWheel = (e: WheelEvent) => {
+    anchor = undefined
     if (e.deltaY >= 0) return
     // If the user is scrolling within a nested scrollable region (tool output,
     // code block, etc), don't treat it as leaving the "follow bottom" mode.
@@ -144,6 +149,54 @@ export function createAutoScroll(options: AutoScrollOptions) {
     stop()
   }
 
+  const restoreAnchor = () => {
+    const el = scroll
+    const saved = anchor
+    if (!el || !saved) return false
+    if (Date.now() > saved.until || !el.contains(saved.element)) {
+      anchor = undefined
+      return false
+    }
+    // Native scroll anchoring may already have compensated. Restore only the
+    // remaining visual displacement, never add the content-height difference.
+    const delta = saved.element.getBoundingClientRect().top - saved.top
+    if (Math.abs(delta) > 1) el.scrollTop += delta
+    return true
+  }
+
+  const captureDisclosure = (event: MouseEvent) => {
+    const el = scroll
+    const target = event.target instanceof Element ? event.target : undefined
+    const button = target?.closest<HTMLElement>("[aria-expanded], summary")
+    if (!el || !button || !el.contains(button) || !canScroll(el)) return
+    const nested = target?.closest("[data-scrollable]")
+    if (nested && nested !== el) return
+    stop()
+    anchor = { element: button, top: button.getBoundingClientRect().top, until: Date.now() + 350 }
+    if (anchorFrame !== undefined) cancelAnimationFrame(anchorFrame)
+    // Capture-phase runs before a disclosure changes layout, including a
+    // keyboard-generated click. ResizeObserver also follows short transitions.
+    anchorFrame = requestAnimationFrame(() => {
+      anchorFrame = undefined
+      restoreAnchor()
+    })
+  }
+
+  const clearAnchor = () => {
+    anchor = undefined
+  }
+
+  const handleKeydown = (event: KeyboardEvent) => {
+    if (event.defaultPrevented) return
+    if (!["PageUp", "PageDown", "ArrowUp", "ArrowDown", "Home", "End", " "].includes(event.key)) return
+    const target = event.target instanceof Element ? event.target : undefined
+    if (target?.closest("input, textarea, select, [contenteditable]:not([contenteditable='false'])")) return
+    // Space activates a focused disclosure; its generated click still needs
+    // the anchor. On ordinary content, these keys are explicit scroll intent.
+    if (event.key === " " && target?.closest("button, summary, [role='button']")) return
+    clearAnchor()
+  }
+
   const updateOverflowAnchor = (el: HTMLElement) => {
     const mode = options.overflowAnchor ?? "dynamic"
 
@@ -166,6 +219,7 @@ export function createAutoScroll(options: AutoScrollOptions) {
       const el = scroll
       const grew = next > height
       height = next
+      if (restoreAnchor()) return
       if (el && !canScroll(el)) return
       if (!active()) return
       if (store.userScrolled) return
@@ -176,6 +230,14 @@ export function createAutoScroll(options: AutoScrollOptions) {
       // ResizeObserver fires after layout, before paint.
       // Keep the bottom locked in the same frame to avoid visible
       // "jump up then catch up" artifacts while streaming content.
+      scrollToBottom(false)
+    },
+  )
+
+  createResizeObserver(
+    () => store.scrollRef,
+    () => {
+      if (restoreAnchor()) return
       scrollToBottom(false)
     },
   )
@@ -210,6 +272,7 @@ export function createAutoScroll(options: AutoScrollOptions) {
   onCleanup(() => {
     if (settleTimer) clearTimeout(settleTimer)
     if (autoTimer) clearTimeout(autoTimer)
+    if (anchorFrame !== undefined) cancelAnimationFrame(anchorFrame)
     if (cleanup) cleanup()
   })
 
@@ -221,6 +284,8 @@ export function createAutoScroll(options: AutoScrollOptions) {
       }
 
       scroll = el
+      setStore("scrollRef", el)
+      anchor = undefined
 
       if (!el) return
 
@@ -228,9 +293,17 @@ export function createAutoScroll(options: AutoScrollOptions) {
 
       updateOverflowAnchor(el)
       el.addEventListener("wheel", handleWheel, { passive: true })
+      el.addEventListener("click", captureDisclosure, true)
+      el.addEventListener("pointerdown", clearAnchor, { passive: true })
+      el.addEventListener("touchmove", clearAnchor, { passive: true })
+      el.addEventListener("keydown", handleKeydown)
 
       cleanup = () => {
         el.removeEventListener("wheel", handleWheel)
+        el.removeEventListener("click", captureDisclosure, true)
+        el.removeEventListener("pointerdown", clearAnchor)
+        el.removeEventListener("touchmove", clearAnchor)
+        el.removeEventListener("keydown", handleKeydown)
       }
     },
     contentRef: (el: HTMLElement | undefined) => setStore("contentRef", el),

--- a/frontend/ui/src/i18n/ar.ts
+++ b/frontend/ui/src/i18n/ar.ts
@@ -1,4 +1,6 @@
 export const dict = {
+  "ui.sessionTurn.steps.show": "إظهار سجل التنفيذ",
+  "ui.sessionTurn.steps.hide": "إخفاء سجل التنفيذ",
   "ui.messagePart.reasoning.label": "Reasoning",
   "ui.messagePart.reasoning.elapsedHint": "Elapsed since reasoning began, including waits.",
   "ui.sessionTurn.totalTime": "Total turn time, including model waits and tools",
@@ -89,6 +91,7 @@ export const dict = {
   "ui.tool.running.edit": "جارٍ التحرير",
   "ui.tool.running.write": "جارٍ الكتابة",
   "ui.tool.running.patch": "جارٍ تطبيق التصحيح",
+  "ui.tool.status.pending": "Preparing",
   "ui.tool.status.running": "قيد التشغيل",
   "ui.tool.status.done": "تم",
   "ui.tool.status.error": "فشل",

--- a/frontend/ui/src/i18n/br.ts
+++ b/frontend/ui/src/i18n/br.ts
@@ -1,4 +1,6 @@
 export const dict = {
+  "ui.sessionTurn.steps.show": "Mostrar rastreamento de execução",
+  "ui.sessionTurn.steps.hide": "Ocultar rastreamento de execução",
   "ui.messagePart.reasoning.label": "Reasoning",
   "ui.messagePart.reasoning.elapsedHint": "Elapsed since reasoning began, including waits.",
   "ui.sessionTurn.totalTime": "Total turn time, including model waits and tools",
@@ -90,6 +92,7 @@ export const dict = {
   "ui.tool.running.edit": "Editando",
   "ui.tool.running.write": "Escrevendo",
   "ui.tool.running.patch": "Aplicando patch",
+  "ui.tool.status.pending": "Preparing",
   "ui.tool.status.running": "Em execução",
   "ui.tool.status.done": "Concluído",
   "ui.tool.status.error": "Falhou",

--- a/frontend/ui/src/i18n/da.ts
+++ b/frontend/ui/src/i18n/da.ts
@@ -1,4 +1,6 @@
 export const dict = {
+  "ui.sessionTurn.steps.show": "Vis udførelsesspor",
+  "ui.sessionTurn.steps.hide": "Skjul udførelsesspor",
   "ui.messagePart.reasoning.label": "Reasoning",
   "ui.messagePart.reasoning.elapsedHint": "Elapsed since reasoning began, including waits.",
   "ui.sessionTurn.totalTime": "Total turn time, including model waits and tools",
@@ -89,6 +91,7 @@ export const dict = {
   "ui.tool.running.edit": "Redigerer",
   "ui.tool.running.write": "Skriver",
   "ui.tool.running.patch": "Anvender patch",
+  "ui.tool.status.pending": "Preparing",
   "ui.tool.status.running": "Kører",
   "ui.tool.status.done": "Færdig",
   "ui.tool.status.error": "Mislykkedes",

--- a/frontend/ui/src/i18n/de.ts
+++ b/frontend/ui/src/i18n/de.ts
@@ -3,6 +3,8 @@ import { dict as en } from "./en"
 type Keys = keyof typeof en
 
 export const dict = {
+  "ui.sessionTurn.steps.show": "Ausführungsprotokoll anzeigen",
+  "ui.sessionTurn.steps.hide": "Ausführungsprotokoll ausblenden",
   "ui.messagePart.reasoning.label": "Reasoning",
   "ui.messagePart.reasoning.elapsedHint": "Elapsed since reasoning began, including waits.",
   "ui.sessionTurn.totalTime": "Total turn time, including model waits and tools",
@@ -94,6 +96,7 @@ export const dict = {
   "ui.tool.running.edit": "Bearbeitet",
   "ui.tool.running.write": "Schreibt",
   "ui.tool.running.patch": "Wendet Patch an",
+  "ui.tool.status.pending": "Preparing",
   "ui.tool.status.running": "Läuft",
   "ui.tool.status.done": "Fertig",
   "ui.tool.status.error": "Fehlgeschlagen",

--- a/frontend/ui/src/i18n/en.ts
+++ b/frontend/ui/src/i18n/en.ts
@@ -1,4 +1,6 @@
 export const dict = {
+  "ui.sessionTurn.steps.show": "Show reasoning and activity",
+  "ui.sessionTurn.steps.hide": "Hide reasoning and activity",
   "ui.lineComment.label.prefix": "Comment on ",
   "ui.lineComment.label.suffix": "",
   "ui.lineComment.editorLabel.prefix": "Commenting on ",
@@ -92,6 +94,7 @@ export const dict = {
   "ui.tool.running.edit": "Editing",
   "ui.tool.running.write": "Writing",
   "ui.tool.running.patch": "Applying patch",
+  "ui.tool.status.pending": "Preparing",
   "ui.tool.status.running": "Running",
   "ui.tool.status.done": "Done",
   "ui.tool.status.error": "Failed",

--- a/frontend/ui/src/i18n/es.ts
+++ b/frontend/ui/src/i18n/es.ts
@@ -1,4 +1,6 @@
 export const dict = {
+  "ui.sessionTurn.steps.show": "Mostrar traza de ejecución",
+  "ui.sessionTurn.steps.hide": "Ocultar traza de ejecución",
   "ui.messagePart.reasoning.label": "Reasoning",
   "ui.messagePart.reasoning.elapsedHint": "Elapsed since reasoning began, including waits.",
   "ui.sessionTurn.totalTime": "Total turn time, including model waits and tools",
@@ -90,6 +92,7 @@ export const dict = {
   "ui.tool.running.edit": "Editando",
   "ui.tool.running.write": "Escribiendo",
   "ui.tool.running.patch": "Aplicando parche",
+  "ui.tool.status.pending": "Preparing",
   "ui.tool.status.running": "En curso",
   "ui.tool.status.done": "Listo",
   "ui.tool.status.error": "Falló",

--- a/frontend/ui/src/i18n/fr.ts
+++ b/frontend/ui/src/i18n/fr.ts
@@ -1,4 +1,6 @@
 export const dict = {
+  "ui.sessionTurn.steps.show": "Afficher la trace d’exécution",
+  "ui.sessionTurn.steps.hide": "Masquer la trace d’exécution",
   "ui.messagePart.reasoning.label": "Reasoning",
   "ui.messagePart.reasoning.elapsedHint": "Elapsed since reasoning began, including waits.",
   "ui.sessionTurn.totalTime": "Total turn time, including model waits and tools",
@@ -92,6 +94,7 @@ export const dict = {
   "ui.tool.running.edit": "Modification",
   "ui.tool.running.write": "Écriture",
   "ui.tool.running.patch": "Application du correctif",
+  "ui.tool.status.pending": "Preparing",
   "ui.tool.status.running": "En cours",
   "ui.tool.status.done": "Terminé",
   "ui.tool.status.error": "Échec",

--- a/frontend/ui/src/i18n/ja.ts
+++ b/frontend/ui/src/i18n/ja.ts
@@ -1,4 +1,6 @@
 export const dict = {
+  "ui.sessionTurn.steps.show": "実行トレースを表示",
+  "ui.sessionTurn.steps.hide": "実行トレースを非表示",
   "ui.messagePart.reasoning.label": "Reasoning",
   "ui.messagePart.reasoning.elapsedHint": "Elapsed since reasoning began, including waits.",
   "ui.sessionTurn.totalTime": "Total turn time, including model waits and tools",
@@ -89,6 +91,7 @@ export const dict = {
   "ui.tool.running.edit": "編集中",
   "ui.tool.running.write": "書き込み中",
   "ui.tool.running.patch": "パッチ適用中",
+  "ui.tool.status.pending": "Preparing",
   "ui.tool.status.running": "実行中",
   "ui.tool.status.done": "完了",
   "ui.tool.status.error": "失敗",

--- a/frontend/ui/src/i18n/ko.ts
+++ b/frontend/ui/src/i18n/ko.ts
@@ -1,4 +1,6 @@
 export const dict = {
+  "ui.sessionTurn.steps.show": "실행 추적 표시",
+  "ui.sessionTurn.steps.hide": "실행 추적 숨기기",
   "ui.messagePart.reasoning.label": "Reasoning",
   "ui.messagePart.reasoning.elapsedHint": "Elapsed since reasoning began, including waits.",
   "ui.sessionTurn.totalTime": "Total turn time, including model waits and tools",
@@ -89,6 +91,7 @@ export const dict = {
   "ui.tool.running.edit": "편집 중",
   "ui.tool.running.write": "쓰는 중",
   "ui.tool.running.patch": "패치 적용 중",
+  "ui.tool.status.pending": "Preparing",
   "ui.tool.status.running": "실행 중",
   "ui.tool.status.done": "완료",
   "ui.tool.status.error": "실패",

--- a/frontend/ui/src/i18n/no.ts
+++ b/frontend/ui/src/i18n/no.ts
@@ -2,6 +2,8 @@ import { dict as en } from "./en"
 type Keys = keyof typeof en
 
 export const dict: Record<Keys, string> = {
+  "ui.sessionTurn.steps.show": "Vis utføringsspor",
+  "ui.sessionTurn.steps.hide": "Skjul utføringsspor",
   "ui.sessionTurn.reasoning.show": "Vis resonnering",
   "ui.sessionTurn.reasoning.hide": "Skjul resonnering",
   "ui.messagePart.reasoning.label": "Reasoning",
@@ -94,6 +96,7 @@ export const dict: Record<Keys, string> = {
   "ui.tool.running.edit": "Redigerer",
   "ui.tool.running.write": "Skriver",
   "ui.tool.running.patch": "Bruker patch",
+  "ui.tool.status.pending": "Preparing",
   "ui.tool.status.running": "Kjører",
   "ui.tool.status.done": "Ferdig",
   "ui.tool.status.error": "Mislyktes",

--- a/frontend/ui/src/i18n/pl.ts
+++ b/frontend/ui/src/i18n/pl.ts
@@ -1,4 +1,6 @@
 export const dict = {
+  "ui.sessionTurn.steps.show": "Pokaż ślad wykonania",
+  "ui.sessionTurn.steps.hide": "Ukryj ślad wykonania",
   "ui.messagePart.reasoning.label": "Reasoning",
   "ui.messagePart.reasoning.elapsedHint": "Elapsed since reasoning began, including waits.",
   "ui.sessionTurn.totalTime": "Total turn time, including model waits and tools",
@@ -89,6 +91,7 @@ export const dict = {
   "ui.tool.running.edit": "Edytowanie",
   "ui.tool.running.write": "Zapisywanie",
   "ui.tool.running.patch": "Stosowanie poprawki",
+  "ui.tool.status.pending": "Preparing",
   "ui.tool.status.running": "W toku",
   "ui.tool.status.done": "Gotowe",
   "ui.tool.status.error": "Niepowodzenie",

--- a/frontend/ui/src/i18n/ru.ts
+++ b/frontend/ui/src/i18n/ru.ts
@@ -1,4 +1,6 @@
 export const dict = {
+  "ui.sessionTurn.steps.show": "Показать трассировку выполнения",
+  "ui.sessionTurn.steps.hide": "Скрыть трассировку выполнения",
   "ui.messagePart.reasoning.label": "Reasoning",
   "ui.messagePart.reasoning.elapsedHint": "Elapsed since reasoning began, including waits.",
   "ui.sessionTurn.totalTime": "Total turn time, including model waits and tools",
@@ -89,6 +91,7 @@ export const dict = {
   "ui.tool.running.edit": "Редактирование",
   "ui.tool.running.write": "Запись",
   "ui.tool.running.patch": "Применение патча",
+  "ui.tool.status.pending": "Preparing",
   "ui.tool.status.running": "Выполняется",
   "ui.tool.status.done": "Готово",
   "ui.tool.status.error": "Ошибка",

--- a/frontend/ui/src/i18n/th.ts
+++ b/frontend/ui/src/i18n/th.ts
@@ -1,4 +1,6 @@
 export const dict = {
+  "ui.sessionTurn.steps.show": "แสดงร่องรอยการทำงาน",
+  "ui.sessionTurn.steps.hide": "ซ่อนร่องรอยการทำงาน",
   "ui.messagePart.reasoning.label": "Reasoning",
   "ui.messagePart.reasoning.elapsedHint": "Elapsed since reasoning began, including waits.",
   "ui.sessionTurn.totalTime": "Total turn time, including model waits and tools",
@@ -90,6 +92,7 @@ export const dict = {
   "ui.tool.running.edit": "กำลังแก้ไข",
   "ui.tool.running.write": "กำลังเขียน",
   "ui.tool.running.patch": "กำลังใช้แพตช์",
+  "ui.tool.status.pending": "Preparing",
   "ui.tool.status.running": "กำลังทำงาน",
   "ui.tool.status.done": "เสร็จสิ้น",
   "ui.tool.status.error": "ล้มเหลว",

--- a/frontend/ui/src/i18n/zh.ts
+++ b/frontend/ui/src/i18n/zh.ts
@@ -3,6 +3,8 @@ import { dict as en } from "./en"
 type Keys = keyof typeof en
 
 export const dict = {
+  "ui.sessionTurn.steps.show": "显示执行轨迹",
+  "ui.sessionTurn.steps.hide": "隐藏执行轨迹",
   "ui.messagePart.reasoning.label": "Reasoning",
   "ui.messagePart.reasoning.elapsedHint": "Elapsed since reasoning began, including waits.",
   "ui.sessionTurn.totalTime": "Total turn time, including model waits and tools",
@@ -93,6 +95,7 @@ export const dict = {
   "ui.tool.running.edit": "编辑中",
   "ui.tool.running.write": "写入中",
   "ui.tool.running.patch": "应用补丁中",
+  "ui.tool.status.pending": "Preparing",
   "ui.tool.status.running": "运行中",
   "ui.tool.status.done": "完成",
   "ui.tool.status.error": "失败",

--- a/frontend/ui/src/i18n/zht.ts
+++ b/frontend/ui/src/i18n/zht.ts
@@ -3,6 +3,8 @@ import { dict as en } from "./en"
 type Keys = keyof typeof en
 
 export const dict = {
+  "ui.sessionTurn.steps.show": "顯示執行軌跡",
+  "ui.sessionTurn.steps.hide": "隱藏執行軌跡",
   "ui.messagePart.reasoning.label": "Reasoning",
   "ui.messagePart.reasoning.elapsedHint": "Elapsed since reasoning began, including waits.",
   "ui.sessionTurn.totalTime": "Total turn time, including model waits and tools",
@@ -93,6 +95,7 @@ export const dict = {
   "ui.tool.running.edit": "編輯中",
   "ui.tool.running.write": "寫入中",
   "ui.tool.running.patch": "套用修補程式中",
+  "ui.tool.status.pending": "Preparing",
   "ui.tool.status.running": "執行中",
   "ui.tool.status.done": "完成",
   "ui.tool.status.error": "失敗",

--- a/frontend/workspace/e2e/classic-chat.spec.ts
+++ b/frontend/workspace/e2e/classic-chat.spec.ts
@@ -1,0 +1,159 @@
+import type { AssistantMessage, Part, ReasoningPart, TextPart, UserMessage } from "@synsci/sdk/v2"
+import type { Locator, Page } from "@playwright/test"
+import { test, expect } from "./fixtures"
+
+test.skip(process.env.OPENSCIENCE_E2E_FAKE_MODEL !== "1", "requires the isolated deterministic model")
+
+const disclosure = '[data-slot="session-turn-collapsible-trigger-content"]'
+const reasoningBody = '[data-slot="reasoning-part-body"]'
+const expansionKey = "openscience-trace-expansion-v1"
+
+async function placeInViewport(page: Page, control: Locator) {
+  await control.evaluate((button) => {
+    const scroller = button.closest<HTMLElement>(".session-scroller")!
+    scroller.scrollTop += button.getBoundingClientRect().top - scroller.getBoundingClientRect().top - 140
+  })
+  await settleLayout(page)
+  const box = await control.boundingBox()
+  if (!box) throw new Error("The disclosure did not render")
+  return box.y
+}
+
+async function settleLayout(page: Page) {
+  await page.evaluate(
+    () => new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve()))),
+  )
+}
+
+test("classic long-chat disclosures preserve the reader, stay per-turn, and survive reload", async ({
+  page,
+  sdk,
+  gotoSession,
+}) => {
+  const session = await sdk.session.create({ title: "Classic chat scroll regression" }).then((result) => result.data)
+  if (!session) throw new Error("The isolated session was not created")
+  const sessionID = session.id
+  try {
+    const reply = await sdk.session
+      .prompt({
+        sessionID,
+        model: { providerID: "e2e", modelID: "echo" },
+        parts: [{ type: "text", text: "Seed the isolated classic chat fixture." }],
+      })
+      .then((result) => result.data)
+    if (!reply?.info.id) throw new Error("The deterministic model did not return a reply")
+    const saved = await sdk.session.messages({ sessionID }).then((result) => result.data ?? [])
+    const source = saved.find((message) => message.info.role === "user")?.info
+    if (source?.role !== "user") throw new Error("The isolated user turn is missing")
+
+    const ids = Array.from({ length: 12 }, (_, index) => `msg_classic_${String(index * 2).padStart(4, "0")}`)
+    const messages: Array<{ info: UserMessage | AssistantMessage; parts: Part[] }> = []
+    for (const [index, id] of ids.entries()) {
+      const assistantID = `msg_classic_${String(index * 2 + 1).padStart(4, "0")}`
+      const created = source.time.created + index * 2_000
+      const user: UserMessage = { ...source, id, time: { created } }
+      const assistant: AssistantMessage = {
+        ...reply.info,
+        id: assistantID,
+        parentID: id,
+        time: { created: created + 100, completed: created + 1_000 },
+        finish: "stop",
+      }
+      const question: TextPart = {
+        id: `prt_classic_${index}_0`,
+        messageID: id,
+        sessionID,
+        type: "text",
+        text: `Compare the controls for experiment ${index}.`,
+      }
+      const reasoning: ReasoningPart = {
+        id: `prt_classic_${index}_1`,
+        messageID: assistantID,
+        sessionID,
+        type: "reasoning",
+        text:
+          Array.from(
+            { length: 18 },
+            (_, paragraph) =>
+              `Experiment ${index}, observation ${paragraph}: the control and treatment use the same evaluation conditions. Keep all measured observations and uncertainty visible, with no summary replacing these supplied sentences.`,
+          ).join("\n\n") + `\n\nReasoning complete for experiment ${index}.`,
+        time: { start: created + 100, end: created + 700 },
+      }
+      const answer: TextPart = {
+        id: `prt_classic_${index}_2`,
+        messageID: assistantID,
+        sessionID,
+        type: "text",
+        text:
+          `Conclusion for experiment ${index}.\n\n` +
+          Array.from(
+            { length: 5 },
+            () =>
+              "The measured effect remains uncertain. Preserve the controls and replicate the observation before changing the experimental plan.",
+          ).join("\n\n"),
+        time: { start: created + 700, end: created + 1_000 },
+      }
+      messages.push({ info: user, parts: [question] }, { info: assistant, parts: [reasoning, answer] })
+    }
+
+    // Only this disposable session's transcript response is overridden. The
+    // app, scroll hooks, settings persistence, and routing are the real ones.
+    await page.route(new RegExp(`/session/${sessionID}/message(?:\\?|$)`), (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(messages),
+      }),
+    )
+    await page.addInitScript(
+      ({ key, id }) => {
+        if (localStorage.getItem(key) === null) localStorage.setItem(key, JSON.stringify({ [id]: true }))
+      },
+      { key: expansionKey, id: ids[1] },
+    )
+    await gotoSession(sessionID)
+    await expect(page.locator(disclosure)).toHaveCount(ids.length)
+    await page.evaluate(() => document.fonts.ready)
+    const turn = (index: number) => page.locator(`[data-message-id="${ids[index]}"]`)
+    const target = turn(8).locator(disclosure)
+    await expect(turn(1).locator(disclosure)).toHaveAttribute("aria-expanded", "true")
+    await expect(target).toHaveAttribute("aria-expanded", "false")
+    await expect(page.locator(reasoningBody)).toHaveCount(1)
+
+    const before = await placeInViewport(page, target)
+    await target.click()
+    await expect(target).toHaveAttribute("aria-expanded", "true")
+    await expect(turn(8).locator(reasoningBody)).toContainText("Reasoning complete for experiment 8.")
+    await settleLayout(page)
+    expect(Math.abs((await target.boundingBox())!.y - before)).toBeLessThanOrEqual(2)
+    await expect(page.locator(reasoningBody)).toHaveCount(2)
+    await expect(turn(7).locator(disclosure)).toHaveAttribute("aria-expanded", "false")
+    await expect(turn(9).locator(disclosure)).toHaveAttribute("aria-expanded", "false")
+    await expect(turn(1).locator(disclosure)).toHaveAttribute("aria-expanded", "true")
+
+    await target.click()
+    await expect(target).toHaveAttribute("aria-expanded", "false")
+    await expect(turn(8).locator(reasoningBody)).toHaveCount(0)
+    await settleLayout(page)
+    expect(Math.abs((await target.boundingBox())!.y - before)).toBeLessThanOrEqual(2)
+    await page.reload()
+    await expect(target).toHaveAttribute("aria-expanded", "false")
+    await expect(page.locator(reasoningBody)).toHaveCount(1)
+    await expect(turn(1).locator(disclosure)).toHaveAttribute("aria-expanded", "true")
+
+    const keyboardBefore = await placeInViewport(page, target)
+    await target.focus()
+    await target.press("Enter")
+    await expect(target).toHaveAttribute("aria-expanded", "true")
+    await expect(turn(8).locator(reasoningBody)).toContainText("Reasoning complete for experiment 8.")
+    await settleLayout(page)
+    expect(Math.abs((await target.boundingBox())!.y - keyboardBefore)).toBeLessThanOrEqual(2)
+    await page.reload()
+    await expect(target).toHaveAttribute("aria-expanded", "true")
+    await expect(page.locator(reasoningBody)).toHaveCount(2)
+    await expect(turn(7).locator(disclosure)).toHaveAttribute("aria-expanded", "false")
+    await expect(turn(1).locator(disclosure)).toHaveAttribute("aria-expanded", "true")
+  } finally {
+    await sdk.session.delete({ sessionID }).catch(() => undefined)
+  }
+})

--- a/frontend/workspace/e2e/science-artifact.spec.ts
+++ b/frontend/workspace/e2e/science-artifact.spec.ts
@@ -162,7 +162,7 @@ async function withArtifact(
   }
 }
 
-test("reasoning prose and artifacts respect Show reasoning but ignore obsolete activity preferences", async ({
+test("classic per-turn disclosure preserves full reasoning and results despite legacy global preferences", async ({
   page,
   sdk,
   gotoSession,
@@ -221,19 +221,27 @@ test("reasoning prose and artifacts respect Show reasoning but ignore obsolete a
     })
     await page.addInitScript((id) => {
       localStorage.setItem("openscience:activity-view:v1", "compact")
-      localStorage.setItem("openscience-trace-expansion-v1", JSON.stringify({ [id]: false }))
+      if (localStorage.getItem("openscience-trace-expansion-v1") === null) {
+        localStorage.setItem("openscience-trace-expansion-v1", JSON.stringify({ [id]: false }))
+      }
+      // Old global hiding must not override an explicitly expanded classic turn.
+      localStorage.setItem("settings.v3", JSON.stringify({ general: { showReasoning: false } }))
     }, userID)
     await gotoSession(sessionID)
     const artifact = page.locator('[data-component="science-artifact"][data-kind="sequence"]')
     const reasoningRows = page.locator('[data-component="reasoning-part"]')
-    const toggle = page.locator('[data-slot="session-turn-reasoning-toggle"]')
+    const toggle = page.locator('[data-slot="session-turn-collapsible-trigger-content"]')
     await expect(page.getByRole("group", { name: "Activity view", exact: true })).toHaveCount(0)
-    await expect(page.locator('[data-slot="session-turn-collapsible-trigger-content"]')).toHaveCount(0)
+    await expect(page.locator('[data-slot="session-turn-reasoning-toggle"]')).toHaveCount(0)
+    await expect(toggle).toHaveAttribute("aria-expanded", "false")
+    await expect(reasoningRows).toHaveCount(0)
+    await expect(artifact).toBeVisible()
+    await toggle.click()
     await expect(reasoningRows).toHaveCount(2)
     await expect(reasoningRows.locator("button")).toHaveCount(0)
     await expect(reasoningRows.locator('[data-slot="reasoning-part-body"]')).toHaveText(prose)
     await expect(reasoningRows.locator("strong")).toHaveText("same evaluation conditions")
-    await expect(toggle).toHaveText("Hide reasoning")
+    await expect(toggle).toContainText("Hide reasoning and activity")
     await expect(toggle).toHaveAttribute("aria-expanded", "true")
     await expect(artifact).toBeVisible()
     await expect(artifact.locator('[data-slot="sequence-residues"]')).toHaveText("ACGTACGT")
@@ -251,30 +259,24 @@ test("reasoning prose and artifacts respect Show reasoning but ignore obsolete a
 
     await toggle.click()
     await expect(reasoningRows).toHaveCount(0)
-    await expect(toggle).toHaveText("Show reasoning")
+    await expect(toggle).toContainText("Show reasoning and activity")
     await expect(toggle).toHaveAttribute("aria-expanded", "false")
     await expect(artifact).toBeVisible()
     await expect(artifact.locator('[data-slot="sequence-residues"]')).toHaveText("ACGTACGT")
     await page.reload()
-    await expect(toggle).toHaveText("Show reasoning")
+    await expect(toggle).toContainText("Show reasoning and activity")
     await expect(reasoningRows).toHaveCount(0)
     await expect(artifact).toBeVisible()
 
     const dialog = await openSettings(page)
     await dialog.getByRole("button", { name: "General", exact: true }).click()
-    const setting = dialog.getByRole("switch", { name: "Show reasoning", exact: true })
-    await expect(setting).not.toBeChecked()
-    await setting.locator("..").locator('[data-slot="switch-control"]').click()
-    await expect(setting).toBeChecked()
-    await setting.focus()
-    await expect(setting).toBeFocused()
-    await setting.press("Space")
-    await expect(setting).not.toBeChecked()
-    await setting.press("Space")
-    await expect(setting).toBeChecked()
+    await expect(dialog.getByRole("switch", { name: "Show reasoning", exact: true })).toHaveCount(0)
     await dialog.getByRole("button", { name: "Close", exact: true }).click()
+    await expect(reasoningRows).toHaveCount(0)
+    await expect(toggle).toHaveAttribute("aria-expanded", "false")
+    await toggle.click()
     await expect(reasoningRows.locator('[data-slot="reasoning-part-body"]')).toHaveText(prose)
-    await expect(toggle).toHaveText("Hide reasoning")
+    await expect(toggle).toContainText("Hide reasoning and activity")
     await page.reload()
     await expect(reasoningRows.locator('[data-slot="reasoning-part-body"]')).toHaveText(prose)
     await expect(artifact).toBeVisible()

--- a/frontend/workspace/src/components/chat-surface.css
+++ b/frontend/workspace/src/components/chat-surface.css
@@ -343,7 +343,7 @@
   border-bottom: 0;
 }
 
-.session-scroller [data-slot="session-turn-status"] {
+.session-scroller [data-slot="session-turn-collapsible-trigger-content"] {
   color: var(--color-text-muted, var(--text-weak));
   font-size: var(--font-size-small);
   font-weight: var(--font-weight-regular);

--- a/frontend/workspace/src/components/settings-general.tsx
+++ b/frontend/workspace/src/components/settings-general.tsx
@@ -190,14 +190,6 @@ export const AppearanceSections: Component = () => {
               triggerVariant="settings"
             />
           </SettingsRow>
-          <SettingsRow
-            title={language.t("settings.general.reasoning.title")}
-            description={language.t("settings.general.reasoning.description")}
-          >
-            <Switch hideLabel checked={settings.general.showReasoning()} onChange={settings.general.setShowReasoning}>
-              {language.t("settings.general.reasoning.title")}
-            </Switch>
-          </SettingsRow>
         </div>
       </SettingsSection>
 

--- a/frontend/workspace/src/context/settings-reasoning.test.tsx
+++ b/frontend/workspace/src/context/settings-reasoning.test.tsx
@@ -20,67 +20,80 @@ const subject = (await vite.ssrLoadModule("/src/context/settings.tsx")) as typeo
 
 afterAll(() => vite.close())
 
-test("reasoning visibility defaults on for older settings and survives desktop provider remounts", async () => {
-  const values = new Map([
-    ["settings.v3", JSON.stringify({ general: { autoSave: false }, appearance: { fontSize: 16 } })],
-  ])
-  const desktop = {
-    platform: "desktop",
-    storage: () => ({
-      async getItem(key: string) {
-        return values.get(key) ?? null
-      },
-      async setItem(key: string, value: string) {
-        values.set(key, value)
-      },
-      async removeItem(key: string) {
-        values.delete(key)
-      },
-    }),
-  } as Platform
-  const cleanups: Array<() => void> = []
-  const mount = async () => {
-    const current: { settings?: ReturnType<typeof subject.useSettings> } = {}
-    runtime.createRoot((dispose) => {
-      cleanups.push(dispose)
-      platform.PlatformProvider({
-        value: desktop,
-        get children() {
-          return runtime.untrack(() =>
-            subject.SettingsProvider({
-              get children() {
-                current.settings = subject.useSettings()
-                return undefined
-              },
-            }),
-          )
+test.each([undefined, false, true])(
+  "legacy global reasoning preference %s is ignored without resetting settings",
+  async (showReasoning) => {
+    const saved = {
+      general: { autoSave: false, releaseNotes: false, ...(showReasoning === undefined ? {} : { showReasoning }) },
+      appearance: { fontSize: 16, font: "fira-code" },
+      keybinds: { "session.new": "mod+shift+n" },
+    }
+    const values = new Map([["settings.v3", JSON.stringify(saved)]])
+    const removed: string[] = []
+    const desktop = {
+      platform: "desktop",
+      storage: () => ({
+        async getItem(key: string) {
+          return values.get(key) ?? null
         },
+        async setItem(key: string, value: string) {
+          values.set(key, value)
+        },
+        async removeItem(key: string) {
+          removed.push(key)
+          values.delete(key)
+        },
+      }),
+    } as Platform
+    const cleanups: Array<() => void> = []
+    const mount = async () => {
+      const current: { settings?: ReturnType<typeof subject.useSettings> } = {}
+      runtime.createRoot((dispose) => {
+        cleanups.push(dispose)
+        platform.PlatformProvider({
+          value: desktop,
+          get children() {
+            return runtime.untrack(() =>
+              subject.SettingsProvider({
+                get children() {
+                  current.settings = subject.useSettings()
+                  return undefined
+                },
+              }),
+            )
+          },
+        })
       })
-    })
-    for (let attempt = 0; attempt < 50 && !current.settings; attempt++) await Bun.sleep(1)
-    if (!current.settings) throw new Error("Settings provider did not hydrate")
-    return current.settings
-  }
+      for (let attempt = 0; attempt < 50 && !current.settings; attempt++) await Bun.sleep(1)
+      if (!current.settings) throw new Error("Settings provider did not hydrate")
+      return current.settings
+    }
 
-  try {
-    const first = await mount()
-    expect(first.general.showReasoning()).toBe(true)
-    expect(first.general.autoSave()).toBe(false)
-    first.general.setShowReasoning(false)
-    expect(first.general.showReasoning()).toBe(false)
-    cleanups.pop()?.()
+    try {
+      const first = await mount()
+      expect("showReasoning" in first.general).toBe(false)
+      expect("setShowReasoning" in first.general).toBe(false)
+      expect(first.general.autoSave()).toBe(false)
+      expect(first.general.releaseNotes()).toBe(false)
+      expect(first.appearance.font()).toBe("fira-code")
+      expect(first.appearance.fontSize()).toBe(16)
+      expect(first.keybinds.get("session.new")).toBe("mod+shift+n")
+      first.general.setAutoSave(true)
+      cleanups.pop()?.()
 
-    const second = await mount()
-    expect(second.general.showReasoning()).toBe(false)
-    expect(second.general.autoSave()).toBe(false)
-    expect(second.appearance.fontSize()).toBe(16)
-    second.general.setShowReasoning(true)
-    cleanups.pop()?.()
-
-    const third = await mount()
-    expect(third.general.showReasoning()).toBe(true)
-    expect(third.appearance.fontSize()).toBe(16)
-  } finally {
-    cleanups.splice(0).forEach((dispose) => dispose())
-  }
-})
+      const second = await mount()
+      expect("showReasoning" in second.general).toBe(false)
+      expect(second.general.autoSave()).toBe(true)
+      expect(second.general.releaseNotes()).toBe(false)
+      expect(second.appearance.fontSize()).toBe(16)
+      expect(second.appearance.font()).toBe("fira-code")
+      expect(second.keybinds.get("session.new")).toBe("mod+shift+n")
+      // The obsolete field may remain on disk for compatibility; it is not a
+      // reason to rewrite or erase the user's preference store.
+      expect(JSON.parse(values.get("settings.v3")!).general.showReasoning).toBe(showReasoning)
+      expect(removed).toEqual([])
+    } finally {
+      cleanups.splice(0).forEach((dispose) => dispose())
+    }
+  },
+)

--- a/frontend/workspace/src/context/settings.tsx
+++ b/frontend/workspace/src/context/settings.tsx
@@ -21,7 +21,6 @@ export interface Settings {
   general: {
     autoSave: boolean
     releaseNotes: boolean
-    showReasoning: boolean
   }
   updates: {
     startup: boolean
@@ -45,7 +44,6 @@ const defaultSettings: Settings = {
   general: {
     autoSave: true,
     releaseNotes: true,
-    showReasoning: true,
   },
   updates: {
     startup: true,
@@ -116,10 +114,6 @@ export const { use: useSettings, provider: SettingsProvider } = createSimpleCont
         return store
       },
       general: {
-        showReasoning: createMemo(() => store.general?.showReasoning ?? defaultSettings.general.showReasoning),
-        setShowReasoning(value: boolean) {
-          setStore("general", "showReasoning", value)
-        },
         autoSave: createMemo(() => store.general?.autoSave ?? defaultSettings.general.autoSave),
         setAutoSave(value: boolean) {
           setStore("general", "autoSave", value)

--- a/frontend/workspace/src/i18n/en.ts
+++ b/frontend/workspace/src/i18n/en.ts
@@ -1,7 +1,4 @@
 export const dict = {
-  "settings.general.reasoning.title": "Show reasoning",
-  "settings.general.reasoning.description":
-    "Display the readable reasoning supplied by the model. Tool activity stays visible.",
   "command.category.suggested": "Suggested",
   "command.category.view": "View",
   "command.category.project": "Project",

--- a/frontend/workspace/src/pages/session-trace.test.ts
+++ b/frontend/workspace/src/pages/session-trace.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test"
+import { createTraceExpansion } from "./session-trace"
+
+const key = "openscience-trace-expansion-v1"
+const storage = (value = "{}") => {
+  const data = new Map([[key, value]])
+  return {
+    getItem: (key: string) => data.get(key) ?? null,
+    setItem: (key: string, value: string) => void data.set(key, value),
+  }
+}
+
+describe("classic per-turn trace expansion", () => {
+  test("a live turn opens once, then the first click collapses the actual displayed state", () => {
+    const saved = storage()
+    const trace = createTraceExpansion(saved)
+    expect(trace.expanded("active")).toBe(false)
+    trace.open("active")
+    expect(trace.expanded("active")).toBe(true)
+    trace.toggle("active")
+    expect(trace.expanded("active")).toBe(false)
+    trace.open("active")
+    expect(trace.expanded("active")).toBe(false)
+    expect(createTraceExpansion(saved).expanded("active")).toBe(false)
+  })
+
+  test("opening a new turn does not change other turns and survives remount", () => {
+    const saved = storage('{"historic":true,"collapsed":false,"invalid":"true"}')
+    const trace = createTraceExpansion(saved)
+    trace.open("active")
+    expect(trace.expanded("historic")).toBe(true)
+    expect(trace.expanded("collapsed")).toBe(false)
+    expect(trace.expanded("invalid")).toBe(false)
+    trace.toggle("historic")
+    const restored = createTraceExpansion(saved)
+    expect(restored.expanded("active")).toBe(true)
+    expect(restored.expanded("historic")).toBe(false)
+  })
+
+  test("malformed or unavailable storage degrades without blocking the control", () => {
+    for (const value of ["broken", "null", "[]"]) {
+      const trace = createTraceExpansion(storage(value))
+      trace.toggle("active")
+      expect(trace.expanded("active")).toBe(true)
+    }
+    const trace = createTraceExpansion({
+      getItem() {
+        throw new Error("unavailable")
+      },
+      setItem() {
+        throw new Error("full")
+      },
+    })
+    trace.open("active")
+    expect(trace.expanded("active")).toBe(true)
+  })
+
+  test("retains only the latest 200 turn choices, including explicit false", () => {
+    const saved = storage()
+    const trace = createTraceExpansion(saved)
+    for (let n = 0; n < 205; n++) trace.open(`turn-${n}`)
+    trace.toggle("turn-204")
+    const values = JSON.parse(saved.getItem(key)!)
+    expect(Object.keys(values)).toHaveLength(200)
+    expect(values["turn-0"]).toBeUndefined()
+    expect(values["turn-204"]).toBe(false)
+  })
+})

--- a/frontend/workspace/src/pages/session-trace.ts
+++ b/frontend/workspace/src/pages/session-trace.ts
@@ -1,0 +1,47 @@
+import { createStore, reconcile } from "solid-js/store"
+
+const key = "openscience-trace-expansion-v1"
+type Storage = Pick<globalThis.Storage, "getItem" | "setItem">
+
+const browserStorage = () => {
+  try {
+    return globalThis.localStorage
+  } catch {
+    return undefined
+  }
+}
+
+/** Keep the classic per-turn preference, including an explicit collapse of a
+ * live turn. A working turn opens once; finishing never closes it again. */
+export function createTraceExpansion(storage: Storage | undefined = browserStorage()) {
+  const read = () => {
+    try {
+      const value: unknown = JSON.parse(storage?.getItem(key) ?? "{}")
+      if (!value || typeof value !== "object" || Array.isArray(value)) return {}
+      return Object.fromEntries(
+        Object.entries(value)
+          .filter((entry): entry is [string, boolean] => typeof entry[1] === "boolean")
+          .slice(-200),
+      )
+    } catch {
+      return {}
+    }
+  }
+  const [state, setState] = createStore<Record<string, boolean>>(read())
+  const set = (id: string, expanded: boolean) => {
+    const next = Object.fromEntries(
+      [...Object.entries(state).filter(([name]) => name !== id), [id, expanded]].slice(-200),
+    )
+    setState(reconcile(next))
+    try {
+      storage?.setItem(key, JSON.stringify(next))
+    } catch {}
+  }
+  return {
+    expanded: (id: string) => state[id] === true,
+    toggle: (id: string) => set(id, state[id] !== true),
+    open: (id: string) => {
+      if (state[id] === undefined) set(id, true)
+    },
+  }
+}

--- a/frontend/workspace/src/pages/session.tsx
+++ b/frontend/workspace/src/pages/session.tsx
@@ -74,6 +74,7 @@ import { useExecutionAuthority } from "@/atlas/use-execution-authority"
 import { sessionEntryTarget } from "@/pages/session-entry"
 import { shouldConfirmUndo, undoPreview, undoSummary, type UndoPreview } from "@/pages/session-undo"
 import { SessionContextUsage } from "@/components/session-context-usage"
+import { createTraceExpansion } from "@/pages/session-trace"
 import { estimate, latestContext, type ContextEstimate, type ContextSample } from "@/pages/session-context"
 import "./session-header.css"
 import "./session-undo.css"
@@ -835,6 +836,16 @@ export default function Page(): JSX.Element {
     return !!status && status.type !== "idle"
   })
 
+  const traceExpansion = createTraceExpansion()
+  createEffect(
+    on(
+      () => (working() ? lastUserMessage()?.id : undefined),
+      (id) => {
+        if (id) traceExpansion.open(id)
+      },
+    ),
+  )
+
   const chatScroll = createAutoScroll({
     working,
     overflowAnchor: "dynamic",
@@ -1306,8 +1317,8 @@ export default function Page(): JSX.Element {
                                   sessionID={params.id!}
                                   messageID={message.id}
                                   lastUserMessageID={lastUserMessage()?.id}
-                                  showReasoning={settings.general.showReasoning()}
-                                  onShowReasoningChange={settings.general.setShowReasoning}
+                                  stepsExpanded={traceExpansion.expanded(message.id)}
+                                  onStepsExpandedToggle={() => traceExpansion.toggle(message.id)}
                                   classes={{
                                     root: "min-w-0 w-full relative",
                                     content: "flex flex-col justify-between !overflow-visible",


### PR DESCRIPTION
## Summary
Restore the 2.0.61–2.0.63-style per-turn reasoning/activity disclosure and compact tool rows. Preserve full readable reasoning and original outputs, remove the obsolete global reasoning preference, and keep mouse/keyboard disclosure interactions anchored in long chats.

Pending parent/child approvals and question drafts, explicit kernel failures, partial delegated outcomes, and scientific results remain available when activity is collapsed. Streaming, billing, cancellation, and unknown-outcome retry safeguards are unchanged.

## Verification
- 159 focused UI/workspace tests passed
- Two isolated Chromium workspace regressions passed, including long-chat scroll stability and reload persistence
- UI/workspace typechecks and production workspace build passed
- Formatting and secret scan passed

Release will follow exact-source Deep CI and the fully gated packaged rehearsal. No paid model inference or customer data mutations were used for local verification.