### PR TITLE
fix(desktop): avoid macOS process checks on Windows startup

### DIFF
--- a/.github/workflows/windows-signing.yml
+++ b/.github/workflows/windows-signing.yml
@@ -36,7 +36,7 @@ jobs:
         shell: pwsh
         env:
           OPENSCIENCE_DESKTOP_SIDECAR: ${{ github.workspace }}/backend/cli/dist/@synsci/openscience-windows-x64/bin/openscience.exe
-        run: bun frontend/desktop/script/startup-smoke.mjs
+        run: node frontend/desktop/script/startup-smoke.mjs
   signatures:
     name: Windows Authenticode verification
     runs-on: windows-2025

--- a/.github/workflows/windows-signing.yml
+++ b/.github/workflows/windows-signing.yml
@@ -1,4 +1,4 @@
-name: Windows signing checks
+name: Windows desktop checks
 
 on:
   pull_request:
@@ -20,6 +20,23 @@ permissions:
   contents: read
 
 jobs:
+  startup:
+    name: Windows desktop startup
+    runs-on: windows-2025
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ./.github/actions/setup-bun
+      - name: Build the real desktop runtime and workspace
+        shell: pwsh
+        run: |
+          $env:OPENSCIENCE_VERSION = (Get-Content backend/cli/package.json | ConvertFrom-Json).version
+          bun run --cwd backend/cli build --single --skip-install
+      - name: Launch the real Electron app through final startup health
+        shell: pwsh
+        env:
+          OPENSCIENCE_DESKTOP_SIDECAR: ${{ github.workspace }}/backend/cli/dist/@synsci/openscience-windows-x64/bin/openscience.exe
+        run: bun frontend/desktop/script/startup-smoke.mjs
   signatures:
     name: Windows Authenticode verification
     runs-on: windows-2025

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ tagged release also ships native binaries for Linux, macOS, and Windows.
 
 ### Changed
 
+- Fix Windows desktop startup failing with `spawn /bin/ps ENOENT` by limiting
+  macOS updater process-identity checks to supervised update launches.
 - Require Microsoft Artifact Signing for stable Windows desktop installers,
   including the bundled runtime and native libraries, and verify publisher,
   signature trust, and timestamps before publishing.

--- a/frontend/desktop/script/startup-smoke.mjs
+++ b/frontend/desktop/script/startup-smoke.mjs
@@ -1,28 +1,36 @@
 import assert from "node:assert/strict"
-import { cp, mkdir, mkdtemp, rm } from "node:fs/promises"
+import { access, cp, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { createRequire } from "node:module"
 import os from "node:os"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
+import { setTimeout as pause } from "node:timers/promises"
 
 const desktop = fileURLToPath(new URL("../", import.meta.url))
 const require = createRequire(new URL("../package.json", import.meta.url))
 const workspace = createRequire(new URL("../../workspace/package.json", import.meta.url))
 const playwright = createRequire(workspace.resolve("@playwright/test"))("playwright")
 const binary = process.env.OPENSCIENCE_DESKTOP_SIDECAR
-if (!binary || !(await Bun.file(binary).exists())) throw new Error("Build and set OPENSCIENCE_DESKTOP_SIDECAR first")
+if (
+  !binary ||
+  !(await access(binary).then(
+    () => true,
+    () => false,
+  ))
+)
+  throw new Error("Build and set OPENSCIENCE_DESKTOP_SIDECAR first")
 
 const root = await mkdtemp(path.join(os.tmpdir(), "openscience-desktop-startup-"))
-const packaged = await Bun.file(path.join(desktop, "package.json")).json()
+const packaged = JSON.parse(await readFile(path.join(desktop, "package.json"), "utf8"))
 const source = path.join(root, "app")
 const profile = path.join(root, "electron")
 await mkdir(profile, { recursive: true })
 await cp(path.join(desktop, "src"), path.join(source, "src"), { recursive: true })
-await Bun.write(
+await writeFile(
   path.join(source, "package.json"),
   JSON.stringify({ name: "openscience-startup-smoke", version: packaged.version, type: "module", main: "smoke.mjs" }),
 )
-await Bun.write(
+await writeFile(
   path.join(source, "smoke.mjs"),
   `import { app } from "electron"
 app.setPath("userData", ${JSON.stringify(profile)})
@@ -84,7 +92,7 @@ try {
       console.log(`Desktop startup passed on ${process.platform}: workspace mounted, splash closed, runtime healthy`)
       break
     }
-    await Bun.sleep(100)
+    await pause(100)
   }
 } finally {
   await electron.close()

--- a/frontend/desktop/script/startup-smoke.mjs
+++ b/frontend/desktop/script/startup-smoke.mjs
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict"
+import { cp, mkdir, mkdtemp, rm } from "node:fs/promises"
+import { createRequire } from "node:module"
+import os from "node:os"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const desktop = fileURLToPath(new URL("../", import.meta.url))
+const require = createRequire(new URL("../package.json", import.meta.url))
+const workspace = createRequire(new URL("../../workspace/package.json", import.meta.url))
+const playwright = createRequire(workspace.resolve("@playwright/test"))("playwright")
+const binary = process.env.OPENSCIENCE_DESKTOP_SIDECAR
+if (!binary || !(await Bun.file(binary).exists())) throw new Error("Build and set OPENSCIENCE_DESKTOP_SIDECAR first")
+
+const root = await mkdtemp(path.join(os.tmpdir(), "openscience-desktop-startup-"))
+const packaged = await Bun.file(path.join(desktop, "package.json")).json()
+const source = path.join(root, "app")
+const profile = path.join(root, "electron")
+await mkdir(profile, { recursive: true })
+await cp(path.join(desktop, "src"), path.join(source, "src"), { recursive: true })
+await Bun.write(
+  path.join(source, "package.json"),
+  JSON.stringify({ name: "openscience-startup-smoke", version: packaged.version, type: "module", main: "smoke.mjs" }),
+)
+await Bun.write(
+  path.join(source, "smoke.mjs"),
+  `import { app } from "electron"
+app.setPath("userData", ${JSON.stringify(profile)})
+app.setPath("logs", ${JSON.stringify(path.join(root, "logs"))})
+await import("./src/main.mjs")
+`,
+)
+
+const env = {
+  ...process.env,
+  OPENSCIENCE_DESKTOP_SIDECAR: path.resolve(binary),
+  OPENSCIENCE_CONFIG_DIR: path.join(root, "config"),
+  OPENSCIENCE_DATA_DIR: path.join(root, "data"),
+  OPENSCIENCE_TEST_HOME: path.join(root, "home"),
+  OPENSCIENCE_DISABLE_MODELS_FETCH: "true",
+  OPENSCIENCE_DISABLE_LSP_DOWNLOAD: "true",
+}
+for (const name of ["ELECTRON_RUN_AS_NODE", "NODE_OPTIONS", "NODE_PATH"]) delete env[name]
+const electron = await playwright._electron.launch({
+  executablePath: require("electron"),
+  args: [source],
+  env,
+  timeout: 30_000,
+})
+
+try {
+  const deadline = Date.now() + 60_000
+  while (true) {
+    if (Date.now() >= deadline) throw new Error("Desktop startup did not finish within 60 seconds")
+    const windows = await electron.evaluate(async ({ BrowserWindow }) =>
+      Promise.all(
+        BrowserWindow.getAllWindows().map(async (window) => ({
+          url: window.webContents.getURL(),
+          page: await window.webContents
+            .executeJavaScript(
+              `({
+              ready: document.documentElement.dataset.openscienceReady === "true",
+              error: document.querySelector("h1")?.textContent === "OpenScience could not start"
+                ? document.body.innerText : undefined
+            })`,
+            )
+            .catch(() => ({})),
+        })),
+      ),
+    )
+    const failed = windows.find((window) => window.page.error)
+    if (failed) throw new Error(failed.page.error)
+
+    // The workspace can mount before final runtime health fails. Requiring
+    // the splash to close exercises the complete startup path from #543.
+    if (windows.length === 1 && windows[0].page.ready && windows[0].url.startsWith("http://127.0.0.1:")) {
+      const response = await fetch(new URL("/global/health", windows[0].url), { signal: AbortSignal.timeout(3_000) })
+      assert.equal(response.status, 200)
+      const health = await response.json()
+      assert.equal(health.healthy, true)
+      assert.equal(health.version, packaged.version)
+      assert.equal(typeof health.runId, "string")
+      assert.ok(health.runId)
+      console.log(`Desktop startup passed on ${process.platform}: workspace mounted, splash closed, runtime healthy`)
+      break
+    }
+    await Bun.sleep(100)
+  }
+} finally {
+  await electron.close()
+  await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 })
+}

--- a/frontend/desktop/src/main.mjs
+++ b/frontend/desktop/src/main.mjs
@@ -244,7 +244,9 @@ async function proveServiceHealth() {
     throw new Error("The local OpenScience runtime failed its final desktop health check")
   }
   return {
-    identity: await processIdentity(service.pid, state.serviceExecutable),
+    // Exact process identity belongs to the supervised macOS update receipt.
+    // Ordinary startup still checks runtime health on every platform.
+    identity: validateUpdateHealthRequest() ? await processIdentity(service.pid, state.serviceExecutable) : undefined,
     health: { version: health.version, run_id: health.runId },
   }
 }

--- a/frontend/docs/src/content/openscience/troubleshooting.mdx
+++ b/frontend/docs/src/content/openscience/troubleshooting.mdx
@@ -18,6 +18,12 @@ Download the desktop build that matches your operating system and processor. If 
 
 See [Installation and updates](/openscience/installation).
 
+If Windows reports `spawn /bin/ps ENOENT`, the desktop build is running a macOS
+updater check during startup. Track the fixed installer in
+[issue #543](https://github.com/synthetic-sciences/openscience/issues/543).
+To keep working, install Node.js and run `npx synsci` in a terminal to open the
+CLI's browser workspace, which uses a separate startup path.
+
 ## No models available
 
 Open **Customize → Models** and check the selected access mode.


### PR DESCRIPTION
Windows desktop startup fails with `spawn /bin/ps ENOENT` because the final health check unconditionally gathers process identity for the macOS updater. Gather that identity only when a validated supervised-update request exists; keep runtime liveness, health, version, and run-ID checks on every platform.

Adds native Windows CI that builds the real runtime and workspace, launches the real Electron main, and requires both a mounted workspace and a closed startup splash. The smoke uses isolated app/config/data directories. It also documents the CLI browser-workspace workaround.

Validation: 12 focused desktop/update/parent tests; backend typecheck; documentation checks and 6 tests; Prettier and actionlint; compiled runtime build and full Electron startup smoke on macOS. Native Windows startup CI passed on Windows Server 2025: the real Electron workspace mounted, the startup splash closed, and the compiled runtime reported healthy. All PR checks passed.

Fixes #543.
