### PR TITLE
fix: preserve harness payloads and verifiable worker handoffs

### DIFF
--- a/.github/workflows/deep-ci.yml
+++ b/.github/workflows/deep-ci.yml
@@ -144,6 +144,7 @@ jobs:
               bun test --timeout 15000
               test/global/data-dir.test.ts
               test/process/darwin-responsibility.test.ts
+              test/compute/local-python-runtime.test.ts
               test/credentials/process-ledger.test.ts
               test/project/authority-process-ledger.test.ts
               test/file/safe-io.test.ts
@@ -158,6 +159,7 @@ jobs:
               bun test --timeout 15000
               test/global/data-dir.test.ts
               test/process/windows-job.test.ts
+              test/compute/local-python-runtime.test.ts
               test/global/data-root.test.ts
               test/openscience-env.test.ts
               test/file/safe-io.test.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ tagged release also ships native binaries for Linux, macOS, and Windows.
   metadata honestly. Explain changes to advertised tools at the provider boundary.
 - Discover Git Bash across Windows installation layouts and require a POSIX shell
   for local compute, so a fallback command prompt cannot report success without
-  executing the job script.
+  executing the job script. Capture mixed shell and native-program output through
+  one append writer, and flush it before reporting completion.
 - Keep delegated-agent progress connected throughout execution and propagate parent
   cancellation through child preparation, resumed work and active model requests.
   Normalize empty continuation fields and stop repeated same-cause failures even

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ tagged release also ships native binaries for Linux, macOS, and Windows.
 - Record the selected Python executable separately from measured version evidence,
   use that same interpreter for local compute receipts, and label remote submitter
   metadata honestly. Explain changes to advertised tools at the provider boundary.
+- Discover Git Bash across Windows installation layouts and require a POSIX shell
+  for local compute, so a fallback command prompt cannot report success without
+  executing the job script.
 - Keep delegated-agent progress connected throughout execution and propagate parent
   cancellation through child preparation, resumed work and active model requests.
   Normalize empty continuation fields and stop repeated same-cause failures even

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ tagged release also ships native binaries for Linux, macOS, and Windows.
 
 ### Changed
 
+- Preserve complete historical tool arguments during output compaction and reject
+  copied legacy argument previews before file mutations. Retain Task outcomes and
+  immutable output handles during compaction; earlier progress text no longer
+  counts as a worker's final handoff.
+- Let leads read saved worker Results by exact artifact and version IDs without
+  opening private scratch directories. Include observed command receipt references
+  in handoffs, without treating shell success as proof of passing tests.
+- Record the selected Python executable separately from measured version evidence,
+  use that same interpreter for local compute receipts, and label remote submitter
+  metadata honestly. Explain changes to advertised tools at the provider boundary.
 - Keep delegated-agent progress connected throughout execution and propagate parent
   cancellation through child preparation, resumed work and active model requests.
   Normalize empty continuation fields and stop repeated same-cause failures even

--- a/backend/cli/src/compute/jobs.ts
+++ b/backend/cli/src/compute/jobs.ts
@@ -219,6 +219,8 @@ export namespace ComputeJobs {
     bun: z.string(),
     node: z.string(),
     python: z.string().optional(),
+    capture_scope: z.enum(["execution_host", "submitter"]).optional(),
+    execution_environment: KernelEnvironmentMutation.SubprocessEnvironment.optional(),
     git: z
       .object({
         repository: z.string().optional(),
@@ -467,6 +469,7 @@ export namespace ComputeJobs {
 
   type Launch = {
     argv: string[]
+    runtime?: Awaited<ReturnType<typeof KernelEnvironmentMutation.pythonSubprocessRuntime>>
     sandbox?: Job["sandbox"]
     temporary?: string
   }
@@ -1660,6 +1663,7 @@ export namespace ComputeJobs {
     host: Host | undefined,
     scope: Scope,
     authority: ExecutionAuthority.Decision,
+    runtime?: Launch["runtime"],
   ): Promise<Launch> {
     if (!host) await reattestLocalCapability(job, authority)
     const spec = command(job, host)
@@ -1689,18 +1693,24 @@ export namespace ComputeJobs {
     await fs.writeFile(exitOf(scope.root, job.id), "", { mode: 0o600 })
     // Generic local jobs share Bash's selected interpreter and package overlay.
     // Capability jobs already carry their exact attested runtime and command.
-    const runtime = job.capability_execution ? undefined : await KernelEnvironmentMutation.pythonSubprocessRuntime()
     // Set these after login-shell initialization too, which can reset PATH.
-    const initialize = runtime
-      ? `export PATH=${quote(runtime.env.PATH ?? process.env.PATH ?? "")}; export PYTHONPATH=${quote(runtime.env.PYTHONPATH)}; `
-      : ""
-    const wrapped = `${initialize}(${job.command}\n); code=$?; printf %s "$code" > ${quote(exitOf(scope.root, job.id))}; exit "$code"`
+    const wrapped = `(${job.command}\n); code=$?; printf %s "$code" > ${quote(exitOf(scope.root, job.id))}; exit "$code"`
     const sandboxOptions = job.capability_execution
       ? { ...authority.sandbox, enabled: true, network: "deny" as const }
       : authority.sandbox
     const planned = Sandbox.wrapArgv({
       file: Shell.acceptable(),
-      args: ["-lc", wrapped],
+      args: (selectedPath) => {
+        const value = quote(selectedPath ?? runtime?.env.PATH ?? process.env.PATH ?? "")
+        // Native Windows PATH uses semicolons and drive letters. Git Bash's
+        // login shell needs its POSIX spelling after startup resets PATH.
+        const restore =
+          process.platform === "win32"
+            ? `PATH=$(cygpath -up ${value}) || exit $?; export PATH; `
+            : `export PATH=${value}; `
+        return ["-lc", `${runtime ? `${restore}export PYTHONPATH=${quote(runtime.env.PYTHONPATH)}; ` : ""}${wrapped}`]
+      },
+      runtime: runtime ? { python: runtime.binary, path: runtime.env.PATH } : undefined,
       workspace: authority.writable,
       readable: [
         ...authority.readable,
@@ -1723,6 +1733,7 @@ export namespace ComputeJobs {
     }
     return {
       argv: [planned.file, ...planned.args],
+      runtime,
       temporary: planned.temporary,
       sandbox: {
         requested: sandboxOptions.enabled,
@@ -1739,20 +1750,27 @@ export namespace ComputeJobs {
     cwd: string,
     authority: ExecutionAuthority.Decision,
     partial = false,
+    runtime?: Launch["runtime"],
   ): Promise<string | undefined> {
     await currentAuthority(authority)
     const planned = Sandbox.wrapArgv({
       file: argv[0]!,
       args: argv.slice(1),
       workspace: authority.writable,
-      readable: authority.readable,
+      readable: [
+        ...authority.readable,
+        ...(runtime?.extraReadable ?? []),
+        ...(runtime?.binary ? [path.dirname(path.dirname(await fs.realpath(runtime.binary)))] : []),
+      ],
       unreadable: OpenScience.kernelSensitivePaths(),
       options: authority.sandbox,
     })
     try {
       const proc = Bun.spawn([planned.file, ...planned.args], {
         cwd,
-        env: OpenScience.kernelEnv(process.env),
+        env: runtime
+          ? KernelEnvironmentMutation.subprocessEnv(runtime, OpenScience.kernelEnv(process.env))
+          : OpenScience.kernelEnv(process.env),
         stdin: "ignore",
         stdout: "pipe",
         stderr: "ignore",
@@ -1957,16 +1975,23 @@ export namespace ComputeJobs {
     "Cargo.lock",
   ]
 
-  async function reproduce(job: Job, authority: ExecutionAuthority.Decision): Promise<Reproducibility> {
+  async function reproduce(
+    job: Job,
+    authority: ExecutionAuthority.Decision,
+    runtime?: Launch["runtime"],
+  ): Promise<Reproducibility> {
     const cwd = path.resolve(job.cwd ?? process.cwd())
+    const binary =
+      job.target.kind === "local" ? (job.capability_execution?.runtime_binary ?? runtime?.binary) : undefined
     const [repository, branch, commit, status, python, capturedLocks] = await Promise.all([
       output(["git", "remote", "get-url", "origin"], cwd, authority),
       output(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd, authority),
       output(["git", "rev-parse", "HEAD"], cwd, authority),
       output(["git", "-c", "core.fsmonitor=false", "status", "--porcelain"], cwd, authority, true),
-      output(["python3", "--version"], cwd, authority),
+      runtime?.binary ? output([runtime.binary, "--version"], cwd, authority, false, runtime) : undefined,
       Promise.all(lockfiles.map((file) => fingerprint(cwd, file))),
     ])
+    const version = python?.match(/^Python ([0-9]+\.[0-9]+\.[0-9]+\S*)$/)?.[1]
     const git =
       repository || branch || commit || status !== undefined
         ? { repository, branch, commit, dirty: !!status }
@@ -1979,7 +2004,28 @@ export namespace ComputeJobs {
       arch: process.arch,
       bun: Bun.version,
       node: process.version,
-      python,
+      // A remote job's local source snapshot must never masquerade as the
+      // remote interpreter or host. No remote runtime probe is implied here.
+      capture_scope: job.target.kind === "local" ? "execution_host" : "submitter",
+      python: version ? `Python ${version}` : undefined,
+      execution_environment: {
+        target: job.target.kind,
+        ...(job.target.kind === "local" ? { cwd } : job.ssh ? { cwd: job.ssh.cwd } : {}),
+        ...(job.capability
+          ? { profile: `${job.capability.id}:${job.capability.profile}` }
+          : runtime
+            ? { profile: runtime.environmentName ?? "python" }
+            : {}),
+        ...(job.target.kind === "local"
+          ? {
+              python: {
+                role: job.capability_execution ? "capability" : "selected_default",
+                ...(binary ? { executable: binary } : {}),
+                ...(version ? { version } : {}),
+              },
+            }
+          : {}),
+      },
       git,
       lockfiles: capturedLocks.filter((item): item is Artifact => !!item),
       resources: job.resources,
@@ -2029,18 +2075,19 @@ export namespace ComputeJobs {
       cwd: job.cwd,
       codeState: job.reproducibility?.git,
       codeReason: job.target.kind === "ssh" ? "remote_unverified" : "not_captured",
-      host: job.reproducibility
-        ? {
-            platform: job.reproducibility.platform,
-            arch: job.reproducibility.arch,
-            runtimes: {
-              bun: job.reproducibility.bun,
-              node: job.reproducibility.node,
-              ...(job.reproducibility.python ? { python: job.reproducibility.python } : {}),
-            },
-          }
-        : undefined,
-      hostReason: job.target.kind === "ssh" ? "remote_unverified" : "not_captured",
+      host:
+        job.target.kind === "local" && job.reproducibility
+          ? {
+              platform: job.reproducibility.platform,
+              arch: job.reproducibility.arch,
+              runtimes: {
+                bun: job.reproducibility.bun,
+                node: job.reproducibility.node,
+                ...(job.reproducibility.python ? { python: job.reproducibility.python } : {}),
+              },
+            }
+          : undefined,
+      hostReason: job.target.kind !== "local" ? "remote_unverified" : "not_captured",
       status,
       outputs,
       createdAt: job.created_at,
@@ -2771,7 +2818,7 @@ export namespace ComputeJobs {
           })
           const proc = spawn(wrapped.file, wrapped.args, {
             cwd: host ? authority.workspace : job.cwd,
-            env,
+            env: launch.runtime ? KernelEnvironmentMutation.subprocessEnv(launch.runtime, env) : env,
             detached,
             windowsHide: true,
             stdio: ["ignore", output.fd, output.fd],
@@ -3733,9 +3780,11 @@ export namespace ComputeJobs {
         }
       }
     }
-    const reproducibility = host ? undefined : await reproduce(draft, authority)
+    const runtime =
+      !host && !draft.capability_execution ? await KernelEnvironmentMutation.pythonSubprocessRuntime() : undefined
+    const reproducibility = host ? undefined : await reproduce(draft, authority, runtime)
     await currentAuthority(authority)
-    const planned = await launch(draft, host, scope, authority).catch(async (error) => {
+    const planned = await launch(draft, host, scope, authority, runtime).catch(async (error) => {
       if (!host) await fs.rm(exitOf(scope.root, id), { force: true })
       throw error
     })

--- a/backend/cli/src/compute/jobs.ts
+++ b/backend/cli/src/compute/jobs.ts
@@ -1620,7 +1620,7 @@ export namespace ComputeJobs {
   ): { argv: string[]; scheduler: Scheduler; label: string } {
     if (!host) {
       return {
-        argv: [Shell.acceptable(), "-lc", input.command],
+        argv: [Shell.posix(), "-lc", input.command],
         scheduler: "none",
         label: "This computer",
       }
@@ -1699,7 +1699,7 @@ export namespace ComputeJobs {
       ? { ...authority.sandbox, enabled: true, network: "deny" as const }
       : authority.sandbox
     const planned = Sandbox.wrapArgv({
-      file: Shell.acceptable(),
+      file: Shell.posix(),
       args: (selectedPath) => {
         const value = quote(selectedPath ?? runtime?.env.PATH ?? process.env.PATH ?? "")
         // Native Windows PATH uses semicolons and drive letters. Git Bash's

--- a/backend/cli/src/compute/jobs.ts
+++ b/backend/cli/src/compute/jobs.ts
@@ -1,7 +1,8 @@
 import { spawn, type ChildProcess } from "node:child_process"
 import crypto from "node:crypto"
-import { createReadStream, watch as watchFile } from "node:fs"
+import { createReadStream, createWriteStream, watch as watchFile } from "node:fs"
 import fs from "node:fs/promises"
+import { finished } from "node:stream/promises"
 import path from "node:path"
 import os from "node:os"
 import z from "zod"
@@ -2786,7 +2787,49 @@ export namespace ComputeJobs {
   ): Promise<void> {
     await fs.mkdir(logsOf(scope.root), { recursive: true })
     const log = path.join(logsOf(scope.root), `${job.id}.log`)
-    const output = await fs.open(log, "a", 0o600)
+    const output = process.platform === "win32" ? undefined : await fs.open(log, "a", 0o600)
+    // Mixed MSYS/native output was lost with a shared inherited regular file.
+    // One parent-owned writer avoids independent handle semantics and appends
+    // both pipes with standard stream backpressure and no log buffer.
+    const writer = process.platform === "win32" ? createWriteStream(log, { flags: "a", mode: 0o600 }) : undefined
+    const logFailed = Promise.withResolvers<Error>()
+    const logging = {
+      error: undefined as Error | undefined,
+      streams: [] as NonNullable<ChildProcess["stdout"]>[],
+      drains: [] as Promise<void>[],
+    }
+    const failLog = (cause: Error) => {
+      if (logging.error) return
+      logging.error = new Error(`Could not capture compute job log: ${cause.message}`, { cause })
+      logFailed.resolve(logging.error)
+    }
+    const flushed = writer ? finished(writer, { cleanup: true }).catch(failLog) : Promise.resolve()
+    const closeLog = async () => {
+      if (!writer) return output?.close()
+      if (logging.error) {
+        for (const stream of logging.streams) stream.destroy()
+        writer.destroy()
+      }
+      const drained = Promise.all(logging.drains).then(async () => {
+        if (!writer.destroyed) writer.end()
+        await flushed
+      })
+      const deadline = Promise.withResolvers<void>()
+      const timer = setTimeout(() => {
+        failLog(new Error("Output pipes did not drain after compute process cleanup"))
+        for (const stream of logging.streams) stream.destroy()
+        writer.destroy()
+        deadline.resolve()
+      }, 5_000)
+      try {
+        await Promise.race([drained, deadline.promise])
+      } finally {
+        clearTimeout(timer)
+        for (const stream of logging.streams) stream.destroy()
+        writer.destroy()
+        await flushed
+      }
+    }
     const detached = process.platform !== "win32"
     const ledgerID = credentialProcessID(scope.root, job.id)
     let launched:
@@ -2800,6 +2843,7 @@ export namespace ComputeJobs {
       launched = await AuthoritySignal.exclusive(() =>
         OpenScience.withSubprocessEnv(process.env, async (env, overlay) => {
           await currentAuthority(authority)
+          if (logging.error) throw logging.error
           const queued = (await read(scope.root)).find((item) => item.id === job.id)
           if (!queued || terminal.has(queued.status)) return
           const linuxIdentity = process.platform === "linux" ? await processIdentity(process.pid) : undefined
@@ -2821,15 +2865,29 @@ export namespace ComputeJobs {
             env: launch.runtime ? KernelEnvironmentMutation.subprocessEnv(launch.runtime, env) : env,
             detached,
             windowsHide: true,
-            stdio: ["ignore", output.fd, output.fd],
+            stdio: writer ? ["ignore", "pipe", "pipe"] : ["ignore", output!.fd, output!.fd],
           })
+          if (writer) {
+            for (const stream of [proc.stdout, proc.stderr]) {
+              if (!stream) {
+                failLog(new Error("Compute child did not expose its output pipe"))
+                continue
+              }
+              logging.streams.push(stream)
+              logging.drains.push(finished(stream, { cleanup: true }).catch(failLog))
+              stream.pipe(writer, { end: false })
+            }
+          }
           WindowsJobLauncher.bind(proc, wrapped.release)
           proc.once("exit", () => Sandbox.cleanup(launch))
           proc.once("error", () => Sandbox.cleanup(launch))
-          const result = new Promise<{ code: number | null; error?: string }>((resolve) => {
+          const exited = new Promise<{ code: number | null; error?: string }>((resolve) => {
             proc.once("error", (error) => resolve({ code: null, error: error.message }))
             proc.once("exit", (code) => resolve({ code }))
           })
+          const result = writer
+            ? Promise.race([exited, logFailed.promise.then((error) => ({ code: null, error: error.message }))])
+            : exited
           const identity = proc.pid ? await processIdentity(proc.pid) : undefined
           try {
             if (!proc.pid || !identity) {
@@ -2900,28 +2958,32 @@ export namespace ComputeJobs {
         }),
       )
     } catch (error) {
-      await output.close().catch(() => undefined)
+      await closeLog().catch(() => undefined)
       Sandbox.cleanup(launch)
       throw error
     }
     if (!launched) {
-      await output.close()
+      await closeLog()
       await deactivate(keyOf(scope.root, job.id))
       Sandbox.cleanup(launch)
       ready?.()
       return
     }
     const { proc, result, key } = launched
-    // Keep inherited log handles alive until the gated payload and its owned
-    // descendants settle. In particular, Windows starts the payload only
-    // after durable Job Object registration has released the supervisor.
-    const completed = await result.finally(async () => {
-      try {
-        await completeCredentialProcess(ledgerID)
-      } finally {
-        await output.close()
-      }
-    })
+    const outcome = await result
+      .finally(async () => {
+        try {
+          if (logging.error) await Shell.killTree(proc, { detached, exited: () => proc.exitCode !== null })
+          await completeCredentialProcess(ledgerID)
+        } finally {
+          await closeLog()
+        }
+      })
+      .catch(async (error) => {
+        await deactivate(key)
+        throw error
+      })
+    const completed = logging.error ? { code: null, error: logging.error.message } : outcome
     const captureResult = host
       ? undefined
       : await capture(job)

--- a/backend/cli/src/compute/jobs.ts
+++ b/backend/cli/src/compute/jobs.ts
@@ -2904,16 +2904,24 @@ export namespace ComputeJobs {
       Sandbox.cleanup(launch)
       throw error
     }
-    await output.close()
     if (!launched) {
+      await output.close()
       await deactivate(keyOf(scope.root, job.id))
       Sandbox.cleanup(launch)
       ready?.()
       return
     }
     const { proc, result, key } = launched
-    const completed = await result
-    await completeCredentialProcess(ledgerID)
+    // Keep inherited log handles alive until the gated payload and its owned
+    // descendants settle. In particular, Windows starts the payload only
+    // after durable Job Object registration has released the supervisor.
+    const completed = await result.finally(async () => {
+      try {
+        await completeCredentialProcess(ledgerID)
+      } finally {
+        await output.close()
+      }
+    })
     const captureResult = host
       ? undefined
       : await capture(job)

--- a/backend/cli/src/sandbox/sandbox.ts
+++ b/backend/cli/src/sandbox/sandbox.ts
@@ -230,22 +230,25 @@ export namespace Sandbox {
     for (const temporary of [...temporaryRoots]) cleanup({ temporary })
   })
 
-  function withTempEnvironment(argv: string[], temporary: string, runtime?: { python?: string; path?: string }) {
-    const bin = (() => {
-      if (!runtime?.python) return
-      const value = path.join(temporary, "runtime", "bin")
-      fs.mkdirSync(value, { recursive: true })
-      for (const name of process.platform === "win32" ? ["python.exe", "python3.exe"] : ["python", "python3"]) {
-        const link = path.join(value, name)
-        try {
-          fs.symlinkSync(runtime.python, link, process.platform === "win32" ? "file" : undefined)
-        } catch (error) {
-          if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error
-        }
-      }
-      return value
-    })()
-    const inherited = runtime?.path ?? process.env.PATH
+  function runtimePath(temporary: string, runtime?: { python?: string; path?: string }) {
+    if (!runtime?.python) return runtime?.path
+    // Windows Python installations carry DLLs beside python.exe and cannot
+    // rely on privileged symlink creation. Keep their selected directory first.
+    if (process.platform === "win32") {
+      return [path.dirname(runtime.python), runtime.path ?? process.env.PATH].filter(Boolean).join(path.delimiter)
+    }
+    const bin = path.join(temporary, "runtime", "bin")
+    fs.mkdirSync(bin, { recursive: true })
+    // A symlink placed outside a venv loses its pyvenv.cfg lookup and starts
+    // the base interpreter instead. exec preserves the selected binary path.
+    const wrapper = `#!/bin/sh\nexec '${runtime.python.replaceAll("'", "'\\''")}' "$@"\n`
+    for (const name of ["python", "python3"]) {
+      fs.writeFileSync(path.join(bin, name), wrapper, { flag: "wx", mode: 0o700 })
+    }
+    return [bin, runtime.path ?? process.env.PATH].filter(Boolean).join(path.delimiter)
+  }
+
+  function withTempEnvironment(argv: string[], temporary: string, runtimePath?: string) {
     return [
       "/usr/bin/env",
       `TMPDIR=${temporary}`,
@@ -256,7 +259,7 @@ export namespace Sandbox {
       // read-only inside the sandbox. Keep those files in the same private,
       // owner-only temp root as every other runtime.
       `TMPPREFIX=${path.join(temporary, "zsh")}`,
-      ...(bin ? [`PATH=${[bin, inherited].filter(Boolean).join(path.delimiter)}`] : []),
+      ...(runtimePath ? [`PATH=${runtimePath}`] : []),
       ...argv,
     ]
   }
@@ -822,6 +825,23 @@ export namespace Sandbox {
   }): Plan {
     const { backend: b, warning } = decide(input.options)
     if (b === "none") {
+      if (input.runtime?.python && process.platform !== "win32") {
+        const temporary = privateTemp()
+        try {
+          const selectedPath = runtimePath(temporary, input.runtime)!
+          return {
+            file: `export PATH='${selectedPath.replaceAll("'", "'\\''")}'; ${input.command}`,
+            useShell: input.shell,
+            sandboxed: false,
+            backend: "none",
+            warning,
+            temporary,
+          }
+        } catch (error) {
+          cleanup({ temporary })
+          throw error
+        }
+      }
       return { file: input.command, useShell: input.shell, sandboxed: false, backend: "none", warning }
     }
     const temporary = privateTemp()
@@ -835,7 +855,10 @@ export namespace Sandbox {
         entrypoints: [input.shell, input.runtime?.python].filter((value): value is string => !!value),
         options: input.options!,
       })
-      const s = specForArgv(withTempEnvironment([input.shell, "-c", input.command], temporary, input.runtime), policy)!
+      const s = specForArgv(
+        withTempEnvironment([input.shell, "-c", input.command], temporary, runtimePath(temporary, input.runtime)),
+        policy,
+      )!
       log.info("sandboxing command", { backend: b, network: policy.network, writable: policy.writable.length })
       return { file: s.file, args: s.args, useShell: false, sandboxed: true, backend: b, temporary, warning }
     } catch (error) {
@@ -852,7 +875,9 @@ export namespace Sandbox {
    */
   export function wrapArgv(input: {
     file: string
-    args: string[]
+    /** Login shells can restore this selected PATH after their startup files. */
+    args: string[] | ((runtimePath?: string) => string[])
+    runtime?: { python?: string; path?: string }
     /** Workspace roots that stay writable. */
     workspace: string[]
     /** Explicit read-only grant roots for this process. */
@@ -866,11 +891,20 @@ export namespace Sandbox {
     options?: Options
   }): Wrapped {
     const { backend: b, warning } = decide(input.options)
-    if (b === "none") {
-      return { file: input.file, args: input.args, sandboxed: false, backend: "none", warning }
+    if (b === "none" && !input.runtime) {
+      return {
+        file: input.file,
+        args: typeof input.args === "function" ? input.args() : input.args,
+        sandboxed: false,
+        backend: "none",
+        warning,
+      }
     }
     const temporary = privateTemp()
     try {
+      const selectedPath = runtimePath(temporary, input.runtime)
+      const args = typeof input.args === "function" ? input.args(selectedPath) : input.args
+      if (b === "none") return { file: input.file, args, temporary, sandboxed: false, backend: "none", warning }
       const policy = buildPolicy({
         workspace: input.workspace,
         temporary,
@@ -878,10 +912,10 @@ export namespace Sandbox {
         readOnly: input.readOnly,
         extraWritable: input.extraWritable,
         unreadable: input.unreadable,
-        entrypoints: [input.file],
+        entrypoints: [input.file, input.runtime?.python].filter((value): value is string => !!value),
         options: input.options!,
       })
-      const s = specForArgv(withTempEnvironment([input.file, ...input.args], temporary), policy)!
+      const s = specForArgv(withTempEnvironment([input.file, ...args], temporary, selectedPath), policy)!
       log.info("sandboxing process", { backend: b, network: policy.network, writable: policy.writable.length })
       return { file: s.file, args: s.args, sandboxed: true, backend: b, temporary, warning }
     } catch (error) {

--- a/backend/cli/src/science/kernel/environment-mutation.ts
+++ b/backend/cli/src/science/kernel/environment-mutation.ts
@@ -1,4 +1,5 @@
 import { Global } from "@/global"
+import { OpenScience } from "@/openscience"
 import { Instance } from "@/project/instance"
 import { ManagedEnvironments } from "@/science/kernel/environment-manager"
 import { pythonEnvironment } from "@/science/kernel/interpreter"
@@ -104,6 +105,43 @@ async function hostPython() {
 
 export namespace KernelEnvironmentMutation {
   export type Language = "python" | "r"
+
+  export const SubprocessEnvironment = z.object({
+    target: z.enum(["local", "ssh", "modal"]),
+    cwd: z.string().optional(),
+    profile: z.string().optional(),
+    python: z
+      .object({
+        role: z.enum(["selected_default", "capability"]),
+        executable: z.string().optional(),
+        version: z.string().optional(),
+      })
+      .optional()
+      .describe("Selected runtime, not proof that arbitrary shell code used Python. Missing fields were not measured."),
+  })
+  export type SubprocessEnvironment = z.infer<typeof SubprocessEnvironment>
+
+  export function subprocessIdentity(runtime: KernelStartOptions, cwd: string): SubprocessEnvironment {
+    return {
+      target: "local",
+      cwd,
+      profile: runtime.environmentName ?? "python",
+      python: { role: "selected_default", ...(runtime.binary ? { executable: runtime.binary } : {}) },
+    }
+  }
+
+  /** Restore only resolver-owned Python paths after the ordinary subprocess
+   * filter. Reuse this final overlay for both the launched command and its
+   * runtime-version probe; arbitrary ambient PYTHONPATH remains excluded. */
+  export function subprocessEnv(runtime: Awaited<ReturnType<typeof pythonSubprocessRuntime>>, env: NodeJS.ProcessEnv) {
+    return {
+      ...OpenScience.filterEnvForSubprocess({ ...env, ...runtime.env }),
+      PYTHONPATH: runtime.env.PYTHONPATH,
+      GIT_CONFIG_NOSYSTEM: env.GIT_CONFIG_NOSYSTEM,
+      GIT_CONFIG_GLOBAL: env.GIT_CONFIG_GLOBAL,
+      GIT_TERMINAL_PROMPT: env.GIT_TERMINAL_PROMPT,
+    }
+  }
 
   export type Plan = {
     language: Language

--- a/backend/cli/src/session/llm.ts
+++ b/backend/cli/src/session/llm.ts
@@ -28,6 +28,7 @@ import { ToolSelection } from "./tool-selection"
 import { InvalidCall } from "@/tool/invalid-call"
 import { resolveAccessRoute } from "./access-route"
 import { providerErrorMetadata } from "./provider-error"
+import { Toolset } from "./toolset"
 
 export namespace LLM {
   const log = Log.create({ service: "llm" })
@@ -251,6 +252,23 @@ export namespace LLM {
     }
 
     const trace = input.trace
+    const activeTools = Toolset.active(tools)
+    if (trace && !input.small) {
+      const previous = await SessionTraceStore.read(input.sessionID)
+        .then((state) =>
+          Toolset.previous(state.harness, {
+            messageID: trace.messageID,
+            profile: input.agent.name,
+            mode: input.agent.mode,
+          }),
+        )
+        .catch((error) => {
+          l.warn("failed to read previous tool availability", { error })
+          return undefined
+        })
+      const notice = Toolset.notice(activeTools, previous)
+      if (notice) system.push(notice)
+    }
     const harness = trace
       ? SessionHarness.snapshot({
           agent: input.agent,
@@ -309,7 +327,7 @@ export namespace LLM {
       topP: params.topP,
       topK: params.topK,
       providerOptions: ProviderTransform.providerOptions(input.model, params.options),
-      activeTools: Object.keys(tools).filter((x) => x !== "invalid"),
+      activeTools,
       tools,
       maxOutputTokens,
       abortSignal: input.abort,

--- a/backend/cli/src/session/message-v2.ts
+++ b/backend/cli/src/session/message-v2.ts
@@ -17,6 +17,7 @@ import { Lock } from "@/util/lock"
 import { Token } from "@/util/token"
 import { Inference } from "@/provider/inference"
 import { CredentialRevocation } from "@/credentials/revocation"
+import { PayloadIntegrity } from "@/tool/payload-integrity"
 
 export namespace MessageV2 {
   export const ResearchEffort = z.enum(["normal", "ultra"]).meta({
@@ -857,9 +858,8 @@ export namespace MessageV2 {
                 type: ("tool-" + part.tool) as `tool-${string}`,
                 state: "output-available",
                 toolCallId: part.callID,
-                // A superseded call's output is stubbed to a back-ref, so its (possibly huge)
-                // input args are dead weight too. Task assignments are the exception: later
-                // delegation must never learn an executable prompt from truncated text.
+                // Reducing a result must not turn its authoritative input into
+                // a shortened payload that a later call could execute.
                 input: compactToolInput(part.tool, part.state.input, !!part.state.time.compacted || isDuplicate),
                 output,
                 ...(differentModel
@@ -1077,38 +1077,39 @@ export namespace MessageV2 {
     return superseded
   }
 
-  // Per-string cap for the args of a reduced (pruned) tool call. Once a call is
-  // compacted its result is gone, so an oversized payload arg (a 50KB `write` content, a
-  // long `edit` oldString) is dead weight — truncate it while keeping the JSON valid and
-  // the small identifying args (paths, flags) intact so the call still reads correctly.
-  export const ARG_TRUNCATE_CHARS = 200
   export const TASK_HANDOFF_CHARS = 8_000
-  export const ARG_TRUNCATION_MARKER = /…\[\+\d+ chars\]/u
+  export const ARG_TRUNCATION_MARKER = PayloadIntegrity.MARKER
+  export const hasArgTruncationMarker = PayloadIntegrity.hasMarker
 
-  export function hasArgTruncationMarker(value: string) {
-    return ARG_TRUNCATION_MARKER.test(value)
+  /** Tool inputs remain byte-exact even when results are reduced. Lossy
+   * summaries belong in the result, never in executable argument fields. */
+  export function compactToolInput(_tool: string, input: Record<string, unknown>, _reduced: boolean) {
+    return input
   }
 
-  export function truncateArgs(input: Record<string, unknown>, cap = ARG_TRUNCATE_CHARS): Record<string, unknown> {
-    const out: Record<string, unknown> = {}
-    for (const [k, v] of Object.entries(input ?? {}))
-      out[k] = typeof v === "string" && v.length > cap ? v.slice(0, cap) + `…[+${v.length - cap} chars]` : v
-    return out
+  const TaskArtifactHandle = z.object({ artifactID: z.string().min(1), versionID: z.string().min(1) })
+  const TaskOutcome = z.enum(["completed", "partial", "error"])
+
+  function taskReceipt(metadata: Record<string, unknown>) {
+    const outcome = TaskOutcome.safeParse(metadata.outcome).data
+    const reason = z.string().max(120).safeParse(metadata.stopReason).data
+    const evidence = z.object({ artifacts: z.array(z.unknown()) }).safeParse(metadata.evidence).data
+    const handles = (evidence?.artifacts ?? []).slice(0, 8).flatMap((value) => {
+      const handle = TaskArtifactHandle.safeParse(value).data
+      return handle
+        ? [`- artifact_id=${JSON.stringify(handle.artifactID)}, version_id=${JSON.stringify(handle.versionID)}`]
+        : []
+    })
+    return [
+      ...(outcome ? [`Task outcome: ${outcome}${reason ? ` (${JSON.stringify(reason)})` : ""}.`] : []),
+      ...(handles.length ? ["Saved outputs: use artifact read_file with these exact IDs.", ...handles] : []),
+      ...((evidence?.artifacts.length ?? 0) > 8 ? ["More saved outputs are listed in the full child trace."] : []),
+    ].join("\n")
   }
 
-  /** A Task prompt is executable input, not diagnostic history. Keep it
-   * byte-exact even after its output is reduced so a later model can never
-   * copy an internal truncation marker into a new child assignment. */
-  export function compactToolInput(tool: string, input: Record<string, unknown>, reduced: boolean) {
-    if (!reduced || tool === "task") return input
-    return truncateArgs(input)
-  }
-
-  // A 1-line, tool-aware stand-in for a reduced (pruned) tool output. Replaces the blunt
-  // "[Old tool result content cleared]" so the model retains the gist — which tool ran,
-  // against what, and how big the result was — and knows it can re-run to recover the
-  // body. Keeps the token cost to a single line. Used by both toModelMessages (render)
-  // and composition (accounting) so the two never disagree.
+  // Keep reduced results recognizable and recoverable. Delegated outcomes and
+  // immutable output handles survive even when the prose handoff is shortened.
+  // Rendering and context accounting share this representation.
   export function toolSummary(tool: string, state: ToolStateCompleted): string {
     const descriptor = iife(() => {
       const title = state.title?.trim()
@@ -1125,16 +1126,18 @@ export namespace MessageV2 {
     // that thread. task.ts also writes it as the first line of the live output.
     const sessionID = tool === "task" && typeof state.metadata.sessionId === "string" ? state.metadata.sessionId : ""
     const idLine = sessionID ? `Task session ${sessionID}: reuse this sessionId to continue the same worker.\n` : ""
+    const receipt = tool === "task" ? taskReceipt(state.metadata) : ""
+    const prefix = idLine + (receipt ? `${receipt}\n` : "")
     const handoff = tool === "task" && typeof state.metadata.handoff === "string" ? state.metadata.handoff.trim() : ""
     if (handoff) {
       const retained =
         handoff.length <= TASK_HANDOFF_CHARS
           ? handoff
           : handoff.slice(0, TASK_HANDOFF_CHARS).trimEnd() + "\n[… child handoff truncated …]"
-      return `${idLine}[task]${descriptor ? " " + descriptor : ""} → retained child handoff\n${retained}`
+      return `${prefix}[task]${descriptor ? " " + descriptor : ""} → retained child handoff\n${retained}`
     }
     const lines = state.output ? state.output.split("\n").length : 0
-    return `${idLine}[${tool}]${descriptor ? " " + descriptor : ""} → cleared (${lines} line${lines === 1 ? "" : "s"})`
+    return `${prefix}[${tool}]${descriptor ? " " + descriptor : ""} → cleared (${lines} line${lines === 1 ? "" : "s"})`
   }
 
   export type Composition = {
@@ -1208,8 +1211,7 @@ export namespace MessageV2 {
         if (part.type === "tool") {
           const bucket = SKILL_TOOLS.has(part.tool) ? "skills" : "tool"
           const compacted = part.state.status === "completed" && !!part.state.time.compacted
-          // Mirror toModelMessages: a compacted OR superseded call's args are reduced in
-          // the render except for byte-exact Task assignments.
+          // Mirror toModelMessages: inputs remain exact while results may be reduced.
           const reducedArgs = compacted || superseded.has(part.id)
           out[bucket] += Token.estimate(
             JSON.stringify(compactToolInput(part.tool, part.state.input, reducedArgs) ?? {}),

--- a/backend/cli/src/session/prompt.ts
+++ b/backend/cli/src/session/prompt.ts
@@ -578,6 +578,8 @@ export namespace SessionPrompt {
         }
         const attempt = await TaskAttempt.read(identity)
         if (attempt?.status !== "completed" || !attempt.result) return false
+        // This restores committed work, not a new admission. Later sibling
+        // evidence must not invalidate the original fingerprinted assignment.
         const attemptInput = normalizeTaskAttemptInput(part.state.input, session.id)
         const source = TaskAttempt.wrapperSource(part)
         const subtask = source

--- a/backend/cli/src/session/tool-selection.ts
+++ b/backend/cli/src/session/tool-selection.ts
@@ -8,6 +8,7 @@ export namespace ToolSelection {
     return agent === "research" || agent === THIN_RESEARCH_AGENT
   }
   const core = new Set([
+    "artifact",
     "invalid",
     "question",
     "bash",
@@ -218,7 +219,6 @@ export namespace ToolSelection {
     if (codeTools.has(tool)) return code.test(text)
     if (python.has(tool)) return analysis || /\bpython\b|\bnotebook\b/i.test(text)
     if (r.has(tool)) return /\bR\b|\br (?:kernel|language)\b|\brstudio\b/.test(text)
-    if (tool === "artifact") return writing || analysis || /\b(?:deliverable|result)\b/i.test(text)
     if (tool === "generate_image")
       return /\b(?:diagrams?|figures?|graphics?|illustrations?|images?|posters?|schematics?|slides?|visuals?)\b/i.test(
         text,

--- a/backend/cli/src/session/toolset.ts
+++ b/backend/cli/src/session/toolset.ts
@@ -1,0 +1,45 @@
+import type { SessionHarness } from "./harness"
+
+export namespace Toolset {
+  /** The repair-only tool is executable internally, but is never advertised. */
+  export function active(tools: Record<string, unknown>) {
+    return Object.keys(tools).filter((name) => name !== "invalid")
+  }
+
+  export function previous(
+    records: SessionHarness.Entry[],
+    input: { messageID: string; profile: string; mode: string },
+  ) {
+    // Internal compaction/title requests must not replace the active agent's
+    // baseline. Retried requests compare against the same preceding assistant.
+    const entry = records.findLast(
+      (item) => item.messageID !== input.messageID && item.profile === input.profile && item.mode === input.mode,
+    )
+    return entry?.tools.map((item) => item.name).filter((name) => name !== "invalid")
+  }
+
+  function list(names: string[]) {
+    const shown: string[] = []
+    for (const name of names) {
+      const value = JSON.stringify(name)
+      if (shown.length === 20 || shown.join(", ").length + value.length > 384) break
+      shown.push(value)
+    }
+    return `[${shown.join(", ")}]${shown.length < names.length ? ` (${names.length - shown.length} more)` : ""}`
+  }
+
+  export function notice(current: string[], previous?: string[]) {
+    if (!previous) return
+    const before = new Set(previous)
+    const after = new Set(current)
+    const added = [...after].filter((name) => !before.has(name)).toSorted()
+    const removed = [...before].filter((name) => !after.has(name)).toSorted()
+    if (!added.length && !removed.length) return
+    return [
+      "Tool availability changed for this request.",
+      ...(added.length ? [`Added tools: ${list(added)}.`] : []),
+      ...(removed.length ? [`Removed tools: ${list(removed)}.`] : []),
+      "Use only the currently advertised tool definitions. This changes availability, not filesystem or execution authority.",
+    ].join("\n")
+  }
+}

--- a/backend/cli/src/shell/shell.ts
+++ b/backend/cli/src/shell/shell.ts
@@ -219,16 +219,49 @@ export namespace Shell {
     }
   }
 
+  /** Git Bash exposes different git.exe directories depending on its entry
+   * point. Search within that installation, never System32's WSL bash.exe. */
+  export function windowsGitBash(git: string | null, available: (file: string) => boolean = exists) {
+    if (!git) return
+    const directory = path.win32.dirname(git)
+    const name = path.win32.basename(directory).toLowerCase()
+    const parent = path.win32.dirname(directory)
+    const nested = ["mingw64", "mingw32", "usr"].includes(path.win32.basename(parent).toLowerCase())
+    const root = name === "cmd" ? parent : name === "bin" ? (nested ? path.win32.dirname(parent) : parent) : undefined
+    if (!root) return
+    return [path.win32.join(root, "bin", "bash.exe"), path.win32.join(root, "usr", "bin", "bash.exe")].find(available)
+  }
+
+  export function requirePosix(shell: string, platform: NodeJS.Platform = process.platform) {
+    if (platform !== "win32") return shell
+    const name = path.win32.basename(shell).toLowerCase()
+    if (
+      ["bash", "bash.exe", "sh", "sh.exe", "zsh", "zsh.exe"].includes(name) &&
+      !/[\\/](?:system32|sysnative|syswow64)[\\/]/i.test(shell)
+    )
+      return shell
+    throw new Error(
+      "Local compute jobs require Git Bash on Windows. Install Git for Windows or set OPENSCIENCE_GIT_BASH_PATH to its bash.exe; cmd.exe and PowerShell cannot execute the generated POSIX job script.",
+    )
+  }
+
+  export function posix() {
+    // A terminal may prefer cmd or PowerShell. Compute emits POSIX scripts
+    // and must select Git Bash independently of that terminal preference.
+    const shell = requirePosix(process.platform === "win32" ? fallback() : acceptable())
+    if (process.platform === "win32" && !exists(shell)) {
+      throw new Error(
+        `Configured Git Bash was not found at ${shell}. Set OPENSCIENCE_GIT_BASH_PATH to an installed bash.exe.`,
+      )
+    }
+    return shell
+  }
+
   function fallback() {
     if (process.platform === "win32") {
       if (Flag.OPENSCIENCE_GIT_BASH_PATH) return Flag.OPENSCIENCE_GIT_BASH_PATH
-      const git = Bun.which("git")
-      if (git) {
-        // git.exe is typically at: C:\Program Files\Git\cmd\git.exe
-        // bash.exe is at: C:\Program Files\Git\bin\bash.exe
-        const bash = path.join(git, "..", "..", "bin", "bash.exe")
-        if (Bun.file(bash).size) return bash
-      }
+      const bash = windowsGitBash(Bun.which("git"))
+      if (bash) return bash
       return process.env.COMSPEC || "cmd.exe"
     }
     if (process.platform === "darwin") {

--- a/backend/cli/src/tool/apply_patch.ts
+++ b/backend/cli/src/tool/apply_patch.ts
@@ -1,4 +1,5 @@
 import z from "zod"
+import { PayloadIntegrity } from "./payload-integrity"
 import * as path from "path"
 import * as fs from "fs/promises"
 import crypto from "node:crypto"
@@ -592,6 +593,10 @@ export const ApplyPatchTool = Tool.define("apply_patch", {
           break
         }
       }
+    }
+
+    for (const change of fileChanges) {
+      PayloadIntegrity.assert({ content: change.newContent, before: change.oldContent, messages: ctx.messages })
     }
 
     // Permission describes the proposed edit. The result is captured separately

--- a/backend/cli/src/tool/artifact.ts
+++ b/backend/cli/src/tool/artifact.ts
@@ -10,6 +10,9 @@ import type { Node, Run } from "@/science/provenance/store"
 import { Log } from "@/util/log"
 
 const log = Log.create({ service: "tool.artifact" })
+// A text window verifies the whole immutable blob. Keep repeated reads bounded;
+// larger datasets belong in the download/analysis path, not model context.
+const MAX_INLINE_BYTES = 8 * 1024 * 1024
 
 function result(title: string, output: string, metadata: Record<string, unknown> = {}) {
   return { title, output, metadata }
@@ -102,19 +105,94 @@ async function traceSavedArtifact(saved: ArtifactStore.Artifact, run?: Run) {
 
 export const ArtifactTool = Tool.define("artifact", {
   description:
-    "Save an important workspace file as a durable Result with a stable identity, immutable versions, and optional execution provenance. Empirical contract Results need provenance_id to pass completion. Keep drafts and large mutable working data in the workspace instead.",
-  parameters: z.object({
-    action: z.literal("save_file").describe("Save a workspace file as a durable Result"),
-    path: z.string().trim().min(1).max(10_000).describe("Workspace file path"),
-    summary: z.string().optional().describe("Concise user-facing Result title"),
-    provenance_id: z
-      .string()
-      .optional()
-      .describe(
-        "Producing run provenance ID from this project and session. Required for empirical contract Results to pass completion; may reference a manually recorded run.",
-      ),
-  }),
+    "Save an important workspace file as a durable Result, or read an exact immutable Result version by artifact_id and version_id (including outputs handed back by a worker). read_file returns bounded text or binary metadata; it does not grant access to another session's scratch. Empirical contract Results need provenance_id to pass completion. Keep drafts and large mutable working data in the workspace instead.",
+  parameters: z
+    .object({
+      action: z.enum(["save_file", "read_file"]),
+      path: z.string().trim().min(1).max(10_000).optional().describe("Required for save_file: workspace file path"),
+      summary: z.string().optional().describe("Concise user-facing Result title"),
+      provenance_id: z
+        .string()
+        .optional()
+        .describe(
+          "Producing run provenance ID from this project and session. Required for empirical contract Results to pass completion; may reference a manually recorded run.",
+        ),
+      artifact_id: z.string().min(1).optional().describe("Required for read_file: exact saved artifact ID"),
+      version_id: z.string().min(1).optional().describe("Required for read_file: exact immutable version ID"),
+      offset: z.number().int().nonnegative().optional().describe("Byte offset for the next bounded text window"),
+    })
+    .superRefine((input, ctx) => {
+      for (const field of input.action === "save_file"
+        ? (["path"] as const)
+        : (["artifact_id", "version_id"] as const)) {
+        if (!input[field])
+          ctx.addIssue({ code: "custom", path: [field], message: `${field} is required for ${input.action}` })
+      }
+    }),
   async execute(params, ctx) {
+    if (params.action === "read_file") {
+      ctx.abort.throwIfAborted()
+      const detail = await ArtifactStore.get(Instance.project.id, params.artifact_id!)
+      const version = detail?.versions.find((item) => item.id === params.version_id)
+      if (version && version.size > MAX_INLINE_BYTES) {
+        return result(
+          `Saved Result: ${version.filename}`,
+          "This Result exceeds the 8 MiB inline-text limit. Retrieve this exact version through Files > Results or the artifact API and analyze it as a file. This response contains stored metadata only; it has not verified or read the blob bytes.",
+          {
+            artifactID: version.artifactID,
+            versionID: version.id,
+            size: version.size,
+            sha256: version.sha256,
+            readStatus: "metadata_only",
+          },
+        )
+      }
+      const stored = await ArtifactStore.read(Instance.project.id, params.artifact_id!, params.version_id!)
+      if (!stored)
+        throw new Error("This artifact version is unavailable or failed integrity verification in the current project.")
+      const info = stored.info
+      const offset = params.offset ?? 0
+      if (offset > info.size) throw new Error(`Byte offset ${offset} exceeds artifact size ${info.size}.`)
+      const bytes = new Uint8Array(await stored.content.slice(offset, offset + 50 * 1024).arrayBuffer())
+      ctx.abort.throwIfAborted()
+      const metadata = {
+        artifactID: info.artifactID,
+        versionID: info.id,
+        filename: info.filename,
+        size: info.size,
+        sha256: info.sha256,
+        mimeType: info.mimeType,
+        offset,
+        readStatus: "verified",
+      }
+      const textual = info.mimeType.startsWith("text/") || /(?:json|xml|yaml|javascript)/i.test(info.mimeType)
+      if (!textual || bytes.includes(0)) {
+        return result(
+          `Saved Result: ${info.filename}`,
+          "This is a binary Result. Open it from Files > Results or retrieve the exact version through the artifact API; it is not a text document.",
+          metadata,
+        )
+      }
+      // Streaming decode leaves an incomplete trailing UTF-8 sequence for the
+      // next window instead of corrupting it at the byte boundary.
+      const decoder = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true })
+      const text = (() => {
+        try {
+          return decoder.decode(bytes, { stream: offset + bytes.length < info.size })
+        } catch {
+          throw new Error(
+            "This window is not valid UTF-8 text. Use the returned byte offset from the preceding window, or retrieve the Result as a file to decode its original encoding.",
+          )
+        }
+      })()
+      const end = offset + new TextEncoder().encode(text).length
+      const more = end < info.size
+      return result(
+        `Saved Result: ${info.filename}`,
+        text + (more ? `\n\n[More content: call artifact read_file with the same IDs and offset=${end}.]` : ""),
+        { ...metadata, nextOffset: more ? end : undefined, truncated: more },
+      )
+    }
     const node = params.provenance_id
       ? await Provenance.find(
           {
@@ -137,17 +215,17 @@ export const ArtifactTool = Tool.define("artifact", {
       return result("Invalid provenance", "The producing run was not found in this project and session.")
     }
     {
-      const file = await File.rawSource(params.path, {
+      const file = await File.rawSource(params.path!, {
         sessionID: ctx.sessionID,
         maxBytes: ArtifactStore.MAX_VERSION_BYTES,
       })
-      const name = path.basename(params.path)
+      const name = path.basename(params.path!)
       const classified = ArtifactFile.classify(name)
       const title = params.summary?.trim() || name
       const saved = await ArtifactStore.save({
         projectID: Instance.project.id,
         sessionID: ctx.sessionID,
-        sourcePath: params.path,
+        sourcePath: params.path!,
         filename: name,
         kind: classified?.kind ?? "file",
         content: file,

--- a/backend/cli/src/tool/bash.ts
+++ b/backend/cli/src/tool/bash.ts
@@ -452,19 +452,7 @@ export const BashTool = Tool.define("bash", async () => {
               // Re-sanitize at the final process boundary too: runtime/cache
               // overlays must never restore a managed token or re-pair a
               // user's key with the Ace managed proxy after subprocessEnv ran.
-              env: {
-                ...OpenScience.filterEnvForSubprocess({ ...env, ...(runtime.env ?? {}), ...cache }),
-                // This path is constructed by the runtime resolver, never an
-                // ambient PYTHONPATH. The same directory is in readable above.
-                PYTHONPATH: runtime.env.PYTHONPATH,
-                // The final overlay pass re-sanitizes runtime/cache values and
-                // therefore drops control variables. Restore only the fixed
-                // Git policy from subprocessEnv so Git never falls back to a
-                // user-owned ~/.gitconfig or credential prompt.
-                GIT_CONFIG_NOSYSTEM: env.GIT_CONFIG_NOSYSTEM,
-                GIT_CONFIG_GLOBAL: env.GIT_CONFIG_GLOBAL,
-                GIT_TERMINAL_PROMPT: env.GIT_TERMINAL_PROMPT,
-              },
+              env: KernelEnvironmentMutation.subprocessEnv(runtime, { ...env, ...cache }),
               stdio: ["ignore", "pipe", "pipe"],
               detached: process.platform !== "win32",
             })
@@ -615,6 +603,7 @@ export const BashTool = Tool.define("bash", async () => {
           output: clipped,
           description: params.description,
           provenanceID: node?.id,
+          execution_environment: KernelEnvironmentMutation.subprocessIdentity(runtime, cwd),
           ...files,
         },
       })
@@ -625,6 +614,7 @@ export const BashTool = Tool.define("bash", async () => {
           exit: proc.exitCode,
           description: params.description,
           provenanceID: node?.id,
+          execution_environment: KernelEnvironmentMutation.subprocessIdentity(runtime, cwd),
           ...files,
         },
         output: redactedOutput,

--- a/backend/cli/src/tool/edit.ts
+++ b/backend/cli/src/tool/edit.ts
@@ -19,6 +19,7 @@ import { Snapshot } from "@/snapshot"
 import { assertExternalDirectory, sessionToolDirectory } from "./external-directory"
 import { SafeFileIO } from "@/file/safe-io"
 import { AuthoritySignal } from "@/project/authority-signal"
+import { PayloadIntegrity } from "./payload-integrity"
 
 const MAX_DIAGNOSTICS_PER_FILE = 20
 
@@ -64,6 +65,7 @@ export const EditTool = Tool.define("edit", {
         contentOld = approved?.bytes.toString("utf8") ?? ""
         if (approved) await FileTime.assert(ctx.sessionID, filePath)
         contentNew = params.newString
+        PayloadIntegrity.assert({ content: contentNew, before: contentOld, messages: ctx.messages })
         diff = trimDiff(createTwoFilesPatch(filePath, filePath, contentOld, contentNew))
         await ctx.ask({
           permission: "edit",
@@ -93,6 +95,7 @@ export const EditTool = Tool.define("edit", {
       await FileTime.assert(ctx.sessionID, filePath)
       contentOld = approved.bytes.toString("utf8")
       contentNew = replace(contentOld, params.oldString, params.newString, params.replaceAll)
+      PayloadIntegrity.assert({ content: contentNew, before: contentOld, messages: ctx.messages })
 
       diff = trimDiff(
         createTwoFilesPatch(filePath, filePath, normalizeLineEndings(contentOld), normalizeLineEndings(contentNew)),

--- a/backend/cli/src/tool/payload-integrity.ts
+++ b/backend/cli/src/tool/payload-integrity.ts
@@ -1,0 +1,43 @@
+import type { MessageV2 } from "../session/message-v2"
+
+export namespace PayloadIntegrity {
+  export const MARKER = /…\[\+\d+ chars\]/u
+  const LEGACY_LIMIT = 200
+
+  export function hasMarker(value: string) {
+    return MARKER.test(value)
+  }
+
+  /** Reconstruct an older release's lossy history representation, never an
+   * executable argument. New history retains the authoritative input. */
+  export function legacyPreview(value: string) {
+    if (value.length <= LEGACY_LIMIT) return value
+    return value.slice(0, LEGACY_LIMIT) + `…[+${value.length - LEGACY_LIMIT} chars]`
+  }
+
+  function occurrences(value: string, needle: string) {
+    return value.split(needle).length - 1
+  }
+
+  export function assert(input: { content: string; before: string; messages: MessageV2.WithParts[] }) {
+    if (!hasMarker(input.content)) return
+    for (const message of input.messages) {
+      for (const part of message.parts) {
+        if (part.type !== "tool" || part.state.status !== "completed") continue
+        for (const [field, value] of Object.entries(part.state.input)) {
+          if (typeof value !== "string" || value.length <= LEGACY_LIMIT) continue
+          const preview = legacyPreview(value)
+          if (!input.content.includes(preview)) continue
+          // Literal examples already present in a file may be retained or
+          // removed. A matching marker alone is not evidence of truncation.
+          if (occurrences(input.content, preview) <= occurrences(input.before, preview)) continue
+          throw new Error(
+            `Refusing a shortened historical argument from ${part.tool} call ${part.callID} (${field}). ` +
+              "No action was taken. Recover the complete argument or read the source file; " +
+              "OpenScience's …[+N chars] history previews are not complete input.",
+          )
+        }
+      }
+    }
+  }
+}

--- a/backend/cli/src/tool/registry.ts
+++ b/backend/cli/src/tool/registry.ts
@@ -219,7 +219,7 @@ export namespace ToolRegistry {
   }
 
   const ARTIFACT_TOOL_ID = "artifact"
-  const ARTIFACT_AGENTS = ["research", "biology", "ml", "researchagent-test"]
+  const ARTIFACT_AGENTS = ["research", "biology", "physics", "ml", "explore", "execute", "researchagent-test"]
 
   const COMPUTE_AGENTS = ["research", "biology", "physics", "ml"]
 

--- a/backend/cli/src/tool/task-evidence.ts
+++ b/backend/cli/src/tool/task-evidence.ts
@@ -1,0 +1,63 @@
+import { ArtifactStore } from "@/artifact/store"
+import type { MessageV2 } from "@/session/message-v2"
+import { observableToolStatus } from "@/session/tool-outcome"
+
+/** Evidence is derived from persisted execution records, never parsed out of
+ * the worker's prose. Exit zero is an outer-process result, not test success. */
+export namespace TaskEvidence {
+  export async function collect(input: {
+    projectID: string
+    sessionID: string
+    messages: MessageV2.WithParts[]
+    previous: Set<string>
+  }) {
+    const current = input.messages.filter((message) => !input.previous.has(message.info.id))
+    const ids = new Set(current.map((message) => message.info.id))
+    const artifacts = (await ArtifactStore.listSessionVersions(input.projectID, input.sessionID))
+      .filter((version) => version.messageID && ids.has(version.messageID))
+      .map((version) => ({
+        artifactID: version.artifactID,
+        versionID: version.id,
+        filename: version.filename,
+        size: version.size,
+        sha256: version.sha256,
+        captureQuality: version.captureQuality,
+      }))
+    const commands = current
+      .filter((message) => message.info.role === "assistant")
+      .flatMap((message) =>
+        message.parts.flatMap((part) => {
+          if (part.type !== "tool" || part.tool !== "bash") return []
+          const metadata = part.state.status === "completed" ? part.state.metadata : undefined
+          return [
+            {
+              messageID: part.messageID,
+              partID: part.id,
+              callID: part.callID,
+              status: observableToolStatus(part),
+              exit: typeof metadata?.exit === "number" ? metadata.exit : null,
+              ...(typeof metadata?.provenanceID === "string" && { provenanceID: metadata.provenanceID }),
+            },
+          ]
+        }),
+      )
+    return { artifacts, commands }
+  }
+
+  export function describe(evidence: Awaited<ReturnType<typeof collect>>) {
+    const lines = evidence.artifacts.map(
+      (artifact) =>
+        `- ${JSON.stringify(artifact.filename)}: artifact_id=${artifact.artifactID}, version_id=${artifact.versionID}, bytes=${artifact.size}, sha256=${artifact.sha256}`,
+    )
+    return [
+      ...(lines.length
+        ? ["Saved outputs (immutable versions; use artifact read_file with these exact IDs):", ...lines]
+        : []),
+      ...(evidence.commands.length
+        ? [
+            `Execution receipts: ${evidence.commands.length} shell calls, ${evidence.commands.filter((item) => item.exit === 0).length} with outer exit 0, ${evidence.commands.filter((item) => item.status === "error").length} failed. Full receipts remain in the child trace. An outer exit 0 alone does not verify nested tests or scientific conclusions.`,
+          ]
+        : []),
+    ].join("\n")
+  }
+}

--- a/backend/cli/src/tool/task.ts
+++ b/backend/cli/src/tool/task.ts
@@ -23,6 +23,8 @@ import { ToolSelection } from "@/session/tool-selection"
 import { availableParallelism } from "node:os"
 import { SubtaskAttachments } from "@/session/subtask-attachments"
 import { SessionWorkspace } from "@/session/workspace"
+import { TaskEvidence } from "./task-evidence"
+import { PayloadIntegrity } from "./payload-integrity"
 
 export const DELEGATION_PROFILES = ["explore", "execute"] as const
 export const DELEGATION_SPECIALISTS = ["biology", "physics", "ml"] as const
@@ -139,13 +141,13 @@ const parameters = z.object({
 /** Canonicalize model-supplied continuation placeholders before a Task attempt
  * is fingerprinted. Execution and restart recovery must use the same input or
  * an interrupted, already-completed child can permanently poison its parent. */
-export function normalizeTaskAttemptInput(input: unknown, parentSessionID: string) {
+export function normalizeTaskAttemptInput(
+  input: unknown,
+  parentSessionID: string,
+  messages: MessageV2.WithParts[] = [],
+) {
   const parsed = parameters.parse(input)
-  if (MessageV2.hasArgTruncationMarker(parsed.prompt)) {
-    throw new Error(
-      "Task assignment contains OpenScience's internal argument-compaction marker (…[+N chars]). No child was started. Reconstruct and submit the complete assignment instead of executing truncated text.",
-    )
-  }
+  PayloadIntegrity.assert({ content: parsed.prompt, before: "", messages })
   return {
     ...parsed,
     session_id: taskContinuationID(parsed.session_id, parentSessionID),
@@ -300,10 +302,8 @@ export function summarizeTurn(messages: MessageV2.WithParts[], previous: Set<str
   return { summary, usage }
 }
 
-/** The child's handoff is the text of its final assistant message that said
- * anything, after that message's last tool call. Earlier narration and tool
- * chatter stay in the child session, which the parent can open by the id in
- * the result metadata. */
+/** Only text after the final assistant message's last tool is a handoff.
+ * Earlier narration cannot establish completion of later work. */
 export function taskText(messages: MessageV2.WithParts[], previous: Set<string>) {
   const text = (parts: readonly MessageV2.Part[]) =>
     parts
@@ -316,10 +316,10 @@ export function taskText(messages: MessageV2.WithParts[], previous: Set<string>)
   const final = messages
     .filter((message) => !previous.has(message.info.id) && message.info.role === "assistant")
     .toSorted((a, b) => a.info.time.created - b.info.time.created || a.info.id.localeCompare(b.info.id))
-    .findLast((message) => text(message.parts).length > 0)
+    .at(-1)
   if (!final) return ""
   const lastTool = final.parts.findLastIndex((part) => part.type === "tool")
-  return text(final.parts.slice(lastTool + 1)) || text(final.parts)
+  return text(final.parts.slice(lastTool + 1))
 }
 
 export type TaskOutcome = {
@@ -462,6 +462,7 @@ export const TaskTool = Tool.define("task", async (ctx) => {
         const current = await TaskAttempt.read(identity)
         if (!current) throw new Error(`Durable Task attempt ${ctx.callID} disappeared after reservation`)
         if (current.status === "completed" && current.result) return current.result
+        PayloadIntegrity.assert({ content: attemptInput.prompt, before: "", messages: ctx.messages })
 
         const existing =
           continuation ??
@@ -619,6 +620,7 @@ export const TaskTool = Tool.define("task", async (ctx) => {
                   "Do not return a diary of searches, reads, or commands. Your final response is a decision-ready handoff to the lead, not a second user-facing report.",
                   "Use only the Markdown sections that carry substance: Outcome; Findings; Evidence; Changes / outputs; Limitations; Next action.",
                   "Preserve exact paths, identifiers, numeric results, commands, and error strings when they matter. Distinguish observed evidence from inference. If blocked or partial, say exactly what remains.",
+                  'Save important scratch outputs with artifact(action="save_file", path=...) before returning. The lead receives immutable artifact/version handles and can read them without access to your private scratch. A saved file proves an output exists, not that its claims or tests passed.',
                   "Do not wrap the response in XML or JSON and do not restate these instructions.",
                   settings.autonomy === "interactive"
                     ? "If the assignment contains a genuinely consequential ambiguity, return one precise question to the lead instead of guessing."
@@ -677,6 +679,12 @@ export const TaskTool = Tool.define("task", async (ctx) => {
         const complete = await Session.messages({ sessionID: session.id })
         const { summary, usage } = summarizeTurn(complete, previous)
         const text = taskText(complete, previous)
+        const evidence = await TaskEvidence.collect({
+          projectID: Instance.project.id,
+          sessionID: session.id,
+          messages: complete,
+          previous,
+        })
         const child = execution.result?.info.role === "assistant" ? execution.result.info : terminal?.info
         const failedToolCalls = summary.filter((part) => part.state.status === "error").length
         const partialToolCalls = summary.filter((part) => part.state.status === "partial").length
@@ -699,7 +707,7 @@ export const TaskTool = Tool.define("task", async (ctx) => {
         // metadata) so the lead can continue this exact worker via `session_id`.
         // Compaction preserves it: MessageV2.toolSummary re-emits it from metadata.
         const output = [
-          `Task session ${session.id}: reuse this sessionId to continue the same worker.`,
+          `Task session ${session.id}: ${taskOutcome.outcome} (${taskOutcome.stopReason}). Reuse this sessionId to continue the same worker.`,
           ...(taskOutcome.stopReason === "max_steps"
             ? ["[Child reached its bounded step limit; partial result follows.]"]
             : taskOutcome.stopReason === "tool_failures"
@@ -716,6 +724,7 @@ export const TaskTool = Tool.define("task", async (ctx) => {
                         ]
                       : []),
           handoff.text,
+          TaskEvidence.describe(evidence),
         ]
           .filter(Boolean)
           .join("\n")
@@ -743,6 +752,7 @@ export const TaskTool = Tool.define("task", async (ctx) => {
             handoff: handoff.text,
             handoffTruncated: handoff.truncated,
             resultChars: raw.length,
+            evidence,
           },
           output,
         })

--- a/backend/cli/src/tool/write.ts
+++ b/backend/cli/src/tool/write.ts
@@ -14,6 +14,7 @@ import { trimDiff } from "./edit"
 import { assertExternalDirectory, sessionToolDirectory } from "./external-directory"
 import { SafeFileIO } from "@/file/safe-io"
 import { AuthoritySignal } from "@/project/authority-signal"
+import { PayloadIntegrity } from "./payload-integrity"
 
 const MAX_DIAGNOSTICS_PER_FILE = 20
 const MAX_PROJECT_DIAGNOSTICS_FILES = 5
@@ -34,6 +35,7 @@ export const WriteTool = Tool.define("write", {
     const exists = !!approved
     const contentOld = approved?.bytes.toString("utf8") ?? ""
     if (exists) await FileTime.assert(ctx.sessionID, filepath)
+    PayloadIntegrity.assert({ content: params.content, before: contentOld, messages: ctx.messages })
 
     const diff = trimDiff(createTwoFilesPatch(filepath, filepath, contentOld, params.content))
     await ctx.ask({

--- a/backend/cli/test/compute/jobs.test.ts
+++ b/backend/cli/test/compute/jobs.test.ts
@@ -906,6 +906,16 @@ describe("ComputeJobs local lifecycle", () => {
       expect(finished.sandbox).toMatchObject({ requested: true, enforced: true, network: "deny" })
       expect(restarted?.capability).toEqual(capability)
       expect(restarted?.capability_execution).toEqual(capabilityExecution)
+      // Capability identity comes from its exact attested binding. No extra
+      // version command runs outside the workload; absent measurement must
+      // not fall back to an unrelated host Python version.
+      expect(restarted?.reproducibility?.python).toBeUndefined()
+      expect(restarted?.reproducibility?.execution_environment).toMatchObject({
+        target: "local",
+        profile: "scipy:smoke",
+        python: { role: "capability", executable: capabilityExecution.runtime_binary },
+      })
+      expect(restarted?.reproducibility?.execution_environment?.python?.version).toBeUndefined()
       expect(restarted?.provenance?.scientific_capability).toEqual({
         ...capability,
         execution_network: "none",
@@ -1587,7 +1597,16 @@ describe("ComputeJobs Modal governance", () => {
     expect((await ComputeJobs.get(job.id, { root, workspace: tmp.path }))?.status).toBe("running")
 
     gate.resolve()
-    expect((await ComputeJobs.wait(job.id, { root, workspace: tmp.path, timeout: 5_000 })).status).toBe("succeeded")
+    const finished = await ComputeJobs.wait(job.id, { root, workspace: tmp.path, timeout: 5_000 })
+    expect(finished.status).toBe("succeeded")
+    expect(finished.reproducibility).toMatchObject({
+      capture_scope: "submitter",
+      execution_environment: { target: "modal" },
+    })
+    expect(finished.reproducibility?.python).toBeUndefined()
+    expect(finished.reproducibility?.execution_environment?.python).toBeUndefined()
+    expect(finished.reproducibility?.execution_environment?.cwd).toBeUndefined()
+    expect(finished.provenance?.environment.host).toEqual({ status: "unavailable", reason: "remote_unverified" })
   }, 15_000)
 
   test("records a Modal sandbox timeout as a terminal timed-out job", async () => {

--- a/backend/cli/test/compute/local-python-runtime.test.ts
+++ b/backend/cli/test/compute/local-python-runtime.test.ts
@@ -5,6 +5,9 @@ import { ComputeJobs } from "../../src/compute/jobs"
 import { Instance } from "../../src/project/instance"
 import { SessionFilesystem } from "../../src/session/filesystem"
 import { KernelEnvironmentMutation } from "../../src/science/kernel/environment-mutation"
+import { Config } from "../../src/config/config"
+import { BashTool } from "../../src/tool/bash"
+import { Sandbox } from "../../src/sandbox/sandbox"
 import { executionSession, tmpdir } from "../fixture/fixture"
 
 const quote = (value: string) => `'${value.replaceAll("'", "'\\''")}'`
@@ -38,7 +41,7 @@ test.skipIf(process.platform === "win32")(
           await Bun.write(module, "value = 'canonical-package'\n")
           const options = { root: path.join(tmp.path, ".jobs"), projectDirectory: tmp.path, workspace }
           try {
-            const code = `import ${name}, sys, os, importlib.util, json, shutil; assert importlib.util.find_spec("unapproved_import") is None; assert os.getenv("MODAL_TOKEN_ID") is None; open("receipt.json", "w").write(json.dumps({"binary": os.path.realpath(sys.executable), "selected": os.path.dirname(shutil.which("python3")), "value": ${name}.value}))`
+            const code = `import ${name}, sys, os, importlib.util, json; assert importlib.util.find_spec("unapproved_import") is None; assert os.getenv("MODAL_TOKEN_ID") is None; open("receipt.json", "w").write(json.dumps({"binary": os.path.realpath(sys.executable), "value": ${name}.value}))`
             const job = await ComputeJobs.start(
               {
                 name: "Canonical runtime check",
@@ -51,9 +54,14 @@ test.skipIf(process.platform === "win32")(
             try {
               const result = await ComputeJobs.wait(job.id, { ...options, timeout: 5_000 })
               expect(result.status).toBe("succeeded")
+              expect(result.reproducibility?.execution_environment).toMatchObject({
+                target: "local",
+                cwd: workspace,
+                profile: "python",
+                python: { role: "selected_default", executable: runtime.binary },
+              })
               expect(await Bun.file(path.join(workspace, "receipt.json")).json()).toEqual({
                 binary: await fs.realpath(runtime.binary!),
-                selected: bin,
                 value: "canonical-package",
               })
             } finally {
@@ -73,3 +81,185 @@ test.skipIf(process.platform === "win32")(
     }
   },
 )
+
+// Use two real installed interpreters. A symlink to the same Python verifies
+// path selection but cannot catch a host-version receipt attached to a job
+// launched with another interpreter. No interpreter is installed by the test.
+function version(binary: string | null) {
+  if (!binary) return
+  const result = Bun.spawnSync([binary, "--version"], { stdin: "ignore", stdout: "pipe", stderr: "pipe" })
+  if (result.exitCode !== 0) return
+  return result.stdout
+    .toString()
+    .trim()
+    .match(/^Python (\d+\.\d+\.\d+\S*)$/)?.[1]
+}
+
+const host = Bun.which("python3") ?? Bun.which("python")
+const hostVersion = version(host)
+const alternate = ["python3.11", "python3.12", "python3.13", "python3.14"]
+  .map((name) => Bun.which(name))
+  .filter((binary): binary is string => !!binary)
+  .map((binary) => ({ binary, version: version(binary) }))
+  .find((item) => item.version && hostVersion && item.version !== hostVersion)
+
+test.skipIf(process.platform === "win32" || !alternate)(
+  "records the actual selected Python version when it differs from host python3",
+  async () => {
+    if (!alternate) throw new Error("This fixture requires two different installed Python versions")
+    await using tmp = await tmpdir()
+    const bin = path.join(tmp.path, ".venv", "bin")
+    await fs.mkdir(bin, { recursive: true })
+    await fs.symlink(alternate.binary, path.join(bin, "python"))
+    // No python3 exists in this selected prefix. Merely prepending its
+    // directory would still dispatch the unrelated host python3.
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await executionSession()
+        const workspace = await SessionFilesystem.workspace(session.id)
+        const options = { root: path.join(tmp.path, ".jobs"), projectDirectory: tmp.path, workspace }
+        const job = await ComputeJobs.start(
+          {
+            name: "Selected interpreter identity",
+            command: `python3 -c ${quote('import sys, json; print(json.dumps({"version":sys.version.split()[0],"executable":sys.executable}))')}`,
+            target: { kind: "local" },
+            sessionID: session.id,
+          },
+          options,
+        )
+        try {
+          const result = await ComputeJobs.wait(job.id, { ...options, timeout: 5_000 })
+          expect(result.status).toBe("succeeded")
+          const actual = JSON.parse((await ComputeJobs.log(job.id, options)).trim())
+          expect(actual.version).toBe(alternate.version)
+          expect(actual.version).not.toBe(hostVersion)
+          expect(result.reproducibility?.python).toBe(`Python ${actual.version}`)
+          expect(result.reproducibility?.capture_scope).toBe("execution_host")
+          expect(result.reproducibility?.execution_environment).toEqual({
+            target: "local",
+            cwd: workspace,
+            profile: "python",
+            python: { role: "selected_default", executable: path.join(bin, "python"), version: actual.version },
+          })
+          expect(await fs.realpath(actual.executable)).toBe(await fs.realpath(alternate.binary))
+        } finally {
+          const current = await ComputeJobs.get(job.id, options)
+          if (current && ["pending", "running"].includes(current.status)) await ComputeJobs.cancel(job.id, options)
+        }
+      },
+    })
+  },
+)
+
+test.skipIf(process.platform !== "win32")("Windows login shell retains the selected native Python path", async () => {
+  if (!host) throw new Error("Local runtime fixture needs Python")
+  await using tmp = await tmpdir()
+  const prefix = path.join(tmp.path, ".venv")
+  // No pip or package installation: this creates only a disposable interpreter
+  // launcher pointing to the already installed native Python runtime.
+  const prepared = Bun.spawnSync([host, "-m", "venv", "--without-pip", prefix])
+  expect(prepared.exitCode, prepared.stderr.toString()).toBe(0)
+  const previous = await Config.trustedSandbox()
+  await Config.setSandbox({ enabled: false })
+  try {
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await executionSession()
+        const workspace = await SessionFilesystem.workspace(session.id)
+        const options = { root: path.join(tmp.path, ".jobs"), projectDirectory: tmp.path, workspace }
+        const job = await ComputeJobs.start(
+          {
+            name: "Windows selected interpreter",
+            command: `python -c ${quote('import sys,json; print(json.dumps({"executable":sys.executable,"version":sys.version.split()[0]}))')}`,
+            target: { kind: "local" },
+            sessionID: session.id,
+          },
+          options,
+        )
+        try {
+          const result = await ComputeJobs.wait(job.id, { ...options, timeout: 5_000 })
+          const log = await ComputeJobs.log(job.id, options)
+          expect(result.status, log).toBe("succeeded")
+          const actual = JSON.parse(log.trim())
+          expect(await fs.realpath(actual.executable)).toBe(
+            await fs.realpath(path.join(prefix, "Scripts", "python.exe")),
+          )
+          expect(result.reproducibility?.execution_environment?.python).toEqual({
+            role: "selected_default",
+            executable: path.join(prefix, "Scripts", "python.exe"),
+            version: actual.version,
+          })
+        } finally {
+          const current = await ComputeJobs.get(job.id, options)
+          if (current && ["pending", "running"].includes(current.status)) await ComputeJobs.cancel(job.id, options)
+        }
+      },
+    })
+  } finally {
+    await Config.setSandbox(previous)
+  }
+})
+
+for (const enabled of [false, true]) {
+  test.skipIf(process.platform === "win32" || (enabled && !Sandbox.available()))(
+    `Bash and compute preserve a real venv prefix (${enabled ? "sandboxed" : "unsandboxed"})`,
+    async () => {
+      if (!host) throw new Error("Local runtime fixture needs Python")
+      await using tmp = await tmpdir()
+      const prefix = path.join(tmp.path, ".venv")
+      const prepared = Bun.spawnSync([host, "-m", "venv", "--without-pip", prefix])
+      expect(prepared.exitCode, prepared.stderr.toString()).toBe(0)
+      await fs.rm(path.join(prefix, "bin", "python3"), { force: true })
+      const previous = await Config.trustedSandbox()
+      await Config.setSandbox({ enabled, onUnavailable: "error" })
+      try {
+        await Instance.provide({
+          directory: tmp.path,
+          fn: async () => {
+            const session = await executionSession()
+            const workspace = await SessionFilesystem.workspace(session.id)
+            const options = { root: path.join(tmp.path, ".jobs"), projectDirectory: tmp.path, workspace }
+            const command = `python3 -c ${quote('import sys,json; print(json.dumps({"prefix":sys.prefix,"executable":sys.executable}))')}`
+            const shell = await (
+              await BashTool.init()
+            ).execute(
+              { command, description: "Check selected venv" },
+              {
+                sessionID: session.id,
+                messageID: "msg_venv",
+                callID: "call_venv",
+                agent: "research",
+                abort: AbortSignal.any([]),
+                messages: [],
+                metadata() {},
+                async ask() {},
+              },
+            )
+            expect(shell.metadata.exit, shell.output).toBe(0)
+            expect(JSON.parse(shell.output.trim())).toEqual({ prefix, executable: path.join(prefix, "bin", "python") })
+            const job = await ComputeJobs.start(
+              { name: "Selected venv prefix", command, target: { kind: "local" }, sessionID: session.id },
+              options,
+            )
+            try {
+              const result = await ComputeJobs.wait(job.id, { ...options, timeout: 5_000 })
+              const log = await ComputeJobs.log(job.id, options)
+              expect(result.status, log).toBe("succeeded")
+              expect(JSON.parse(log.trim())).toEqual({ prefix, executable: path.join(prefix, "bin", "python") })
+              expect(result.reproducibility?.execution_environment?.python?.executable).toBe(
+                path.join(prefix, "bin", "python"),
+              )
+            } finally {
+              const current = await ComputeJobs.get(job.id, options)
+              if (current && ["pending", "running"].includes(current.status)) await ComputeJobs.cancel(job.id, options)
+            }
+          },
+        })
+      } finally {
+        await Config.setSandbox(previous)
+      }
+    },
+  )
+}

--- a/backend/cli/test/compute/local-python-runtime.test.ts
+++ b/backend/cli/test/compute/local-python-runtime.test.ts
@@ -1,4 +1,5 @@
-import { expect, test } from "bun:test"
+import { expect, spyOn, test } from "bun:test"
+import * as nativeFS from "node:fs"
 import fs from "node:fs/promises"
 import path from "node:path"
 import { ComputeJobs } from "../../src/compute/jobs"
@@ -177,7 +178,17 @@ test.skipIf(process.platform !== "win32")("Windows login shell retains the selec
         const job = await ComputeJobs.start(
           {
             name: "Windows selected interpreter",
-            command: `printf '/fixture startup diagnostic\\n' >&2; python -c ${quote('import sys,json; json.dump({"executable":sys.executable,"version":sys.version.split()[0]},open("runtime-windows.json","w")); print("runtime stdout sentinel",flush=True); print("runtime stderr sentinel",file=sys.stderr,flush=True)')}`,
+            command: [
+              "printf '/fixture startup diagnostic\\n' >&2",
+              'printf %s "$?" > builtin-before.exit',
+              "printf 'builtin before stdout\\n'",
+              `python -c ${quote('import sys,json; json.dump({"executable":sys.executable,"version":sys.version.split()[0]},open("runtime-windows.json","w")); print("runtime stdout sentinel",flush=True); print("runtime stderr sentinel",file=sys.stderr,flush=True)')}`,
+              "code=$?",
+              "printf 'builtin middle stdout\\n'; printf 'builtin middle stderr\\n' >&2",
+              `python -c ${quote('import sys; print("second native stdout",flush=True); print("second native stderr",file=sys.stderr,flush=True)')}`,
+              "printf 'builtin after stdout\\n'; printf 'builtin after stderr\\n' >&2",
+              'exit "$code"',
+            ].join("; "),
             target: { kind: "local" },
             sessionID: session.id,
           },
@@ -199,6 +210,7 @@ test.skipIf(process.platform !== "win32")("Windows login shell retains the selec
             }),
           ).toBe(true)
           const actual = await receipt.json()
+          expect(await Bun.file(path.join(workspace, "builtin-before.exit")).text()).toBe("0")
           expect(await fs.realpath(actual.executable)).toBe(
             await fs.realpath(path.join(prefix, "Scripts", "python.exe")),
           )
@@ -218,6 +230,17 @@ test.skipIf(process.platform !== "win32")("Windows login shell retains the selec
           expect(log, diagnostic).toContain("/fixture startup diagnostic")
           expect(log, diagnostic).toContain("runtime stdout sentinel")
           expect(log, diagnostic).toContain("runtime stderr sentinel")
+          for (const marker of [
+            "builtin before stdout",
+            "builtin middle stdout",
+            "builtin middle stderr",
+            "second native stdout",
+            "second native stderr",
+            "builtin after stdout",
+            "builtin after stderr",
+          ]) {
+            expect(log, diagnostic).toContain(marker)
+          }
         } finally {
           const current = await ComputeJobs.get(job.id, options)
           if (current && ["pending", "running"].includes(current.status)) await ComputeJobs.cancel(job.id, options)
@@ -228,6 +251,88 @@ test.skipIf(process.platform !== "win32")("Windows login shell retains the selec
     await Config.setSandbox(previous)
   }
 })
+
+for (const mode of ["cancel", "background", "write-error"] as const) {
+  test.skipIf(process.platform !== "win32")(`Windows compute output closes after ${mode}`, async () => {
+    if (!host) throw new Error("Local runtime fixture needs Python")
+    await using tmp = await tmpdir()
+    const previous = await Config.trustedSandbox()
+    await Config.setSandbox({ enabled: false })
+    const active = ComputeJobs.activeCount()
+    const create = nativeFS.createWriteStream
+    const writeError =
+      mode === "write-error"
+        ? spyOn(nativeFS, "createWriteStream").mockImplementation((file, options) => {
+            if (typeof file !== "string" || !file.startsWith(tmp.path) || !file.endsWith(".log")) {
+              return create(file, options)
+            }
+            // A real read-only descriptor forces the parent append writer's
+            // asynchronous I/O error. The stream is its sole owner and closes
+            // it; the child's output pipe is still valid.
+            nativeFS.writeFileSync(file, "", { mode: 0o600 })
+            return create(file, {
+              ...(typeof options === "object" ? options : {}),
+              fd: nativeFS.openSync(file, "r"),
+            })
+          })
+        : undefined
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const session = await executionSession()
+          const workspace = await SessionFilesystem.workspace(session.id)
+          const options = { root: path.join(tmp.path, ".jobs"), projectDirectory: tmp.path, workspace }
+          const code =
+            mode === "background"
+              ? 'import sys,subprocess; subprocess.Popen([sys.executable,"-c","import time; time.sleep(30)"]); print("primary finished",flush=True)'
+              : 'import sys,time; print("native ready stdout",flush=True); print("native ready stderr",file=sys.stderr,flush=True); time.sleep(30)'
+          const job = await ComputeJobs.start(
+            {
+              name: `Windows output ${mode}`,
+              command: `python -c ${quote(code)}`,
+              target: { kind: "local" },
+              sessionID: session.id,
+            },
+            options,
+          )
+          try {
+            if (mode === "cancel") {
+              for (let attempt = 0; attempt < 250; attempt++) {
+                if ((await ComputeJobs.log(job.id, options)).includes("native ready stderr")) break
+                await Bun.sleep(20)
+              }
+              expect(await ComputeJobs.log(job.id, options)).toContain("native ready stderr")
+              await ComputeJobs.cancel(job.id, options)
+            }
+            const result = await ComputeJobs.wait(job.id, { ...options, timeout: 5_000 })
+            expect(result.status, JSON.stringify(result)).toBe(
+              mode === "cancel" ? "cancelled" : mode === "write-error" ? "failed" : "succeeded",
+            )
+            expect(result.lifecycle?.resource, JSON.stringify(result)).toBe("closed")
+            if (mode === "write-error") {
+              expect(result.error).toContain("Could not capture compute job log")
+            } else {
+              const log = await ComputeJobs.log(job.id, options)
+              expect(log).toContain(mode === "background" ? "primary finished" : "native ready stdout")
+              if (mode === "cancel") expect(log).toContain("native ready stderr")
+            }
+          } finally {
+            const current = await ComputeJobs.get(job.id, options)
+            if (current && ["pending", "running"].includes(current.status)) await ComputeJobs.cancel(job.id, options)
+            for (let attempt = 0; attempt < 250 && ComputeJobs.activeCount() > active; attempt++) {
+              await Bun.sleep(20)
+            }
+            expect(ComputeJobs.activeCount()).toBe(active)
+          }
+        },
+      })
+    } finally {
+      writeError?.mockRestore()
+      await Config.setSandbox(previous)
+    }
+  })
+}
 
 for (const enabled of [false, true]) {
   test.skipIf(process.platform === "win32" || (enabled && !Sandbox.available()))(

--- a/backend/cli/test/compute/local-python-runtime.test.ts
+++ b/backend/cli/test/compute/local-python-runtime.test.ts
@@ -177,7 +177,7 @@ test.skipIf(process.platform !== "win32")("Windows login shell retains the selec
         const job = await ComputeJobs.start(
           {
             name: "Windows selected interpreter",
-            command: `printf '/fixture startup diagnostic\\n' >&2; python -c ${quote('import sys,json; json.dump({"executable":sys.executable,"version":sys.version.split()[0]},open("runtime-windows.json","w"))')}`,
+            command: `printf '/fixture startup diagnostic\\n' >&2; python -c ${quote('import sys,json; json.dump({"executable":sys.executable,"version":sys.version.split()[0]},open("runtime-windows.json","w")); print("runtime stdout sentinel",flush=True); print("runtime stderr sentinel",file=sys.stderr,flush=True)')}`,
             target: { kind: "local" },
             sessionID: session.id,
           },
@@ -198,7 +198,6 @@ test.skipIf(process.platform !== "win32")("Windows login shell retains the selec
               log,
             }),
           ).toBe(true)
-          expect(log).toContain("/fixture startup diagnostic")
           const actual = await receipt.json()
           expect(await fs.realpath(actual.executable)).toBe(
             await fs.realpath(path.join(prefix, "Scripts", "python.exe")),
@@ -208,6 +207,17 @@ test.skipIf(process.platform !== "win32")("Windows login shell retains the selec
             executable: path.join(prefix, "Scripts", "python.exe"),
             version: actual.version,
           })
+          const logFile = path.join(options.root, "jobs", `${job.id}.log`)
+          const diagnostic = JSON.stringify({
+            shell: Shell.posix(),
+            logFile,
+            bytes: await fs.stat(logFile).then((stat) => stat.size),
+            direct: await fs.readFile(logFile, "utf8"),
+            events: await ComputeJobs.events(job.id, options),
+          })
+          expect(log, diagnostic).toContain("/fixture startup diagnostic")
+          expect(log, diagnostic).toContain("runtime stdout sentinel")
+          expect(log, diagnostic).toContain("runtime stderr sentinel")
         } finally {
           const current = await ComputeJobs.get(job.id, options)
           if (current && ["pending", "running"].includes(current.status)) await ComputeJobs.cancel(job.id, options)

--- a/backend/cli/test/compute/local-python-runtime.test.ts
+++ b/backend/cli/test/compute/local-python-runtime.test.ts
@@ -8,6 +8,7 @@ import { KernelEnvironmentMutation } from "../../src/science/kernel/environment-
 import { Config } from "../../src/config/config"
 import { BashTool } from "../../src/tool/bash"
 import { Sandbox } from "../../src/sandbox/sandbox"
+import { Shell } from "../../src/shell/shell"
 import { executionSession, tmpdir } from "../fixture/fixture"
 
 const quote = (value: string) => `'${value.replaceAll("'", "'\\''")}'`
@@ -122,7 +123,7 @@ test.skipIf(process.platform === "win32" || !alternate)(
         const job = await ComputeJobs.start(
           {
             name: "Selected interpreter identity",
-            command: `python3 -c ${quote('import sys, json; print(json.dumps({"version":sys.version.split()[0],"executable":sys.executable}))')}`,
+            command: `printf '/fixture startup diagnostic\\n' >&2; python3 -c ${quote('import sys, json; json.dump({"version":sys.version.split()[0],"executable":sys.executable},open("runtime-version.json","w"))')}`,
             target: { kind: "local" },
             sessionID: session.id,
           },
@@ -130,8 +131,12 @@ test.skipIf(process.platform === "win32" || !alternate)(
         )
         try {
           const result = await ComputeJobs.wait(job.id, { ...options, timeout: 5_000 })
-          expect(result.status).toBe("succeeded")
-          const actual = JSON.parse((await ComputeJobs.log(job.id, options)).trim())
+          const log = await ComputeJobs.log(job.id, options)
+          expect(result.status, log).toBe("succeeded")
+          expect(log).toContain("/fixture startup diagnostic")
+          const receipt = Bun.file(path.join(workspace, "runtime-version.json"))
+          expect(await receipt.exists(), log).toBe(true)
+          const actual = await receipt.json()
           expect(actual.version).toBe(alternate.version)
           expect(actual.version).not.toBe(hostVersion)
           expect(result.reproducibility?.python).toBe(`Python ${actual.version}`)
@@ -172,7 +177,7 @@ test.skipIf(process.platform !== "win32")("Windows login shell retains the selec
         const job = await ComputeJobs.start(
           {
             name: "Windows selected interpreter",
-            command: `python -c ${quote('import sys,json; print(json.dumps({"executable":sys.executable,"version":sys.version.split()[0]}))')}`,
+            command: `printf '/fixture startup diagnostic\\n' >&2; python -c ${quote('import sys,json; json.dump({"executable":sys.executable,"version":sys.version.split()[0]},open("runtime-windows.json","w"))')}`,
             target: { kind: "local" },
             sessionID: session.id,
           },
@@ -182,7 +187,19 @@ test.skipIf(process.platform !== "win32")("Windows login shell retains the selec
           const result = await ComputeJobs.wait(job.id, { ...options, timeout: 5_000 })
           const log = await ComputeJobs.log(job.id, options)
           expect(result.status, log).toBe("succeeded")
-          const actual = JSON.parse(log.trim())
+          const receipt = Bun.file(path.join(workspace, "runtime-windows.json"))
+          expect(
+            await receipt.exists(),
+            JSON.stringify({
+              shell: Shell.posix(),
+              terminalShell: Shell.acceptable(),
+              git: Bun.which("git"),
+              job: result.status,
+              log,
+            }),
+          ).toBe(true)
+          expect(log).toContain("/fixture startup diagnostic")
+          const actual = await receipt.json()
           expect(await fs.realpath(actual.executable)).toBe(
             await fs.realpath(path.join(prefix, "Scripts", "python.exe")),
           )
@@ -211,7 +228,16 @@ for (const enabled of [false, true]) {
       const prefix = path.join(tmp.path, ".venv")
       const prepared = Bun.spawnSync([host, "-m", "venv", "--without-pip", prefix])
       expect(prepared.exitCode, prepared.stderr.toString()).toBe(0)
+      // Linux venvs can make python a relative symlink to python3. Preserve
+      // that selected entrypoint before removing only the optional alias.
+      const selected = path.join(prefix, "bin", "python")
+      const target = await fs.realpath(selected)
+      await fs.rm(selected)
+      await fs.symlink(target, selected)
       await fs.rm(path.join(prefix, "bin", "python3"), { force: true })
+      const direct = Bun.spawnSync([selected, "-c", "import sys; print(sys.prefix)"])
+      expect(direct.exitCode, direct.stderr.toString()).toBe(0)
+      expect(direct.stdout.toString().trim()).toBe(prefix)
       const previous = await Config.trustedSandbox()
       await Config.setSandbox({ enabled, onUnavailable: "error" })
       try {
@@ -221,11 +247,12 @@ for (const enabled of [false, true]) {
             const session = await executionSession()
             const workspace = await SessionFilesystem.workspace(session.id)
             const options = { root: path.join(tmp.path, ".jobs"), projectDirectory: tmp.path, workspace }
-            const command = `python3 -c ${quote('import sys,json; print(json.dumps({"prefix":sys.prefix,"executable":sys.executable}))')}`
+            const command = (file: string) =>
+              `printf '/fixture startup diagnostic\\n' >&2; python3 -c ${quote(`import sys,json; json.dump({"prefix":sys.prefix,"executable":sys.executable},open(${JSON.stringify(file)},"w"))`)}`
             const shell = await (
               await BashTool.init()
             ).execute(
-              { command, description: "Check selected venv" },
+              { command: command("bash-venv.json"), description: "Check selected venv" },
               {
                 sessionID: session.id,
                 messageID: "msg_venv",
@@ -238,16 +265,27 @@ for (const enabled of [false, true]) {
               },
             )
             expect(shell.metadata.exit, shell.output).toBe(0)
-            expect(JSON.parse(shell.output.trim())).toEqual({ prefix, executable: path.join(prefix, "bin", "python") })
+            expect(shell.output).toContain("/fixture startup diagnostic")
+            const shellReceipt = Bun.file(path.join(workspace, "bash-venv.json"))
+            expect(await shellReceipt.exists(), shell.output).toBe(true)
+            expect(await shellReceipt.json(), shell.output).toEqual({ prefix, executable: selected })
             const job = await ComputeJobs.start(
-              { name: "Selected venv prefix", command, target: { kind: "local" }, sessionID: session.id },
+              {
+                name: "Selected venv prefix",
+                command: command("compute-venv.json"),
+                target: { kind: "local" },
+                sessionID: session.id,
+              },
               options,
             )
             try {
               const result = await ComputeJobs.wait(job.id, { ...options, timeout: 5_000 })
               const log = await ComputeJobs.log(job.id, options)
               expect(result.status, log).toBe("succeeded")
-              expect(JSON.parse(log.trim())).toEqual({ prefix, executable: path.join(prefix, "bin", "python") })
+              expect(log).toContain("/fixture startup diagnostic")
+              const receipt = Bun.file(path.join(workspace, "compute-venv.json"))
+              expect(await receipt.exists(), log).toBe(true)
+              expect(await receipt.json(), log).toEqual({ prefix, executable: selected })
               expect(result.reproducibility?.execution_environment?.python?.executable).toBe(
                 path.join(prefix, "bin", "python"),
               )

--- a/backend/cli/test/sandbox/sandbox.test.ts
+++ b/backend/cli/test/sandbox/sandbox.test.ts
@@ -52,6 +52,30 @@ describe("Sandbox.cacheEnvironment", () => {
 })
 
 describe("Sandbox local runtime support", () => {
+  for (const enabled of [false, true]) {
+    test.skipIf(process.platform === "win32" || (enabled && !Sandbox.available()))(
+      `restores the selected interpreter after login PATH changes (${enabled ? "sandboxed" : "unsandboxed"})`,
+      async () => {
+        await using tmp = await tmpdir()
+        const selected = path.join(tmp.path, "selected-python")
+        await Bun.write(selected, "#!/bin/sh\nprintf selected-runtime\n")
+        fs.chmodSync(selected, 0o755)
+        const plan = Sandbox.wrapArgv({
+          file: shell,
+          runtime: { python: selected, path: process.env.PATH },
+          args: (runtimePath) => ["-lc", `PATH=/usr/bin:/bin; export PATH=${JSON.stringify(runtimePath)}; python3`],
+          workspace: [tmp.path],
+          options: { enabled, network: "deny", onUnavailable: "error" },
+        })
+        expect(plan.temporary).toBeString()
+        const result = await execute(plan, tmp.path)
+        expect(result.exit, result.stderr).toBe(0)
+        expect(result.stdout).toBe("selected-runtime")
+        expect(fs.existsSync(plan.temporary!)).toBe(false)
+      },
+    )
+  }
+
   test.skipIf(process.platform === "win32" || !Sandbox.available())(
     "keeps the selected OpenScience Conda environment readable without exposing its parent data root",
     async () => {

--- a/backend/cli/test/science/kernel/environment-mutation.test.ts
+++ b/backend/cli/test/science/kernel/environment-mutation.test.ts
@@ -8,6 +8,45 @@ import type { PermissionNext } from "../../../src/permission/next"
 import { executionSession, tmpdir } from "../../fixture/fixture"
 import fs from "node:fs/promises"
 
+test("subprocess identity preserves the configured executable on every platform and leaves unmeasured values absent", () => {
+  for (const binary of ["/project/.venv/bin/python", "C:\\project\\.venv\\Scripts\\python.exe"]) {
+    expect(KernelEnvironmentMutation.subprocessIdentity({ binary, environmentName: "python" }, "workspace")).toEqual({
+      target: "local",
+      cwd: "workspace",
+      profile: "python",
+      python: { role: "selected_default", executable: binary },
+    })
+  }
+  expect(KernelEnvironmentMutation.subprocessIdentity({}, "workspace").python).toEqual({ role: "selected_default" })
+})
+
+test("subprocess overlay retains only the resolver-owned import path and sanitized Git policy", () => {
+  const env = KernelEnvironmentMutation.subprocessEnv(
+    {
+      binary: "/project/.venv/bin/python",
+      env: {
+        PYTHONPATH: "/derived/site-packages",
+        MODAL_TOKEN_ID: "ak-denied-runtime-overlay",
+        NODE_OPTIONS: "--require injected",
+      },
+    },
+    {
+      PYTHONPATH: "/unapproved",
+      PYTHONHOME: "/unapproved",
+      MODAL_TOKEN_SECRET: "as-denied-ambient",
+      GIT_CONFIG_NOSYSTEM: "1",
+      GIT_CONFIG_GLOBAL: "/dev/null",
+      GIT_TERMINAL_PROMPT: "0",
+    },
+  )
+  expect(env).toEqual({
+    PYTHONPATH: "/derived/site-packages",
+    GIT_CONFIG_NOSYSTEM: "1",
+    GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_TERMINAL_PROMPT: "0",
+  })
+})
+
 test("recognizes Python and R package/environment mutations as exact immutable plans", () => {
   const python = KernelEnvironmentMutation.detect({
     language: "python",

--- a/backend/cli/test/session/reduce.test.ts
+++ b/backend/cli/test/session/reduce.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { MessageV2 } from "../../src/session/message-v2"
 import { Token } from "../../src/util/token"
 import type { Provider } from "../../src/provider/provider"
+import { PayloadIntegrity } from "../../src/tool/payload-integrity"
 
 const sessionID = "session"
 
@@ -110,6 +111,39 @@ describe("session.message-v2.toolSummary", () => {
     expect(s).toContain("refs.bib:41")
     expect(s).not.toContain("→ cleared")
   })
+
+  test("retains partial outcomes and bounded immutable output handles independently of handoff prose", () => {
+    const artifacts = Array.from({ length: 10 }, (_, index) => ({
+      artifactID: `artifact-${index}`,
+      versionID: `v-${index}`,
+    }))
+    for (const handoff of ["", "Long findings. ".repeat(1000)]) {
+      const summary = MessageV2.toolSummary(
+        "task",
+        completedTool("task", { prompt: "Run analysis" }, "raw output", {
+          metadata: {
+            outcome: "partial",
+            stopReason: "empty_handoff",
+            sessionId: "ses_child",
+            handoff,
+            evidence: { artifacts },
+          },
+        }),
+      )
+      expect(summary).toContain("Task outcome: partial")
+      expect(summary).toContain("empty_handoff")
+      expect(summary).toContain("ses_child")
+      expect(summary).toContain('artifact_id="artifact-0", version_id="v-0"')
+      expect(summary).toContain('artifact_id="artifact-7", version_id="v-7"')
+      expect(summary).not.toContain('artifact_id="artifact-8"')
+      expect(summary).toContain("More saved outputs are listed in the full child trace")
+    }
+    const malformed = MessageV2.toolSummary(
+      "task",
+      completedTool("task", {}, "", { metadata: { evidence: { artifacts: [null, { artifactID: "incomplete" }] } } }),
+    )
+    expect(malformed).not.toContain("artifact_id=")
+  })
 })
 
 describe("session.message-v2.toModelMessages — compacted tool rendering (P2.2)", () => {
@@ -177,15 +211,13 @@ describe("session.message-v2.toModelMessages — compacted tool rendering (P2.2)
   })
 })
 
-describe("session.message-v2.truncateArgs (P2.3)", () => {
-  test("truncates a string value longer than the cap and marks how much was dropped", () => {
-    const out = MessageV2.truncateArgs({ content: "x".repeat(1000) }, 200)
-    expect(out.content).toBe("x".repeat(200) + "…[+800 chars]")
+describe("legacy argument history recognition", () => {
+  test("reconstructs older previews for integrity checks", () => {
+    expect(PayloadIntegrity.legacyPreview("x".repeat(1000))).toBe("x".repeat(200) + "…[+800 chars]")
   })
 
-  test("leaves short strings and non-string values untouched", () => {
-    const out = MessageV2.truncateArgs({ filePath: "/a", count: 5, deep: { a: 1 } }, 200)
-    expect(out).toEqual({ filePath: "/a", count: 5, deep: { a: 1 } })
+  test("leaves short strings untouched", () => {
+    expect(PayloadIntegrity.legacyPreview("/a")).toBe("/a")
   })
 
   test("recognizes only the internal argument-compaction marker", () => {
@@ -195,15 +227,16 @@ describe("session.message-v2.truncateArgs (P2.3)", () => {
 })
 
 describe("session.message-v2.toModelMessages — compacted tool args (P2.3)", () => {
-  test("truncates oversized args of a compacted tool call, keeps small ones", () => {
+  test("keeps every argument exact after output compaction without mutating stored input", () => {
     const state = completedTool("write", { filePath: "/a", content: "x".repeat(1000) }, "ok", { compacted: true })
     const input: MessageV2.WithParts[] = [
       { info: assistantInfo("a1", "u1"), parts: [toolPart("a1", "t1", "write", state)] },
     ]
     const s = JSON.stringify(MessageV2.toModelMessages(input, model))
-    expect(s).not.toContain("x".repeat(1000))
-    expect(s).toContain("chars]") // truncation marker present
-    expect(s).toContain("/a") // small arg preserved
+    expect(s).toContain("x".repeat(1000))
+    expect(s).not.toContain("chars]")
+    expect(s).toContain("/a")
+    expect(state.input).toEqual({ filePath: "/a", content: "x".repeat(1000) })
   })
 
   test("does NOT truncate args of a live (non-compacted) tool call", () => {
@@ -230,7 +263,7 @@ describe("session.message-v2.toModelMessages — compacted tool args (P2.3)", ()
     expect(rendered).not.toContain("…[+")
   })
 
-  test("truncates oversized args of a SUPERSEDED (duplicate) tool call — its output is a stub, so the args are dead weight", () => {
+  test("keeps duplicate call arguments exact while reducing duplicate results", () => {
     const big = "y".repeat(300)
     const content = "z".repeat(1000)
     const input: MessageV2.WithParts[] = [
@@ -244,8 +277,9 @@ describe("session.message-v2.toModelMessages — compacted tool args (P2.3)", ()
       },
     ]
     const s = JSON.stringify(MessageV2.toModelMessages(input, model))
-    expect(s).toContain("chars]") // the later (superseded) call's content arg is truncated
-    expect(s.split(content).length - 1).toBe(1) // the full content ships only once (the kept first call)
+    expect(s).not.toContain("chars]")
+    expect(s.split(content).length - 1).toBe(2)
+    expect(s.split(big).length - 1).toBe(1)
   })
 })
 

--- a/backend/cli/test/session/stall-recovery.test.ts
+++ b/backend/cli/test/session/stall-recovery.test.ts
@@ -23,6 +23,7 @@ test.each(["silence", "keepalive", "private-reasoning"])(
   async (mode) => {
     let requests = 0
     let cancelled = false
+    let ready = false
     const timers = new Set<ReturnType<typeof setInterval>>()
     using server = Bun.serve({
       hostname: "127.0.0.1",
@@ -43,16 +44,20 @@ test.each(["silence", "keepalive", "private-reasoning"])(
                 encoder.encode(chunk({ role: "assistant", reasoning_content: "Saved partial reasoning." })),
               )
               controller.enqueue(encoder.encode(chunk({ content: "Saved partial answer." })))
-              if (mode === "silence") return
-              timer = setInterval(
-                () =>
-                  controller.enqueue(
-                    encoder.encode(
-                      mode === "keepalive" ? ": PROCESSING\n\n" : chunk({ reasoning_content: "[REDACTED]" }),
-                    ),
+              // Do not begin the intentional stall until the real session has
+              // persisted both seed parts. SDK startup and storage are not a
+              // subsecond timing contract, especially in the full CI shard.
+              timer = setInterval(() => {
+                if (ready && mode === "silence") {
+                  clearInterval(timer)
+                  return
+                }
+                controller.enqueue(
+                  encoder.encode(
+                    !ready || mode === "keepalive" ? ": PROCESSING\n\n" : chunk({ reasoning_content: "[REDACTED]" }),
                   ),
-                20,
-              )
+                )
+              }, 20)
               timers.add(timer)
             },
             cancel() {
@@ -73,9 +78,9 @@ test.each(["silence", "keepalive", "private-reasoning"])(
           ...base.provider[STRESS_PROVIDER_ID],
           options: {
             ...base.provider[STRESS_PROVIDER_ID].options,
-            connectTimeout: 2_000,
-            idleTimeout: mode === "silence" ? 160 : 2_000,
-            outputIdleTimeout: 240,
+            connectTimeout: 5_000,
+            idleTimeout: mode === "silence" ? 1_000 : 5_000,
+            outputIdleTimeout: 2_000,
           },
         },
       },
@@ -90,13 +95,33 @@ test.each(["silence", "keepalive", "private-reasoning"])(
         },
         fn: async () => {
           const session = await Session.create({ title: "Stall recovery" })
-          const result = await SessionPrompt.prompt({
+          let settled = false
+          const pending = SessionPrompt.prompt({
             sessionID: session.id,
             model: { providerID: STRESS_PROVIDER_ID, modelID: STRESS_PROVIDER_MODEL },
             agent: "research",
             delegation: false,
             system: marker,
             parts: [{ type: "text", text: "Answer once." }],
+          }).finally(() => {
+            settled = true
+          })
+          void pending.catch(() => undefined)
+          const result = await (async () => {
+            const deadline = Date.now() + 5_000
+            while (Date.now() < deadline) {
+              const parts = (await Session.messages({ sessionID: session.id })).flatMap((message) => message.parts)
+              ready =
+                parts.some((part) => part.type === "text" && part.text.includes("Saved partial answer.")) &&
+                parts.some((part) => part.type === "reasoning" && part.text.includes("Saved partial reasoning."))
+              if (ready || settled) break
+              await Bun.sleep(100)
+            }
+            expect(ready, "seed parts must be durable before the intentional stall").toBe(true)
+            return await pending
+          })().finally(async () => {
+            if (!settled) await SessionPrompt.cancel(session.id)
+            await pending.catch(() => undefined)
           })
           expect(requests).toBe(1)
           expect(result.info).toMatchObject({

--- a/backend/cli/test/session/toolset.test.ts
+++ b/backend/cli/test/session/toolset.test.ts
@@ -1,0 +1,195 @@
+import { expect, test } from "bun:test"
+import { jsonSchema, tool } from "ai"
+import { Agent } from "../../src/agent/agent"
+import { Identifier } from "../../src/id/id"
+import { Instance } from "../../src/project/instance"
+import { Provider } from "../../src/provider/provider"
+import { Session } from "../../src/session"
+import { SessionHarness } from "../../src/session/harness"
+import { LLM } from "../../src/session/llm"
+import type { MessageV2 } from "../../src/session/message-v2"
+import { SessionPrompt } from "../../src/session/prompt"
+import { SessionTraceStore } from "../../src/session/trace-store"
+import { Toolset } from "../../src/session/toolset"
+import { ToolRegistry } from "../../src/tool/registry"
+import { tmpdir, trustProject } from "../fixture/fixture"
+import { stressProviderConfig } from "../fixture/stress-provider"
+
+test("tool availability notices omit initial/unchanged catalogs and bound changed names", () => {
+  expect(Toolset.notice(["read", "write"])).toBeUndefined()
+  expect(Toolset.notice(["write", "read"], ["read", "write"])).toBeUndefined()
+  expect(Toolset.active({ read: {}, invalid: {}, fixture_extension: {} })).toEqual(["read", "fixture_extension"])
+  const notice = Toolset.notice(
+    Array.from({ length: 500 }, (_, index) => `new_${index}`),
+    Array.from({ length: 500 }, (_, index) => `old_${index}`),
+  )!
+  expect(notice.length).toBeLessThan(1_024)
+  expect(notice).toContain("480 more")
+  expect(notice).not.toContain("new_499")
+  expect(notice).toContain("not filesystem or execution authority")
+})
+
+test("retries and internal compaction preserve the preceding agent snapshot", async () => {
+  const make = async (messageID: string, profile: string, names: string[]) => ({
+    ...(await SessionHarness.snapshot({
+      agent: { name: profile, mode: "primary" },
+      provider: "fixture",
+      model: "fixture",
+      system: [],
+      tools: Object.fromEntries(names.map((name) => [name, tool({ inputSchema: jsonSchema({ type: "object" }) })])),
+    })),
+    messageID,
+    parentMessageID: "msg_user",
+    attempt: 1,
+    createdAt: 1,
+  })
+  const records = [
+    await make("msg_before", "research", ["read", "invalid"]),
+    await make("msg_compact", "compaction", []),
+    await make("msg_current", "research", ["read", "write", "invalid"]),
+  ]
+  expect(Toolset.previous(records, { messageID: "msg_current", profile: "research", mode: "primary" })).toEqual([
+    "read",
+  ])
+  expect(Toolset.previous(records, { messageID: "msg_new", profile: "research", mode: "primary" })).toEqual([
+    "read",
+    "write",
+  ])
+})
+
+test("actual provider requests and durable snapshots agree after model, mask and permission changes", async () => {
+  const captured: Array<{ tools?: Array<{ function: { name: string } }>; messages: unknown }> = []
+  using server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    async fetch(request) {
+      expect(new URL(request.url).pathname).toBe("/v1/chat/completions")
+      captured.push(await request.json())
+      const chunk = (delta: object, finish: string | null) =>
+        `data: ${JSON.stringify({
+          id: "chatcmpl-toolset",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: "fixture",
+          choices: [{ index: 0, delta, finish_reason: finish }],
+        })}\n\n`
+      return new Response(
+        chunk({ role: "assistant", content: "FIXTURE_COMPLETE" }, null) + chunk({}, "stop") + "data: [DONE]\n\n",
+        { headers: { "content-type": "text/event-stream" } },
+      )
+    },
+  })
+  const config = stressProviderConfig(`${server.url.origin}/v1`)
+  await using tmp = await tmpdir({
+    git: true,
+    config: {
+      ...config,
+      provider: {
+        stress: {
+          ...config.provider.stress,
+          models: {
+            "gpt-snapshot": { name: "GPT fixture", tool_call: true, limit: { context: 128_000, output: 4_096 } },
+            "claude-snapshot": { name: "Claude fixture", tool_call: true, limit: { context: 128_000, output: 4_096 } },
+          },
+        },
+      },
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    init: trustProject,
+    fn: async () => {
+      const session = await Session.create({ title: "Tool availability fixture" })
+      const research = await Agent.get("research")
+      if (!research) throw new Error("missing fixture agent")
+      const invoke = async (
+        modelID: string,
+        masked = false,
+        messageID = Identifier.ascending("message"),
+        attempt = 1,
+      ) => {
+        const model = await Provider.getModel("stress", modelID)
+        const agent: Agent.Info = {
+          ...research,
+          permission: [
+            { permission: "*", pattern: "*", action: "allow" },
+            ...(masked ? [{ permission: "read", pattern: "*", action: "deny" } as const] : []),
+          ],
+        }
+        const definitions = await ToolRegistry.tools({ providerID: "stress", modelID }, agent, (id) =>
+          ["read", "write", "edit", "apply_patch"].includes(id),
+        )
+        const tools = Object.fromEntries(
+          definitions.map((item) => [
+            item.id,
+            tool({
+              description: item.description,
+              inputSchema: SessionPrompt.toolInputSchema(model, item),
+            }),
+          ]),
+        )
+        tools.fixture_extension = tool({
+          description: "HIDDEN_EXTENSION_DESCRIPTION",
+          inputSchema: jsonSchema({ type: "object" }),
+        })
+        tools.invalid = tool({ description: "INTERNAL_REPAIR_ONLY", inputSchema: jsonSchema({ type: "object" }) })
+        const user: MessageV2.User = {
+          id: Identifier.ascending("message"),
+          sessionID: session.id,
+          role: "user",
+          agent: agent.name,
+          effort: "normal",
+          time: { created: Date.now() },
+          model: { providerID: model.providerID, modelID: model.id },
+          tools: { fixture_extension: false, ...(masked ? { write: false } : {}) },
+        }
+        const stream = await LLM.stream({
+          user,
+          sessionID: session.id,
+          model,
+          agent,
+          system: [],
+          abort: new AbortController().signal,
+          messages: [{ role: "user", content: "Continue the existing assignment." }],
+          tools,
+          trace: { messageID, attempt },
+          route: "fixture",
+          retries: 0,
+        })
+        const errors = []
+        for await (const event of stream.fullStream) if (event.type === "error") errors.push(event.error)
+        expect(errors).toEqual([])
+        const request = captured.at(-1)!
+        const names = (request.tools ?? []).map((entry) => entry.function.name).toSorted()
+        const record = (await SessionTraceStore.read(session.id)).harness.at(-1)!
+        expect(record.messageID).toBe(messageID)
+        expect(record.model).toBe(modelID)
+        expect(record.tools.map((entry) => entry.name).filter((name) => name !== "invalid")).toEqual(names)
+        expect(JSON.stringify(request)).not.toContain("HIDDEN_EXTENSION_DESCRIPTION")
+        expect(JSON.stringify(request)).not.toContain("INTERNAL_REPAIR_ONLY")
+        return { names, messages: JSON.stringify(request.messages), messageID }
+      }
+      try {
+        const first = await invoke("gpt-snapshot")
+        expect(first.names).toEqual(["apply_patch", "read"])
+        expect(first.messages).not.toContain("Tool availability changed")
+        const switched = await invoke("claude-snapshot")
+        expect(switched.names).toEqual(["edit", "read", "write"])
+        expect(switched.messages).toContain('Added tools: [\\"edit\\", \\"write\\"]')
+        expect(switched.messages).toContain('Removed tools: [\\"apply_patch\\"]')
+        expect((await invoke("claude-snapshot")).messages).not.toContain("Tool availability changed")
+        const masked = await invoke("claude-snapshot", true)
+        expect(masked.names).toEqual(["edit"])
+        expect(masked.messages).toContain('Removed tools: [\\"read\\", \\"write\\"]')
+        const restored = await invoke("claude-snapshot")
+        const retried = await invoke("claude-snapshot", false, restored.messageID, 2)
+        expect(restored.messages).toContain('Added tools: [\\"read\\", \\"write\\"]')
+        expect(retried.messages).toBe(restored.messages)
+        expect(captured).toHaveLength(6)
+      } finally {
+        await Session.remove(session.id)
+        await Instance.dispose()
+      }
+    },
+  })
+})

--- a/backend/cli/test/shell/windows-posix.test.ts
+++ b/backend/cli/test/shell/windows-posix.test.ts
@@ -1,0 +1,90 @@
+import { expect, spyOn, test } from "bun:test"
+import fs from "node:fs"
+import { ComputeJobs } from "../../src/compute/jobs"
+import { Flag } from "../../src/flag/flag"
+import { Shell } from "../../src/shell/shell"
+
+const root = "C:\\Program Files\\Git"
+const bash = `${root}\\bin\\bash.exe`
+
+for (const directory of ["cmd", "bin", "mingw64\\bin", "mingw32\\bin", "usr\\bin"]) {
+  test(`finds the same Git Bash from Git/${directory.replaceAll("\\", "/")}/git.exe`, () => {
+    expect(Shell.windowsGitBash(`${root}\\${directory}\\git.exe`, (file) => file === bash)).toBe(bash)
+  })
+}
+
+test("supports the Git usr/bin entrypoint without searching unrelated WSL locations", () => {
+  const unix = `${root}\\usr\\bin\\bash.exe`
+  expect(Shell.windowsGitBash(`${root}\\mingw64\\bin\\git.exe`, (file) => file === unix)).toBe(unix)
+  expect(Shell.windowsGitBash("C:\\Windows\\System32\\git.exe", () => true)).toBeUndefined()
+  expect(Shell.windowsGitBash(null, () => true)).toBeUndefined()
+  expect(Shell.windowsGitBash(`${root}\\cmd\\git.exe`, () => false)).toBeUndefined()
+})
+
+test("the generated POSIX script rejects cmd, PowerShell, and the WSL bridge", () => {
+  for (const shell of [
+    "cmd.exe",
+    "powershell.exe",
+    "pwsh.exe",
+    "C:\\Windows\\System32\\bash.exe",
+    "C:\\Windows\\Sysnative\\bash.exe",
+    "C:\\Windows\\SysWOW64\\bash.exe",
+  ]) {
+    expect(() => Shell.requirePosix(shell, "win32")).toThrow("Local compute jobs require Git Bash")
+  }
+  expect(Shell.requirePosix(bash, "win32")).toBe(bash)
+  expect(Shell.requirePosix("/bin/zsh", "darwin")).toBe("/bin/zsh")
+})
+
+function windows(input: { git?: string; configured?: string; files: string[] }, run: () => void) {
+  const platform = Object.getOwnPropertyDescriptor(process, "platform")!
+  const configured = Object.getOwnPropertyDescriptor(Flag, "OPENSCIENCE_GIT_BASH_PATH")!
+  const prior = process.env.SHELL
+  const which = spyOn(Bun, "which").mockImplementation((name) => (name === "git" ? (input.git ?? null) : null))
+  const exists = spyOn(fs, "existsSync").mockImplementation((file) => input.files.includes(String(file)))
+  try {
+    Object.defineProperty(process, "platform", { ...platform, value: "win32" })
+    Object.defineProperty(Flag, "OPENSCIENCE_GIT_BASH_PATH", { ...configured, value: input.configured })
+    process.env.SHELL = "cmd.exe"
+    Shell.preferred.reset()
+    Shell.acceptable.reset()
+    run()
+  } finally {
+    Object.defineProperty(process, "platform", platform)
+    Object.defineProperty(Flag, "OPENSCIENCE_GIT_BASH_PATH", configured)
+    if (prior === undefined) delete process.env.SHELL
+    else process.env.SHELL = prior
+    which.mockRestore()
+    exists.mockRestore()
+    Shell.preferred.reset()
+    Shell.acceptable.reset()
+  }
+}
+
+test("compute selects Git Bash while ordinary terminals retain their cmd preference", () => {
+  windows({ git: `${root}\\mingw64\\bin\\git.exe`, files: [bash] }, () => {
+    expect(Shell.preferred()).toBe("cmd.exe")
+    expect(Shell.acceptable()).toBe("cmd.exe")
+    expect(ComputeJobs.command({ id: "job-fixture", name: "Shell contract", command: "printf executed" }).argv).toEqual(
+      [bash, "-lc", "printf executed"],
+    )
+  })
+})
+
+test("an explicit installed Git Bash override is honored and missing shells fail before a job argv is admitted", () => {
+  const configured = "D:\\Portable Git\\bin\\bash.exe"
+  windows({ configured, files: [configured] }, () => {
+    expect(Shell.posix()).toBe(configured)
+  })
+  windows({ configured, files: [] }, () => {
+    expect(() =>
+      ComputeJobs.command({ id: "job-fixture", name: "Shell contract", command: "printf never-executed" }),
+    ).toThrow("Configured Git Bash was not found")
+  })
+  windows({ files: [] }, () => {
+    expect(() =>
+      ComputeJobs.command({ id: "job-fixture", name: "Shell contract", command: "printf never-executed" }),
+    ).toThrow("Local compute jobs require Git Bash")
+    expect(Shell.preferred()).toBe("cmd.exe")
+  })
+})

--- a/backend/cli/test/tool/artifact-save-file.test.ts
+++ b/backend/cli/test/tool/artifact-save-file.test.ts
@@ -19,6 +19,32 @@ const context = (sessionID: string) => ({
   async ask() {},
 })
 
+test.each(["\ufeff", "\ufeff" + "α".repeat(25_599) + "🧬ending"])(
+  "artifact read_file preserves BOM bytes and advances exact UTF-8 offsets",
+  async (content) => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await executionSession()
+        const tool = await ArtifactTool.init()
+        const source = path.join(await SessionFilesystem.workspace(session.id), "bom.txt")
+        await Bun.write(source, content)
+        const saved = await tool.execute({ action: "save_file", path: source }, context(session.id))
+        const handle = saved.metadata.savedArtifact as { id: string; versionID: string }
+        const args = { action: "read_file" as const, artifact_id: handle.id, version_id: handle.versionID }
+        const first = await tool.execute(args, context(session.id))
+        if (typeof first.metadata.nextOffset === "number") {
+          expect(first.metadata.nextOffset).toBeGreaterThan(0)
+          const second = await tool.execute({ ...args, offset: first.metadata.nextOffset }, context(session.id))
+          expect(first.output.split("\n\n[More content:")[0] + second.output).toBe(content)
+          expect(second.metadata.nextOffset).toBeUndefined()
+        } else expect(first.output).toBe(content)
+      },
+    })
+  },
+)
+
 test("artifact save_file promotes a workspace result into immutable versions", async () => {
   await using tmp = await tmpdir({ git: true })
   await Instance.provide({
@@ -65,6 +91,29 @@ test("artifact save_file promotes a workspace result into immutable versions", a
           meta: { artifactID: firstSaved.id, versionID: version.id, sessionID: session.id },
         })
       }
+    },
+  })
+})
+
+test("large artifact text returns metadata without repeatedly hashing or paging a dataset into context", async () => {
+  await using tmp = await tmpdir({ git: true })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const session = await executionSession()
+      const tool = await ArtifactTool.init()
+      const source = path.join(await SessionFilesystem.workspace(session.id), "large.txt")
+      await Bun.write(source, new Uint8Array(8 * 1024 * 1024 + 1).fill(65))
+      const saved = await tool.execute({ action: "save_file", path: source }, context(session.id))
+      const handle = saved.metadata.savedArtifact as { id: string; versionID: string }
+      const read = await tool.execute(
+        { action: "read_file", artifact_id: handle.id, version_id: handle.versionID },
+        context(session.id),
+      )
+      expect(read.metadata).toMatchObject({ readStatus: "metadata_only", size: 8 * 1024 * 1024 + 1 })
+      expect(read.metadata.nextOffset).toBeUndefined()
+      expect(read.output).toContain("has not verified or read the blob bytes")
+      expect(read.output.length).toBeLessThan(500)
     },
   })
 })

--- a/backend/cli/test/tool/bash-python-runtime.test.ts
+++ b/backend/cli/test/tool/bash-python-runtime.test.ts
@@ -4,6 +4,7 @@ import path from "node:path"
 import { BashTool } from "../../src/tool/bash"
 import { PythonTool } from "../../src/tool/notebook"
 import { Instance } from "../../src/project/instance"
+import { SessionFilesystem } from "../../src/session/filesystem"
 import { KernelEnvironmentMutation } from "../../src/science/kernel/environment-mutation"
 import { executionSession, tmpdir } from "../fixture/fixture"
 
@@ -40,6 +41,20 @@ test("Bash uses the kernel project package overlay without ambient import paths 
           ).execute({ command: `python3 -c '${code}'`, description: "Import approved project package" }, context)
           expect(result.metadata.exit, result.output).toBe(0)
           expect(result.output).toContain("approved-project-package")
+          expect(result.metadata.execution_environment).toEqual({
+            target: "local",
+            cwd: await SessionFilesystem.workspace(session.id),
+            profile: "python",
+            python: { role: "selected_default", executable: runtime.binary },
+          })
+          // Arbitrary shell commands receive a selected default, not a claim
+          // that Python ran or that its version was measured for this command.
+          const shell = await (
+            await BashTool.init()
+          ).execute({ command: "printf ordinary-shell", description: "Run a non-Python command" }, context)
+          expect(shell.metadata.exit, shell.output).toBe(0)
+          expect(shell.metadata.execution_environment).toEqual(result.metadata.execution_environment)
+          expect(shell.metadata.execution_environment.python?.version).toBeUndefined()
           // Kernels already support this package location; prove the repaired
           // shell agrees using the actual canonical Python tool too.
           const kernel = await (

--- a/backend/cli/test/tool/payload-integrity.test.ts
+++ b/backend/cli/test/tool/payload-integrity.test.ts
@@ -1,0 +1,191 @@
+import { expect, test } from "bun:test"
+import path from "node:path"
+import { WriteTool } from "../../src/tool/write"
+import { ReadTool } from "../../src/tool/read"
+import { EditTool } from "../../src/tool/edit"
+import { ApplyPatchTool } from "../../src/tool/apply_patch"
+import { PayloadIntegrity } from "../../src/tool/payload-integrity"
+import { MessageV2 } from "../../src/session/message-v2"
+import { Instance } from "../../src/project/instance"
+import { Session } from "../../src/session"
+import { Provider } from "../../src/provider/provider"
+import { FileTime } from "../../src/file/time"
+import type { Tool } from "../../src/tool/tool"
+import { tmpdir } from "../fixture/fixture"
+
+const content = `# Complete research plan\n${"Measure λ and 🧬 exactly, retaining every sample identifier.\n".repeat(40)}`
+const preview = PayloadIntegrity.legacyPreview(content)
+
+async function fixture(run: (context: Tool.Context, record: typeof history) => Promise<void>) {
+  await using tmp = await tmpdir({ config: { lsp: false, provider: { openai: { options: { apiKey: "test" } } } } })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const session = await Session.create({ title: "Payload integrity" })
+      try {
+        await run(
+          {
+            sessionID: session.id,
+            messageID: "current",
+            agent: "research",
+            abort: new AbortController().signal,
+            messages: [],
+            metadata: () => {},
+            ask: async () => {},
+          },
+          history,
+        )
+      } finally {
+        try {
+          await Session.remove(session.id)
+        } finally {
+          await Instance.dispose()
+        }
+      }
+    },
+  })
+}
+
+function history(
+  context: Tool.Context,
+  tool: string,
+  input: Record<string, unknown>,
+  result: { title: string; output: string; metadata: Record<string, unknown> },
+): MessageV2.WithParts {
+  const id = `history-${context.messages.length}`
+  return {
+    info: {
+      id,
+      sessionID: context.sessionID,
+      role: "assistant",
+      parentID: "user",
+      time: { created: 1, completed: 2 },
+      modelID: "gpt-4o",
+      providerID: "openai",
+      mode: "research",
+      agent: "research",
+      path: { cwd: Instance.directory, root: Instance.worktree },
+      cost: 0,
+      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    },
+    parts: [
+      {
+        id: `part-${id}`,
+        sessionID: context.sessionID,
+        messageID: id,
+        callID: `call-${id}`,
+        type: "tool",
+        tool,
+        state: { status: "completed", input, ...result, time: { start: 1, end: 2, compacted: 3 } },
+      },
+    ],
+  }
+}
+
+test("long write/read history stays exact, and copying its legacy preview cannot create or overwrite files", async () => {
+  await fixture(async (context, record) => {
+    const source = path.join(Instance.directory, "plan.md")
+    const writer = await WriteTool.init()
+    const args = { filePath: source, content }
+    context.messages.push(record(context, "write", args, await writer.execute(args, context)))
+    const reader = await ReadTool.init()
+    const read = await reader.execute({ filePath: source }, context)
+    expect(read.output).toContain("retaining every sample identifier")
+    context.messages.push(record(context, "read", { filePath: source }, read))
+
+    const model = await Provider.getModel("openai", "gpt-4o")
+    const rendered = JSON.stringify(MessageV2.toModelMessages(context.messages, model))
+    expect(rendered).toContain(JSON.stringify(content).slice(1, -1))
+    expect(rendered).not.toContain("…[+")
+    expect(context.messages[0].parts[0]).toMatchObject({ state: { input: args } })
+
+    const asks: string[] = []
+    context.ask = async (request) => {
+      asks.push(request.permission)
+    }
+    const destination = path.join(Instance.directory, "copied.md")
+    await expect(writer.execute({ filePath: destination, content: preview }, context)).rejects.toThrow(
+      "shortened historical argument",
+    )
+    expect(await Bun.file(destination).exists()).toBe(false)
+    await expect(writer.execute({ filePath: source, content: preview }, context)).rejects.toThrow("No action was taken")
+    expect(await Bun.file(source).text()).toBe(content)
+    expect(asks).toEqual([])
+  })
+})
+
+test("edit refuses an embedded legacy preview before changing a file", async () => {
+  await fixture(async (context, record) => {
+    const target = path.join(Instance.directory, "report.md")
+    const writer = await WriteTool.init()
+    const args = { filePath: target, content }
+    context.messages.push(record(context, "write", args, await writer.execute(args, context)))
+    const editor = await EditTool.init()
+    await expect(
+      editor.execute({ filePath: target, oldString: content, newString: `# Replacement\n${preview}\n` }, context),
+    ).rejects.toThrow("shortened historical argument")
+    expect(await Bun.file(target).text()).toBe(content)
+  })
+})
+
+test("patch refuses a copied preview before applying any file in the transaction", async () => {
+  await fixture(async (context, record) => {
+    context.messages.push(record(context, "write", { content }, { title: "source", output: "written", metadata: {} }))
+    const patch = [
+      "*** Begin Patch",
+      `*** Add File: ${path.join(Instance.directory, "valid.md")}`,
+      "+Complete content",
+      `*** Add File: ${path.join(Instance.directory, "shortened.md")}`,
+      ...preview.split("\n").map((line) => `+${line}`),
+      "*** End Patch",
+    ].join("\n")
+    await expect((await ApplyPatchTool.init()).execute({ patchText: patch }, context)).rejects.toThrow(
+      "shortened historical argument",
+    )
+    expect(await Bun.file(path.join(Instance.directory, "valid.md")).exists()).toBe(false)
+    expect(await Bun.file(path.join(Instance.directory, "shortened.md")).exists()).toBe(false)
+  })
+})
+
+test("literal marker documentation can be written, edited, and patched", async () => {
+  await fixture(async (context, record) => {
+    context.messages.push(record(context, "write", { content }, { title: "source", output: "written", metadata: {} }))
+    const target = path.join(Instance.directory, "markers.md")
+    const literal = "# Marker reference\n`…[+1988 chars]` is a literal example in this document.\n"
+    await (await WriteTool.init()).execute({ filePath: target, content: literal }, context)
+    expect(await Bun.file(target).text()).toBe(literal)
+    await (
+      await EditTool.init()
+    ).execute({ filePath: target, oldString: "literal example", newString: "documented literal example" }, context)
+    await (
+      await ApplyPatchTool.init()
+    ).execute(
+      {
+        patchText: `*** Begin Patch\n*** Update File: ${target}\n@@\n-# Marker reference\n+# Literal markers\n*** End Patch`,
+      },
+      context,
+    )
+    expect(await Bun.file(target).text()).toContain("`…[+1988 chars]` is a documented literal example")
+
+    // A document may already quote even an exact historical preview. Preserve
+    // that evidence while editing surrounding prose, including whole-file writes.
+    const quoted = `# Historical evidence\n${preview}\nExplanation.\n`
+    await Bun.write(target, quoted)
+    FileTime.read(context.sessionID, target)
+    await (
+      await WriteTool.init()
+    ).execute({ filePath: target, content: quoted.replace("Explanation", "Background") }, context)
+    await (
+      await EditTool.init()
+    ).execute({ filePath: target, oldString: "Background", newString: "Verified background" }, context)
+    await (
+      await ApplyPatchTool.init()
+    ).execute(
+      {
+        patchText: `*** Begin Patch\n*** Update File: ${target}\n@@\n-Verified background.\n+Verified context.\n*** End Patch`,
+      },
+      context,
+    )
+    expect(await Bun.file(target).text()).toBe(quoted.replace("Explanation", "Verified context"))
+  })
+})

--- a/backend/cli/test/tool/task-attempt-process.test.ts
+++ b/backend/cli/test/tool/task-attempt-process.test.ts
@@ -7,6 +7,7 @@ import { Session } from "../../src/session"
 import { MessageV2 } from "../../src/session/message-v2"
 import { SessionPrompt } from "../../src/session/prompt"
 import { TaskAttempt, TaskCapacity } from "../../src/tool/task-attempt"
+import { normalizeTaskAttemptInput } from "../../src/tool/task"
 import { LockCoordination } from "../../src/util/lock-coordination"
 import { tmpdir, trustProject } from "../fixture/fixture"
 import { spawn } from "../fixture/spawn"
@@ -122,7 +123,7 @@ async function result(proc: ReturnType<typeof worker>) {
   return JSON.parse(line) as Result
 }
 
-async function seed(directory: string, options?: { eagerParentPlaceholder?: boolean }): Promise<Seed> {
+async function seed(directory: string, options?: { eagerParentPlaceholder?: boolean; prompt?: string }): Promise<Seed> {
   return Instance.provide({
     directory,
     init: async () => {
@@ -167,7 +168,7 @@ async function seed(directory: string, options?: { eagerParentPlaceholder?: bool
           status: "running",
           input: {
             description: "Durable restart fixture",
-            prompt: "Return the deterministic child result.",
+            prompt: options?.prompt ?? "Return the deterministic child result.",
             subagent_type: "execute",
             ...(options?.eagerParentPlaceholder ? { session_id: parent.id } : {}),
           },
@@ -504,7 +505,7 @@ describe("durable Task attempts across Bun processes", () => {
     }
   }, 30_000)
 
-  test("restores a durable child result into an ordinary running Task call after restart", async () => {
+  test("restores a durable Task result despite later sibling evidence matching its literal marker", async () => {
     const local = provider()
     const processes = new Set<ReturnType<typeof parent>>()
     try {
@@ -512,7 +513,9 @@ describe("durable Task attempts across Bun processes", () => {
         git: true,
         config: stressProviderConfig(`http://127.0.0.1:${local.server.port}/v1`),
       })
-      const input = await seed(tmp.path)
+      const original = "Document the retained literal example. ".repeat(30)
+      const prompt = original.slice(0, 200) + `…[+${original.length - 200} chars]`
+      const input = await seed(tmp.path, { prompt })
       await Instance.provide({
         directory: tmp.path,
         fn: async () => {
@@ -525,7 +528,7 @@ describe("durable Task attempts across Bun processes", () => {
           }
           const params = {
             description: "Durable restart fixture",
-            prompt: "Return the deterministic child result.",
+            prompt,
             subagent_type: "execute" as const,
           }
           await TaskAttempt.reserve({ ...identity, fingerprint: TaskAttempt.fingerprint(params) })
@@ -537,6 +540,30 @@ describe("durable Task attempts across Bun processes", () => {
               output: "DURABLE_ORDINARY_CHILD_RESULT",
             },
           })
+          // This sibling was not in the Task's execution-visible history.
+          // A new admission now rejects the preview; recovery must still use
+          // the already committed result after checking its exact fingerprint.
+          await Session.updatePart({
+            id: `prt_${crypto.randomUUID().replaceAll("-", "").slice(0, 26)}`,
+            sessionID: input.parentID,
+            messageID: input.messageID,
+            callID: "call_later_sibling",
+            type: "tool",
+            tool: "write",
+            state: {
+              status: "completed",
+              input: { content: original },
+              title: "Later sibling",
+              output: "Saved full content",
+              metadata: {},
+              time: { start: Date.now(), end: Date.now() },
+            },
+          })
+          await Session.flushPendingParts(input.parentID)
+          const later = await Session.messages({ sessionID: input.parentID })
+          expect(() => normalizeTaskAttemptInput(params, input.parentID, later)).toThrow(
+            "shortened historical argument",
+          )
         },
       })
       const ready = path.join(tmp.path, "ordinary-recovery.ready")

--- a/backend/cli/test/tool/task-evidence.test.ts
+++ b/backend/cli/test/tool/task-evidence.test.ts
@@ -1,0 +1,78 @@
+import { expect, test } from "bun:test"
+import path from "node:path"
+import { ArtifactStore } from "../../src/artifact/store"
+import { Instance } from "../../src/project/instance"
+import { Session } from "../../src/session"
+import { SessionFilesystem } from "../../src/session/filesystem"
+import { ArtifactTool } from "../../src/tool/artifact"
+import { TaskEvidence } from "../../src/tool/task-evidence"
+import type { MessageV2 } from "../../src/session/message-v2"
+import { tmpdir } from "../fixture/fixture"
+
+test("Task hands back only this turn's immutable child outputs, readable by the parent without scratch access", async () => {
+  await using tmp = await tmpdir({ git: true })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const parent = await Session.create({})
+      const child = await Session.create({ parentID: parent.id })
+      const ctx = {
+        sessionID: child.id,
+        messageID: "msg_old",
+        agent: "research",
+        abort: new AbortController().signal,
+        messages: [],
+        metadata() {},
+        async ask() {},
+      }
+      const source = path.join(await SessionFilesystem.workspace(child.id), "report.md")
+      const content = "α".repeat(25_599) + "🧬" + "important final evidence".repeat(500)
+      await Bun.write(source, "old report")
+      const tool = await ArtifactTool.init()
+      await tool.execute({ action: "save_file", path: source }, ctx)
+      await Bun.write(source, content)
+      await tool.execute({ action: "save_file", path: source }, { ...ctx, messageID: "msg_new" })
+      await Bun.write(source, "later mutable scratch must not change handoff")
+      const msg = (id: string): MessageV2.WithParts => ({
+        info: {
+          id,
+          sessionID: child.id,
+          role: "user",
+          agent: "research",
+          effort: "normal",
+          model: { providerID: "fixture", modelID: "offline" },
+          time: { created: 1 },
+        },
+        parts: [],
+      })
+      const evidence = await TaskEvidence.collect({
+        projectID: Instance.project.id,
+        sessionID: child.id,
+        messages: [msg("msg_old"), msg("msg_new")],
+        previous: new Set(["msg_old"]),
+      })
+      expect(evidence.artifacts).toHaveLength(1)
+      const artifact = evidence.artifacts[0]
+      expect(TaskEvidence.describe(evidence)).toContain(artifact.versionID)
+      await expect(
+        SessionFilesystem.authorize({ sessionID: parent.id, path: source, access: "read" }),
+      ).rejects.toBeInstanceOf(SessionFilesystem.DeniedError)
+      const params = { action: "read_file" as const, artifact_id: artifact.artifactID, version_id: artifact.versionID }
+      const read = await tool.execute(params, { ...ctx, sessionID: parent.id })
+      expect(read.metadata.sha256).toBe(artifact.sha256)
+      expect(read.metadata.nextOffset).toBe(51_198)
+      const rest = await tool.execute(
+        { ...params, offset: read.metadata.nextOffset as number },
+        { ...ctx, sessionID: parent.id },
+      )
+      expect(read.output.split("\n\n[More content:")[0] + rest.output).toBe(content)
+      await expect(tool.execute({ ...params, version_id: "foreign-version" }, ctx)).rejects.toThrow("unavailable")
+      await expect(tool.execute({ action: "read_file", artifact_id: artifact.artifactID }, ctx)).rejects.toThrow(
+        "invalid arguments",
+      )
+      expect(await ArtifactStore.read("another-project", artifact.artifactID, artifact.versionID)).toBeUndefined()
+      await Session.remove(child.id)
+      await Session.remove(parent.id)
+    },
+  })
+})

--- a/backend/cli/test/tool/task-outcome-recovery.test.ts
+++ b/backend/cli/test/tool/task-outcome-recovery.test.ts
@@ -4,7 +4,7 @@ import { Instance } from "../../src/project/instance"
 import { Session } from "../../src/session"
 import type { MessageV2 } from "../../src/session/message-v2"
 import { TaskAttempt } from "../../src/tool/task-attempt"
-import { TaskTool } from "../../src/tool/task"
+import { normalizeTaskAttemptInput, TaskTool } from "../../src/tool/task"
 import { tmpdir } from "../fixture/fixture"
 
 const report =
@@ -15,6 +15,8 @@ async function retained(input: {
   stopReason?: string
   finish?: string
   error?: MessageV2.Assistant["error"]
+  narrationOnly?: boolean
+  literalReplay?: boolean
 }) {
   await using tmp = await tmpdir({ git: true })
   return await Instance.provide({
@@ -25,9 +27,12 @@ async function retained(input: {
       const userID = Identifier.ascending("message")
       const messageID = Identifier.ascending("message")
       const callID = `call_${crypto.randomUUID()}`
+      const original = "Document this historical literal example. ".repeat(30)
       const params = {
         description: "Review retained sources",
-        prompt: "Return the source comparison.",
+        prompt: input.literalReplay
+          ? original.slice(0, 200) + `…[+${original.length - 200} chars]`
+          : "Return the source comparison.",
         subagent_type: "explore" as const,
       }
       const model = { providerID: "offline-fixture", modelID: "no-provider-called" }
@@ -153,6 +158,22 @@ async function retained(input: {
         text: report,
         time: { start: 8, end: 9 },
       })
+      if (input.narrationOnly) {
+        await Session.updatePart({
+          ...tools[1],
+          id: Identifier.ascending("part"),
+          messageID: finalID,
+          callID: "call_after_narration",
+        })
+        await Session.updateMessage({
+          ...base,
+          id: Identifier.ascending("message"),
+          sessionID: child.id,
+          parentID: attempt.childMessageID,
+          finish: "stop",
+          time: { created: 10, completed: 11 },
+        })
+      }
       await Session.flushPendingParts(child.id)
       const before = await Session.messages({ sessionID: child.id })
       try {
@@ -163,7 +184,7 @@ async function retained(input: {
           callID,
           agent: "research",
           abort: new AbortController().signal,
-          messages: [],
+          messages: [] as MessageV2.WithParts[],
           metadata: () => {},
           ask: async () => {},
           extra: { effort: "normal", bypassAgentCheck: true },
@@ -171,8 +192,37 @@ async function retained(input: {
         const result = await task.execute(params, ctx)
         expect(await Session.messages({ sessionID: child.id })).toEqual(before)
         expect((await TaskAttempt.read(identity))?.previousMessageIDs).toEqual(previous)
+        if (input.literalReplay) {
+          ctx.messages.push({
+            info: { ...base, id: messageID, sessionID: parent.id, parentID: userID, time: { created: 2 } },
+            parts: [
+              {
+                ...tools[0],
+                sessionID: parent.id,
+                messageID,
+                tool: "write",
+                state: {
+                  status: "completed",
+                  input: { content: original },
+                  title: "Later sibling",
+                  output: "Saved",
+                  metadata: {},
+                  time: { start: 10, end: 11 },
+                },
+              },
+            ],
+          })
+          expect(() => normalizeTaskAttemptInput(params, parent.id, ctx.messages)).toThrow(
+            "shortened historical argument",
+          )
+        }
         const repeated = await task.execute(params, ctx)
         expect(repeated).toEqual(result)
+        if (input.literalReplay) {
+          await expect(task.execute({ ...params, prompt: "Changed assignment" }, ctx)).rejects.toThrow(
+            "changed arguments",
+          )
+        }
         expect(await Session.messages({ sessionID: child.id })).toEqual(before)
         return { result, tools }
       } finally {
@@ -234,4 +284,16 @@ test("provider failures preserve partial handoff text without claiming normal co
 test("recovering a first child turn preserves its empty baseline and final handoff", async () => {
   const { result } = await retained({ emptyBaseline: true })
   expect(result.metadata).toMatchObject({ handoff: report, outcome: "completed", failedToolCalls: 1 })
+})
+
+test("direct replay of a completed Task ignores later sibling preview evidence after verifying its fingerprint", async () => {
+  const { result } = await retained({ literalReplay: true })
+  expect(result.metadata).toMatchObject({ handoff: report, outcome: "completed" })
+})
+
+test("durable recovery marks pre-tool narration incomplete instead of returning it as final findings", async () => {
+  const { result } = await retained({ narrationOnly: true })
+  expect(result.metadata).toMatchObject({ outcome: "partial", stopReason: "empty_handoff" })
+  expect(result.output).toContain("ended without a textual handoff")
+  expect(result.output).not.toContain(report)
 })

--- a/backend/cli/test/tool/task-profiles.test.ts
+++ b/backend/cli/test/tool/task-profiles.test.ts
@@ -315,13 +315,14 @@ test("Task handoffs return the child's final answer, written after its last tool
   )
 })
 
-test("Task handoffs fall back to the last message that said anything", () => {
+test("Task handoffs never promote pre-tool narration or an earlier message to final findings", () => {
   const trailing = handoffMessage("msg_tool_only", 30, [{ id: "prt_last_tool", tool: true }])
   const spoke = handoffMessage("msg_spoke", 20, [
     { id: "prt_note", text: "partial note before a final check" },
     { id: "prt_check", tool: true },
   ])
-  expect(taskText([trailing, spoke], new Set())).toBe("partial note before a final check")
+  expect(taskText([trailing, spoke], new Set())).toBe("")
+  expect(taskText([spoke], new Set())).toBe("")
   expect(taskText([trailing], new Set())).toBe("")
   expect(taskText([spoke, trailing], new Set(["msg_spoke"]))).toBe("")
 })
@@ -391,8 +392,12 @@ test("Task outcomes distinguish bounded partial work from completion and failure
   })
 })
 
-test("Task preserves byte-exact long assignments and rejects internal compaction markers", () => {
+test("Task preserves exact assignments, rejects known shortened history, and allows literal marker documentation", () => {
   const prompt = `Collect these exact identifiers and destinations without guessing:\n${"🧬ßλ".repeat(1_000)}`
+  const source = handoffMessage("msg_full_assignment", 1, [{ id: "prt_source", tool: true }])
+  const part = source.parts[0]
+  if (part.type !== "tool") throw new Error("Expected historical tool input")
+  part.state.input = { content: prompt }
   const normalized = normalizeTaskAttemptInput(
     { description: "Collect exact papers", prompt, subagent_type: "explore" },
     "ses_parent",
@@ -402,12 +407,21 @@ test("Task preserves byte-exact long assignments and rejects internal compaction
     normalizeTaskAttemptInput(
       {
         description: "Collect exact papers",
-        prompt: `${prompt.slice(0, 200)}…[+1712 chars]`,
+        prompt: `${prompt.slice(0, 200)}…[+${prompt.length - 200} chars]`,
         subagent_type: "explore",
       },
       "ses_parent",
+      [source],
     ),
-  ).toThrow("No child was started")
+  ).toThrow("No action was taken")
+  const literal = "Document the literal marker `…[+1712 chars]` and explain why it is not file content."
+  expect(
+    normalizeTaskAttemptInput(
+      { description: "Explain marker syntax", prompt: literal, subagent_type: "explore" },
+      "ses_parent",
+      [source],
+    ).prompt,
+  ).toBe(literal)
 })
 
 test("Task classifies every placeholder, empty and self-referential session id as a new child", () => {

--- a/docs/notes/harness-handoffs.md
+++ b/docs/notes/harness-handoffs.md
@@ -1,0 +1,60 @@
+# Harness handoff boundaries
+
+The server owns execution and durable records. Clients render those records;
+they do not reconstruct executable inputs from presentation summaries. This
+keeps the same behavior available to the desktop, CLI, SDK and future plugins.
+
+This follows the useful boundaries in OpenCode's implementation, inspected at
+`d6855b6b47a8433462ac6aeeba882ccf734cb7f1`: preserve tool inputs while pruning
+outputs, keep a durable child identity, and resolve tools at the model boundary.
+OpenScience retains its stricter project, child-session and filesystem checks.
+
+## Arguments and outputs
+
+`MessageV2.compactToolInput` retains authoritative arguments byte for byte.
+Compaction summarizes old outputs separately. Write, Edit, ApplyPatch and Task
+reject copies of an identifiable legacy shortened argument before mutation or
+child dispatch. The check reconstructs a known preview from retained history;
+it does not guess that every literal ellipsis is damaged data. Existing literal
+examples in files remain editable. An intentional new quotation of an exact
+known shortened argument is conservatively rejected; recover its full source.
+
+## Worker completion and evidence
+
+The latest assistant message's text after its last tool call is the handoff.
+Earlier progress is not a substitute for missing final findings. Step limits,
+provider errors, partial operations and missing handoffs keep explicit outcomes.
+The durable Task attempt stores the result; restart recovery compares its
+canonical fingerprint before returning it, without rerunning completed work.
+
+Task evidence comes from recorded operations and ArtifactStore versions, not
+from parsing the worker's claims. The parent receives artifact/version IDs,
+hashes, sizes and references to shell receipts. Exit zero refers to the outer
+process; scientific validity and nested test success need separate evidence.
+This is an evidence handoff, not a mandatory model-generated report schema or
+a new verifier loop.
+
+Workers explicitly save important outputs with `artifact.save_file`. The lead
+uses `artifact.read_file` with exact IDs to read immutable versions within the
+same project. This does not grant access to the child's scratch directory or
+copy an entire workspace. Text windows preserve UTF-8 byte boundaries. Reads
+verify the stored blob hash; files over the 8 MiB inline limit return clearly
+labeled metadata and use the existing Files/API retrieval path. No automatic
+publication or artifact-store capacity bypass is added.
+
+## Environment and tool identity
+
+Local compute chooses its Python runtime once for both execution and receipt
+generation. Shell receipts distinguish a selected default from a measured
+version. An explicit interpreter in a command can override that default.
+On Windows, `python` selects this default; an independently installed `python3`
+or an absolute executable path can select another interpreter.
+Remote source capture is labeled as submitter metadata; unmeasured remote
+environment details remain unknown. Exact scientific capability runtimes keep
+their separate attestation and admission path.
+
+The LLM boundary records the actual advertised tool definitions using the
+existing harness trace. A change in tool names produces a compact added/removed
+notice in the next request. The initial request does not duplicate the tool
+catalog in prose. Permission checks still run at execution time; a notice
+cannot grant authority.

--- a/frontend/docs/src/content/openscience/agents.mdx
+++ b/frontend/docs/src/content/openscience/agents.mdx
@@ -57,6 +57,17 @@ keep their earlier conversation, while the heading identifies their active assig
 Stopping the lead also cancels its active delegated work, including workers preparing
 to start. A stopped task's saved files and recorded tool results remain available.
 
+Saved worker Results carry immutable artifact and version IDs back to the lead.
+The lead can read these versions without access to the worker's private scratch.
+Only the latest assistant message's text after its final tool call counts as the
+handoff; earlier progress text cannot make an unfinished worker look complete.
+An empty handoff remains incomplete, even if the worker saved files.
+
+Handoffs retain command receipt references and failures. A shell exit of zero
+describes the outer process; it does not establish that nested tests passed or
+that a scientific conclusion is valid. Those claims still need their actual
+test or evaluation evidence.
+
 The **Show reasoning and activity** control stays available during execution. Some
 providers return tool activity without readable reasoning; OpenScience indicates that
 state rather than presenting missing reasoning as an empty trace. A compute submission

--- a/frontend/docs/src/content/openscience/built-in-tools.mdx
+++ b/frontend/docs/src/content/openscience/built-in-tools.mdx
@@ -73,6 +73,23 @@ OpenScience can track work, ask questions, delegate a bounded task, load a skill
 | Load a procedure | Select a [skill](/openscience/skills) and describe its task. |
 | Generate or edit an image | Use the [image tool](/openscience/image-generation) with an output path. |
 | Retain a file | Ask to save the verified output as a [Result](/openscience/results). |
+
+For programmatic workflows, `artifact` supports `save_file` with a workspace
+`path`, and `read_file` with an exact `artifact_id` and `version_id`. Reading a
+version verifies its stored hash and stays within the current project. Text is
+returned in bounded windows with a byte offset for continuation; binary Results
+and files above the 8 MiB inline limit remain available through Files and the
+artifact API. Large-file responses explicitly contain stored metadata only.
+Saving a file captures its
+bytes; it does not by itself verify the file's scientific claims.
+
+Historical tool inputs retain their complete arguments when older outputs are
+compacted. A copied legacy `…[+N chars]` argument preview is rejected before a file
+mutation when its source can be identified. Literal examples already in a file
+remain editable. Recover the original source before using a shortened preview as
+input. When the model or permissions change the advertised tool set, the next
+model request receives a compact added/removed notice; permissions still apply at
+execution time.
 | Keep sources and evidence | Ask for a source list and claim-level evidence in the research deliverables. |
 
 Optional language-service or batch operations can appear in configurations that enable them. External MCP servers, plugins, and project tools add their own operations; inspect their documentation and availability before relying on them.

--- a/frontend/docs/src/content/openscience/compute.mdx
+++ b/frontend/docs/src/content/openscience/compute.mdx
@@ -11,6 +11,15 @@ Open **Customize → Compute** and check the Python and R starter setup. If eith
 
 The Python starter includes common analysis libraries such as NumPy, pandas, SciPy, and Matplotlib. The R starter includes tidyverse, ggplot2, and jsonlite. Additional tools may need a separate installation or account.
 
+Shell and local compute receipts identify the selected default Python separately
+from any measured version. A command can explicitly choose another interpreter,
+so this default is not proof of which Python an arbitrary shell command used.
+On Windows, `python` selects this default; an independently installed `python3`
+or an absolute executable path can select another interpreter.
+Local compute using the default Python measures that binary in the admitted execution environment.
+Remote submissions label local source metadata as belonging to the submitter;
+an unmeasured remote interpreter is left unknown.
+
 Try a small task first:
 
 ```text

--- a/frontend/docs/src/content/openscience/compute.mdx
+++ b/frontend/docs/src/content/openscience/compute.mdx
@@ -20,6 +20,10 @@ Local compute using the default Python measures that binary in the admitted exec
 Remote submissions label local source metadata as belonging to the submitter;
 an unmeasured remote interpreter is left unknown.
 
+Local compute on Windows requires Git Bash. If discovery fails, install Git for
+Windows or set `OPENSCIENCE_GIT_BASH_PATH` to its installed `bash.exe`. OpenScience
+reports a missing or incompatible shell before dispatching a POSIX job script.
+
 Try a small task first:
 
 ```text

--- a/tooling/sdk/js/src/v2/gen/types.gen.ts
+++ b/tooling/sdk/js/src/v2/gen/types.gen.ts
@@ -4769,6 +4769,20 @@ export type SettingsComputeJobsListResponses = {
       bun: string
       node: string
       python?: string
+      capture_scope?: "execution_host" | "submitter"
+      execution_environment?: {
+        target: "local" | "ssh" | "modal"
+        cwd?: string
+        profile?: string
+        /**
+         * Selected runtime, not proof that arbitrary shell code used Python. Missing fields were not measured.
+         */
+        python?: {
+          role: "selected_default" | "capability"
+          executable?: string
+          version?: string
+        }
+      }
       git?: {
         repository?: string
         branch?: string
@@ -5573,6 +5587,20 @@ export type SettingsComputeJobsStartResponses = {
       bun: string
       node: string
       python?: string
+      capture_scope?: "execution_host" | "submitter"
+      execution_environment?: {
+        target: "local" | "ssh" | "modal"
+        cwd?: string
+        profile?: string
+        /**
+         * Selected runtime, not proof that arbitrary shell code used Python. Missing fields were not measured.
+         */
+        python?: {
+          role: "selected_default" | "capability"
+          executable?: string
+          version?: string
+        }
+      }
       git?: {
         repository?: string
         branch?: string
@@ -6586,6 +6614,20 @@ export type SettingsComputeJobsRetryResponses = {
       bun: string
       node: string
       python?: string
+      capture_scope?: "execution_host" | "submitter"
+      execution_environment?: {
+        target: "local" | "ssh" | "modal"
+        cwd?: string
+        profile?: string
+        /**
+         * Selected runtime, not proof that arbitrary shell code used Python. Missing fields were not measured.
+         */
+        python?: {
+          role: "selected_default" | "capability"
+          executable?: string
+          version?: string
+        }
+      }
       git?: {
         repository?: string
         branch?: string
@@ -7345,6 +7387,20 @@ export type SettingsComputeJobsReleaseResponses = {
       bun: string
       node: string
       python?: string
+      capture_scope?: "execution_host" | "submitter"
+      execution_environment?: {
+        target: "local" | "ssh" | "modal"
+        cwd?: string
+        profile?: string
+        /**
+         * Selected runtime, not proof that arbitrary shell code used Python. Missing fields were not measured.
+         */
+        python?: {
+          role: "selected_default" | "capability"
+          executable?: string
+          version?: string
+        }
+      }
       git?: {
         repository?: string
         branch?: string
@@ -8100,6 +8156,20 @@ export type SettingsComputeJobsCancelResponses = {
       bun: string
       node: string
       python?: string
+      capture_scope?: "execution_host" | "submitter"
+      execution_environment?: {
+        target: "local" | "ssh" | "modal"
+        cwd?: string
+        profile?: string
+        /**
+         * Selected runtime, not proof that arbitrary shell code used Python. Missing fields were not measured.
+         */
+        python?: {
+          role: "selected_default" | "capability"
+          executable?: string
+          version?: string
+        }
+      }
       git?: {
         repository?: string
         branch?: string

--- a/tooling/sdk/openapi.json
+++ b/tooling/sdk/openapi.json
@@ -7208,6 +7208,57 @@
                           "python": {
                             "type": "string"
                           },
+                          "capture_scope": {
+                            "type": "string",
+                            "enum": [
+                              "execution_host",
+                              "submitter"
+                            ]
+                          },
+                          "execution_environment": {
+                            "type": "object",
+                            "properties": {
+                              "target": {
+                                "type": "string",
+                                "enum": [
+                                  "local",
+                                  "ssh",
+                                  "modal"
+                                ]
+                              },
+                              "cwd": {
+                                "type": "string"
+                              },
+                              "profile": {
+                                "type": "string"
+                              },
+                              "python": {
+                                "description": "Selected runtime, not proof that arbitrary shell code used Python. Missing fields were not measured.",
+                                "type": "object",
+                                "properties": {
+                                  "role": {
+                                    "type": "string",
+                                    "enum": [
+                                      "selected_default",
+                                      "capability"
+                                    ]
+                                  },
+                                  "executable": {
+                                    "type": "string"
+                                  },
+                                  "version": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "role"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "target"
+                            ]
+                          },
                           "git": {
                             "type": "object",
                             "properties": {
@@ -9796,6 +9847,57 @@
                         },
                         "python": {
                           "type": "string"
+                        },
+                        "capture_scope": {
+                          "type": "string",
+                          "enum": [
+                            "execution_host",
+                            "submitter"
+                          ]
+                        },
+                        "execution_environment": {
+                          "type": "object",
+                          "properties": {
+                            "target": {
+                              "type": "string",
+                              "enum": [
+                                "local",
+                                "ssh",
+                                "modal"
+                              ]
+                            },
+                            "cwd": {
+                              "type": "string"
+                            },
+                            "profile": {
+                              "type": "string"
+                            },
+                            "python": {
+                              "description": "Selected runtime, not proof that arbitrary shell code used Python. Missing fields were not measured.",
+                              "type": "object",
+                              "properties": {
+                                "role": {
+                                  "type": "string",
+                                  "enum": [
+                                    "selected_default",
+                                    "capability"
+                                  ]
+                                },
+                                "executable": {
+                                  "type": "string"
+                                },
+                                "version": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "role"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "target"
+                          ]
                         },
                         "git": {
                           "type": "object",
@@ -13538,6 +13640,57 @@
                         "python": {
                           "type": "string"
                         },
+                        "capture_scope": {
+                          "type": "string",
+                          "enum": [
+                            "execution_host",
+                            "submitter"
+                          ]
+                        },
+                        "execution_environment": {
+                          "type": "object",
+                          "properties": {
+                            "target": {
+                              "type": "string",
+                              "enum": [
+                                "local",
+                                "ssh",
+                                "modal"
+                              ]
+                            },
+                            "cwd": {
+                              "type": "string"
+                            },
+                            "profile": {
+                              "type": "string"
+                            },
+                            "python": {
+                              "description": "Selected runtime, not proof that arbitrary shell code used Python. Missing fields were not measured.",
+                              "type": "object",
+                              "properties": {
+                                "role": {
+                                  "type": "string",
+                                  "enum": [
+                                    "selected_default",
+                                    "capability"
+                                  ]
+                                },
+                                "executable": {
+                                  "type": "string"
+                                },
+                                "version": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "role"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "target"
+                          ]
+                        },
                         "git": {
                           "type": "object",
                           "properties": {
@@ -16156,6 +16309,57 @@
                         "python": {
                           "type": "string"
                         },
+                        "capture_scope": {
+                          "type": "string",
+                          "enum": [
+                            "execution_host",
+                            "submitter"
+                          ]
+                        },
+                        "execution_environment": {
+                          "type": "object",
+                          "properties": {
+                            "target": {
+                              "type": "string",
+                              "enum": [
+                                "local",
+                                "ssh",
+                                "modal"
+                              ]
+                            },
+                            "cwd": {
+                              "type": "string"
+                            },
+                            "profile": {
+                              "type": "string"
+                            },
+                            "python": {
+                              "description": "Selected runtime, not proof that arbitrary shell code used Python. Missing fields were not measured.",
+                              "type": "object",
+                              "properties": {
+                                "role": {
+                                  "type": "string",
+                                  "enum": [
+                                    "selected_default",
+                                    "capability"
+                                  ]
+                                },
+                                "executable": {
+                                  "type": "string"
+                                },
+                                "version": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "role"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "target"
+                          ]
+                        },
                         "git": {
                           "type": "object",
                           "properties": {
@@ -18773,6 +18977,57 @@
                         },
                         "python": {
                           "type": "string"
+                        },
+                        "capture_scope": {
+                          "type": "string",
+                          "enum": [
+                            "execution_host",
+                            "submitter"
+                          ]
+                        },
+                        "execution_environment": {
+                          "type": "object",
+                          "properties": {
+                            "target": {
+                              "type": "string",
+                              "enum": [
+                                "local",
+                                "ssh",
+                                "modal"
+                              ]
+                            },
+                            "cwd": {
+                              "type": "string"
+                            },
+                            "profile": {
+                              "type": "string"
+                            },
+                            "python": {
+                              "description": "Selected runtime, not proof that arbitrary shell code used Python. Missing fields were not measured.",
+                              "type": "object",
+                              "properties": {
+                                "role": {
+                                  "type": "string",
+                                  "enum": [
+                                    "selected_default",
+                                    "capability"
+                                  ]
+                                },
+                                "executable": {
+                                  "type": "string"
+                                },
+                                "version": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "role"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "target"
+                          ]
                         },
                         "git": {
                           "type": "object",


### PR DESCRIPTION
Workers could return progress as final findings, carry shortened historical arguments into new operations, or describe a different Python from the one selected for execution. This change preserves authoritative tool inputs and gives Task handoffs explicit outcomes, recorded execution references, and immutable saved-output handles. Leads can read exact artifact versions without opening child scratch directories.

Local shell and compute launchers retain the selected virtualenv and label measured versus configured runtime identity. Exact scientific capability runtimes keep their existing attestation path. Windows compute discovers Git Bash across installation layouts and rejects incompatible shells before dispatch; runtime regressions require files written by the workload instead of trusting a zero exit or parsing combined logs as JSON. Windows compute captures shell and native output through one append writer, with backpressure, flush-before-completion, and explicit failure cleanup. The watchdog fixture waits for durable partial text before inducing a stall. Tool availability changes are explained at the actual provider boundary using existing durable harness snapshots.

Validation: regression coverage for payload integrity and literal-marker edits, empty and durable/replayed handoffs, project-scoped artifact reads with UTF-8/BOM pagination, real virtualenv and different-interpreter execution, and model/tool switches through captured local provider requests. SDK regenerated with additive optional fields; SDK/docs checks passed. Native macOS and Windows CI now run the local Python runtime regression. Full CI, browser E2E, and the exact-source packaged release rehearsal are required before publication.

Design and limits are documented in docs/notes/harness-handoffs.md. No version bump is included; publication remains owned by the release workflow.
