### PR TITLE
feat(onboarding): start desktop setup with workspace sign-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ tagged release also ships native binaries for Linux, macOS, and Windows.
 
 ### Changed
 
+- Start desktop onboarding with Synthetic Sciences sign-in and workspace selection,
+  then continue to research project setup. A small Skip action allows local setup
+  without an account; existing completed setups remain unchanged.
 - Preserve optional/defaulted tool inputs in provider schemas and clarify inline
   page reads versus raw downloads. Distinguish completed subagent handoffs with
   failed attempts from unfinished work, retain empty first-turn recovery baselines,

--- a/frontend/docs/src/content/openscience/installation.mdx
+++ b/frontend/docs/src/content/openscience/installation.mdx
@@ -16,7 +16,15 @@ Open the [download page](https://openscience.sh/download) and choose your operat
 
 On macOS, open the disk image and move OpenScience to Applications. On Windows, run the installer. On Linux, make the downloaded AppImage executable and open it. Check the [latest release](https://github.com/synthetic-sciences/openscience/releases/latest) for the files and release-specific installation notes.
 
-Open the app, create or open a project, and follow [Quickstart](/openscience/quickstart) to connect a model.
+On first launch, select **Sign in with Synthetic Sciences**. Your browser opens
+[app.syntheticsciences.ai](https://app.syntheticsciences.ai), where you can sign in
+and choose a workspace you belong to. OpenScience continues automatically to
+**Start with your research**, where you can open a folder or start a blank project.
+
+To use your own provider access or local models without an account, select the
+small **Skip** action at the bottom right of the sign-in screen. You can sign in
+later from **Customize → General**. Follow [Quickstart](/openscience/quickstart) to
+connect a model and begin your first task.
 
 ## Command-line app
 

--- a/frontend/docs/src/content/openscience/quickstart.mdx
+++ b/frontend/docs/src/content/openscience/quickstart.mdx
@@ -22,7 +22,18 @@ openscience ~/research/my-project
 
 `npx synsci` is an alternative launcher that installs and opens OpenScience. It requires Node.js and npm.
 
-## 2. Choose model access
+## 2. Sign in and set up your desktop workspace
+
+The desktop app starts with **Sign in with Synthetic Sciences**. Continue at
+[app.syntheticsciences.ai](https://app.syntheticsciences.ai) in your browser and
+choose any workspace you belong to. After sign-in, OpenScience automatically
+shows **Start with your research**. Open an existing folder or start a blank project.
+
+If you prefer to use your own provider access or local models without signing in,
+select **Skip** at the bottom right. You will reach the same project setup screen
+and can sign in later from **Customize → General**.
+
+## 3. Choose model access
 
 Open **Customize → Models** and choose the option that fits your setup:
 
@@ -36,7 +47,7 @@ An OpenScience account is optional when using your own provider access or local 
 
 For terminal setup, run `openscience keys add` to connect a provider, or `openscience local add` to connect a local endpoint.
 
-## 3. Open a project and add your inputs
+## 4. Open a project and add your inputs
 
 Create a project or open an existing folder in the workspace. Add the files the task needs and mention them in your request. Keep the original data and ask OpenScience to write results to a separate folder.
 
@@ -55,7 +66,7 @@ Help me plan a literature review on protein language models. Ask about
 my research question and inclusion criteria before searching.
 ```
 
-## 4. Review and continue
+## 5. Review and continue
 
 Read the response and open the files it produced. Check the cited sources, assumptions, and any reported limitations. Continue in the same conversation to refine the result:
 

--- a/frontend/workspace/src/atlas/DesktopOnboarding.css
+++ b/frontend/workspace/src/atlas/DesktopOnboarding.css
@@ -50,6 +50,35 @@
   gap: 20px;
 }
 
+.desktop-onboarding__signin {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  justify-content: center;
+  gap: 28px;
+  padding-block: 24px;
+}
+
+.desktop-onboarding__signin-actions {
+  display: flex;
+  align-items: flex-start;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.desktop-onboarding__signin-hint {
+  margin: 0;
+  color: var(--text-weak);
+  font-size: var(--font-size-x-small);
+  line-height: 1.5;
+}
+
+.desktop-onboarding__skip {
+  flex-shrink: 0;
+  margin-left: auto;
+  color: var(--text-weak);
+}
+
 .desktop-onboarding__intro {
   max-width: 580px;
 }
@@ -69,6 +98,10 @@
   letter-spacing: -0.04em;
   line-height: 1.08;
   text-wrap: balance;
+}
+
+.desktop-onboarding__intro h1:focus {
+  outline: none;
 }
 
 .desktop-onboarding__intro > span,

--- a/frontend/workspace/src/atlas/DesktopOnboarding.test.tsx
+++ b/frontend/workspace/src/atlas/DesktopOnboarding.test.tsx
@@ -1,0 +1,301 @@
+import { afterAll, afterEach, expect, test } from "bun:test"
+import { fileURLToPath } from "node:url"
+import { createServer } from "vite"
+import solid from "vite-plugin-solid"
+import type { Platform } from "@/context/platform"
+
+// happy-dom replaces the global Response; Bun's HTTP server needs its native one.
+const Response = (await Bun.fetch("data:text/plain,")).constructor as typeof globalThis.Response
+
+const vite = await createServer({
+  configFile: false,
+  root: fileURLToPath(new URL("../..", import.meta.url)),
+  mode: "production",
+  logLevel: "silent",
+  optimizeDeps: { noDiscovery: true, include: [] },
+  plugins: [solid({ ssr: false, dev: false })],
+  server: { middlewareMode: true },
+  appType: "custom",
+  resolve: {
+    alias: { "@": fileURLToPath(new URL("..", import.meta.url)) },
+    conditions: ["browser", "production"],
+    dedupe: ["solid-js", "solid-js/web"],
+  },
+  ssr: { noExternal: true, resolve: { conditions: ["browser", "production"] } },
+})
+const web = (await vite.ssrLoadModule("solid-js/web")) as typeof import("solid-js/web")
+const subject = (await vite.ssrLoadModule("/src/atlas/DesktopOnboarding.tsx")) as typeof import("./DesktopOnboarding")
+const cleanups: Array<() => void> = []
+const versionKey = "openscience.desktop_onboarding_version"
+
+afterAll(() => vite.close())
+afterEach(() => {
+  cleanups
+    .splice(0)
+    .reverse()
+    .forEach((cleanup) => cleanup())
+  document.body.replaceChildren()
+  localStorage.removeItem(versionKey)
+  window.history.replaceState(null, "", "/")
+})
+
+async function until(check: () => boolean) {
+  const deadline = Date.now() + 2_000
+  while (!check() && Date.now() < deadline) await Bun.sleep(5)
+  expect(check()).toBe(true)
+}
+
+function fixture(
+  options: {
+    version?: number
+    connected?: boolean
+    login?: () => Response | Promise<Response>
+    session?: () => Response | Promise<Response>
+    preferences?: () => Response | Promise<Response>
+  } = {},
+) {
+  const state = { version: options.version ?? 0, connected: options.connected ?? false }
+  const requests: string[] = []
+  const opened: string[] = []
+  const touched: string[] = []
+  const project = { id: "prj_onboarding", worktree: "/tmp/onboarding-fixture" }
+  const api = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    async fetch(request) {
+      const route = `${request.method} ${new URL(request.url).pathname}`
+      requests.push(route)
+      if (route === "GET /settings/preferences") {
+        return options.preferences?.() ?? Response.json({ desktop_onboarding_version: state.version })
+      }
+      if (route === "GET /account/session") {
+        return options.session?.() ?? Response.json({ session: state.connected })
+      }
+      if (route === "POST /account/login-browser") {
+        const response = await (options.login?.() ?? Response.json({ ok: true }))
+        if ((await response.clone().json()).ok) state.connected = true
+        return response
+      }
+      if (route === "POST /settings/preferences/onboarding-operation") {
+        return Response.json({ operation_id: "51eb90b2-534b-4b48-aaba-d2a95a01ea16" })
+      }
+      if (route === "POST /global/project") return Response.json(project)
+      if (route === "PATCH /settings/preferences") {
+        state.version = (await request.json()).desktop_onboarding_version
+        return Response.json({ desktop_onboarding_version: state.version })
+      }
+      if (route === "DELETE /settings/preferences/onboarding-operation") return Response.json(true)
+      return Response.json({ error: `Unexpected request: ${route}` }, { status: 404 })
+    },
+  })
+  cleanups.push(() => void api.stop(true))
+  const server = {
+    url: api.url.origin,
+    projects: {
+      open: (directory: string) => {
+        opened.push(directory)
+      },
+      touch: (id: string) => {
+        touched.push(id)
+      },
+    },
+  }
+  const platform: Platform = {
+    platform: "desktop",
+    fetch: Bun.fetch,
+    openLink() {},
+    restart: async () => {},
+    notify: async () => {},
+    back() {},
+    forward() {},
+  }
+  const mount = (desktop = true) => {
+    const host = document.createElement("div")
+    document.body.append(host)
+    const dispose = web.render(
+      () =>
+        subject.DesktopOnboardingController({
+          server,
+          platform,
+          desktop,
+          get children() {
+            const content = document.createElement("div")
+            content.textContent = "Research workspace loaded"
+            return content
+          },
+        }),
+      host,
+    )
+    cleanups.push(dispose)
+    return { host, dispose }
+  }
+  return { state, requests, opened, touched, project, mount }
+}
+
+function button(host: HTMLElement, label: string) {
+  const result = Array.from(host.querySelectorAll("button")).find((element) => element.textContent?.trim() === label)
+  if (!result) throw new Error(`Missing button: ${label}`)
+  return result
+}
+
+test("a fresh desktop starts with sign-in and a separate Skip action", async () => {
+  const app = fixture()
+  const view = app.mount()
+  await until(() => view.host.textContent?.includes("Welcome to OpenScience") === true)
+
+  expect(button(view.host, "Sign in with Synthetic Sciences").disabled).toBe(false)
+  expect(button(view.host, "Skip").closest("footer")).not.toBeNull()
+  expect(view.host.textContent).toContain("app.syntheticsciences.ai")
+  expect(view.host.textContent).not.toContain("Start with your research")
+  expect(view.host.textContent).not.toContain("Research workspace loaded")
+  expect(app.requests).toEqual(["GET /settings/preferences", "GET /account/session"])
+})
+
+test("browser sign-in waits for workspace approval and then advances automatically", async () => {
+  const approval = Promise.withResolvers<Response>()
+  const app = fixture({ login: () => approval.promise })
+  const view = app.mount()
+  await until(() => view.host.textContent?.includes("Welcome to OpenScience") === true)
+  button(view.host, "Sign in with Synthetic Sciences").click()
+  await until(() => app.requests.includes("POST /account/login-browser"))
+  expect(button(view.host, "Waiting for sign-in…").disabled).toBe(true)
+  button(view.host, "Waiting for sign-in…").click()
+  expect(app.requests.filter((route) => route === "POST /account/login-browser")).toHaveLength(1)
+  expect(view.host.querySelector('[role="status"]')?.textContent).toContain("Choose your workspace in your browser")
+  expect(view.host.textContent).not.toContain("Start with your research")
+
+  approval.resolve(Response.json({ ok: true }))
+  await until(() => view.host.textContent?.includes("Start with your research") === true)
+  expect(view.host.textContent).toContain("Account connected")
+  expect(document.activeElement).toBe(view.host.querySelector("h1"))
+  expect(app.state.version).toBe(0)
+
+  view.dispose()
+  const resumed = app.mount()
+  await until(() => resumed.host.textContent?.includes("Start with your research") === true)
+  expect(resumed.host.textContent).not.toContain("Sign in with Synthetic Sciences")
+})
+
+test("skipping sign-in still requires project setup before onboarding is saved", async () => {
+  const app = fixture()
+  const view = app.mount()
+  await until(() => view.host.textContent?.includes("Welcome to OpenScience") === true)
+  button(view.host, "Skip").click()
+  await until(() => view.host.textContent?.includes("Start with your research") === true)
+  expect(app.state.version).toBe(0)
+  expect(app.requests.some((route) => route.startsWith("POST"))).toBe(false)
+  expect(document.activeElement).toBe(view.host.querySelector("h1"))
+
+  const blank = Array.from(view.host.querySelectorAll("button")).find((element) =>
+    element.textContent?.includes("Start a blank project"),
+  )!
+  blank.click()
+  await until(() => view.host.textContent?.includes("Research workspace loaded") === true)
+  expect(app.state.version).toBe(1)
+  expect(localStorage.getItem(versionKey)).toBe("1")
+  expect(app.opened).toEqual([app.project.worktree])
+  expect(app.touched).toEqual([app.project.id])
+  expect(app.requests.filter((route) => route === "POST /global/project")).toHaveLength(1)
+  expect(app.requests).not.toContain("POST /account/login-browser")
+
+  view.dispose()
+  localStorage.removeItem(versionKey)
+  const resumed = app.mount()
+  await until(() => resumed.host.textContent?.includes("Research workspace loaded") === true)
+  expect(resumed.host.textContent).not.toContain("Welcome to OpenScience")
+})
+
+test("failed login stays on sign-in, focuses the error, and can be retried", async () => {
+  const responses = [
+    Response.json({ ok: false, error: "Workspace approval expired. Try again." }),
+    Response.json({ ok: true }),
+  ]
+  const app = fixture({ login: () => responses.shift()! })
+  const view = app.mount()
+  await until(() => view.host.textContent?.includes("Welcome to OpenScience") === true)
+  button(view.host, "Sign in with Synthetic Sciences").click()
+  await until(() => view.host.querySelector('[role="alert"]') !== null)
+  expect(view.host.textContent).toContain("Workspace approval expired. Try again.")
+  expect(view.host.textContent).not.toContain("Start with your research")
+  expect(document.activeElement).toBe(view.host.querySelector('[role="alert"]'))
+  button(view.host, "Sign in with Synthetic Sciences").click()
+  await until(() => view.host.textContent?.includes("Start with your research") === true)
+  expect(view.host.querySelector('[role="alert"]')).toBeNull()
+})
+
+test.each([true, false])("Skip remains available while browser sign-in is pending (success: %s)", async (ok) => {
+  const approval = Promise.withResolvers<Response>()
+  const app = fixture({ login: () => approval.promise })
+  const view = app.mount()
+  await until(() => view.host.textContent?.includes("Welcome to OpenScience") === true)
+  button(view.host, "Sign in with Synthetic Sciences").click()
+  await until(() => app.requests.includes("POST /account/login-browser"))
+  expect(button(view.host, "Skip").disabled).toBe(false)
+  button(view.host, "Skip").click()
+  expect(view.host.textContent).toContain("Start with your research")
+
+  approval.resolve(Response.json({ ok, error: "Browser authorization timed out." }))
+  await Bun.sleep(25)
+  expect(view.host.textContent).toContain("Start with your research")
+  expect(view.host.querySelector('[role="alert"]')).toBeNull()
+  expect(app.state.version).toBe(0)
+})
+
+test("an existing account proceeds directly to research setup", async () => {
+  const app = fixture({ connected: true })
+  const view = app.mount()
+  await until(() => view.host.textContent?.includes("Start with your research") === true)
+  expect(view.host.textContent).toContain("Account connected")
+  expect(view.host.textContent).not.toContain("Sign in with Synthetic Sciences")
+  expect(app.state.version).toBe(0)
+})
+
+test("completed onboarding does not require an account or reopen setup", async () => {
+  const app = fixture({ version: 1 })
+  const view = app.mount()
+  await until(() => view.host.textContent?.includes("Research workspace loaded") === true)
+  expect(app.requests).toEqual(["GET /settings/preferences"])
+  expect(view.host.textContent).not.toContain("Welcome to OpenScience")
+})
+
+test("server reset overrides a cached onboarding completion", async () => {
+  localStorage.setItem(versionKey, "1")
+  const app = fixture()
+  const view = app.mount()
+  await until(() => view.host.textContent?.includes("Welcome to OpenScience") === true)
+  expect(view.host.textContent).not.toContain("Research workspace loaded")
+  expect(localStorage.getItem(versionKey)).toBe("0")
+})
+
+test("a cached completion waits for the account check before exposing setup actions", async () => {
+  localStorage.setItem(versionKey, "1")
+  const session = Promise.withResolvers<Response>()
+  const app = fixture({ session: () => session.promise })
+  const view = app.mount()
+  await until(() => app.requests.includes("GET /account/session"))
+  expect(view.host.querySelector('[aria-label="Loading desktop setup"]')).not.toBeNull()
+  expect(view.host.querySelector("button")).toBeNull()
+
+  session.resolve(Response.json({ session: false }))
+  await until(() => view.host.textContent?.includes("Welcome to OpenScience") === true)
+  button(view.host, "Skip").click()
+  expect(view.host.textContent).toContain("Start with your research")
+})
+
+test("an unavailable account check leaves sign-in and Skip usable", async () => {
+  const app = fixture({ session: () => Response.json({ error: "Account check unavailable" }, { status: 503 }) })
+  const view = app.mount()
+  await until(() => view.host.textContent?.includes("Welcome to OpenScience") === true)
+  expect(view.host.querySelector('[role="alert"]')?.textContent).toContain("Account check unavailable")
+  expect(button(view.host, "Sign in with Synthetic Sciences").disabled).toBe(false)
+  button(view.host, "Skip").click()
+  expect(view.host.textContent).toContain("Start with your research")
+  expect(view.host.querySelector('[role="alert"]')).toBeNull()
+})
+
+test("browser workspaces do not enter desktop onboarding", async () => {
+  const app = fixture()
+  const view = app.mount(false)
+  expect(view.host.textContent).toContain("Research workspace loaded")
+  expect(app.requests).toEqual([])
+})

--- a/frontend/workspace/src/atlas/DesktopOnboarding.tsx
+++ b/frontend/workspace/src/atlas/DesktopOnboarding.tsx
@@ -1,9 +1,11 @@
-import { For, Show, createEffect, createSignal, onMount, type ParentProps } from "solid-js"
+import { For, Show, createEffect, createSignal, onCleanup, onMount, type ParentProps } from "solid-js"
+import { createStore } from "solid-js/store"
 import { Button } from "@synsci/ui/button"
 import { TextField } from "@synsci/ui/text-field"
 import { IconFolder, IconPlus } from "@/atlas/shared/Icon"
 import { Wordmark } from "@/atlas/Wordmark"
 import { settingsApi } from "@/components/settings/api"
+import { ACCOUNT_DEADLINE_MS, withAccountDeadline } from "@/components/settings/account-deadline"
 import type { ProjectCreateInput } from "@/components/dialog-create-project"
 import { usePlatform } from "@/context/platform"
 import type { Platform } from "@/context/platform"
@@ -155,26 +157,86 @@ export function DesktopOnboardingController(
   const [configured, setConfigured] = createSignal<Configured>()
   const [busy, setBusy] = createSignal<Busy>()
   const [error, setError] = createSignal<string>()
+  const [account, setAccount] = createStore({
+    step: "account" as "account" | "project",
+    connected: false,
+    pending: false,
+  })
+  const lifetime = new AbortController()
   let errorElement: HTMLParagraphElement | undefined
+  let projectTitle: HTMLHeadingElement | undefined
   const server = props.server
   const platform = props.platform
   const fetcher = () => platform.fetch ?? fetch
 
+  onCleanup(() => lifetime.abort())
+
   onMount(() => {
     if (!desktop) return
-    void settingsApi<DesktopPreferences>(server.url, fetcher(), "/settings/preferences")
-      .then((value) => {
-        setComplete(value.desktop_onboarding_version >= 1)
-        rememberVersion(value.desktop_onboarding_version)
+    void withAccountDeadline(async (deadline) => {
+      const signal = AbortSignal.any([deadline, lifetime.signal])
+      const value = await settingsApi<DesktopPreferences>(server.url, fetcher(), "/settings/preferences", { signal })
+      if (signal.aborted) return
+      rememberVersion(value.desktop_onboarding_version)
+      if (value.desktop_onboarding_version >= 1) {
+        setComplete(true)
+        return
+      }
+      setReady(false)
+      setComplete(false)
+      const session = await settingsApi<{ session: boolean }>(server.url, fetcher(), "/account/session", { signal })
+      if (signal.aborted) return
+      setAccount({ connected: session.session, step: session.session ? "project" : "account" })
+    }, ACCOUNT_DEADLINE_MS)
+      .catch((cause) => {
+        if (!lifetime.signal.aborted) setError(cause instanceof Error ? cause.message : String(cause))
       })
-      .catch((cause) => setError(cause instanceof Error ? cause.message : String(cause)))
-      .finally(() => setReady(true))
+      .finally(() => {
+        if (!lifetime.signal.aborted) setReady(true)
+      })
   })
 
   createEffect(() => {
     if (!error()) return
     queueMicrotask(() => errorElement?.focus())
   })
+
+  createEffect(() => {
+    if (!ready() || complete() || account.step !== "project") return
+    queueMicrotask(() => projectTitle?.focus())
+  })
+
+  const login = async () => {
+    if (account.pending) return
+    setAccount("pending", true)
+    setError(undefined)
+    try {
+      const result = await settingsApi<{ ok: boolean; error?: string }>(
+        server.url,
+        fetcher(),
+        "/account/login-browser",
+        {
+          method: "POST",
+          signal: lifetime.signal,
+        },
+      )
+      if (lifetime.signal.aborted) return
+      if (!result.ok) throw new Error(result.error || "Sign in did not complete. Try again.")
+      setAccount({ connected: true, step: "project" })
+      window.dispatchEvent(new Event("openscience:account-changed"))
+    } catch (cause) {
+      if (!lifetime.signal.aborted && account.step === "account") {
+        setError(cause instanceof Error ? cause.message : String(cause))
+      }
+    } finally {
+      if (!lifetime.signal.aborted) setAccount("pending", false)
+    }
+  }
+
+  const skip = () => {
+    setError(undefined)
+    setAccount("step", "project")
+  }
 
   const projectFlow = createOnboardingProjectFlow({
     create: (input) =>
@@ -278,109 +340,143 @@ export function DesktopOnboardingController(
             <section class="desktop-onboarding__shell">
               <header class="desktop-onboarding__header">
                 <Wordmark size="sm" />
-                <span class="desktop-onboarding__account-state">Local workspace</span>
+                <span class="desktop-onboarding__account-state">
+                  {account.step === "account"
+                    ? "Step 1 of 2"
+                    : account.connected
+                      ? "Account connected · Step 2 of 2"
+                      : "Step 2 of 2"}
+                </span>
               </header>
 
-              <div class="desktop-onboarding__content">
-                <div class="desktop-onboarding__intro">
-                  <p>YOUR FIRST WORKSPACE</p>
-                  <h1 id="desktop-onboarding-title">Start with your research</h1>
-                  <span>
-                    Open an existing folder to keep files, sessions, and results together. You can change model and
-                    compute access anytime in Customize. Projects and credentials stay on this device.
-                  </span>
-                </div>
-
-                <div class="desktop-onboarding__workspace-actions" aria-label="Choose your first workspace">
-                  <button
-                    type="button"
-                    class="desktop-onboarding__workspace-action desktop-onboarding__workspace-action--primary"
-                    disabled={Boolean(busy())}
-                    onClick={() => void openFolder()}
-                  >
-                    <span class="desktop-onboarding__workspace-icon" aria-hidden="true">
-                      <IconFolder size={19} strokeWidth={1.55} />
-                    </span>
-                    <span>
-                      <strong>{busy() === "folder" ? "Opening folder…" : "Open a folder"}</strong>
-                      <small>Recommended · continue with an existing research directory</small>
-                    </span>
-                  </button>
-                  <button
-                    type="button"
-                    class="desktop-onboarding__workspace-action"
-                    disabled={Boolean(busy())}
-                    onClick={() => void startBlank()}
-                  >
-                    <span class="desktop-onboarding__workspace-icon" aria-hidden="true">
-                      <IconPlus size={18} strokeWidth={1.65} />
-                    </span>
-                    <span>
-                      <strong>{busy() === "blank" ? "Creating project…" : "Start a blank project"}</strong>
-                      <small>Create a clean workspace and connect folders later</small>
-                    </span>
-                  </button>
-                </div>
-
-                <details class="desktop-onboarding__models">
-                  <summary>
-                    <span>
-                      <strong>Model access</strong>
-                      <small>Optional · set up now or later</small>
-                    </span>
-                    <span aria-hidden="true">+</span>
-                  </summary>
-                  <div class="desktop-onboarding__model-options">
-                    <section class="desktop-onboarding__model-option desktop-onboarding__model-option--key">
-                      <div class="desktop-onboarding__model-copy">
-                        <strong>Provider key</strong>
-                        <small>Stored locally and billed directly by the provider.</small>
-                      </div>
-                      <div class="desktop-onboarding__credentials">
-                        <label>
-                          <span>Provider</span>
-                          <select
-                            value={provider()}
-                            disabled={Boolean(busy())}
-                            onChange={(event) => setProvider(event.currentTarget.value)}
-                          >
-                            <For each={providers}>{(item) => <option value={item.id}>{item.label}</option>}</For>
-                          </select>
-                        </label>
-                        <label class="desktop-onboarding__field">
-                          <span>API key</span>
-                          <TextField
-                            hideLabel
-                            type="password"
-                            value={key()}
-                            disabled={Boolean(busy())}
-                            onChange={setKey}
-                            placeholder="Paste provider key"
-                            autocomplete="off"
-                            onKeyDown={(event: KeyboardEvent) => {
-                              if (event.key !== "Enter") return
-                              event.preventDefault()
-                              void saveKey()
-                            }}
-                          />
-                        </label>
-                        <Button
-                          variant="secondary"
-                          size="small"
-                          disabled={Boolean(busy()) || !key().trim()}
-                          onClick={() => void saveKey()}
-                        >
-                          {busy() === "api" ? "Saving…" : configured() === "api" ? "Saved" : "Save key"}
-                        </Button>
-                      </div>
-                    </section>
-
-                    <p class="desktop-onboarding__note">
-                      You can also connect ChatGPT / Codex or a local runtime later in Customize → Models.
-                    </p>
+              <Show
+                when={account.step === "project"}
+                fallback={
+                  <div class="desktop-onboarding__signin">
+                    <div class="desktop-onboarding__intro">
+                      <p>YOUR RESEARCH STARTS HERE</p>
+                      <h1 id="desktop-onboarding-title">Welcome to OpenScience</h1>
+                      <span>
+                        Sign in to Synthetic Sciences and choose any workspace you belong to. Connect its model access
+                        and shared credentials before starting your research.
+                      </span>
+                    </div>
+                    <div class="desktop-onboarding__signin-actions">
+                      <Button variant="primary" size="large" disabled={account.pending} onClick={() => void login()}>
+                        {account.pending ? "Waiting for sign-in…" : "Sign in with Synthetic Sciences"}
+                      </Button>
+                      <p class="desktop-onboarding__signin-hint" role="status" aria-live="polite">
+                        {account.pending
+                          ? "Choose your workspace in your browser. This window will continue automatically."
+                          : "Opens app.syntheticsciences.ai in your browser."}
+                      </p>
+                    </div>
                   </div>
-                </details>
-              </div>
+                }
+              >
+                <div class="desktop-onboarding__content">
+                  <div class="desktop-onboarding__intro">
+                    <p>YOUR FIRST WORKSPACE</p>
+                    <h1 ref={projectTitle} id="desktop-onboarding-title" tabindex="-1">
+                      Start with your research
+                    </h1>
+                    <span>
+                      Open an existing folder to keep files, sessions, and results together. You can change model and
+                      compute access anytime in Customize. Project files stay on this device.
+                    </span>
+                  </div>
+
+                  <div class="desktop-onboarding__workspace-actions" aria-label="Choose your first workspace">
+                    <button
+                      type="button"
+                      class="desktop-onboarding__workspace-action desktop-onboarding__workspace-action--primary"
+                      disabled={Boolean(busy())}
+                      onClick={() => void openFolder()}
+                    >
+                      <span class="desktop-onboarding__workspace-icon" aria-hidden="true">
+                        <IconFolder size={19} strokeWidth={1.55} />
+                      </span>
+                      <span>
+                        <strong>{busy() === "folder" ? "Opening folder…" : "Open a folder"}</strong>
+                        <small>Recommended · continue with an existing research directory</small>
+                      </span>
+                    </button>
+                    <button
+                      type="button"
+                      class="desktop-onboarding__workspace-action"
+                      disabled={Boolean(busy())}
+                      onClick={() => void startBlank()}
+                    >
+                      <span class="desktop-onboarding__workspace-icon" aria-hidden="true">
+                        <IconPlus size={18} strokeWidth={1.65} />
+                      </span>
+                      <span>
+                        <strong>{busy() === "blank" ? "Creating project…" : "Start a blank project"}</strong>
+                        <small>Create a clean workspace and connect folders later</small>
+                      </span>
+                    </button>
+                  </div>
+
+                  <details class="desktop-onboarding__models">
+                    <summary>
+                      <span>
+                        <strong>Model access</strong>
+                        <small>Optional · set up now or later</small>
+                      </span>
+                      <span aria-hidden="true">+</span>
+                    </summary>
+                    <div class="desktop-onboarding__model-options">
+                      <section class="desktop-onboarding__model-option desktop-onboarding__model-option--key">
+                        <div class="desktop-onboarding__model-copy">
+                          <strong>Provider key</strong>
+                          <small>Stored locally and billed directly by the provider.</small>
+                        </div>
+                        <div class="desktop-onboarding__credentials">
+                          <label>
+                            <span>Provider</span>
+                            <select
+                              value={provider()}
+                              disabled={Boolean(busy())}
+                              onChange={(event) => setProvider(event.currentTarget.value)}
+                            >
+                              <For each={providers}>{(item) => <option value={item.id}>{item.label}</option>}</For>
+                            </select>
+                          </label>
+                          <label class="desktop-onboarding__field">
+                            <span>API key</span>
+                            <TextField
+                              hideLabel
+                              type="password"
+                              value={key()}
+                              disabled={Boolean(busy())}
+                              onChange={setKey}
+                              placeholder="Paste provider key"
+                              autocomplete="off"
+                              onKeyDown={(event: KeyboardEvent) => {
+                                if (event.key !== "Enter") return
+                                event.preventDefault()
+                                void saveKey()
+                              }}
+                            />
+                          </label>
+                          <Button
+                            variant="secondary"
+                            size="small"
+                            disabled={Boolean(busy()) || !key().trim()}
+                            onClick={() => void saveKey()}
+                          >
+                            {busy() === "api" ? "Saving…" : configured() === "api" ? "Saved" : "Save key"}
+                          </Button>
+                        </div>
+                      </section>
+
+                      <p class="desktop-onboarding__note">
+                        You can also connect ChatGPT / Codex or a local runtime later in Customize → Models.
+                      </p>
+                    </div>
+                  </details>
+                </div>
+              </Show>
 
               <Show when={error()}>
                 <p ref={errorElement} class="desktop-onboarding__error" role="alert" tabindex="-1">
@@ -389,7 +485,19 @@ export function DesktopOnboardingController(
               </Show>
 
               <footer class="desktop-onboarding__footer">
-                <span>Model setup is optional. OpenScience works with credentials and runtimes you control.</span>
+                <Show
+                  when={account.step === "project"}
+                  fallback={
+                    <>
+                      <span>You can also use your own models and sign in later.</span>
+                      <Button class="desktop-onboarding__skip" variant="ghost" size="small" onClick={skip}>
+                        Skip
+                      </Button>
+                    </>
+                  }
+                >
+                  <span>Model setup is optional. OpenScience works with credentials and runtimes you control.</span>
+                </Show>
               </footer>
             </section>
           </main>


### PR DESCRIPTION
### What does this PR do, and why?

Fresh desktop installs currently jump straight into project setup, leaving Synthetic Sciences sign-in and workspace selection buried in settings. Start onboarding with **Sign in with Synthetic Sciences**, using the existing browser approval flow at app.syntheticsciences.ai so users can choose a workspace they belong to. After successful login, automatically show **Start with your research**.

A small **Skip** action at the bottom right opens the same research setup without an account, including while browser approval is pending. Login failures stay retryable, keyboard focus follows the next step, and onboarding is only saved after project creation. Existing signed-in users and completed setups keep their expected entry points. Update the installation guide, quickstart, and changelog.

### Linked issue

User-reported onboarding flow; no separate issue.

### How did you verify it?

- 12 rendered onboarding tests over a real loopback HTTP fixture: first launch, successful login, duplicate submission, retry, skip, pending approval, saved completion, reset/cache race, and account-check failure.
- 2 backend browser-login tests covering workspace-scoped device approval and switching to another workspace.
- Monorepo typecheck, production workspace build, documentation checks/tests, and changed-file formatting passed.
- Inspected the production build at desktop and narrow widths; verified keyboard navigation to Skip and focus on the research-setup heading.
- Full frontend suite passed with `bun test --timeout 30000` from `frontend/workspace`. The default-timeout run hit three existing cleanup-hook timeouts; the final rerun and GitHub Frontend unit tests are green.
- GitHub Typecheck, Format, Build (web), Test, Frontend unit tests, Gitleaks, and Vercel checks passed.

### Checklist

- [x] Workspace build succeeds.
- [x] User-visible change has an Unreleased changelog entry.
- [x] Matching documentation is updated.
- [x] No package version bumps.
