### PR TITLE
Verify composer roster without a stale row limit

### DIFF
--- a/frontend/workspace/e2e/model-picker.spec.ts
+++ b/frontend/workspace/e2e/model-picker.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "./fixtures"
 import { modelPopoverSelector, modelRowValue, modelTriggerSelector, setModelEffort } from "./utils"
+import { COMPOSER_MODEL_ROSTER } from "../src/context/model-catalog"
 
 test("smoke model selection updates the composer trigger", async ({ page, gotoSession }) => {
   await gotoSession()
@@ -33,13 +34,24 @@ test("effort selection closes cleanly and Manage models opens Customize", async 
   const picker = page.locator(modelPopoverSelector)
   await setModelEffort(page, "high")
   await expect(modelRowValue(page, "effort")).resolves.toBe("High")
+  const current = (await trigger.locator(":scope > .truncate").innerText()).trim()
+  expect(current).not.toBe("")
 
   await trigger.click()
   await expect(picker).toHaveAttribute("data-model-settings-view", "root")
   await expect(picker.getByRole("radiogroup", { name: "Model", exact: true })).toBeVisible()
-  const quickCount = await picker.locator("[data-model-quick]").count()
-  expect(quickCount).toBeGreaterThan(0)
-  expect(quickCount).toBeLessThanOrEqual(10)
+  // An explicitly selected model outside the roster (the isolated Echo model,
+  // for example) stays reachable without leaking the full provider catalog.
+  const roster: string[] = COMPOSER_MODEL_ROSTER.map((model) => model.label)
+  const expected = roster.includes(current) ? roster : [...roster, current]
+  await expect(picker.locator("[data-model-quick] .model-settings-model > strong")).toHaveText(expected)
+  const selected = picker.locator('[data-model-quick][aria-checked="true"]')
+  await expect(selected).toHaveCount(1)
+  await expect(selected.locator(".model-settings-model > strong")).toHaveText(current)
+  const choices = await picker
+    .locator("[data-model-quick][data-model-choice]")
+    .evaluateAll((elements) => elements.map((element) => element.getAttribute("data-model-choice")))
+  expect(new Set(choices).size).toBe(choices.length)
   await expect.poll(() => picker.evaluate((element) => element.scrollTop)).toBe(0)
 
   await picker.locator('[data-model-menu-row="model"]').click()


### PR DESCRIPTION
## Summary

The exact-package release rehearsal exposed one stale browser-test assertion: the composer now correctly renders ten curated model rows plus the explicitly selected out-of-roster test model, while this test assumed at most ten total rows.

Replace the numeric cap with assertions for the rendered roster order, retained current model, exactly one selected choice and unique callable logical-model choices. Preserve all existing effort-selection, scroll-position, footer containment and Manage Models navigation checks. No production UI or model behavior changes.

## Verification

- Isolated real-browser model-picker tests: 4 passed, 0 failed across two repetitions, retries disabled.
- Workspace typecheck, formatting and git diff check passed.
- Independent review approved the behavior assertions.

The prior immutable candidate is preserved. After merge, the new exact source will receive a fresh fully gated release rehearsal; no original candidate bytes, cache markers or publication gates are changed.