### PR TITLE
Isolate packaged macOS workers from application state

### DIFF
--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -417,6 +417,14 @@ jobs:
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 25
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: runner.os == 'macOS'
+        with:
+          ref: ${{ needs.publish-test.outputs.source }}
+      - uses: ./.github/actions/setup-bun
+        if: runner.os == 'macOS'
+        with:
+          install: "false"
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24"
@@ -445,6 +453,30 @@ jobs:
           echo "::error::openscience server never became healthy"
           cat "$RUNNER_TEMP/openscience-smoke.log" || true
           exit 1
+      - name: Verify compiled macOS worker startup with piped stdin
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -euo pipefail
+          modules="$RUNNER_TEMP/openscience-prefix/lib/node_modules"
+          native=$(node --input-type=module - "$modules" <<'NODE'
+          import path from "node:path"
+          import { createRequire } from "node:module"
+          const require = createRequire(path.join(process.argv[2], "@synsci/openscience/package.json"))
+          const manifest = require.resolve(`@synsci/openscience-darwin-${process.arch}/package.json`)
+          console.log(path.join(path.dirname(manifest), "bin/openscience"))
+          NODE
+          )
+          bun --no-env-file backend/cli/script/smoke-darwin-launcher.ts "$native" "$RUNNER_TEMP/darwin-launcher-smoke"
+      - name: Upload macOS worker startup evidence
+        if: always() && runner.os == 'macOS'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: npm-test-darwin-launcher-${{ github.run_attempt }}
+          if-no-files-found: error
+          include-hidden-files: true
+          retention-days: 30
+          path: ${{ runner.temp }}/darwin-launcher-smoke
       - name: Install and smoke OpenScience test package
         if: runner.os == 'Windows'
         shell: pwsh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ tagged release also ships native binaries for Linux, macOS, and Windows.
 
 ### Changed
 
+- Start packaged macOS workers without loading application configuration or
+  migrating storage, and verify their gated startup and piped input in release smokes.
 - Preserve optional/defaulted tool inputs in provider schemas and clarify inline
   page reads versus raw downloads. Distinguish completed subagent handoffs with
   failed attempts from unfinished work, retain empty first-turn recovery baselines,

--- a/backend/cli/script/smoke-darwin-launcher.ts
+++ b/backend/cli/script/smoke-darwin-launcher.ts
@@ -1,0 +1,235 @@
+#!/usr/bin/env bun
+
+import assert from "node:assert/strict"
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { spawn } from "node:child_process"
+import { DarwinResponsibility } from "../src/process/darwin-responsibility"
+import {
+  DARWIN_RESPONSIBILITY_ACTIVATION_SUFFIX,
+  DARWIN_RESPONSIBILITY_LAUNCHER_ARG,
+} from "../src/process/darwin-responsibility-launcher"
+
+// The parent needs only Bun's libproc bindings. The subject must be the real
+// installed binary: source launchers bypass the compiled bootstrap graph.
+const binary = process.argv[2]
+if (!binary || process.platform !== "darwin") {
+  throw new Error("usage (macOS): smoke-darwin-launcher.ts <native-binary> [evidence-directory]")
+}
+const executable = await fs.realpath(binary)
+const evidence = process.argv[3]
+  ? path.resolve(process.argv[3])
+  : await fs.mkdtemp(path.join(os.tmpdir(), "openscience-darwin-launcher-evidence-"))
+await fs.mkdir(evidence, { recursive: true })
+// After responsibility disclaim, a developer's Documents directory can be
+// protected by macOS privacy controls. Evidence placement must not change the
+// worker's cwd or HOME; CI already installs the native package in runner temp.
+const root = await fs.mkdtemp(path.join(os.tmpdir(), "openscience-darwin-launcher-"))
+const retainedRoot = path.join(evidence, path.basename(root))
+const application = path.join(root, "application")
+const directories = Object.fromEntries(
+  ["home", "data", "cache", "config", "share", "state"].map((name) => [name, path.join(application, name)]),
+)
+await Promise.all(
+  Object.entries(directories)
+    .filter(([name]) => name !== "config")
+    .map(([, directory]) => fs.mkdir(directory, { recursive: true })),
+)
+// A worker launcher does not need application configuration. A regular file
+// at the configured directory catches accidental imports of Global/DataRoot.
+await Bun.write(directories.config, "Internal launchers must not initialize application configuration.\n")
+const release = path.join(root, "release")
+const ready = path.join(root, "stage-one-ready")
+const latch = path.join(root, "stage-two-ready")
+const payload = path.join(root, "payload-started")
+const started = Date.now()
+const stages: Array<{ name: string; elapsedMs: number }> = []
+const record = (name: string) => stages.push({ name, elapsedMs: Date.now() - started })
+
+async function snapshot(directory: string): Promise<Record<string, string>> {
+  const result: Record<string, string> = {}
+  for (const entry of await fs.readdir(directory, { withFileTypes: true })) {
+    const file = path.join(directory, entry.name)
+    result[entry.name] = entry.isDirectory()
+      ? "directory"
+      : entry.isSymbolicLink()
+        ? `symlink:${await fs.readlink(file)}`
+        : new Bun.CryptoHasher("sha256").update(await Bun.file(file).arrayBuffer()).digest("hex")
+    if (!entry.isDirectory()) continue
+    for (const [name, value] of Object.entries(await snapshot(file))) result[`${entry.name}/${name}`] = value
+  }
+  return result
+}
+
+const before = await snapshot(application)
+await Bun.write(path.join(evidence, "application-before.json"), JSON.stringify(before, null, 2) + "\n")
+const owner = DarwinResponsibility.identity(process.pid)
+assert.ok(owner, "could not capture the smoke runner's macOS process identity")
+const child = spawn(
+  executable,
+  [
+    DARWIN_RESPONSIBILITY_LAUNCHER_ARG,
+    release,
+    ready,
+    "0",
+    "0",
+    String(process.pid),
+    owner,
+    "/bin/sh",
+    "-c",
+    'printf started > "$1"; exec /bin/cat',
+    "--",
+    payload,
+  ],
+  {
+    cwd: root,
+    detached: true,
+    stdio: ["pipe", "pipe", "pipe"],
+    // Never inherit developer/CI provider credentials or application state.
+    env: {
+      PATH: "/usr/bin:/bin:/usr/sbin:/sbin",
+      HOME: directories.home,
+      TMPDIR: root,
+      OPENSCIENCE_TEST_HOME: directories.home,
+      OPENSCIENCE_DATA_DIR: directories.data,
+      OPENSCIENCE_CONFIG_DIR: directories.config,
+      XDG_DATA_HOME: directories.share,
+      XDG_CACHE_HOME: directories.cache,
+      XDG_CONFIG_HOME: directories.config,
+      XDG_STATE_HOME: directories.state,
+      OPENSCIENCE_DISABLE_MODELS_FETCH: "true",
+      OPENSCIENCE_DISABLE_PROJECT_CONFIG: "true",
+      OPENSCIENCE_DISABLE_DEFAULT_PLUGINS: "true",
+      OPENSCIENCE_DISABLE_SHARE: "true",
+      OPENSCIENCE_DARWIN_SUPERVISOR_TEST_READY: latch,
+    },
+  },
+)
+let stdout = Buffer.alloc(0)
+let stderr = Buffer.alloc(0)
+let failure: unknown
+let identity: string | undefined
+let responsibility: string | undefined
+let closed = false
+const completion = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve, reject) => {
+  child.once("error", reject)
+  child.once("close", (code, signal) => {
+    closed = true
+    resolve({ code, signal })
+  })
+})
+void completion.catch(() => undefined)
+child.stdout.on("data", (chunk: Buffer) => {
+  stdout = Buffer.concat([stdout, chunk]).subarray(0, 65_536)
+})
+child.stderr.on("data", (chunk: Buffer) => {
+  stderr = Buffer.concat([stderr, chunk]).subarray(0, 65_536)
+})
+child.stdin.on("error", (error) => {
+  failure ??= error
+})
+
+async function wait(name: string, condition: () => boolean | Promise<boolean>) {
+  const deadline = Date.now() + 10_000
+  while (!(await condition())) {
+    if (closed) throw new Error(`${name}: launcher exited early (${JSON.stringify(await completion)})`)
+    if (failure) throw failure
+    if (Date.now() >= deadline) throw new Error(`${name}: timed out after 10000ms`)
+    await Bun.sleep(25)
+  }
+  record(name)
+}
+
+try {
+  assert.ok(child.pid, "native launcher did not receive a PID")
+  identity = DarwinResponsibility.identity(child.pid)
+  assert.ok(identity, "could not capture the native launcher's identity")
+  // An empty pipe must not block either bootstrap. Input is deliberately sent
+  // only after both ownership gates, just as the control-plane bridge does.
+  await wait(
+    "stage one ready with stdin open",
+    async () =>
+      (await Bun.file(ready)
+        .text()
+        .catch(() => "")) === String(child.pid),
+  )
+  assert.equal(await Bun.file(payload).exists(), false, "payload ran before stage-one release")
+  await fs.writeFile(release, String(child.pid), { flag: "wx", mode: 0o600 })
+  await wait("independent responsibility root", () => DarwinResponsibility.responsible(child.pid!) === child.pid)
+  responsibility = DarwinResponsibility.unique(child.pid)
+  assert.ok(responsibility, "native launcher has no unique responsibility identity")
+  await wait(
+    "stage two ready with stdin open",
+    async () =>
+      (await Bun.file(latch)
+        .text()
+        .catch(() => "")) === String(child.pid),
+  )
+  assert.equal(await Bun.file(payload).exists(), false, "payload ran before durable activation")
+  await fs.writeFile(`${release}${DARWIN_RESPONSIBILITY_ACTIVATION_SUFFIX}`, String(child.pid), {
+    flag: "wx",
+    mode: 0o600,
+  })
+  const input = Buffer.from(JSON.stringify({ nonce: crypto.randomUUID(), text: "scientific stdin\nαβ" }) + "\n")
+  child.stdin.end(input)
+  await wait("payload exited", () => closed)
+  const outcome = await completion
+  assert.deepEqual(outcome, { code: 0, signal: null }, stderr.toString())
+  assert.equal(await Bun.file(payload).text(), "started")
+  assert.deepEqual(stdout, input, "native supervisor changed or consumed the payload's stdin")
+  assert.deepEqual(await snapshot(application), before, "internal launcher initialized application state")
+  record("verified exact stdin round trip without application initialization")
+} catch (error) {
+  failure = error
+} finally {
+  // Authenticate every cleanup target. The release smoke must never signal
+  // another local process merely because a recorded PID was reused.
+  try {
+    if (responsibility) {
+      for (const pid of DarwinResponsibility.uniqueMembers(responsibility)) {
+        if (pid === child.pid || !DarwinResponsibility.uniquelyOwns(responsibility, pid)) continue
+        try {
+          process.kill(pid, "SIGKILL")
+        } catch {}
+      }
+    }
+  } catch (error) {
+    failure ??= error
+  }
+  if (!closed && child.pid && identity && DarwinResponsibility.identity(child.pid) === identity) child.kill("SIGKILL")
+  await Promise.race([completion.catch(() => undefined), Bun.sleep(2_000)])
+  await fs.cp(root, retainedRoot, { recursive: true, preserveTimestamps: true }).catch((error) => {
+    failure ??= error
+  })
+  await Promise.all([
+    Bun.write(path.join(evidence, "stdout.log"), stdout),
+    Bun.write(path.join(evidence, "stderr.log"), stderr),
+    Bun.write(
+      path.join(evidence, "application-after.json"),
+      JSON.stringify(await snapshot(application), null, 2) + "\n",
+    ),
+    Bun.write(
+      path.join(evidence, "result.json"),
+      JSON.stringify(
+        {
+          executable,
+          root,
+          retainedRoot,
+          pid: child.pid,
+          identity,
+          responsibility,
+          stages,
+          status: failure ? "failed" : "passed",
+          error: failure instanceof Error ? failure.message : failure,
+        },
+        null,
+        2,
+      ) + "\n",
+    ),
+  ])
+  if (!failure) await fs.rm(root, { recursive: true, force: true })
+}
+console.log(`Darwin launcher evidence: ${evidence}`)
+if (failure) throw failure
+console.log("Verified compiled Darwin launcher activation, stdin round trip, and application-state isolation")

--- a/backend/cli/src/bootstrap.ts
+++ b/backend/cli/src/bootstrap.ts
@@ -13,6 +13,19 @@ if (process.argv[2] === updateSwap) {
   }
 }
 
+// Worker environments intentionally omit application configuration. Dispatch
+// the ownership supervisor before the command graph can initialize a different
+// data root or migrate the user's default storage in that reduced environment.
+if (process.argv[2] === "__openscience_darwin_responsibility_launcher__") {
+  try {
+    const { DarwinResponsibilityLauncher } = await import("./process/darwin-responsibility-launcher")
+    process.exit(await DarwinResponsibilityLauncher.run(process.argv.slice(3)))
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exit(1)
+  }
+}
+
 // Desktop sidecars establish their exact parent/death receipt before loading
 // provider configuration or the command graph. A hard-killed desktop can then
 // never strand a half-initialized runtime that blocks update rollback.

--- a/backend/cli/test/process/darwin-responsibility.test.ts
+++ b/backend/cli/test/process/darwin-responsibility.test.ts
@@ -87,6 +87,89 @@ test.skipIf(process.platform !== "darwin")(
 )
 
 test.skipIf(process.platform !== "darwin")(
+  "Darwin activation preserves open piped stdin and its exact payload through EOF",
+  async () => {
+    expect(DarwinResponsibility.available()).toBe(true)
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openscience-darwin-responsibility-stdin-"))
+    const payload = path.join(root, "payload.pid")
+    const latchReady = path.join(root, "latch-ready")
+    const wrapped = DarwinResponsibilityLauncher.wrap({
+      file: "/bin/sh",
+      args: ["-c", 'printf "%s" "$$" > "$1"; printf "payload-stderr\\n" >&2; exec /bin/cat', "piped-stdin", payload],
+    })
+    if (!wrapped.release) throw new Error("Darwin responsibility launch did not create a registration gate")
+    const child = spawn(wrapped.file, wrapped.args, {
+      cwd: path.resolve(import.meta.dir, "../.."),
+      detached: true,
+      env: {
+        ...process.env,
+        OPENSCIENCE_TEST_HOME: root,
+        OPENSCIENCE_DARWIN_SUPERVISOR_TEST_READY: latchReady,
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    })
+    const stdout: Buffer[] = []
+    const stderr: Buffer[] = []
+    child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk))
+    child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk))
+    const closed = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve, reject) => {
+      child.once("error", reject)
+      child.once("close", (code, signal) => resolve({ code, signal }))
+    })
+    let timer: ReturnType<typeof setTimeout> | undefined
+    let owner: string | undefined
+    try {
+      if (!child.pid) throw new Error("Darwin responsibility launcher did not start")
+      await fs.writeFile(wrapped.release, String(child.pid), { encoding: "utf8", flag: "wx", mode: 0o600 })
+      await independentRoot(child.pid)
+      owner = DarwinResponsibility.unique(child.pid)
+      expect(owner).toBeDefined()
+      // The launcher must finish SETEXEC and install its control handlers while
+      // stdin is still empty and open, before the second gate admits a payload.
+      expect(Number(await text(latchReady))).toBe(child.pid)
+      expect(child.stdin.writableEnded).toBe(false)
+      expect(await Bun.file(payload).exists()).toBe(false)
+      expect(Buffer.concat(stdout).length).toBe(0)
+      await fs.writeFile(`${wrapped.release}${DARWIN_RESPONSIBILITY_ACTIVATION_SUFFIX}`, String(child.pid), {
+        encoding: "utf8",
+        flag: "wx",
+        mode: 0o600,
+      })
+      const payloadPID = Number(await text(payload))
+      expect(DarwinResponsibility.unique(payloadPID)).toBe(owner)
+      const input = Buffer.from(JSON.stringify({ nonce: crypto.randomUUID(), message: "stdin → payload\nEOF" }))
+      child.stdin.end(input)
+      const outcome = await Promise.race([
+        closed,
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(() => reject(new Error("Darwin payload did not close its pipes after EOF")), 5_000)
+        }),
+      ])
+      expect(outcome, Buffer.concat(stderr).toString()).toEqual({ code: 0, signal: null })
+      expect(Buffer.concat(stdout)).toEqual(input)
+      expect(Buffer.concat(stderr).toString()).toBe("payload-stderr\n")
+      expect(DarwinResponsibility.uniqueMembers(owner!)).toEqual([])
+    } finally {
+      if (timer) clearTimeout(timer)
+      if (owner) {
+        for (const pid of DarwinResponsibility.uniqueMembers(owner)) {
+          if (!DarwinResponsibility.uniquelyOwns(owner, pid)) continue
+          try {
+            process.kill(pid, "SIGKILL")
+          } catch {}
+        }
+      }
+      child.kill("SIGKILL")
+      await closed.catch(() => undefined)
+      await fs.rm(wrapped.release, { force: true })
+      await fs.rm(`${wrapped.release}${DARWIN_RESPONSIBILITY_ACTIVATION_SUFFIX}`, { force: true })
+      await fs.rm(root, { recursive: true, force: true })
+    }
+  },
+  15_000,
+)
+
+test.skipIf(process.platform !== "darwin")(
   "kernel responsibility tracks a setsid double-fork after it reparents to launchd",
   async () => {
     if (!Bun.which("python3")) return


### PR DESCRIPTION
Packaged macOS worker launchers imported the full CLI before entering the ownership supervisor. Because worker environments omit application configuration overrides, that import could initialize or migrate unrelated default storage; an isolated configuration-file sentinel made the packaged worker fail before its payload started.

Dispatch the Darwin supervisor directly from bootstrap, retaining both ownership gates and existing signal/cleanup behavior. Add a source stdin/activation regression and an offline smoke against the installed compiled npm binary in the existing macOS release gate. The packaged smoke verifies empty-pipe startup, activation, exact nonce/EOF forwarding, and an unchanged application-state tree even when configuration is unavailable.

Validation: pinned Bun1.3.14; 9 native process/updater tests pass with38 assertions; backend typecheck and formatting pass. The old npm candidate fails the configuration-isolation probe; identical repaired native build bytes pass with isolated temporary paths. The source of the earlier intermittent native startup timeout is not claimed resolved by this change. A fresh exact-source full release rehearsal and five candidate Modal capability smokes remain required before stable publication.
