### PR TITLE
fix: restore settings access and reliable Windows job status

### DIFF
--- a/.github/workflows/deep-ci.yml
+++ b/.github/workflows/deep-ci.yml
@@ -160,6 +160,7 @@ jobs:
               test/global/data-dir.test.ts
               test/process/windows-job.test.ts
               test/compute/local-python-runtime.test.ts
+              test/compute/jobs-persistence.test.ts
               test/global/data-root.test.ts
               test/openscience-env.test.ts
               test/file/safe-io.test.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ tagged release also ships native binaries for Linux, macOS, and Windows.
 
 ### Changed
 
+- Keep settings dropdowns inside their dialog so assistive technology can reach
+  skill creation and filter options. Restore the skill-authoring browser test.
 - Keep delayed history loading from undoing a newer **Jump to Latest**, send, or
   reading position; discard scroll restoration after switching conversations.
 - Publish the official Homebrew tap with a credential scoped to that repository,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ tagged release also ships native binaries for Linux, macOS, and Windows.
 
 ### Changed
 
+- Retry transient Windows sharing errors when atomically saving compute job status,
+  preserving the previous file and reporting persistent storage failures.
 - Keep settings dropdowns inside their dialog so assistive technology can reach
   skill creation and filter options. Restore the skill-authoring browser test.
 - Keep delayed history loading from undoing a newer **Jump to Latest**, send, or

--- a/backend/cli/src/compute/jobs.ts
+++ b/backend/cli/src/compute/jobs.ts
@@ -14,6 +14,7 @@ import { Instance } from "../project/instance"
 import { Sandbox } from "../sandbox/sandbox"
 import { Filesystem } from "../util/filesystem"
 import { FileLease } from "../util/file-lease"
+import { AtomicRename } from "../util/atomic-rename"
 import { ProvenanceEnvelope } from "../science/provenance/envelope"
 import { ExecutionAuthority } from "../project/execution"
 import { ComputeLifecycle } from "./lifecycle"
@@ -659,7 +660,7 @@ export namespace ComputeJobs {
         .then(() => file.writeFile(JSON.stringify(clean, null, 2), "utf8"))
         .then(() => file.sync())
         .finally(() => file.close())
-      await fs.rename(temp, filepath)
+      await AtomicRename.replace(temp, filepath)
       const directory = await fs.open(root, "r").catch(() => undefined)
       await directory?.sync().catch(() => undefined)
       await directory?.close().catch(() => undefined)

--- a/backend/cli/src/global/data-root-barrier.ts
+++ b/backend/cli/src/global/data-root-barrier.ts
@@ -3,6 +3,7 @@ import path from "node:path"
 import { randomUUID } from "node:crypto"
 import { AsyncLocalStorage } from "node:async_hooks"
 import { ProcessIdentity } from "../process/process-identity"
+import { AtomicRename } from "../util/atomic-rename"
 
 /**
  * Cross-process drain barrier used only for data-root relocation.
@@ -56,9 +57,6 @@ export namespace DataRootBarrier {
 
   const pause = 20
   const wait = 30_000
-  const replaceWait = 2_000
-  const replacePause = 10
-  const replaceMaxPause = 100
 
   /** Point the barrier at a data root. Boot configures the process once;
    * callers that swap the root temporarily (a relocation rehearsal, a test
@@ -186,24 +184,6 @@ export namespace DataRootBarrier {
       .catch(() => undefined)
   }
 
-  function replaceable(error: NodeJS.ErrnoException, windows: boolean) {
-    return windows && (error.code === "EPERM" || error.code === "EACCES" || error.code === "EBUSY")
-  }
-
-  async function replace(
-    source: string,
-    destination: string,
-    windows: boolean,
-    deadline = Date.now() + replaceWait,
-    delay = replacePause,
-  ): Promise<void> {
-    return fs.rename(source, destination).catch(async (error: NodeJS.ErrnoException) => {
-      if (!replaceable(error, windows) || Date.now() >= deadline) throw error
-      await Bun.sleep(Math.min(delay, Math.max(0, deadline - Date.now())))
-      return replace(source, destination, windows, deadline, Math.min(delay * 2, replaceMaxPause))
-    })
-  }
-
   async function exactOwner(value?: Owner): Promise<Owner> {
     if (value) {
       if (!Number.isSafeInteger(value.pid) || value.pid <= 0 || !/^[a-f0-9]{64}$/.test(value.identity)) {
@@ -309,7 +289,7 @@ export namespace DataRootBarrier {
                 // Windows can reject replacement while a scanner holds a
                 // conflicting destination handle. Retrying the same atomic
                 // update keeps the old complete marker authoritative.
-                await replace(temporary, marker, windows)
+                await AtomicRename.replace(temporary, marker, windows)
               } catch (error) {
                 await replacement.close().catch(() => undefined)
                 await fs.rm(temporary, { force: true }).catch(() => undefined)

--- a/backend/cli/src/util/atomic-rename.ts
+++ b/backend/cli/src/util/atomic-rename.ts
@@ -1,0 +1,20 @@
+import fs from "node:fs/promises"
+
+export namespace AtomicRename {
+  /** Windows sharing failures can outlive a reader's handle briefly. Retry the
+   * atomic rename itself; never unlink the committed destination to make room. */
+  export async function replace(source: string, destination: string, windows = process.platform === "win32"): Promise<void> {
+    const deadline = Date.now() + 2_000
+    return attempt(10)
+
+    async function attempt(delay: number): Promise<void> {
+      return fs.rename(source, destination).catch(async (error: NodeJS.ErrnoException) => {
+        if (!windows || !["EPERM", "EACCES", "EBUSY"].includes(error.code ?? "") || Date.now() >= deadline) {
+          throw error
+        }
+        await Bun.sleep(Math.min(delay, Math.max(0, deadline - Date.now())))
+        return attempt(Math.min(delay * 2, 100))
+      })
+    }
+  }
+}

--- a/backend/cli/src/util/atomic-rename.ts
+++ b/backend/cli/src/util/atomic-rename.ts
@@ -3,7 +3,11 @@ import fs from "node:fs/promises"
 export namespace AtomicRename {
   /** Windows sharing failures can outlive a reader's handle briefly. Retry the
    * atomic rename itself; never unlink the committed destination to make room. */
-  export async function replace(source: string, destination: string, windows = process.platform === "win32"): Promise<void> {
+  export async function replace(
+    source: string,
+    destination: string,
+    windows = process.platform === "win32",
+  ): Promise<void> {
     const deadline = Date.now() + 2_000
     return attempt(10)
 

--- a/backend/cli/test/compute/jobs-persistence.test.ts
+++ b/backend/cli/test/compute/jobs-persistence.test.ts
@@ -1,0 +1,117 @@
+import { expect, spyOn, test } from "bun:test"
+import fs from "node:fs/promises"
+import path from "node:path"
+import { ComputeJobs } from "../../src/compute/jobs"
+import { AtomicRename } from "../../src/util/atomic-rename"
+import { tmpdir } from "../fixture/fixture"
+
+async function fixture() {
+  const tmp = await tmpdir()
+  const root = path.join(tmp.path, "state")
+  const filepath = path.join(root, "jobs.json")
+  const original = JSON.stringify([
+    ComputeJobs.Job.parse({
+      id: "completed-job",
+      name: "previous completed job",
+      command: "true",
+      target: { kind: "local" },
+      target_label: "Local",
+      scheduler: "none",
+      status: "succeeded",
+      created_at: new Date().toISOString(),
+    }),
+  ])
+  await fs.mkdir(root)
+  await fs.writeFile(filepath, original, { mode: 0o600 })
+  const sibling = `${filepath}.interrupted.tmp`
+  await fs.writeFile(sibling, "interrupted bytes", { mode: 0o600 })
+  return { ...tmp, root, filepath, original, sibling, options: { root, workspace: tmp.path } }
+}
+
+test("retries transient Windows job-history sharing failures with the committed bytes continuously intact", async () => {
+  await using data = await fixture()
+  const rename = fs.rename.bind(fs)
+  const replace = AtomicRename.replace
+  // Exercise the actual Windows rename policy without changing process-wide
+  // platform detection used by native ownership and filesystem leases.
+  using policy = spyOn(AtomicRename, "replace").mockImplementation((source, destination) =>
+    replace(source, destination, true),
+  )
+  const staged: string[] = []
+  const codes = ["EPERM", "EACCES", "EBUSY"]
+  using failures = spyOn(fs, "rename").mockImplementation(async (source, destination) => {
+    if (String(destination) !== data.filepath) return rename(source, destination)
+    staged.push(String(source))
+    expect(await fs.readFile(destination, "utf8")).toBe(data.original)
+    expect(JSON.parse(await fs.readFile(source, "utf8"))).toEqual([])
+    const code = codes[staged.length - 1]
+    if (code) throw Object.assign(new Error(`injected ${code}`), { code })
+    return rename(source, destination)
+  })
+
+  expect(await ComputeJobs.clear(data.options)).toBe(1)
+  expect(staged).toHaveLength(4)
+  expect(new Set(staged).size).toBe(1)
+  expect(await fs.readFile(data.filepath, "utf8")).toBe("[]")
+  expect(await fs.readFile(data.sibling, "utf8")).toBe("interrupted bytes")
+  expect((await fs.readdir(data.root)).sort()).toEqual(["jobs.json", path.basename(data.sibling)].sort())
+})
+
+test("bounds persistent Windows job-history locks, preserves the original, and cleans only its unpublished temp", async () => {
+  await using data = await fixture()
+  const rename = fs.rename.bind(fs)
+  const replace = AtomicRename.replace
+  using policy = spyOn(AtomicRename, "replace").mockImplementation((source, destination) =>
+    replace(source, destination, true),
+  )
+  const failure = Object.assign(new Error("injected persistent EPERM"), { code: "EPERM" })
+  const staged: string[] = []
+  using failures = spyOn(fs, "rename").mockImplementation(async (source, destination) => {
+    if (String(destination) !== data.filepath) return rename(source, destination)
+    staged.push(String(source))
+    expect(await fs.readFile(destination, "utf8")).toBe(data.original)
+    expect(JSON.parse(await fs.readFile(source, "utf8"))).toEqual([])
+    throw failure
+  })
+
+  const started = performance.now()
+  await expect(ComputeJobs.clear(data.options)).rejects.toBe(failure)
+  const elapsed = performance.now() - started
+  expect(elapsed).toBeGreaterThanOrEqual(1_900)
+  expect(elapsed).toBeLessThan(6_000)
+  expect(staged.length).toBeGreaterThan(3)
+  expect(new Set(staged).size).toBe(1)
+  expect(await fs.readFile(data.filepath, "utf8")).toBe(data.original)
+  expect(await fs.readFile(data.sibling, "utf8")).toBe("interrupted bytes")
+  expect((await fs.readdir(data.root)).sort()).toEqual(["jobs.json", path.basename(data.sibling)].sort())
+})
+
+for (const [windows, code] of [
+  [false, "EPERM"],
+  [false, "EACCES"],
+  [false, "EBUSY"],
+  [true, "EIO"],
+  [true, "ENOENT"],
+] as const) {
+  test(`does not retry ${code} job-history failures with Windows policy ${windows}`, async () => {
+    await using data = await fixture()
+    const rename = fs.rename.bind(fs)
+    const replace = AtomicRename.replace
+    using policy = spyOn(AtomicRename, "replace").mockImplementation((source, destination) =>
+      replace(source, destination, windows),
+    )
+    const failure = Object.assign(new Error(`injected ${code}`), { code })
+    let attempts = 0
+    using failures = spyOn(fs, "rename").mockImplementation(async (source, destination) => {
+      if (String(destination) !== data.filepath) return rename(source, destination)
+      attempts++
+      throw failure
+    })
+
+    await expect(ComputeJobs.clear(data.options)).rejects.toBe(failure)
+    expect(attempts).toBe(1)
+    expect(await fs.readFile(data.filepath, "utf8")).toBe(data.original)
+    expect(await fs.readFile(data.sibling, "utf8")).toBe("interrupted bytes")
+    expect((await fs.readdir(data.root)).sort()).toEqual(["jobs.json", path.basename(data.sibling)].sort())
+  })
+}

--- a/frontend/workspace/e2e/skills.spec.ts
+++ b/frontend/workspace/e2e/skills.spec.ts
@@ -40,28 +40,74 @@ test("skills can be searched and disabled", async ({ page, gotoSession }) => {
   await expect(skill).not.toHaveAttribute("aria-busy", "true", { timeout: 15_000 })
 })
 
-// The product bug is fixed: the add-skill dropdown now mounts inside the
-// settings dialog's layer (AddMenu in components/settings/_shared.tsx), so it
-// opens and its items activate — verified live in a real browser, and the
-// menu renders `[expanded]` in this test's own trace. What remains is a
-// Playwright actionability quirk clicking the menuitem inside the nested
-// modal portal (it reports the item as not hittable though it is visibly on
-// top). Kept fixme until the click is made robust against that quirk.
-test.fixme("skills can be authored from scratch", async ({ page, gotoSession }) => {
+test("skills can be authored from scratch", async ({ page, gotoSession }) => {
   await gotoSession()
-  const dialog = await openSkills(page)
+  let dialog = await openSkills(page)
+
+  // Both keyboard and pointer users must reach the menu through the dialog's
+  // accessible tree. A visually open portal under aria-hidden is not enough.
+  const add = dialog.getByRole("button", { name: "Add skill", exact: true })
+  await add.focus()
+  await add.press("ArrowDown")
+  const scratch = dialog.getByRole("menuitem", { name: "Write from scratch", exact: true })
+  await expect(scratch).toBeVisible()
+  await page.keyboard.press("Home")
+  await expect(scratch).toBeFocused()
+  await page.keyboard.press("Enter")
+  await expect(dialog.getByRole("heading", { name: "Write a new skill" })).toBeVisible()
+  await dialog.getByRole("button", { name: "Cancel", exact: true }).click()
 
   const name = `e2e-skill-${Date.now()}`
-  await dialog.getByRole("button", { name: "add skill" }).click()
-  await page.getByRole("menuitem", { name: /write from scratch/i }).click()
+  const description = "Created by the isolated browser E2E suite"
+  const body = "Run the requested check and report the result."
+  const content = `---\nname: ${name}\ndescription: ${description}\n---\n\n${body}\n`
+  await add.click()
+  await scratch.click()
 
   await dialog.getByLabel("Name").fill(name)
-  await dialog.getByLabel("Description").fill("Created by the isolated browser E2E suite")
-  await dialog.getByLabel("Instructions (Markdown)").fill("Run the requested check and report the result.")
-  await dialog.getByRole("button", { name: "create skill" }).click()
+  await dialog.getByLabel("Description").fill(description)
+  await dialog.getByLabel("Instructions (Markdown)").fill(body)
+  const saving = page.waitForResponse(
+    (response) => response.request().method() === "PUT" && new URL(response.url()).pathname === `/skill/${name}`,
+  )
+  await dialog.getByRole("button", { name: "Create skill", exact: true }).click()
+  const response = await saving
+  expect(response.status()).toBe(200)
+  expect(response.request().postDataJSON()).toEqual({ content })
+  const saved = await response.json()
+  expect(saved.name).toBe(name)
+  expect(saved.description).toBe(description)
 
   const search = dialog.getByPlaceholder("Search skills")
   await expect(search).toBeVisible()
   await search.fill(name)
-  await expect(dialog.getByText(name, { exact: true }).first()).toBeVisible()
+  await expect(
+    dialog
+      .getByRole("listitem")
+      .filter({ hasText: `/${name}` })
+      .locator("code"),
+  ).toHaveText(`/${name}`)
+
+  await page.reload()
+  dialog = await openSkills(page)
+  await dialog.getByPlaceholder("Search skills").fill(name)
+  await expect(
+    dialog
+      .getByRole("listitem")
+      .filter({ hasText: `/${name}` })
+      .locator("code"),
+  ).toHaveText(`/${name}`)
+
+  // FilterMenu shares the same portal mount helper as AddMenu.
+  await dialog.getByRole("button", { name: "Filters & view", exact: true }).click()
+  const source = dialog.getByRole("button", { name: "Filter skills by source", exact: true })
+  await source.click()
+  await dialog.getByRole("menuitem", { name: /^Personal/ }).click()
+  await expect(source).toContainText("Personal")
+  await expect(
+    dialog
+      .getByRole("listitem")
+      .filter({ hasText: `/${name}` })
+      .locator("code"),
+  ).toHaveText(`/${name}`)
 })

--- a/frontend/workspace/src/components/settings/_shared.tsx
+++ b/frontend/workspace/src/components/settings/_shared.tsx
@@ -1,21 +1,36 @@
-import { For, Show, createSignal, createUniqueId, type JSX, type ParentComponent, type Component } from "solid-js"
+import {
+  For,
+  Show,
+  createSignal,
+  createUniqueId,
+  onMount,
+  type JSX,
+  type ParentComponent,
+  type Component,
+} from "solid-js"
 import { Icon } from "@synsci/ui/icon"
 import type { IconProps } from "@synsci/ui/icon"
 import { DropdownMenu } from "@synsci/ui/dropdown-menu"
 
 // These menus render inside the modal settings Dialog. Kobalte portals a
-// dropdown to document.body by default, which lands OUTSIDE the dialog's
-// dismissable layer — the dialog then treats the open as an outside
-// interaction and closes the menu instantly. Mounting the portal into the
-// enclosing dialog content nests the layers so the menu opens and stays open.
+// dropdown to document.body by default, outside the dialog's accessible and
+// dismissable layer. Mount the portal inside the enclosing dialog so its
+// items stay accessible and interactions belong to that dialog.
 // Falls back to the default body portal when not inside a dialog.
 function useDialogMount() {
   const [mount, setMount] = createSignal<HTMLElement>()
+  let trigger: HTMLElement | undefined
+  const update = () => setMount(trigger?.closest<HTMLElement>('[data-slot="dialog-content"]') ?? undefined)
   const anchor = (el: HTMLElement) => {
-    const content = el.closest<HTMLElement>('[data-slot="dialog-content"]')
-    if (content) setMount(content)
+    trigger = el
   }
-  return { mount, anchor }
+  // Ref callbacks can run before attachment. Resolve once connected, and
+  // again when opening in case the trigger has moved into another layer.
+  onMount(update)
+  const open = (value: boolean) => {
+    if (value) update()
+  }
+  return { mount, anchor, open }
 }
 
 // Shared visual language for the OpenScience settings panels. Matches the
@@ -194,7 +209,7 @@ export const FilterMenu: Component<{
   const active = () => props.options.find((o) => o.id === props.value) ?? props.options[0]
   const dialog = useDialogMount()
   return (
-    <DropdownMenu>
+    <DropdownMenu onOpenChange={dialog.open}>
       <DropdownMenu.Trigger
         ref={dialog.anchor}
         aria-label={props.ariaLabel}
@@ -234,7 +249,7 @@ export interface AddItem {
 export const AddMenu: Component<{ label: string; items: AddItem[] }> = (props) => {
   const dialog = useDialogMount()
   return (
-    <DropdownMenu>
+    <DropdownMenu onOpenChange={dialog.open}>
       <DropdownMenu.Trigger
         ref={dialog.anchor}
         aria-label={props.label}


### PR DESCRIPTION
This closes two failures found during release verification.

Settings dropdowns looked up their enclosing dialog in a ref callback before the trigger was attached. The resulting body portal sat outside the modal dialog and was marked hidden, preventing ordinary accessible menu lookup. Resolve the mount after attachment and refresh it when opening; preserve the non-modal dropdown behavior that avoids stacked Windows scroll locks.

Enable the previously skipped skill-authoring browser test. It now exercises accessible keyboard and pointer activation, the exact save request and returned metadata, reload persistence, and the shared source-filter menu. The same test fails against the previous product source and passes with the lifecycle repair; no hidden locators, forced clicks, sleeps, or retry tolerance are added.

Native Windows CI then produced the expected Python output but failed to replace the compute job-status file with EPERM. Share the data-root barrier's existing two-second Windows rename policy with the jobs writer. Retry only the same completed temporary file on EPERM, EACCES, or EBUSY while retaining the writer lease and barrier. Keep the committed destination intact, preserve temporary-file cleanup, and report persistent or unrelated errors.

Validation: the browser suite passed all 94 tests on their first attempt, including the restored skill-authoring test. New failure-injection tests reproduce the immediate failure against the previous jobs writer and cover transient recovery, bounded persistent failure, old-file preservation, cleanup, and no retries for unrelated or non-Windows errors. The new tests also run in the native Windows Deep CI slice; the original selected-Python assertions are unchanged. All seven typecheck tasks passed. Final-source CI results are recorded in the checks.
