### PR TITLE
Publish the Windows installer unsigned while any Artifact Signing value is missing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -157,10 +157,12 @@ jobs:
             echo "::error::Missing release credentials: ${missing[*]}"
             exit 1
           fi
-          # Windows Artifact Signing is all-or-nothing. Until the Public Trust
-          # profile and its Entra application exist, the Windows installer is
-          # published unsigned (as before signing was introduced) with a
-          # warning; a partial configuration is a mistake and fails here.
+          # Windows Artifact Signing needs every value below. The Entra
+          # application and Public Trust profile arrive last (after Microsoft's
+          # approval), so the configuration is expected to be incomplete for a
+          # while; until it is complete the Windows installer is published
+          # unsigned, as before signing was introduced, and the warning names
+          # exactly what is still missing.
           windows=(WINDOWS_SIGNING_CLIENT_ID WINDOWS_SIGNING_TENANT_ID WINDOWS_SIGNING_ENDPOINT WINDOWS_SIGNING_ACCOUNT WINDOWS_SIGNING_PROFILE WINDOWS_SIGNING_PUBLISHER)
           absent=()
           for name in "${windows[@]}"; do
@@ -168,12 +170,9 @@ jobs:
           done
           if (( ${#absent[@]} == 0 )); then
             echo "windows_signing=true" >> "$GITHUB_OUTPUT"
-          elif (( ${#absent[@]} == ${#windows[@]} )); then
-            echo "::warning::Windows Artifact Signing is not configured; the Windows installer will be published unsigned."
-            echo "windows_signing=false" >> "$GITHUB_OUTPUT"
           else
-            echo "::error::Windows Artifact Signing is partially configured; missing: ${absent[*]}"
-            exit 1
+            echo "::warning::Windows Artifact Signing is not configured (missing: ${absent[*]}); the Windows installer will be published unsigned."
+            echo "windows_signing=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Verify npm publisher

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ tagged release also ships native binaries for Linux, macOS, and Windows.
 
 ### Changed
 
-- Publish the Windows desktop installer unsigned, with a workflow warning,
-  until the Microsoft Artifact Signing profile and its repository configuration
-  exist; a partial signing configuration still fails the release preflight.
+- Publish the Windows desktop installer unsigned, with a workflow warning that
+  names the missing values, until the Microsoft Artifact Signing profile and its
+  repository configuration are complete.
 - Match the new-terminal shortcut by physical key so Ctrl+Shift+` works on layouts
   where Shift+backtick reports a different symbol, and point twelve more skills at
   the real scientific-schematics script path.

--- a/docs/notes/release-process.md
+++ b/docs/notes/release-process.md
@@ -158,9 +158,8 @@ Configure these repository variables:
 
 The former `WINDOWS_CSC_LINK` and `WINDOWS_CSC_KEY_PASSWORD` secrets are no longer
 used. Until all six values above exist, the publish preflight records a warning
-and the Windows installer is published unsigned, as it was before Artifact
-Signing was introduced; a partial configuration fails the preflight instead.
-Once they are all set, the workflow requires a trusted, timestamped signature
+naming the missing ones and the Windows installer is published unsigned, as it
+was before Artifact Signing was introduced. Once they are all set, the workflow requires a trusted, timestamped signature
 from the configured publisher on the installer, app, sidecar, and bundled native
 libraries. A resumed
 installer must match its GitHub SHA-256 digest and pass signature verification


### PR DESCRIPTION
### What does this PR do, and why?

Publish run 34176810572 failed the new preflight from #553 with "Windows Artifact Signing is partially configured; missing: WINDOWS_SIGNING_CLIENT_ID WINDOWS_SIGNING_PROFILE": the repository already has the tenant id, endpoint, account and publisher, and only the Entra client id and the Public Trust profile are still pending Microsoft's approval. Treating that as fatal blocks every stable release.

Until all six values exist, the preflight now records a warning that names the missing ones and exports `windows_signing=false`, so the Windows job builds and publishes the installer unsigned exactly as releases did before #551. Once the last two values are added, signing and verification run unchanged with no further code change.

### Linked issue

Release blocked; follows #551 and #553.

### How did you verify it?

- `actionlint` on the workflow; Prettier on touched files.
- The signing module and the Windows job conditions are unchanged from #553; only the preflight's incomplete-configuration branch changed from error to warning.

### Checklist

- [x] Unreleased changelog entry updated.
- [x] Matching documentation updated.
- [x] No package version bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
