### PR TITLE
Name the benchmarks correctly and link them from the figures

### DIFF
--- a/frontend/landing/src/components/BenchmarkFigure.tsx
+++ b/frontend/landing/src/components/BenchmarkFigure.tsx
@@ -193,7 +193,13 @@ export function BenchmarkFigure({ benchmark, index }: { benchmark: Benchmark; in
       </div>
       <span>
         <span data-slot="fig">Fig {index}.</span>
-        {benchmark.name}
+        {benchmark.href ? (
+          <a href={benchmark.href} target="_blank" rel="noreferrer">
+            {benchmark.name}
+          </a>
+        ) : (
+          benchmark.name
+        )}
       </span>
     </div>
   )

--- a/frontend/landing/src/data/benchmarks.ts
+++ b/frontend/landing/src/data/benchmarks.ts
@@ -25,7 +25,8 @@ export type Benchmark = {
   figure: string
   /** OpenScience score, in percent. */
   score: number
-  href: string
+  /** The benchmark's own page. Omitted for internal benchmarks. */
+  href?: string
   chart: Chart
 }
 
@@ -37,7 +38,7 @@ export const BENCHMARKS: readonly Benchmark[] = [
     /* Resolution rate, in percent; cost is total cost in thousands of dollars,
        laid out roughly like the public leaderboard's Pareto view. */
     score: 38.0,
-    href: "https://terminal-bench-science.ai/?view=pareto",
+    href: "https://terminal-bench-science.ai/",
     chart: {
       kind: "pareto",
       points: [
@@ -58,11 +59,11 @@ export const BENCHMARKS: readonly Benchmark[] = [
     },
   },
   {
-    id: "frontierbench-science",
-    name: "FrontierBench (science)",
-    figure: "Performance frontier",
+    id: "terminal-bench-4-science",
+    name: "Terminal-Bench 4.0 (science)",
+    figure: "Performance frontier on the science tasks in Terminal-Bench 4.0",
     score: 44.7,
-    href: "https://github.com/synthetic-sciences/OpenScience/tree/main/evals",
+    href: "https://www.tbench.ai/",
     chart: {
       kind: "frontier",
       series: [
@@ -75,10 +76,9 @@ export const BENCHMARKS: readonly Benchmark[] = [
   },
   {
     id: "openscience-bench",
-    name: "OpenScience Bench",
+    name: "OpenScience Bench (internal)",
     figure: "Internal; against Claude Science, K-Dense (BYOK), and Codex",
     score: 58.3,
-    href: "https://github.com/synthetic-sciences/OpenScience/tree/main/evals",
     chart: {
       kind: "comparison",
       rows: [

--- a/frontend/landing/src/index.css
+++ b/frontend/landing/src/index.css
@@ -908,6 +908,16 @@ pre {
         strong {
           color: var(--color-text-strong);
         }
+        /* The benchmark's own page; internal benchmarks have no link. */
+        a {
+          color: var(--color-text-strong);
+          text-decoration: underline;
+          text-decoration-thickness: 1px;
+          text-underline-offset: 4px;
+        }
+        a:hover {
+          color: var(--color-accent);
+        }
       }
     }
   }

--- a/frontend/landing/src/pages/Landing.tsx
+++ b/frontend/landing/src/pages/Landing.tsx
@@ -85,7 +85,7 @@ const WHAT = [
   ["Scientific databases", "UniProt, PDB, ChEMBL, PubChem, arXiv, and 37 more, as tools"],
   ["Bundled skills", "312 skills across biology, chemistry, physics, ML, and writing"],
   ["ChatGPT Plus/Pro", "Sign in with OpenAI to use the subscription you already have"],
-  ["Your compute", "Run experiments on your laptop, cluster, or cloud GPUs"],
+  ["Manages compute", "Builds environments and scales on demand: your laptop, cluster, or GPUs"],
   ["Multi-session", "Run several agents in parallel on the same project"],
 ] as const
 


### PR DESCRIPTION
## Summary

Corrects the benchmark identities on the home page and makes each figure link to the benchmark it reports.

| Figure | Name | Links to |
| --- | --- | --- |
| Fig 1 | Terminal-Bench Science | terminal-bench-science.ai |
| Fig 2 | Terminal-Bench 4.0 (science) | tbench.ai |
| Fig 3 | OpenScience Bench (internal) | not linked |

- **Figure 2** was labelled "FrontierBench (science)". It is the science subset of tasks within Terminal-Bench 4.0, so it is renamed and its description says so.
- **Figure 3** is internal and now carries "(internal)" in its name, which shows in both the caption and the summary sentence.
- **Links:** the `href` field existed in `src/data/benchmarks.ts` but was never rendered, so no figure was clickable. Captions are now links opening in a new tab. The two hrefs previously stored pointed at this repo's `evals/` folder, which contains only `cadence-harness` and `launch` and no benchmark results; `href` is now optional and the internal benchmark has none rather than a placeholder.

Also rewrites the compute row in "What is OpenScience?" to say what it does: **Manages compute** — "Builds environments and scales on demand: your laptop, cluster, or GPUs".

Benchmark numbers themselves remain placeholders under `PRELIMINARY = true`.

## Test plan

- [x] `tsc --noEmit` and `prettier --check` clean, `vite build` succeeds
- [x] Captions verified in the browser: figures 1 and 2 resolve to the external leaderboards, figure 3 renders unlinked
- [x] All six list rows still fit on one line at 1440 wide; no console errors
- [ ] Vercel production deploy after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
