### PR TITLE
fix: preserve chat scrolling during background refreshes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ tagged release also ships native binaries for Linux, macOS, and Windows.
 
 ### Changed
 
+- Keep the conversation mounted while checking output files or refreshing compute
+  status, so sending a message cannot reset the chat to the top. Sending and
+  **Jump to Latest** follow the latest response; incoming activity preserves the
+  reader's position in earlier messages.
+- Resolve output receipts by their exact absolute path within the active session's
+  authorized files, including session scratch, without falling back to another
+  file with the same name.
 - Preserve complete historical tool arguments during output compaction and reject
   copied legacy argument previews before file mutations. Retain Task outcomes and
   immutable output handles during compaction; earlier progress text no longer

--- a/backend/cli/src/file/index.ts
+++ b/backend/cli/src/file/index.ts
@@ -1122,18 +1122,22 @@ export namespace File {
   }
 
   /**
-   * Resolve a chat-authored relative file reference across the exact roots the
-   * active session may read. Managed projects intentionally keep their durable
-   * directory separate from user-connected source folders, so joining every
+   * Resolve a chat-authored relative reference or an exact absolute receipt
+   * across the roots the active session may read. Managed projects keep their
+   * durable directory separate from user-connected source folders, so joining every
    * relative link to Instance.directory alone cannot open those source files.
    *
-   * Explicit relative paths are checked directly. A bare filename gets a
-   * bounded recursive lookup. Both modes fail closed when multiple authorized
+   * Absolute receipts never fall back to a different file. Relative paths are
+   * checked directly; a bare filename gets a bounded recursive lookup.
+   * Relative lookups fail closed when multiple authorized
    * files match, and the eventual read still re-authorizes the returned path so
    * revocation wins between resolution and I/O.
    */
   export async function resolveReference(reference: string, options: { sessionID: string }) {
-    const requested = relativeReference(reference)
+    const input = reference.trim()
+    if (!input || input.length > 4_096 || input.includes("\0")) return
+    const absolute = path.isAbsolute(input)
+    const requested = absolute ? input : relativeReference(input)
     if (!requested) return
 
     // Preview is brokered I/O, not a native process. Exact session-owned tool
@@ -1166,6 +1170,11 @@ export namespace File {
       if (!regular) return
       if (!(await SessionFilesystem.allows({ sessionID: options.sessionID, path: canonical, access: "read" }))) return
       matches.add(canonical)
+    }
+
+    if (absolute) {
+      for (const root of roots) await add(requested, root.path)
+      return matches.size === 1 ? matches.values().next().value : undefined
     }
 
     const nested = requested.includes("/")

--- a/backend/cli/src/server/routes/file.ts
+++ b/backend/cli/src/server/routes/file.ts
@@ -257,7 +257,7 @@ export const FileRoutes = lazy(() =>
       describeRoute({
         summary: "Resolve a session file reference",
         description:
-          "Resolve an unambiguous relative file reference across project, session, and connected roots authorized for the active session.",
+          "Resolve an exact absolute file receipt or an unambiguous relative reference across project, session, and connected roots authorized for the active session. Absolute paths never fall back to a filename search.",
         operationId: "file.resolveReference",
         responses: {
           200: {

--- a/backend/cli/test/session/filesystem-grants.test.ts
+++ b/backend/cli/test/session/filesystem-grants.test.ts
@@ -1088,6 +1088,52 @@ describe("session filesystem grants", () => {
 })
 
 describe("file access uses session grants", () => {
+  test("resolves exact canonical output receipts without crossing session authority", async () => {
+    await using external = await tmpdir({ init: (directory) => Bun.write(path.join(directory, "secret.json"), "{}") })
+    await using tmp = await tmpdir()
+    await withSession(tmp.path, async (session) => {
+      const sibling = await Session.create({ parentID: session.id })
+      await using cleanup = { [Symbol.asyncDispose]: () => Session.remove(sibling.id) }
+      const scratch = await SessionFilesystem.workspace(session.id)
+      const siblingScratch = await SessionFilesystem.workspace(sibling.id)
+      const projectFile = path.join(tmp.path, "result.json")
+      const scratchFile = path.join(scratch, "result.json")
+      const siblingFile = path.join(siblingScratch, "private.json")
+      const recoveryFile = path.join(tmp.path, ".openscience-trash", "hidden.json")
+      await Promise.all([projectFile, scratchFile, siblingFile, recoveryFile].map((target) => Bun.write(target, "{}")))
+      await fs.symlink(external.path, path.join(tmp.path, "linked"), process.platform === "win32" ? "junction" : "dir")
+      const grants = await SessionFilesystem.list(session.id)
+      const resolve = async (target: string, sessionID = session.id) => {
+        const response = await FileRoutes().request(`/file/resolve?${new URLSearchParams({ path: target, sessionID })}`)
+        expect(response.status).toBe(200)
+        return response.json()
+      }
+      for (const target of [projectFile, scratchFile]) {
+        expect(await resolve(target)).toEqual({ path: target, writable: true, scope: "session" })
+        const content = await FileRoutes().request(
+          `/file/content?${new URLSearchParams({ path: target, sessionID: session.id })}`,
+        )
+        expect(content.status).toBe(200)
+        expect(await content.json()).toMatchObject({ content: "{}" })
+      }
+      for (const target of [
+        "result.json", // Relative basename remains ambiguous across the two authorized roots.
+        path.join(scratch, "missing", "result.json"), // An absolute miss must not search for a namesake.
+        path.join(external.path, "secret.json"),
+        path.join(tmp.path, "linked", "secret.json"),
+        siblingFile,
+        scratch, // Directories and protected recovery files are not output receipts.
+        recoveryFile,
+      ]) {
+        expect(await resolve(target)).toEqual({ path: null, writable: null, scope: null })
+      }
+      expect(await resolve(scratchFile, sibling.id)).toEqual({ path: null, writable: null, scope: null })
+      await fs.rm(scratchFile)
+      expect(await resolve(scratchFile)).toEqual({ path: null, writable: null, scope: null })
+      expect(await SessionFilesystem.list(session.id)).toEqual(grants)
+    })
+  })
+
   test("resolves session-owned tool output links without granting sibling or process access", async () => {
     await using tmp = await tmpdir()
     await withSession(tmp.path, async (session) => {
@@ -1102,8 +1148,10 @@ describe("file access uses session grants", () => {
       const name = path.basename(target)
       expect(await SessionFilesystem.processReadRoots(session.id)).not.toContain(target)
       expect(await File.resolveReference(name, { sessionID: session.id })).toBe(target)
+      expect(await File.resolveReference(target, { sessionID: session.id })).toBe(target)
       expect((await File.read(target, { sessionID: session.id })).content).toContain("trajectory evidence")
       expect(await File.resolveReference(name, { sessionID: sibling.id })).toBeUndefined()
+      expect(await File.resolveReference(target, { sessionID: sibling.id })).toBeUndefined()
       await expect(File.read(target, { sessionID: sibling.id })).rejects.toBeInstanceOf(SessionFilesystem.DeniedError)
       const grant = (await SessionFilesystem.list(session.id)).find(
         (item) => item.path === target && item.source === "tool",
@@ -1111,6 +1159,7 @@ describe("file access uses session grants", () => {
       if (!grant) throw new Error("missing tool output grant")
       await SessionFilesystem.revoke(session.id, grant.id)
       expect(await File.resolveReference(name, { sessionID: session.id })).toBeUndefined()
+      expect(await File.resolveReference(target, { sessionID: session.id })).toBeUndefined()
     })
   })
 
@@ -1182,13 +1231,18 @@ describe("file access uses session grants", () => {
       expect(await (await resolve("unique.csv")).json()).toEqual({ path: null, writable: null, scope: null })
       expect(await (await resolve("../board.py")).json()).toEqual({ path: null, writable: null, scope: null })
       expect(await (await resolve(path.join(source.path, "ioai_final", "board.py"))).json()).toEqual({
-        path: null,
-        writable: null,
-        scope: null,
+        path: path.join(source.path, "ioai_final", "board.py"),
+        writable: false,
+        scope: "session",
       })
 
       await SessionFilesystem.revoke(session.id, sourceGrant.id)
       expect(await (await resolve("ioai_final/board.py")).json()).toEqual({ path: null, writable: null, scope: null })
+      expect(await (await resolve(path.join(source.path, "ioai_final", "board.py"))).json()).toEqual({
+        path: null,
+        writable: null,
+        scope: null,
+      })
       await expect(
         File.read(path.join(source.path, "ioai_final", "board.py"), { sessionID: session.id }),
       ).rejects.toBeInstanceOf(SessionFilesystem.DeniedError)

--- a/frontend/docs/src/content/openscience/files.mdx
+++ b/frontend/docs/src/content/openscience/files.mdx
@@ -33,6 +33,11 @@ Check the location shown in the preview. To open a known final copy, use **Files
 
 An older chat link may not identify the intended copy clearly. Use the file browser when the filename is ambiguous.
 
+**Session outputs** uses the exact paths recorded by tools and checks that the
+files remain available to the current conversation. An absolute path identifies
+that file only; a missing or inaccessible file is not replaced by another copy
+with the same name.
+
 ## Edit a supported text file
 
 Use **Source** when the preview offers it. Edit the document, choose **Save file**, and check the saved content. **Discard** abandons the current unsaved edit. Some chat-linked previews are read-only; open the intended project file through Files when you need an editable copy.

--- a/frontend/docs/src/content/openscience/sessions.mdx
+++ b/frontend/docs/src/content/openscience/sessions.mdx
@@ -58,6 +58,11 @@ Replace `<session-id>` with an ID from the session list. `--continue` chooses th
 
 In the workspace, open the saved conversation in project history. Queued prompts and follow-up messages continue that conversation.
 
+Sending a message follows the latest response. While you read earlier messages,
+incoming activity keeps your reading position; choose **Jump to Latest** to follow
+the conversation again. Background output checks and compute status updates stay
+inside the conversation without resetting its scroll position.
+
 ## Choose model and research settings
 
 | Flag | Purpose |

--- a/frontend/ui/src/components/compute-job-details.tsx
+++ b/frontend/ui/src/components/compute-job-details.tsx
@@ -14,9 +14,11 @@ export function ComputeJobDetails(props: { id: string }) {
         (job) => ({ job, error: undefined }),
         () => ({ job: undefined, error: "Current job status could not be read." }),
       ),
+    // Keep loading and refresh states local to this panel, not the chat route.
+    { initialValue: { job: undefined, error: undefined } },
   )
   createEffect(() => {
-    const job = current()?.job
+    const job = current.latest.job
     if (!view.open || !job) return
     const pending =
       ["queued", "running"].includes(job.status) ||
@@ -35,11 +37,13 @@ export function ComputeJobDetails(props: { id: string }) {
       </Button>
       <Show when={view.open}>
         <div data-component="compute-job-details" aria-busy={current.loading}>
-          <Show when={!current.loading || current()} fallback={<p>Reading current job…</p>}>
+          <Show when={!current.loading || current.latest.job} fallback={<p>Reading current job…</p>}>
             <Show
-              when={current()?.job}
+              when={current.latest.job}
               fallback={
-                <p>{current()?.error ?? "This job is no longer available. The action receipt is retained below."}</p>
+                <p>
+                  {current.latest.error ?? "This job is no longer available. The action receipt is retained below."}
+                </p>
               }
             >
               {(job) => (

--- a/frontend/ui/src/components/session-turn-trajectory.test.ts
+++ b/frontend/ui/src/components/session-turn-trajectory.test.ts
@@ -27,6 +27,7 @@ const vite = await createServer({
   ssr: { noExternal: true, external: ["fuzzysort"], resolve: { conditions: ["browser", "production"] } },
 })
 const web = (await vite.ssrLoadModule("solid-js/web")) as typeof import("solid-js/web")
+const solidRuntime = (await vite.ssrLoadModule("solid-js")) as typeof import("solid-js")
 const reactive = (await vite.ssrLoadModule("solid-js/store")) as typeof import("solid-js/store")
 const data = (await vite.ssrLoadModule("@synsci/ui/context/data")) as typeof import("../context/data")
 const dialog = (await vite.ssrLoadModule("@synsci/ui/context/dialog")) as typeof import("../context/dialog")
@@ -2029,4 +2030,136 @@ test("unavailable file checks stay explicit and can recover without offering unv
   ;[...host.querySelectorAll("button")].find((button) => button.textContent?.includes("Retry file check"))!.click()
   await ready(() => host.querySelector('[data-slot="session-turn-output-file"]') !== null)
   expect(host.textContent).not.toContain("outputs could not be checked")
+})
+
+test("file receipt checks never suspend the conversation during initial load, submit, or retry", async () => {
+  const message = assistant(3000)
+  const file = "/research/result.json"
+  const patch: Part = {
+    id: "prt_nonblocking_receipt",
+    sessionID,
+    messageID: message.id,
+    type: "patch",
+    hash: "hash",
+    files: [file],
+  }
+  const [store, setStore] = reactive.createStore<Store>({
+    ...empty(),
+    session_status: { [sessionID]: { type: "idle" } },
+    message: { [sessionID]: [user, message] },
+    part: { [user.id]: [], [message.id]: [patch] },
+  })
+  const checks: Array<{ resolve: (paths: string[]) => void; reject: (error: Error) => void }> = []
+  const host = mount(
+    () =>
+      solidRuntime.Suspense({
+        fallback: "RECEIPT_SUSPENSE_FALLBACK",
+        get children() {
+          return web.createComponent(turn.SessionTurn, { sessionID, messageID: user.id })
+        },
+      }),
+    store,
+    {
+      saveArtifact: async () => {},
+      resolveFileReceipts: (id, paths) => {
+        expect(id).toBe(sessionID)
+        expect(paths).toEqual([file])
+        return new Promise<string[]>((resolve, reject) => checks.push({ resolve, reject }))
+      },
+    },
+  )
+  await ready(() => checks.length === 1)
+  const transcript = host.querySelector('[data-component="session-turn"]')
+  expect(transcript).not.toBeNull()
+  const stillMounted = () => {
+    expect(transcript!.isConnected).toBe(true)
+    expect(host.querySelector('[data-component="session-turn"]')).toBe(transcript)
+    expect(host.textContent).not.toContain("RECEIPT_SUSPENSE_FALLBACK")
+  }
+  const output = () => host.querySelector<HTMLButtonElement>('[data-slot="session-turn-output-file"]')
+  stillMounted()
+  expect(output()).toBeNull()
+
+  checks[0].resolve([file])
+  await ready(() => output()?.title === file)
+  setStore("session_status", sessionID, { type: "busy" })
+  await ready(() => checks.length === 2)
+  stillMounted()
+  checks[1].resolve([])
+  await settle()
+  setStore("session_status", sessionID, { type: "idle" })
+  await ready(() => checks.length === 3)
+  stillMounted()
+  expect(output()).toBeNull()
+
+  checks[2].reject(new Error("offline"))
+  await ready(() => host.textContent?.includes("outputs could not be checked") === true)
+  stillMounted()
+  expect(output()).toBeNull()
+  ;[...host.querySelectorAll("button")].find((button) => button.textContent?.includes("Retry file check"))!.click()
+  await ready(() => checks.length === 4)
+  stillMounted()
+  expect(output()).toBeNull()
+  checks[3].resolve([file])
+  await ready(() => output()?.title === file)
+  stillMounted()
+  expect(host.textContent).not.toContain("outputs could not be checked")
+})
+
+test("current job lookups and refreshes keep the transcript mounted under Suspense", async () => {
+  type Job = Awaited<ReturnType<NonNullable<Callbacks["loadComputeJob"]>>>
+  const checks: Array<{ resolve: (job: Job) => void; reject: (error: Error) => void }> = []
+  const host = mount(
+    () =>
+      solidRuntime.Suspense({
+        fallback: "JOB_SUSPENSE_FALLBACK",
+        get children() {
+          return web.createComponent(compute.ComputeJobDetails, { id: "job_live" })
+        },
+      }),
+    empty(),
+    {
+      loadComputeJob: (id) => {
+        expect(id).toBe("job_live")
+        return new Promise<Job>((resolve, reject) => checks.push({ resolve, reject }))
+      },
+    },
+  )
+  const toggle = [...host.querySelectorAll("button")].find((button) =>
+    button.textContent?.includes("View current job"),
+  )!
+  toggle.click()
+  await ready(() => checks.length === 1)
+  const stillMounted = () => {
+    expect(toggle.isConnected).toBe(true)
+    expect(host.contains(toggle)).toBe(true)
+    expect(host.textContent).not.toContain("JOB_SUSPENSE_FALLBACK")
+  }
+  stillMounted()
+  expect(host.textContent).toContain("Reading current job")
+  expect(host.textContent).not.toContain("Current status:")
+
+  const job = { id: "job_live", name: "Fixture job", command: "offline" }
+  checks[0].resolve({ ...job, status: "running" })
+  await ready(() => host.textContent?.includes("Current status: running") === true)
+  const refresh = () =>
+    [...host.querySelectorAll("button")].find((button) => button.textContent?.includes("Refresh current status"))!
+  refresh().click()
+  await ready(() => checks.length === 2)
+  stillMounted()
+  expect(host.querySelector('[data-component="compute-job-details"]')?.getAttribute("aria-busy")).toBe("true")
+  expect(host.textContent).toContain("Current status: running")
+
+  checks[1].reject(new Error("offline"))
+  await ready(() => host.textContent?.includes("Current job status could not be read") === true)
+  stillMounted()
+  expect(host.textContent).not.toContain("Current status: running")
+  refresh().click()
+  await ready(() => checks.length === 3)
+  stillMounted()
+  checks[2].resolve({ ...job, status: "succeeded", exit_code: 0 })
+  await ready(() => host.textContent?.includes("Current status: succeeded") === true)
+  stillMounted()
+  expect(host.textContent).toContain("Exit code: 0")
+  expect(host.textContent).not.toContain("Current job status could not be read")
 })

--- a/frontend/ui/src/components/session-turn.tsx
+++ b/frontend/ui/src/components/session-turn.tsx
@@ -533,11 +533,13 @@ export function SessionTurn(
     ({ paths, sessionID }) =>
       data.resolveFileReceipts!(sessionID, paths).then(
         (paths) => ({ paths, error: false }),
-        () => ({ paths: [], error: true }),
+        () => ({ paths: emptyWritten, error: true }),
       ),
+    // Background receipt checks must not suspend the surrounding transcript.
+    { initialValue: { paths: emptyWritten, error: false } },
   )
   const written = createMemo(() =>
-    data.resolveFileReceipts ? candidates().filter((path) => existing()?.paths.includes(path)) : candidates(),
+    data.resolveFileReceipts ? candidates().filter((path) => existing.latest.paths.includes(path)) : candidates(),
   )
   const linkedFiles = written
   const pending = createMemo(() => pendingOperations(turnParts()))
@@ -1045,7 +1047,7 @@ export function SessionTurn(
                       </section>
                     </Show>
                     {/* Session outputs stay editable in scratch until explicitly kept as immutable Results. */}
-                    <Show when={!working() && existing()?.error}>
+                    <Show when={!working() && existing.latest.error}>
                       <div data-slot="session-turn-output-error">
                         <span>Session outputs could not be checked.</span>
                         <Button

--- a/frontend/workspace/e2e/classic-chat.spec.ts
+++ b/frontend/workspace/e2e/classic-chat.spec.ts
@@ -1,7 +1,9 @@
 import type { AssistantMessage, Part, ReasoningPart, TextPart, UserMessage } from "@synsci/sdk/v2"
 import type { Locator, Page } from "@playwright/test"
+import { writeFileSync } from "node:fs"
+import path from "node:path"
 import { test, expect } from "./fixtures"
-import { openFilesSources } from "./utils"
+import { openFilesSources, promptSelector } from "./utils"
 
 test.skip(process.env.OPENSCIENCE_E2E_FAKE_MODEL !== "1", "requires the isolated deterministic model")
 
@@ -50,6 +52,246 @@ async function dragInspector(page: Page, distance: number, verify: () => Promise
   }
   await expect(page.locator("[data-pane-resize-shield]")).toHaveCount(0)
   expect(Math.abs(Number(await handle.getAttribute("aria-valuenow")) - before)).toBeGreaterThan(100)
+}
+
+for (const position of ["bottom", "history"] as const) {
+  test(`submitting from ${position} keeps long chat mounted while output receipts refresh`, async ({
+    page,
+    sdk,
+    gotoSession,
+  }) => {
+    const session = await sdk.session.create({ title: `Submit scroll ${position}` }).then((result) => result.data)
+    if (!session) throw new Error("The isolated session was not created")
+    const sessionID = session.id
+    const releaseReceipts = Promise.withResolvers<void>()
+    const releasePrompt = Promise.withResolvers<void>()
+    let delay = false
+    let closing = false
+    let receiptsPending = false
+    let promptPending = false
+    let initialReceipt: { status: number; body: unknown } | undefined
+    let receiptChecks = 0
+    try {
+      const reply = await sdk.session
+        .prompt({
+          sessionID,
+          model: { providerID: "e2e", modelID: "echo" },
+          parts: [{ type: "text", text: "Seed the isolated submit fixture." }],
+        })
+        .then((result) => result.data)
+      if (!reply?.info.id) throw new Error("The deterministic model did not return a reply")
+      const saved = await sdk.session.messages({ sessionID }).then((result) => result.data ?? [])
+      const source = saved.find((message) => message.info.role === "user")?.info
+      if (source?.role !== "user") throw new Error("The isolated user turn is missing")
+      const filesystem = await sdk.session.filesystem.list({ sessionID }).then((result) => result.data)
+      if (!filesystem?.workspace.scratchRoot) throw new Error("The isolated scratch workspace is missing")
+      const output = path.join(filesystem.workspace.scratchRoot, "scroll-evidence.txt")
+      writeFileSync(output, "Disposable completed-turn output.\n")
+      const messages: Array<{ info: UserMessage | AssistantMessage; parts: Part[] }> = []
+      for (let index = 0; index < 12; index++) {
+        // Older sortable IDs let real optimistic/SSE messages append after
+        // this presentation fixture when the actual composer submits.
+        const id = `msg_000000000${String(index * 2).padStart(3, "0")}ScrollUser`
+        const assistantID = `msg_000000000${String(index * 2 + 1).padStart(3, "0")}ScrollReply`
+        const created = source.time.created - 120_000 + index * 2_000
+        const parts: Part[] = []
+        if (index === 11) {
+          parts.push({
+            id: "prt_scroll_written",
+            messageID: assistantID,
+            sessionID,
+            type: "tool",
+            tool: "bash",
+            callID: "call_scroll_written",
+            state: {
+              status: "completed",
+              input: { command: "fixture output" },
+              title: "Saved experiment evidence",
+              output: "",
+              metadata: {
+                exit: 0,
+                outputFiles: [
+                  { path: output, name: "scroll-evidence.txt", size: 34, modified: created, change: "created" },
+                ],
+              },
+              time: { start: created + 100, end: created + 500 },
+            },
+          })
+        }
+        parts.push({
+          id: `prt_scroll_answer_${index}`,
+          messageID: assistantID,
+          sessionID,
+          type: "text",
+          text:
+            `## Historical experiment ${index}\n\n` +
+            Array.from(
+              { length: 7 },
+              () =>
+                "The measured effect remains uncertain. Preserve the controls and replicate the observation before changing the experimental plan.",
+            ).join("\n\n"),
+          time: { start: created + 500, end: created + 1_000 },
+        })
+        messages.push(
+          {
+            info: { ...source, id, time: { created } },
+            parts: [
+              {
+                id: `prt_scroll_user_${index}`,
+                messageID: id,
+                sessionID,
+                type: "text",
+                text: `Review historical experiment ${index}.`,
+              },
+            ],
+          },
+          {
+            info: {
+              ...reply.info,
+              id: assistantID,
+              parentID: id,
+              finish: "stop",
+              time: { created: created + 100, completed: created + 1_000 },
+            },
+            parts,
+          },
+        )
+      }
+      await page.route(new RegExp(`/session/${sessionID}/message(?:\\?|$)`), (route) => {
+        if (route.request().method() !== "GET") return route.continue()
+        return route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(messages) })
+      })
+      await page.route(/\/file\/resolve(?:\?|$)/, async (route) => {
+        const url = new URL(route.request().url())
+        if (url.searchParams.get("sessionID") !== sessionID || url.searchParams.get("path") !== output) {
+          return route.continue()
+        }
+        if (delay) {
+          receiptsPending = true
+          await releaseReceipts.promise
+        }
+        if (closing) return route.abort()
+        const response = await route.fetch()
+        receiptChecks++
+        initialReceipt ??= { status: response.status(), body: await response.json() }
+        await route.fulfill({ response })
+      })
+      await page.route(/\/runtime\/prompt(?:\?|$)/, async (route) => {
+        if (route.request().postDataJSON()?.sessionID === sessionID) {
+          promptPending = true
+          await releasePrompt.promise
+        }
+        if (closing) return route.abort()
+        await route.continue()
+      })
+      await gotoSession(sessionID)
+      await expect(page.getByRole("heading", { name: "Historical experiment 11", exact: true })).toHaveCount(1)
+      await expect.poll(() => initialReceipt?.status).toBe(200)
+      await test
+        .info()
+        .attach("initial-output-check.json", { body: JSON.stringify(initialReceipt), contentType: "application/json" })
+      // The status listing omits idle sessions. A real completion while this
+      // page is connected supplies the idle SSE state present in an ongoing
+      // conversation, before the next composer send changes it to busy.
+      const primed = `E2E_OK_${Date.now()}`
+      await sdk.session.prompt({
+        sessionID,
+        model: { providerID: "e2e", modelID: "echo" },
+        parts: [{ type: "text", text: `Reply with exactly: ${primed}` }],
+      })
+      await expect(
+        page.locator('[data-slot="session-turn-response-section"]').filter({ hasText: primed }),
+      ).toBeVisible()
+      await expect.poll(() => receiptChecks).toBeGreaterThan(1)
+      await page.evaluate(() => document.fonts.ready)
+      const scroller = page.locator(".session-scroller")
+      const prompt = page.locator(promptSelector)
+      await prompt.click()
+      const token = `E2E_OK_${Date.now()}`
+      await page.keyboard.type(`Reply with exactly: ${token}`)
+      await scroller.evaluate((element, location) => {
+        element.scrollTop = location === "bottom" ? element.scrollHeight : element.scrollHeight * 0.45
+        element.dispatchEvent(new Event("scroll"))
+      }, position)
+      await settleLayout(page)
+      expect(await scroller.evaluate((element) => element.scrollTop)).toBeGreaterThan(500)
+      const recording = await scroller.evaluateHandle((original) => {
+        const samples: Array<{ same: boolean; connected: boolean; top: number; remaining: number }> = []
+        let active = true
+        const frame = () => {
+          const current = document.querySelector<HTMLElement>(".session-scroller")
+          samples.push({
+            same: current === original,
+            connected: original.isConnected,
+            top: current?.scrollTop ?? -1,
+            remaining: current ? current.scrollHeight - current.clientHeight - current.scrollTop : -1,
+          })
+          if (active) requestAnimationFrame(frame)
+        }
+        frame()
+        return {
+          samples,
+          stop: () => {
+            active = false
+          },
+        }
+      })
+      try {
+        delay = true
+        await page.keyboard.press("Enter")
+        await expect.poll(() => receiptsPending).toBe(true)
+        await settleLayout(page)
+        const pending = await recording.evaluate((value) => value.samples)
+        await test
+          .info()
+          .attach(`submit-${position}-pending.json`, { body: JSON.stringify(pending), contentType: "application/json" })
+        expect(
+          pending.every((sample) => sample.same && sample.connected),
+          JSON.stringify(pending),
+        ).toBe(true)
+        expect(Math.min(...pending.map((sample) => sample.top)), JSON.stringify(pending)).toBeGreaterThan(500)
+        await expect.poll(() => promptPending).toBe(true)
+        releaseReceipts.resolve()
+        await settleLayout(page)
+        releasePrompt.resolve()
+        await expect(
+          page.locator('[data-slot="session-turn-response-section"]').filter({ hasText: token }),
+        ).toBeVisible()
+        await settleLayout(page)
+        const completed = await recording.evaluate((value) => value.samples)
+        expect(
+          completed.every((sample) => sample.same && sample.connected),
+          JSON.stringify(completed),
+        ).toBe(true)
+        expect(Math.min(...completed.map((sample) => sample.top)), JSON.stringify(completed)).toBeGreaterThan(500)
+        await expect
+          .poll(() => scroller.evaluate((element) => element.scrollHeight - element.clientHeight - element.scrollTop))
+          .toBeLessThanOrEqual(2)
+      } finally {
+        await recording.evaluate((value) => value.stop())
+        const evidence = test.info().outputPath(`submit-${position}-all-frames.json`)
+        writeFileSync(
+          evidence,
+          JSON.stringify({
+            receiptsPending,
+            promptPending,
+            frames: await recording.evaluate((value) => value.samples),
+          }),
+        )
+        await test.info().attach(`submit-${position}-all-frames.json`, {
+          path: evidence,
+          contentType: "application/json",
+        })
+        await recording.dispose()
+      }
+    } finally {
+      closing = true
+      releaseReceipts.resolve()
+      releasePrompt.resolve()
+      await sdk.session.abort({ sessionID }).catch(() => undefined)
+      await sdk.session.delete({ sessionID }).catch(() => undefined)
+    }
+  })
 }
 
 test("classic long-chat disclosures preserve the reader, stay per-turn, and survive reload", async ({

--- a/frontend/workspace/src/pages/session.tsx
+++ b/frontend/workspace/src/pages/session.tsx
@@ -925,6 +925,11 @@ export default function Page(): JSX.Element {
     restoration.target = undefined
   }
 
+  const followLatest = () => {
+    cancelRestoration()
+    chatScroll.forceScrollToBottom()
+  }
+
   const applyRestoration = () => {
     const target = restoration.target
     const element = chatElement
@@ -1390,12 +1395,7 @@ export default function Page(): JSX.Element {
 
                     <div class="session-jump-latest-rail" aria-live="polite">
                       <Show when={chatScroll.userScrolled()}>
-                        <button
-                          type="button"
-                          class="session-jump-latest"
-                          onClick={() => chatScroll.forceScrollToBottom()}
-                          title="Jump to Latest"
-                        >
+                        <button type="button" class="session-jump-latest" onClick={followLatest} title="Jump to Latest">
                           <IconChevronDown size={13} strokeWidth={1.6} />
                           Jump to Latest
                         </button>
@@ -1437,7 +1437,7 @@ export default function Page(): JSX.Element {
                       </button>
                     </div>
                   </Show>
-                  <PromptInput />
+                  <PromptInput onSubmit={followLatest} />
                 </div>
               </div>
             </section>

--- a/tooling/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/tooling/sdk/js/src/v2/gen/sdk.gen.ts
@@ -5883,7 +5883,7 @@ export class File_ extends HeyApiClient {
   /**
    * Resolve a session file reference
    *
-   * Resolve an unambiguous relative file reference across project, session, and connected roots authorized for the active session.
+   * Resolve an exact absolute file receipt or an unambiguous relative reference across project, session, and connected roots authorized for the active session. Absolute paths never fall back to a filename search.
    */
   public resolveReference<ThrowOnError extends boolean = false>(
     parameters: {

--- a/tooling/sdk/openapi.json
+++ b/tooling/sdk/openapi.json
@@ -32909,7 +32909,7 @@
           }
         ],
         "summary": "Resolve a session file reference",
-        "description": "Resolve an unambiguous relative file reference across project, session, and connected roots authorized for the active session.",
+        "description": "Resolve an exact absolute file receipt or an unambiguous relative reference across project, session, and connected roots authorized for the active session. Absolute paths never fall back to a filename search.",
         "responses": {
           "200": {
             "description": "Resolved authorized file path, or null when the reference is missing or ambiguous",


### PR DESCRIPTION
Sending a message in an existing chat could reset the view to the top because background output-file checks suspended the entire route and detached its scroll element. Keep receipt and compute-status loading local, retain the mounted conversation through refreshes, and make an explicit send follow the latest response while incoming activity preserves a reader's position in history.

Also accept exact absolute output receipts in the existing file resolver. The client already submits these paths; they now resolve only within the current session's authorized roots, with no fallback to another file and with authorization checked again when opened. Documentation and generated SDK descriptions match the contract.

Validation:
- Reproduced scroll-element detachment on the unchanged baseline from both the bottom and history. All three isolated Chromium tests pass with the fix, including disclosure/reload/inspector anchoring; both submit cases retain the same connected scroll element in every sampled frame.
- 48 component tests / 498 assertions pass, including initial receipt/status loading, refresh, failure and retry under a parent Suspense boundary.
- 44 backend tests / 223 assertions and three receipt-client tests / 10 assertions pass, including missing, deleted, inaccessible, revoked and cross-worker paths.
- Monorepo typecheck, strict browser-test typecheck, SDK regeneration/build and formatting pass. Browser tests use disposable sessions and a fake model; no live research run is modified.
