### PR TITLE
test: make release gates reject flaky browser runs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -88,7 +88,7 @@ jobs:
         timeout-minutes: 30
 
       - name: Upload Playwright artifacts
-        if: failure()
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: playwright-${{ matrix.settings.name }}-${{ github.run_attempt }}

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -385,7 +385,7 @@ jobs:
           cat "$RUNNER_TEMP/openscience-server.log" || true
           cat "$RUNNER_TEMP/openscience-fake-model.log" || true
       - name: Upload packaged E2E artifacts
-        if: failure()
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: npm-test-packaged-e2e-${{ github.run_attempt }}

--- a/backend/cli/test/server/settings-storage.test.ts
+++ b/backend/cli/test/server/settings-storage.test.ts
@@ -508,6 +508,7 @@ describe("Storage Settings integration", () => {
       const release = path.join(project, "release")
       await fs.mkdir(project)
 
+      // waitFor() observes existence, so readiness payloads must be complete before publication.
       const ownerFile = path.join(workspace, "compute-owner.ts")
       await fs.writeFile(
         ownerFile,
@@ -536,7 +537,8 @@ describe("Storage Settings integration", () => {
           "      'import os, sys, time',",
           "      'os.setsid()',",
           "      'if os.fork(): os._exit(0)',",
-          "      `open(${JSON.stringify(childReady)}, 'w').write(str(os.getpid()))`,",
+          "      `with open(${JSON.stringify(childReady + '.tmp')}, 'x') as ready: ready.write(str(os.getpid()))`,",
+          "      `os.replace(${JSON.stringify(childReady + '.tmp')}, ${JSON.stringify(childReady)})`,",
           "      `while not os.path.exists(${JSON.stringify(release)}): time.sleep(0.02)`,",
           "      `print('surviving-child', flush=True)`,",
           "      'time.sleep(600)',",
@@ -546,7 +548,8 @@ describe("Storage Settings integration", () => {
           "    const job = await ComputeJobs.start({ name: 'survivor', command, target: { kind: 'local' }, sessionID: session.id }, { root, workspace: project })",
           "    const stored = await ComputeJobs.get(job.id, { root, workspace: project })",
           "    if (!stored?.pid || !stored.process_identity) throw new Error('compute identity was not persisted')",
-          "    await fs.writeFile(ownerReady, JSON.stringify({ id: job.id, pid: stored.pid, identity: stored.process_identity }))",
+          "    await fs.writeFile(ownerReady + '.tmp', JSON.stringify({ id: job.id, pid: stored.pid, identity: stored.process_identity }), { flag: 'wx' })",
+          "    await fs.rename(ownerReady + '.tmp', ownerReady)",
           "    await new Promise(() => undefined)",
           "  },",
           "})",
@@ -573,9 +576,12 @@ describe("Storage Settings integration", () => {
         await waitFor(childReady)
         const running = (await Bun.file(ownerReady).json()) as { id: string; pid: number; identity: string }
         childOwner = running
-        const daemonPID = Number((await fs.readFile(childReady, "utf8")).trim())
+        const daemonReady = (await fs.readFile(childReady, "utf8")).trim()
+        const daemonPID = Number(daemonReady)
+        if (!/^[1-9]\d*$/.test(daemonReady) || !Number.isSafeInteger(daemonPID) || daemonPID <= 1)
+          throw new Error(`Invalid compute daemon PID in readiness file: ${JSON.stringify(daemonReady)}`)
         const daemonIdentity = await ProcessIdentity.capture(daemonPID)
-        if (!daemonIdentity) throw new Error("compute daemon identity was not captured")
+        if (!daemonIdentity) throw new Error(`compute daemon identity was not captured for PID ${daemonPID}`)
         escaped = { pid: daemonPID, identity: daemonIdentity }
         const operations = path.join(workspace, "config", "openscience", "data-root-operations")
         const records = await Promise.all(

--- a/docs/notes/release-process.md
+++ b/docs/notes/release-process.md
@@ -13,6 +13,9 @@ never bump a version in a pull request, and add user-visible changes to the
    CI workflow: Typecheck, Format, the Linux test suite, web/docs and landing
    builds, migration and runtime ownership checks on their platform matrices,
    launcher/release-script smoke tests, and workflow linting.
+   Browser tests must pass on their first attempt. CI keeps one retry for
+   diagnosis, but a passing retry still fails the gate; the original failed
+   attempt's trace and screenshot remain available in the workflow artifacts.
 2. Trigger `test publish` from that exact `main` commit with packaged E2E and
    OS smokes enabled. Promotion is blocked until the exact npm candidate also
    installs and completes all five packaged scientific capability smoke

--- a/frontend/workspace/e2e/classic-chat.spec.ts
+++ b/frontend/workspace/e2e/classic-chat.spec.ts
@@ -13,10 +13,34 @@ const reasoningBody = '[data-slot="reasoning-part-body"]'
 const expansionKey = "openscience-trace-expansion-v1"
 
 async function placeInViewport(page: Page, control: Locator) {
+  await page.evaluate(() => document.fonts.ready)
+  const viewport = await page.locator(".session-scroller").boundingBox()
+  if (!viewport) throw new Error("The conversation did not render")
+  // Real scroll intent cancels the route's saved-position restoration. First
+  // move the non-sticky turn into view: a pinned button's visual box cannot
+  // tell us where its normal-flow position is.
+  await page.mouse.move(viewport.x + viewport.width / 2, viewport.y + viewport.height / 2)
+  await page.mouse.wheel(0, -1)
+  await settleLayout(page)
+  await control.evaluate((button) => {
+    const scroller = button.closest<HTMLElement>(".session-scroller")!
+    const turn = button.closest<HTMLElement>("[data-message-id]")!
+    scroller.scrollTop += turn.getBoundingClientRect().top - scroller.getBoundingClientRect().top - 24
+  })
+  await settleLayout(page)
   await control.evaluate((button) => {
     const scroller = button.closest<HTMLElement>(".session-scroller")!
     scroller.scrollTop += button.getBoundingClientRect().top - scroller.getBoundingClientRect().top - 140
   })
+  await expect
+    .poll(() =>
+      control.evaluate((button) =>
+        Math.abs(
+          button.getBoundingClientRect().top - button.closest(".session-scroller")!.getBoundingClientRect().top - 140,
+        ),
+      ),
+    )
+    .toBeLessThanOrEqual(2)
   await settleLayout(page)
   const box = await control.boundingBox()
   if (!box) throw new Error("The disclosure did not render")
@@ -576,11 +600,35 @@ test("classic long-chat disclosures preserve the reader, stay per-turn, and surv
 
     const keyboardBefore = await placeInViewport(page, target)
     await target.focus()
+    await settleLayout(page)
+    expect(Math.abs((await target.boundingBox())!.y - keyboardBefore)).toBeLessThanOrEqual(2)
     await target.press("Enter")
     await expect(target).toHaveAttribute("aria-expanded", "true")
     await expect(turn(8).locator(reasoningBody)).toContainText("Reasoning complete for experiment 8.")
     await settleLayout(page)
     expect(Math.abs((await target.boundingBox())!.y - keyboardBefore)).toBeLessThanOrEqual(2)
+
+    // Test sticky geometry deliberately, separately from the inset setup.
+    await target.evaluate((button) => {
+      const scroller = button.closest<HTMLElement>(".session-scroller")!
+      scroller.scrollTop += button.getBoundingClientRect().top - scroller.getBoundingClientRect().top + 100
+      scroller.dispatchEvent(new Event("scroll"))
+    })
+    await settleLayout(page)
+    const stickyBefore = await target.evaluate((button) => ({
+      y: button.getBoundingClientRect().y,
+      inset: button.getBoundingClientRect().y - button.closest(".session-scroller")!.getBoundingClientRect().y,
+    }))
+    expect(Math.abs(stickyBefore.inset)).toBeLessThanOrEqual(4)
+    await target.press("Enter")
+    await expect(target).toHaveAttribute("aria-expanded", "false")
+    await settleLayout(page)
+    expect(Math.abs((await target.boundingBox())!.y - stickyBefore.y)).toBeLessThanOrEqual(2)
+    await target.press("Enter")
+    await expect(target).toHaveAttribute("aria-expanded", "true")
+    await expect(turn(8).locator(reasoningBody)).toContainText("Reasoning complete for experiment 8.")
+    await settleLayout(page)
+    expect(Math.abs((await target.boundingBox())!.y - stickyBefore.y)).toBeLessThanOrEqual(2)
     await page.reload()
     await expect(target).toHaveAttribute("aria-expanded", "true")
     await expect(page.locator(reasoningBody)).toHaveCount(2)

--- a/frontend/workspace/playwright.config.ts
+++ b/frontend/workspace/playwright.config.ts
@@ -27,9 +27,9 @@ export default defineConfig({
   },
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
-  // One retry keeps flake tolerance while capping the worst case: a genuine
-  // failure costs 2 × 60s instead of 3 × 60s, which is what pushed the
-  // packaged job past its 60-minute budget when many specs went stale at once.
+  // Keep one retry for diagnosis, but a passing retry must not conceal an
+  // unstable release gate. Local runs keep their existing no-retry behavior.
+  failOnFlakyTests: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
   reporter: [["html", { outputFolder: "e2e/playwright-report", open: "never" }], ["line"]],
   ...(target.startWebServer
@@ -52,11 +52,11 @@ export default defineConfig({
     : {}),
   use: {
     baseURL,
-    trace: "on-first-retry",
+    trace: "retain-on-failure",
     screenshot: "only-on-failure",
     // Recording every attempt and discarding the passing footage costs real
-    // wall-clock time under a single worker. The retry attempt still records,
-    // so every persistent failure keeps a video plus the first-retry trace.
+    // wall-clock time under a single worker. Failed attempts retain traces and
+    // screenshots; the retry also records video for diagnosis.
     video: "on-first-retry",
     // Inject Basic-Auth on every browser request. The frontend's
     // openscience-fetch.ts wraps fetch() with the same header, but its


### PR DESCRIPTION
Browser CI previously reported success when a disclosure-position test failed once and passed on retry, and discarded the original failure trace. Make flaky tests fail CI, retain first-attempt failure evidence, and upload browser artifacts from both source and packaged runs. The diagnostic retry remains enabled; local runs still use zero retries.

The process-supervision fixture also published its readiness filename before writing its PID. Publish child PID and owner metadata atomically, validate the PID before capture, and include it in diagnostic errors. Keep all supervision assertions and timeouts unchanged. Correct the browser fixture to establish its requested reading position before measuring disclosure movement, while retaining explicit sticky-control keyboard coverage and the two-pixel tolerance.

Validation: all six classic-chat browser cases passed without retries, including send/history races and deliberate sticky keyboard toggles. A separate delayed-reload test using actual bundled Inter bytes passed. The real Linux process-supervision test passed with ten assertions, and all seven typecheck tasks plus formatting passed. The isolated intentional-flake proof produced failed then passed attempts, retained the first failure trace/screenshot, and exited 1. Full exact-source CI and a fresh release rehearsal are required before stable publication. The historical CI log did not contain PID bytes or an original browser trace, so these confirmed fixture races do not establish the exclusive causes of those original failures.
