### PR TITLE
fix: trust validated provider tool calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ tagged release also ships native binaries for Linux, macOS, and Windows.
 
 ### Changed
 
+- Treat the validated provider tool call as authoritative, so an incomplete call
+  can be repaired safely without conflicting with its provisional stream event.
 - Preserve completed delegated work when a task is cancelled, report the
   worker's actual outcome and changed files to both the lead and UI, and bound
   silent remote response bodies without cutting off active streams. Keep the

--- a/backend/cli/src/session/processor.ts
+++ b/backend/cli/src/session/processor.ts
@@ -959,7 +959,6 @@ export namespace SessionProcessor {
                   break
 
                 case "tool-input-start":
-                  toolOutcomes.claim(value.id, value.toolName)
                   if (toolOutcomes.closed(value.id)) break
                   if (toolOutcomes.part(value.id)?.state.status === "running") break
                   const part = await Session.updatePart({
@@ -987,6 +986,7 @@ export namespace SessionProcessor {
                   break
 
                 case "tool-call": {
+                  toolOutcomes.claim(value.toolCallId, value.toolName)
                   const match = toolOutcomes.part(value.toolCallId)
                   if (match && !toolOutcomes.closed(value.toolCallId)) {
                     const part = await Session.updatePart({

--- a/frontend/workspace/e2e/prompt.spec.ts
+++ b/frontend/workspace/e2e/prompt.spec.ts
@@ -138,8 +138,18 @@ test("an incomplete provider tool call is recovered without a raw schema error",
       .toContain(`${token}_DONE`)
 
     const messages = await sdk.session.messages({ sessionID, limit: 50 }).then((response) => response.data ?? [])
+    const calls = messages.flatMap((message) => message.parts).filter((part) => part.type === "tool")
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toMatchObject({
+      tool: "invalid",
+      state: {
+        status: "completed",
+        input: { tool: "bash", failure: "invalid_input" },
+        title: "Recovered incomplete bash call",
+        metadata: { recovered: true, sourceTool: "bash" },
+      },
+    })
     const payload = JSON.stringify(messages)
-    expect(payload).toContain("Recovered incomplete bash call")
     expect(payload).not.toContain("expected string, received undefined")
     expect(payload).not.toContain("Please rewrite the input so it satisfies the expected schema")
     await expect(page.locator("body")).not.toContainText("expected string, received undefined")


### PR DESCRIPTION
A malformed provider tool call can emit a provisional `tool-input-start` name before the AI SDK validates and repairs the final call. OpenScience previously claimed the provisional name, so the safe repaired `invalid` execution could conflict with the same call ID and abort the turn.

This makes the validated/repaired `tool-call` authoritative while retaining the existing execution-signature and final-name conflict guards. The packaged prompt regression now proves the malformed Bash call produces exactly one completed `invalid` receipt, never a Bash execution receipt.

Validation:
- `bun test test/session/processor-tool-correlation.test.ts test/session/tool-call-repair.test.ts test/session/doom-loop.test.ts` (38 pass)
- `bun run test:e2e -- e2e/prompt.spec.ts` (3 pass)
- `bun run typecheck`
- `bun run format:check`
