### PR TITLE
Underline the section headings on the landing site

### DIFF
--- a/frontend/landing/src/index.css
+++ b/frontend/landing/src/index.css
@@ -340,11 +340,15 @@ pre {
   [data-slot="section-title"] {
     margin-bottom: 24px;
 
+    /* Section headings carry a rule, like a run-in heading in a paper. */
     h3 {
       font-size: var(--text-title);
       color: var(--color-text-strong);
       margin-bottom: 12px;
       line-height: var(--leading);
+      text-decoration: underline;
+      text-decoration-thickness: 1px;
+      text-underline-offset: 6px;
     }
     p {
       margin-bottom: 12px;
@@ -920,6 +924,9 @@ pre {
         margin-bottom: 16px;
         display: block;
         font-size: var(--text-title);
+        text-decoration: underline;
+        text-decoration-thickness: 1px;
+        text-underline-offset: 6px;
       }
       p {
         color: var(--color-text);


### PR DESCRIPTION
## Summary

Adds a hairline rule under each section heading on the marketing site: 1px, 6px below the text.

It applies to the shared section title component and the Ace teaser heading, so every heading of that rank matches:

- **Landing:** "What is OpenScience?", "The state-of-the-art AI co-scientist", "Access reliable, optimized models for scientific agents", "FAQ"
- **Ace:** "What Ace includes", "How Ace works", "Models"
- **Download:** "FAQ"

The privacy page is untouched; its headings belong to the prose document rather than this component.

## Test plan

- [x] `prettier --check` clean, `vite build` succeeds
- [x] Every affected heading checked in the browser at 1440 wide, no console errors
- [ ] Vercel production deploy after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
