### PR TITLE
Preserve report links and pane reading position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ tagged release also ships native binaries for Linux, macOS, and Windows.
 
 ### Changed
 
+- Preserve original paths in assistant Markdown links, prose, code, and copied
+  responses. Opening an in-project report from chat no longer strips its project
+  prefix or changes it into an outside-workspace path.
+- Keep the reader's place when resizing the chat and file panes, including
+  inside long paragraphs, without pulling a scrolled-up reader to the latest turn.
 - Restore the classic 2.0.61–2.0.63 chat presentation: one saved reasoning/activity
   disclosure per turn, inline reasoning, and quiet tool rows without repeated
   timers or status rails. Keep live turns open on completion, anchor disclosure

--- a/backend/cli/test/mcp/oauth-browser.test.ts
+++ b/backend/cli/test/mcp/oauth-browser.test.ts
@@ -6,12 +6,15 @@ const auth = await import("@modelcontextprotocol/sdk/client/auth.js")
 // Track open() calls and control failure behavior
 let openShouldFail = false
 let openCalledWith: string | undefined
+let browserOpened = Promise.withResolvers<string>()
 let finishAuthCalls = 0
 let connectWithoutAuthorization = false
+let authorizationDelay = 0
 
 mock.module("open", () => ({
   default: async (url: string) => {
     openCalledWith = url
+    browserOpened.resolve(url)
     // Return a mock subprocess that emits an error if openShouldFail is true
     const subprocess = new EventEmitter()
     if (openShouldFail) {
@@ -39,15 +42,20 @@ const transportCalls: Array<{
   options: { authProvider?: unknown; requestInit?: { headers?: Record<string, string> } }
 }> = []
 
+type MockAuthProvider = {
+  redirectToAuthorization?: (url: URL) => Promise<void>
+  saveTokens?: (tokens: { access_token: string; token_type: string }) => Promise<void>
+}
+
 // Mock the transport constructors
 mock.module("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
   StreamableHTTPClientTransport: class MockStreamableHTTP {
     url: string
-    authProvider: { redirectToAuthorization?: (url: URL) => Promise<void> } | undefined
+    authProvider: MockAuthProvider | undefined
     constructor(
       url: URL,
       options?: {
-        authProvider?: { redirectToAuthorization?: (url: URL) => Promise<void> }
+        authProvider?: MockAuthProvider
         requestInit?: { headers?: Record<string, string> }
       },
     ) {
@@ -60,6 +68,9 @@ mock.module("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
       })
     }
     async start() {
+      const delay = authorizationDelay
+      authorizationDelay = 0
+      if (delay) await Bun.sleep(delay)
       if (connectWithoutAuthorization) return
       // Simulate OAuth redirect by calling the authProvider's redirectToAuthorization
       if (this.authProvider?.redirectToAuthorization) {
@@ -70,6 +81,9 @@ mock.module("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
     async finishAuth(_code: string) {
       // Mock successful auth completion
       finishAuthCalls++
+      if (connectWithoutAuthorization) {
+        await this.authProvider?.saveTokens?.({ access_token: "browser-test-token", token_type: "Bearer" })
+      }
     }
   },
 }))
@@ -112,9 +126,11 @@ mock.module("@modelcontextprotocol/sdk/client/auth.js", () => ({
 beforeEach(() => {
   openShouldFail = false
   openCalledWith = undefined
+  browserOpened = Promise.withResolvers<string>()
   transportCalls.length = 0
   finishAuthCalls = 0
   connectWithoutAuthorization = false
+  authorizationDelay = 0
 })
 
 // Import modules after mocking
@@ -127,6 +143,39 @@ const { tmpdir } = await import("../fixture/fixture")
 const { Config } = await import("../../src/config/config")
 const { McpAuth } = await import("../../src/mcp/auth")
 const { Log } = await import("../../src/util/log")
+const { withTimeout } = await import("../../src/util/timeout")
+
+async function authorizeBrowser(name: string, authentication: Promise<unknown>) {
+  // Observe the browser call rather than guessing when cold config, trust and
+  // durable OAuth preparation have finished. Surface early auth failures too.
+  const url = await withTimeout(
+    Promise.race([
+      browserOpened.promise,
+      authentication.then(() => {
+        throw new Error("Authentication settled without opening the browser")
+      }),
+    ]),
+    10_000,
+  )
+  const pending = await McpAuth.pendingOAuthFlow(name)
+  expect(pending?.authorizationUrl).toBe(url)
+  expect(pending?.state).toBeDefined()
+  connectWithoutAuthorization = true
+  const callback = await fetch(
+    `http://127.0.0.1:19876/mcp/oauth/callback?state=${encodeURIComponent(pending!.state)}&code=browser-test-code`,
+    { keepalive: false, signal: AbortSignal.timeout(5_000) },
+  )
+  const page = await callback.text()
+  expect(callback.status).toBe(200)
+  expect(page).toContain("Authorization Successful")
+  // Completing the flow also waits through the real browser error-detection
+  // window. Stopping the listener immediately after open() would reject its
+  // callback promise while that window is still running.
+  expect(await authentication).toEqual({ status: "connected" })
+  expect(finishAuthCalls).toBe(1)
+  expect(await McpAuth.pendingOAuthFlow(name)).toBeUndefined()
+  return url
+}
 
 async function trust() {
   const status = await ProjectTrust.status(Instance.project)
@@ -215,29 +264,27 @@ test("BrowserOpenFailed event is NOT published when open() succeeds", async () =
     fn: async () => {
       await trust()
       openShouldFail = false
+      // Model a cold preparation that exceeds the former 700 ms test sleep.
+      // This is fixture latency, not the synchronization condition.
+      authorizationDelay = 800
 
       const events: Array<{ mcpName: string; url: string }> = []
       const unsubscribe = Bus.subscribe(MCP.BrowserOpenFailed, (evt) => {
         events.push(evt.properties)
       })
 
-      // Run authenticate with a timeout to avoid waiting forever for the callback
-      const authPromise = MCP.authenticate("test-oauth-server-2").catch(() => undefined)
-
-      // Wait for the browser open attempt and the 500ms error detection timeout
-      await new Promise((resolve) => setTimeout(resolve, 700))
-
-      // Stop the callback server and cancel any pending auth
-      await McpOAuthCallback.stop()
-
-      await authPromise
-
-      unsubscribe()
-
-      // Verify NO BrowserOpenFailed event was published
-      expect(events.length).toBe(0)
-      // Verify open() was still called
-      expect(openCalledWith).toBeDefined()
+      const authPromise = MCP.authenticate("test-oauth-server-2")
+      void authPromise.catch(() => undefined)
+      try {
+        await authorizeBrowser("test-oauth-server-2", authPromise)
+        // A successful browser launch and callback must not emit a fallback URL.
+        expect(events.length).toBe(0)
+        expect(openCalledWith).toBeDefined()
+      } finally {
+        await McpOAuthCallback.stop()
+        await authPromise.catch(() => undefined)
+        unsubscribe()
+      }
     },
   })
 })
@@ -266,26 +313,21 @@ test("open() is called with the authorization URL", async () => {
     fn: async () => {
       await trust()
       openShouldFail = false
-      openCalledWith = undefined
+      authorizationDelay = 800
 
-      // Run authenticate with a timeout to avoid waiting forever for the callback
-      const authPromise = MCP.authenticate("test-oauth-server-3").catch(() => undefined)
-
-      // Wait for the browser open attempt and the 500ms error detection timeout
-      await new Promise((resolve) => setTimeout(resolve, 700))
-
-      // Stop the callback server and cancel any pending auth
-      await McpOAuthCallback.stop()
-
-      await authPromise
-
-      // Verify open was called with a URL
-      expect(openCalledWith).toBeDefined()
-      expect(typeof openCalledWith).toBe("string")
-      expect(openCalledWith!).toContain("https://")
-      expect(transportCalls.find((call) => call.type === "streamable")?.options.requestInit?.headers).toEqual({
-        "X-Tenant": "tenant-123",
-      })
+      const authPromise = MCP.authenticate("test-oauth-server-3")
+      void authPromise.catch(() => undefined)
+      try {
+        const url = await authorizeBrowser("test-oauth-server-3", authPromise)
+        expect(url).toBe("https://auth.example.com/authorize?client_id=test")
+        expect(typeof url).toBe("string")
+        expect(transportCalls.find((call) => call.type === "streamable")?.options.requestInit?.headers).toEqual({
+          "X-Tenant": "tenant-123",
+        })
+      } finally {
+        await McpOAuthCallback.stop()
+        await authPromise.catch(() => undefined)
+      }
     },
   })
 })

--- a/docs/notes/classic-chat.md
+++ b/docs/notes/classic-chat.md
@@ -28,12 +28,22 @@ phase headings or Detailed/Compact modes. Tool rows use their original icon,
 title and description, with one accessible lifecycle indicator. Full command
 output and error details remain inspectable.
 
+Assistant Markdown is rendered and copied without replacing project paths in
+the source text. Shortening an entire response can turn an absolute report link
+into a different, outside-workspace path; only explicit display labels may be
+shortened. The existing file resolver and backend still enforce workspace access.
+
 The new global toggle changed the heights of earlier turns. In a long-chat
 Chromium reproduction this displaced the clicked control by 4,400 pixels.
 The restored per-turn control avoids that global mutation. The scroll hook also
 captures a disclosure's viewport position before layout changes and corrects
 only its residual displacement after native scroll anchoring. Corrections are
 immediate, not animated; manual scrolling and Jump to latest release the anchor.
+
+For a scrolled-up reader, width changes preserve the visible text position rather
+than an obsolete pixel offset after paragraphs rewrap. This reading anchor only
+corrects width reflow, yields to manual scrolling and the disclosure anchor, and
+ignores removed content. Readers at the bottom remain there when panes resize.
 
 The 2.0.61–2.0.64 runtime used the same streaming SDK versions as 2.0.75 and
 appended reasoning deltas as they arrived. Keep that path, the readable-reasoning

--- a/frontend/ui/src/components/message-part.tsx
+++ b/frontend/ui/src/components/message-part.tsx
@@ -706,10 +706,11 @@ PART_MAPPING["tool"] = function ToolPartDisplay(props) {
 }
 
 PART_MAPPING["text"] = function TextPartDisplay(props) {
-  const data = useData()
   const i18n = useI18n()
   const part = props.part as TextPart
-  const displayText = () => relativizeProjectPaths((part.text ?? "").trim(), data.directory)
+  // Paths inside Markdown targets, prose, and code are content, not labels.
+  // Removing a project prefix corrupts their meaning before file resolution.
+  const displayText = () => (part.text ?? "").trim()
   const throttledText = createTypewriter(displayText)
   const [copied, setCopied] = createSignal(false)
   const streaming = () => props.message.role === "assistant" && !completedAt(props.message) && !part.time?.end

--- a/frontend/ui/src/components/session-turn-trajectory.test.ts
+++ b/frontend/ui/src/components/session-turn-trajectory.test.ts
@@ -470,6 +470,66 @@ describe("chronological activity in a turn", () => {
 })
 
 describe("execution inspection", () => {
+  test("assistant file links preserve Markdown targets and prose without weakening workspace boundaries", async () => {
+    const opened: string[] = []
+    const copied: string[] = []
+    const original = Object.getOwnPropertyDescriptor(navigator, "clipboard")
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: async (text: string) => {
+          copied.push(text)
+        },
+      },
+    })
+    const text = [
+      "The project is /research. Read the evidence without changing its path.",
+      "[Report](/research/COST_MODEL.md)",
+      "[Relative](COST_MODEL.md)",
+      "[Outside](/research-archive/COST_MODEL.md)",
+      "[Web](https://example.com/research/COST_MODEL.md)",
+      "`cat /research/COST_MODEL.md`",
+    ].join("\n\n")
+    const part: TextPart = { id: "prt_absolute_link", sessionID, messageID: "msg_0002", type: "text", text }
+    try {
+      const host = mount(
+        () =>
+          web.createComponent(markdown.MarkdownImages, {
+            resolve: (src) => src,
+            resolveFile: (path) => assets.workspaceAssetPath(path, "/research"),
+            openFile: (path) => opened.push(path),
+            get children() {
+              return parts.Part({ part, message: assistant(3_000) })
+            },
+          }),
+        empty(),
+      )
+      await ready(() => host.querySelectorAll('[data-slot="assistant-prose"] a').length === 4)
+      const anchors = [...host.querySelectorAll<HTMLAnchorElement>('[data-slot="assistant-prose"] a')]
+      expect(anchors.map((anchor) => anchor.getAttribute("href"))).toEqual([
+        "/research/COST_MODEL.md",
+        "COST_MODEL.md",
+        "/research-archive/COST_MODEL.md",
+        "https://example.com/research/COST_MODEL.md",
+      ])
+      expect(anchors[0].getAttribute("data-file-path")).toBe("/research/COST_MODEL.md")
+      expect(anchors[1].getAttribute("data-file-path")).toBe("COST_MODEL.md")
+      expect(anchors[2].hasAttribute("data-file-path")).toBe(false)
+      expect(anchors[3].hasAttribute("data-file-path")).toBe(false)
+      anchors[0].click()
+      anchors[1].click()
+      expect(opened).toEqual(["/research/COST_MODEL.md", "COST_MODEL.md"])
+      expect(host.textContent).toContain("The project is /research.")
+      expect(host.querySelector("code")?.textContent).toBe("cat /research/COST_MODEL.md")
+      host.querySelector<HTMLButtonElement>('[data-slot="text-part-copy-wrapper"] button')!.click()
+      await ready(() => copied.length === 1)
+      expect(copied).toEqual([text])
+    } finally {
+      if (original) Object.defineProperty(navigator, "clipboard", original)
+      else Reflect.deleteProperty(navigator, "clipboard")
+    }
+  })
+
   test("a preview's explicit file resolver is not replaced by surrounding turn provenance", async () => {
     const opened: string[] = []
     const host = mount(

--- a/frontend/ui/src/hooks/create-auto-scroll.test.ts
+++ b/frontend/ui/src/hooks/create-auto-scroll.test.ts
@@ -37,7 +37,7 @@ const hooks = (await vite.ssrLoadModule("/src/hooks/create-auto-scroll.tsx")) as
 const cleanups: Array<() => void> = []
 const settle = () => new Promise((resolve) => setTimeout(resolve, 0))
 
-const fixture = async (working = false) => {
+const fixture = async (working = false, reader = false) => {
   const scroll = document.createElement("div")
   const content = document.createElement("div")
   const button = document.createElement("button")
@@ -45,17 +45,43 @@ const fixture = async (working = false) => {
   content.append(button)
   scroll.append(content)
   document.body.append(scroll)
-  const size = { height: 3000, viewport: 500, button: 2750, top: 2500 }
+  const size = { height: 3000, viewport: 500, width: 700, button: 2750, reading: 1020, top: 2500 }
   Object.defineProperties(scroll, {
     scrollHeight: { get: () => size.height },
     clientHeight: { get: () => size.viewport },
+    clientWidth: { get: () => size.width },
     scrollTop: {
       get: () => size.top,
       set: (value: number) => (size.top = Math.max(0, Math.min(value, size.height - size.viewport))),
     },
   })
-  content.getBoundingClientRect = () => new DOMRect(0, -size.top, 700, size.height)
+  scroll.getBoundingClientRect = () => new DOMRect(0, 0, size.width, size.viewport)
+  content.getBoundingClientRect = () => new DOMRect(0, -size.top, size.width, size.height)
   button.getBoundingClientRect = () => new DOMRect(0, size.button - size.top, 100, 24)
+  const paragraph = document.createElement("p")
+  paragraph.textContent = "Result 11 remains the current reading position during reflow."
+  paragraph.getBoundingClientRect = () => new DOMRect(0, size.reading - size.top, size.width, 20)
+  if (reader) {
+    content.prepend(paragraph)
+    const position = Object.getOwnPropertyDescriptor(document, "caretPositionFromPoint")
+    const range = Object.getOwnPropertyDescriptor(document, "caretRangeFromPoint")
+    Object.defineProperty(document, "caretPositionFromPoint", { configurable: true, value: undefined })
+    Object.defineProperty(document, "caretRangeFromPoint", {
+      configurable: true,
+      value: () => {
+        const range = document.createRange()
+        range.setStart(paragraph.firstChild!, 10)
+        range.getBoundingClientRect = paragraph.getBoundingClientRect
+        return range
+      },
+    })
+    cleanups.push(() => {
+      if (position) Object.defineProperty(document, "caretPositionFromPoint", position)
+      else Reflect.deleteProperty(document, "caretPositionFromPoint")
+      if (range) Object.defineProperty(document, "caretRangeFromPoint", range)
+      else Reflect.deleteProperty(document, "caretRangeFromPoint")
+    })
+  }
   const follow = reactive.createRoot((dispose) => {
     cleanups.push(dispose)
     const follow = hooks.createAutoScroll({ working: () => working })
@@ -67,7 +93,7 @@ const fixture = async (working = false) => {
   const resize = (target = content) => {
     for (const observer of [...observers]) {
       if (!observer.targets.has(target)) continue
-      const rect = target === content ? content.getBoundingClientRect() : new DOMRect(0, 0, 700, size.viewport)
+      const rect = target.getBoundingClientRect()
       const box = [{ inlineSize: rect.width, blockSize: rect.height }]
       observer.callback(
         [{ target, contentRect: rect, borderBoxSize: box, contentBoxSize: box, devicePixelContentBoxSize: box }],
@@ -76,7 +102,7 @@ const fixture = async (working = false) => {
     }
   }
   resize()
-  return { scroll, content, button, size, follow, resize }
+  return { scroll, content, button, paragraph, size, follow, resize }
 }
 
 afterEach(() => {
@@ -143,6 +169,130 @@ describe("conversation scroll anchoring", () => {
     view.size.viewport = 200
     view.resize(view.scroll)
     expect(view.size.top).toBe(1000)
+  })
+
+  test.each([false, true])("width reflow preserves a detached text position (working=%s)", async (working) => {
+    const view = await fixture(working, true)
+    view.size.top = 1000
+    view.follow.handleScroll()
+    const before = view.paragraph.getBoundingClientRect().top
+    view.size.width = 500
+    view.size.height += 900
+    view.size.reading += 600
+    view.resize()
+    view.resize(view.scroll)
+    expect(view.size.top).toBe(1600)
+    expect(view.paragraph.getBoundingClientRect().top).toBe(before)
+    expect(view.follow.userScrolled()).toBe(true)
+
+    view.size.width = 800
+    view.size.height -= 400
+    view.size.reading -= 250
+    view.resize(view.scroll)
+    view.resize()
+    expect(view.size.top).toBe(1350)
+    expect(view.paragraph.getBoundingClientRect().top).toBe(before)
+  })
+
+  test("native width anchoring is not applied twice and height-only growth does not move the reader", async () => {
+    const view = await fixture(false, true)
+    view.size.top = 1000
+    view.follow.handleScroll()
+    view.size.height += 400
+    view.resize()
+    expect(view.size.top).toBe(1000)
+    view.size.width = 500
+    view.size.reading += 300
+    view.size.top += 300
+    view.resize()
+    expect(view.size.top).toBe(1300)
+  })
+
+  test("a resize shield does not discard the text anchor between pointer moves", async () => {
+    const view = await fixture(false, true)
+    view.size.top = 1000
+    view.follow.handleScroll()
+    Object.defineProperty(document, "caretRangeFromPoint", { configurable: true, value: () => null })
+    view.size.width = 600
+    view.size.height += 400
+    view.size.reading += 200
+    view.resize()
+    expect(view.size.top).toBe(1200)
+    view.size.width = 500
+    view.size.height += 400
+    view.size.reading += 200
+    view.resize()
+    expect(view.size.top).toBe(1400)
+    expect(view.paragraph.getBoundingClientRect().top).toBe(20)
+  })
+
+  test("blank space at the viewport top skips an offscreen caret for the next visible line", async () => {
+    const view = await fixture(false, true)
+    const previous = document.createElement("p")
+    previous.textContent = "This previous result is above the viewport."
+    view.content.prepend(previous)
+    view.size.top = 1000
+    view.size.reading = 1040
+    Object.defineProperty(document, "caretRangeFromPoint", {
+      configurable: true,
+      value: (_x: number, y: number) => {
+        const range = document.createRange()
+        range.setStart(y < 40 ? previous.firstChild! : view.paragraph.firstChild!, 0)
+        range.getBoundingClientRect =
+          y < 40 ? () => new DOMRect(0, -20, view.size.width, 20) : view.paragraph.getBoundingClientRect
+        return range
+      },
+    })
+    view.follow.handleScroll()
+    view.size.width = 500
+    view.size.height += 400
+    view.size.reading += 200
+    view.resize()
+    expect(view.size.top).toBe(1200)
+    expect(view.paragraph.getBoundingClientRect().top).toBe(40)
+  })
+
+  test.each(["wheel", "keydown", "touchmove", "pointerdown"])(
+    "%s intent cancels a stale reading position before width reflow",
+    async (type) => {
+      const view = await fixture(true, true)
+      view.size.top = 1000
+      view.follow.handleScroll()
+      view.scroll.dispatchEvent(
+        type === "wheel"
+          ? new WheelEvent(type, { deltaY: -40 })
+          : type === "keydown"
+            ? new KeyboardEvent(type, { key: "PageUp" })
+            : new window.Event(type),
+      )
+      view.size.top -= 40
+      view.size.width = 500
+      view.size.height += 500
+      view.size.reading += 300
+      view.resize()
+      expect(view.size.top).toBe(960)
+    },
+  )
+
+  test("disconnected reading text is ignored instead of restoring its former parent", async () => {
+    const view = await fixture(false, true)
+    view.size.top = 1000
+    view.follow.handleScroll()
+    view.paragraph.remove()
+    view.size.width = 500
+    view.size.reading += 300
+    view.resize()
+    expect(view.size.top).toBe(1000)
+  })
+
+  test("a bottom reader stays at the bottom on width reflow after the turn settles", async () => {
+    const view = await fixture(false, true)
+    await new Promise((resolve) => setTimeout(resolve, 310))
+    view.size.width = 500
+    view.size.height += 500
+    view.resize()
+    expect(view.size.top).toBe(3000)
+    expect(view.follow.userScrolled()).toBe(false)
   })
 
   test.each(["PageUp", "PageDown", "ArrowUp", "ArrowDown", "Home", "End", " "])(

--- a/frontend/ui/src/hooks/create-auto-scroll.tsx
+++ b/frontend/ui/src/hooks/create-auto-scroll.tsx
@@ -17,8 +17,10 @@ export function createAutoScroll(options: AutoScrollOptions) {
   let cleanup: (() => void) | undefined
   let auto: { top: number; time: number } | undefined
   let height = 0
+  let width = 0
   let anchor: { element: HTMLElement; top: number; until: number } | undefined
   let anchorFrame: number | undefined
+  let reading: { node: Node; range?: Range; top: number } | undefined
 
   const threshold = () => options.bottomThreshold ?? 10
 
@@ -81,7 +83,10 @@ export function createAutoScroll(options: AutoScrollOptions) {
   }
 
   const scrollToBottom = (force: boolean) => {
-    if (force) anchor = undefined
+    if (force) {
+      anchor = undefined
+      reading = undefined
+    }
     if (!force && !active()) return
     const el = scroll
     if (!el) return
@@ -111,6 +116,7 @@ export function createAutoScroll(options: AutoScrollOptions) {
 
   const handleWheel = (e: WheelEvent) => {
     anchor = undefined
+    reading = undefined
     if (e.deltaY >= 0) return
     // If the user is scrolling within a nested scrollable region (tool output,
     // code block, etc), don't treat it as leaving the "follow bottom" mode.
@@ -131,6 +137,7 @@ export function createAutoScroll(options: AutoScrollOptions) {
     }
 
     if (distanceFromBottom(el) < threshold()) {
+      reading = undefined
       if (store.userScrolled) setStore("userScrolled", false)
       return
     }
@@ -142,11 +149,89 @@ export function createAutoScroll(options: AutoScrollOptions) {
     }
 
     stop()
+    captureReading()
   }
 
   const handleInteraction = () => {
-    if (!active()) return
-    stop()
+    if (active()) stop()
+    captureReading()
+  }
+
+  const captureReading = () => {
+    const el = scroll
+    if (!el || !store.userScrolled) return
+    if (reading && (!el.contains(reading.node) || (reading.range && reading.range.startContainer !== reading.node))) {
+      reading = undefined
+    }
+    const bounds = el.getBoundingClientRect()
+    const x = bounds.left + el.clientWidth / 2
+    const document = el.ownerDocument
+    const visible = (rect: DOMRect) => rect.height > 0 && rect.top >= bounds.top && rect.top < bounds.bottom
+    let fallback: typeof reading
+    // A point in paragraph spacing can resolve to the preceding offscreen
+    // text. Sample a few visible lines instead of anchoring that stale line.
+    for (const offset of [12, 32, 56, 80, 120]) {
+      const y = bounds.top + Math.min(offset, el.clientHeight / 2)
+      const caret = document.caretPositionFromPoint?.(x, y)
+      const range = caret ? document.createRange() : document.caretRangeFromPoint?.(x, y)
+      if (caret && range) range.setStart(caret.offsetNode, caret.offset)
+      const node = range?.startContainer
+      if (node?.nodeType === Node.TEXT_NODE && store.contentRef?.contains(node)) {
+        const length = node.textContent?.length ?? 0
+        if (length && range) {
+          // A single text character survives line wrapping better than either
+          // scrollTop or the top of a paragraph that spans several screens.
+          const start = Math.min(range.startOffset, length - 1)
+          range.setStart(node, start)
+          range.setEnd(node, start + 1)
+          const rect = range.getBoundingClientRect()
+          if (visible(rect)) {
+            reading = { node, range, top: rect.top - bounds.top }
+            return
+          }
+        }
+      }
+      const target = document.elementFromPoint?.(x, y)
+      const element = target?.closest("p, li, pre, td, th, h1, h2, h3, h4, h5, h6, button, summary") ?? target
+      if (
+        !fallback &&
+        element &&
+        element !== el &&
+        element !== store.contentRef &&
+        store.contentRef?.contains(element)
+      ) {
+        const rect = element.getBoundingClientRect()
+        if (visible(rect)) fallback = { node: element, top: rect.top - bounds.top }
+      }
+    }
+    // A resize drag can put a pointer-capture shield over the conversation.
+    // Keep the connected anchor until content can be hit-tested again; manual
+    // scroll intent already clears it before reaching this function.
+    if (fallback) reading = fallback
+  }
+
+  const restoreReading = (disclosure: boolean) => {
+    const el = scroll
+    if (!el) return false
+    const previous = width
+    width = el.clientWidth
+    if (!previous || width === previous) return false
+    if (disclosure) {
+      captureReading()
+      return true
+    }
+    if (!store.userScrolled) {
+      scrollToBottom(true)
+      return true
+    }
+    const saved = reading
+    if (saved && el.contains(saved.node) && (!saved.range || saved.range.startContainer === saved.node)) {
+      const rect = saved.range?.getBoundingClientRect() ?? (saved.node as Element).getBoundingClientRect()
+      const delta = rect.top - el.getBoundingClientRect().top - saved.top
+      if (rect.height > 0 && Math.abs(delta) > 1) el.scrollTop += delta
+    }
+    captureReading()
+    return true
   }
 
   const restoreAnchor = () => {
@@ -184,6 +269,7 @@ export function createAutoScroll(options: AutoScrollOptions) {
 
   const clearAnchor = () => {
     anchor = undefined
+    reading = undefined
   }
 
   const handleKeydown = (event: KeyboardEvent) => {
@@ -219,7 +305,8 @@ export function createAutoScroll(options: AutoScrollOptions) {
       const el = scroll
       const grew = next > height
       height = next
-      if (restoreAnchor()) return
+      const disclosure = restoreAnchor()
+      if (restoreReading(disclosure) || disclosure) return
       if (el && !canScroll(el)) return
       if (!active()) return
       if (store.userScrolled) return
@@ -237,7 +324,8 @@ export function createAutoScroll(options: AutoScrollOptions) {
   createResizeObserver(
     () => store.scrollRef,
     () => {
-      if (restoreAnchor()) return
+      const disclosure = restoreAnchor()
+      if (restoreReading(disclosure) || disclosure) return
       scrollToBottom(false)
     },
   )
@@ -273,6 +361,7 @@ export function createAutoScroll(options: AutoScrollOptions) {
     if (settleTimer) clearTimeout(settleTimer)
     if (autoTimer) clearTimeout(autoTimer)
     if (anchorFrame !== undefined) cancelAnimationFrame(anchorFrame)
+    reading = undefined
     if (cleanup) cleanup()
   })
 
@@ -286,6 +375,8 @@ export function createAutoScroll(options: AutoScrollOptions) {
       scroll = el
       setStore("scrollRef", el)
       anchor = undefined
+      reading = undefined
+      width = el?.clientWidth ?? 0
 
       if (!el) return
 

--- a/frontend/workspace/e2e/classic-chat.spec.ts
+++ b/frontend/workspace/e2e/classic-chat.spec.ts
@@ -1,6 +1,7 @@
 import type { AssistantMessage, Part, ReasoningPart, TextPart, UserMessage } from "@synsci/sdk/v2"
 import type { Locator, Page } from "@playwright/test"
 import { test, expect } from "./fixtures"
+import { openFilesSources } from "./utils"
 
 test.skip(process.env.OPENSCIENCE_E2E_FAKE_MODEL !== "1", "requires the isolated deterministic model")
 
@@ -23,6 +24,32 @@ async function settleLayout(page: Page) {
   await page.evaluate(
     () => new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve()))),
   )
+}
+
+async function dragInspector(page: Page, distance: number, verify: () => Promise<void>) {
+  const handle = page.getByRole("separator", { name: "Resize research inspector", exact: true })
+  const box = await handle.boundingBox()
+  if (!box) throw new Error("The inspector resize handle did not render")
+  const before = Number(await handle.getAttribute("aria-valuenow"))
+  const x = box.x + box.width / 2
+  const y = box.y + box.height / 2
+  await page.mouse.move(x, y)
+  await page.mouse.down()
+  try {
+    await expect(page.locator("[data-pane-resize-shield]")).toHaveCount(1)
+    // Separate pointer moves and layout frames are essential: the drag shield
+    // intercepts hit-testing after the first correction, but reading must stay
+    // anchored for the entire drag, not just its first frame.
+    for (const fraction of [0.25, 0.5, 0.75, 1]) {
+      await page.mouse.move(x + distance * fraction, y)
+      await settleLayout(page)
+      await verify()
+    }
+  } finally {
+    await page.mouse.up()
+  }
+  await expect(page.locator("[data-pane-resize-shield]")).toHaveCount(0)
+  expect(Math.abs(Number(await handle.getAttribute("aria-valuenow")) - before)).toBeGreaterThan(100)
 }
 
 test("classic long-chat disclosures preserve the reader, stay per-turn, and survive reload", async ({
@@ -85,7 +112,7 @@ test("classic long-chat disclosures preserve the reader, stay per-turn, and surv
         sessionID,
         type: "text",
         text:
-          `Conclusion for experiment ${index}.\n\n` +
+          `## Conclusion for experiment ${index}.\n\n` +
           Array.from(
             { length: 5 },
             () =>
@@ -153,6 +180,76 @@ test("classic long-chat disclosures preserve the reader, stay per-turn, and surv
     await expect(page.locator(reasoningBody)).toHaveCount(2)
     await expect(turn(7).locator(disclosure)).toHaveAttribute("aria-expanded", "false")
     await expect(turn(1).locator(disclosure)).toHaveAttribute("aria-expanded", "true")
+
+    await page.setViewportSize({ width: 1440, height: 900 })
+    await openFilesSources(page)
+    await expect(page.locator(".session-right-pane")).toHaveAttribute("data-overlay", "false")
+    const handle = page.getByRole("separator", { name: "Resize research inspector", exact: true })
+    await handle.press("Home")
+    await settleLayout(page)
+
+    const paragraph = turn(9).locator('[data-component="text-part"] p').first()
+    await paragraph.evaluate((element) => {
+      const scroller = element.closest<HTMLElement>(".session-scroller")!
+      scroller.scrollTop += element.getBoundingClientRect().top - scroller.getBoundingClientRect().top + 8
+      scroller.dispatchEvent(new Event("scroll"))
+    })
+    await settleLayout(page)
+    const character = await page.locator(".session-scroller").evaluateHandle((scroller) => {
+      const bounds = scroller.getBoundingClientRect()
+      for (const offset of [12, 32, 56]) {
+        const caret = document.caretPositionFromPoint(bounds.left + scroller.clientWidth / 2, bounds.top + offset)
+        if (!caret || caret.offsetNode.nodeType !== Node.TEXT_NODE || !scroller.contains(caret.offsetNode)) continue
+        const range = document.createRange()
+        const start = Math.min(caret.offset, (caret.offsetNode.textContent?.length ?? 0) - 1)
+        if (start < 0) continue
+        range.setStart(caret.offsetNode, start)
+        range.setEnd(caret.offsetNode, start + 1)
+        if (range.getBoundingClientRect().top >= bounds.top) return range
+      }
+      throw new Error("The fixture reading point must be visible conversation text")
+    })
+    const textTop = () =>
+      character.evaluate((range) => {
+        const scroller = range.startContainer.parentElement!.closest(".session-scroller")!
+        return range.getBoundingClientRect().top - scroller.getBoundingClientRect().top
+      })
+    const beforeText = await textTop()
+    expect(beforeText).toBeGreaterThanOrEqual(0)
+    const checkText = async () => expect(Math.abs((await textTop()) - beforeText)).toBeLessThanOrEqual(2)
+    await dragInspector(page, -185, checkText)
+    await dragInspector(page, 185, checkText)
+    await character.dispose()
+
+    // Heading spacing must not select the preceding offscreen paragraph.
+    const heading = turn(9).getByRole("heading", { name: "Conclusion for experiment 9.", exact: true })
+    await heading.evaluate((element) => {
+      const scroller = element.closest<HTMLElement>(".session-scroller")!
+      scroller.scrollTop += element.getBoundingClientRect().top - scroller.getBoundingClientRect().top - 44
+      scroller.dispatchEvent(new Event("scroll"))
+    })
+    await settleLayout(page)
+    const headingTop = () =>
+      heading.evaluate(
+        (element) =>
+          element.getBoundingClientRect().top - element.closest(".session-scroller")!.getBoundingClientRect().top,
+      )
+    const beforeHeading = await headingTop()
+    const checkHeading = async () => expect(Math.abs((await headingTop()) - beforeHeading)).toBeLessThanOrEqual(2)
+    await dragInspector(page, -185, checkHeading)
+    await dragInspector(page, 185, checkHeading)
+
+    await page.getByRole("button", { name: "Jump to Latest", exact: true }).click()
+    await settleLayout(page)
+    const checkBottom = async () => {
+      const remaining = await page
+        .locator(".session-scroller")
+        .evaluate((element) => element.scrollHeight - element.clientHeight - element.scrollTop)
+      expect(Math.abs(remaining)).toBeLessThanOrEqual(2)
+    }
+    await checkBottom()
+    await dragInspector(page, -185, checkBottom)
+    await dragInspector(page, 185, checkBottom)
   } finally {
     await sdk.session.delete({ sessionID }).catch(() => undefined)
   }


### PR DESCRIPTION
## Summary

- Preserve original assistant Markdown targets, prose, code, and copied text. A valid absolute project report link must not lose its project prefix before the workspace resolver sees it; outside-project and external links retain their existing boundaries.
- Preserve the visible text position during chat/inspector width reflow. Keep the anchor through the divider's drag shield, reject offscreen caret selections in blank spacing, yield to explicit scrolling and per-turn disclosures, and retain bottom-follow after completion.
- Replace two OAuth browser tests' fixed 700 ms waits with the actual browser-open and exact callback lifecycle. An 800 ms preparation fixture reproduces the former test race; production OAuth behavior is unchanged.

## Verification

- All package typechecks passed.
- Shared UI suite: 246 passed, 2,740 assertions.
- OAuth browser suite: 8 passed, 48 assertions; old timing assumption independently reproduced as the failure.
- Both focused full-app Chromium regressions passed, including repeated real divider drags and reload/disclosure persistence.
- Hands-on computer-use checks passed: mouse/keyboard per-turn disclosure, complete supplied reasoning and tool output, retained errors when collapsed, file-link preview, repeated divider moves, bottom-follow, and a deterministic loopback streamed response.
- Formatting, diff checks, and pre-commit secret scan passed.

No customer session, provider inference, billing, or account credentials were changed. This follows the classic trace restoration in #538. A fresh exact-source release candidate is required; the previous prerelease is not reused for these changed bytes.
