### PR TITLE
Align browser checks with the runtime prompt API

### DIFF
--- a/frontend/workspace/e2e/model-tier.spec.ts
+++ b/frontend/workspace/e2e/model-tier.spec.ts
@@ -17,7 +17,7 @@ test("model speed toggles through model options and reaches the prompt request",
   const send = async (tier?: string) => {
     const request = page.waitForRequest((request) => {
       const path = new URL(request.url()).pathname
-      return request.method() === "POST" && /\/session\/[^/]+\/message$/.test(path)
+      return request.method() === "POST" && path === "/runtime/prompt"
     })
     const token = `E2E_OK_${Date.now()}`
     const prompt = page.locator(promptSelector)

--- a/frontend/workspace/e2e/thinking-level.spec.ts
+++ b/frontend/workspace/e2e/thinking-level.spec.ts
@@ -15,7 +15,7 @@ test("thinking effort and speed reach the prompt request through the settings po
   const send = async (options: { variant?: string; tier?: string } = {}) => {
     const request = page.waitForRequest((request) => {
       const path = new URL(request.url()).pathname
-      return request.method() === "POST" && /\/session\/[^/]+\/message$/.test(path)
+      return request.method() === "POST" && path === "/runtime/prompt"
     })
     const token = `E2E_OK_${Date.now()}`
     const prompt = page.locator(promptSelector)


### PR DESCRIPTION
The Research composer submits prompts through the public runtime API. Two browser tests still waited for the session-message endpoint, timing out after successful submissions. Update those two endpoint matchers while retaining effort, speed, persistence, and command-model override assertions.

Validation: both focused browser specs passed without retries, and all17 runtime prompt unit tests passed. CI traces from the failed packaged rehearsal independently show successful runtime submissions with the expected controls.
