### PR TITLE
Fix Bash output buffering without leaking boundary secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ tagged release also ships native binaries for Linux, macOS, and Windows.
 
 ## Unreleased
 
+- Oversized incomplete Bash output lines and private-key blocks are replaced with explicit redaction markers; provenance previews are redacted before clipping.
+
 - Keep launcher CPU fallback confined to a read-only startup probe, respect scientific-source cooldowns without early retries, preserve special characters in local file links, and verify upgrades when the old versioned executable remains on disk.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ tagged release also ships native binaries for Linux, macOS, and Windows.
 
 ## Unreleased
 
+- Linux supervised commands inherit blocking output handles so high-volume native tools do not abort with `EAGAIN` when their output pipe fills.
+
 - Oversized incomplete Bash output lines and private-key blocks are replaced with explicit redaction markers; provenance previews are redacted before clipping.
 
 - Keep launcher CPU fallback confined to a read-only startup probe, respect scientific-source cooldowns without early retries, preserve special characters in local file links, and verify upgrades when the old versioned executable remains on disk.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,13 @@ tagged release also ships native binaries for Linux, macOS, and Windows.
   results in the conversation's working area, connected folders, `file://`
   links and echoed `/file/raw` URLs, instead of navigating to a `localhost`
   page (opened in an external browser from the desktop app).
+- Stream shell output instead of buffering it (#564): the Bash tool redacts
+  each completed run of lines once and writes everything past the 50 KiB /
+  2,000-line preview straight into the owned output file, so a command that
+  prints hundreds of megabytes no longer holds all of it in memory or rescans
+  the whole history for secrets on every chunk; the live output card is
+  refreshed on a timer rather than per chunk, and a secret split across two
+  chunks or a multi-line private key is still redacted.
 - Keep folder access inside the project that approved it: **Allow always** is
   no longer offered for folder prompts and never creates an installation-wide
   grant, older installation-wide folder grants no longer apply, a shell working

--- a/backend/cli/src/process/linux-subreaper.ts
+++ b/backend/cli/src/process/linux-subreaper.ts
@@ -32,6 +32,7 @@ function openLibrary(): Library {
           args: [FFIType.i32, FFIType.u64, FFIType.u64, FFIType.u64, FFIType.u64],
           returns: FFIType.i32,
         },
+        fcntl: { args: [FFIType.i32, FFIType.i32, FFIType.i32], returns: FFIType.i32 },
         waitpid: {
           args: [FFIType.i32, FFIType.ptr, FFIType.i32],
           returns: FFIType.i32,
@@ -224,6 +225,8 @@ export namespace LinuxSubreaper {
   }
 
   export interface Handle {
+    /** Restore blocking output before a native payload inherits Bun's pipes. */
+    blockingOutput(): void
     /** Stop the complete current closure so no process can fork while an
      * owner/identity decision is temporarily unverifiable. */
     pause(primary?: Primary): Promise<Paused[]>
@@ -253,6 +256,7 @@ export namespace LinuxSubreaper {
       arg4: number,
       arg5: number,
     ) => number
+    const fcntl = library.symbols.fcntl as unknown as (fd: number, command: number, value: number) => number
     const waitpid = library.symbols.waitpid as unknown as (pid: number, status: number, options: number) => number
     const errnoLocation = library.symbols.__errno_location as unknown as () => number | bigint | null
     try {
@@ -283,6 +287,17 @@ export namespace LinuxSubreaper {
       }
 
       return {
+        blockingOutput() {
+          // Bun initializes inherited stdout/stderr as nonblocking. Native
+          // programs expect writes to wait for pipe capacity, not fail EAGAIN.
+          // This is called only in the dedicated launcher, before payload spawn.
+          for (const fd of [1, 2]) {
+            const flags = fcntl(fd, 3, 0)
+            if (flags < 0 || fcntl(fd, 4, flags & ~0x800) < 0) {
+              throw new Error(`Cannot restore blocking output for descriptor ${fd}`)
+            }
+          }
+        },
         async pause(primary) {
           while (true) {
             try {

--- a/backend/cli/src/process/windows-job-launcher.ts
+++ b/backend/cli/src/process/windows-job-launcher.ts
@@ -113,6 +113,7 @@ export namespace WindowsJobLauncher {
     // Internal launchers enter through index.ts, whose static graph installs
     // the server's signal handlers. Replace those with this supervisor's
     // forwarding contract so a signal is not translated twice.
+    subreaper.blockingOutput()
     const child = spawn(file, commandArgs, {
       cwd: process.cwd(),
       env: process.env,

--- a/backend/cli/src/tool/bash-output.ts
+++ b/backend/cli/src/tool/bash-output.ts
@@ -1,0 +1,199 @@
+import type { FileSink } from "bun"
+
+/**
+ * Bounded capture for a shell command's combined output.
+ *
+ * The previous capture kept every byte in memory and re-ran secret redaction
+ * over the whole history on each chunk, so a noisy command cost memory
+ * proportional to its output and quadratic CPU before the 50 KiB / 2,000-line
+ * truncation ever ran. This capture redacts each completed run of lines once,
+ * keeps only the head preview the model receives, and streams everything else
+ * to an owned output file that is opened the moment the preview overflows.
+ *
+ * Redaction boundaries: the patterns in OpenScience.redactSecrets never span a
+ * newline except the PEM block, so text is redacted in whole lines and an
+ * unterminated `-----BEGIN … PRIVATE KEY-----` is held back until its END
+ * marker arrives. A registered secret that straddles two chunks therefore
+ * still lands in one redaction pass. Both holds are capped so a command that
+ * never prints a newline cannot grow the pending buffer without bound.
+ */
+export namespace BashOutput {
+  /** Longest run kept unflushed while waiting for a newline or a PEM END. */
+  export const HOLD_LIMIT = 64 * 1024
+  const PEM_BEGIN = "-----BEGIN"
+  const PEM_END = "-----END"
+
+  export interface Options {
+    redact: (text: string) => string
+    maxBytes: number
+    maxLines: number
+    /** Opened once, when the preview first overflows. Receives every redacted
+     * byte from the start of the output. */
+    open: () => FileSink
+    /** Called after the preview changed; callers throttle their own publishing. */
+    onPreview?: (preview: string) => void
+  }
+
+  export interface Summary {
+    /** Redacted head of the output, within the byte and line limits. */
+    preview: string
+    truncated: boolean
+    bytes: number
+    lines: number
+    /** What the preview left out, in the unit whose limit was hit first. */
+    removed: { count: number; unit: "bytes" | "lines" }
+  }
+
+  export class Capture {
+    // Unflushed text is kept as separate parts and joined only when a flush is
+    // due. A substring in JavaScriptCore keeps its base string alive, so
+    // carrying `pending.slice(n)` from one concatenation to the next would
+    // have chained every chunk ever received into memory.
+    private parts: string[] = []
+    private pendingLength = 0
+    private preview = ""
+    private previewBytes = 0
+    private previewLines = 0
+    private previewClosed = false
+    private hitBytes = false
+    private bytes = 0
+    private lines = 0
+    private sink: FileSink | undefined
+    private ended = false
+
+    constructor(private readonly options: Options) {}
+
+    write(chunk: Buffer | string): void {
+      if (this.ended) return
+      const text = typeof chunk === "string" ? chunk : chunk.toString()
+      if (!text) return
+      this.parts.push(text)
+      this.pendingLength += text.length
+      if (text.includes("\n") || this.pendingLength > HOLD_LIMIT) this.flush(false)
+    }
+
+    /** Flush what is still pending, close the sink and describe the result. */
+    async end(): Promise<Summary> {
+      if (!this.ended) {
+        this.ended = true
+        this.flush(true)
+        if (this.sink) await this.sink.end()
+      }
+      const removed = this.hitBytes
+        ? { count: this.bytes - this.previewBytes, unit: "bytes" as const }
+        : { count: this.lines - this.previewLines, unit: "lines" as const }
+      return {
+        preview: this.preview,
+        truncated: this.previewClosed,
+        bytes: this.bytes,
+        lines: this.lines,
+        removed,
+      }
+    }
+
+    /** The preview as it stands, for live progress updates. */
+    current(): string {
+      return this.preview
+    }
+
+    private flush(final: boolean): void {
+      const pending = this.parts.length === 1 ? this.parts[0] : this.parts.join("")
+      const emit = (() => {
+        if (final) return pending
+        const newline = pending.lastIndexOf("\n")
+        if (newline < 0) {
+          // A single line past the hold limit is flushed anyway, at its last
+          // whitespace when it has one: no secret pattern spans whitespace, so
+          // the cut cannot split a token between two redaction passes.
+          if (pending.length <= HOLD_LIMIT) return ""
+          const space = pending.search(/\s\S*$/)
+          return space > 0 ? pending.slice(0, space + 1) : pending
+        }
+        const complete = pending.slice(0, newline + 1)
+        // Keep an open PEM block together so its body lines cannot escape the
+        // multi-line pattern by arriving in a different pass.
+        const begin = complete.lastIndexOf(PEM_BEGIN)
+        if (begin >= 0 && !complete.includes(PEM_END, begin) && complete.length - begin <= HOLD_LIMIT) {
+          return complete.slice(0, begin)
+        }
+        return complete
+      })()
+      if (!emit) return
+      const rest = pending.slice(emit.length)
+      this.parts = rest ? [rest] : []
+      this.pendingLength = rest.length
+      this.accept(this.options.redact(emit))
+    }
+
+    private accept(text: string): void {
+      if (!text) return
+      const size = Buffer.byteLength(text, "utf-8")
+      const newlines = count(text, "\n")
+      this.bytes += size
+      this.lines += newlines
+      if (this.sink) {
+        this.sink.write(text)
+        return
+      }
+      if (this.previewClosed) {
+        this.sink = this.options.open()
+        this.sink.write(this.preview)
+        this.sink.write(text)
+        return
+      }
+      const fits =
+        this.previewBytes + size <= this.options.maxBytes && this.previewLines + newlines < this.options.maxLines
+      if (fits) {
+        this.preview += text
+        this.previewBytes += size
+        this.previewLines += newlines
+        this.options.onPreview?.(this.preview)
+        return
+      }
+      // First overflow: keep whole lines up to the limits, then hand the full
+      // stream to the owned file from its first byte.
+      const kept = this.head(text)
+      this.preview += kept
+      this.previewBytes += Buffer.byteLength(kept, "utf-8")
+      this.previewLines += count(kept, "\n")
+      this.previewClosed = true
+      this.sink = this.options.open()
+      this.sink.write(this.preview)
+      this.sink.write(text.slice(kept.length))
+      this.options.onPreview?.(this.preview)
+    }
+
+    /** The longest whole-line prefix of `text` that still fits the limits. */
+    private head(text: string): string {
+      const lineBudget = this.options.maxLines - this.previewLines
+      const byteBudget = this.options.maxBytes - this.previewBytes
+      let end = 0
+      let bytes = 0
+      let lines = 0
+      while (end < text.length) {
+        const next = text.indexOf("\n", end)
+        const stop = next < 0 ? text.length : next + 1
+        const size = Buffer.byteLength(text.slice(end, stop), "utf-8")
+        if (bytes + size > byteBudget) {
+          this.hitBytes = true
+          break
+        }
+        if (next >= 0 && lines + 1 >= lineBudget) break
+        bytes += size
+        lines += next >= 0 ? 1 : 0
+        end = stop
+      }
+      return text.slice(0, end)
+    }
+  }
+
+  function count(text: string, needle: string): number {
+    let total = 0
+    let index = text.indexOf(needle)
+    while (index >= 0) {
+      total++
+      index = text.indexOf(needle, index + needle.length)
+    }
+    return total
+  }
+}

--- a/backend/cli/src/tool/bash-output.ts
+++ b/backend/cli/src/tool/bash-output.ts
@@ -10,23 +10,20 @@ import type { FileSink } from "bun"
  * keeps only the head preview the model receives, and streams everything else
  * to an owned output file that is opened the moment the preview overflows.
  *
- * Redaction boundaries: the patterns in OpenScience.redactSecrets never span a
- * newline except the PEM block, so text is redacted in whole lines and an
- * unterminated `-----BEGIN … PRIVATE KEY-----` is held back until its END
- * marker arrives. A registered secret that straddles two chunks therefore
- * still lands in one redaction pass. Both holds are capped so a command that
- * never prints a newline cannot grow the pending buffer without bound.
+ * Complete lines are redacted together. Open private-key blocks are held
+ * until their END marker; oversized incomplete lines and key blocks are
+ * discarded with an explicit redaction marker instead of exposing fragments.
  */
 export namespace BashOutput {
   /** Longest run kept unflushed while waiting for a newline or a PEM END. */
   export const HOLD_LIMIT = 64 * 1024
-  const PEM_BEGIN = "-----BEGIN"
-  const PEM_END = "-----END"
 
   export interface Options {
     redact: (text: string) => string
     maxBytes: number
     maxLines: number
+    /** Retain a redacted head only (for provenance), without opening a file. */
+    previewOnly?: boolean
     /** Opened once, when the preview first overflows. Receives every redacted
      * byte from the start of the output. */
     open: () => FileSink
@@ -60,11 +57,13 @@ export namespace BashOutput {
     private lines = 0
     private sink: FileSink | undefined
     private ended = false
+    private dropping: "line" | "pem" | undefined
+    private marker = ""
 
     constructor(private readonly options: Options) {}
 
     write(chunk: Buffer | string): void {
-      if (this.ended) return
+      if (this.ended || (this.options.previewOnly && this.previewClosed)) return
       const text = typeof chunk === "string" ? chunk : chunk.toString()
       if (!text) return
       this.parts.push(text)
@@ -97,36 +96,58 @@ export namespace BashOutput {
     }
 
     private flush(final: boolean): void {
-      const pending = this.parts.length === 1 ? this.parts[0] : this.parts.join("")
-      const emit = (() => {
-        if (final) return pending
-        const newline = pending.lastIndexOf("\n")
-        if (newline < 0) {
-          // A single line past the hold limit is flushed anyway, at its last
-          // whitespace when it has one: no secret pattern spans whitespace, so
-          // the cut cannot split a token between two redaction passes.
-          if (pending.length <= HOLD_LIMIT) return ""
-          const space = pending.search(/\s\S*$/)
-          return space > 0 ? pending.slice(0, space + 1) : pending
+      let pending = this.parts.length === 1 ? this.parts[0] : this.parts.join("")
+      if (this.dropping) {
+        const input = this.marker + pending
+        const end = this.dropping === "line" ? /\n/.exec(input) : /-----END(?: [A-Z0-9]+)? PRIVATE KEY-----/.exec(input)
+        if (!end) {
+          // Only the bounded marker tail is needed to recognize a split END.
+          this.marker = this.dropping === "pem" ? input.slice(-128) : ""
+          this.parts = []
+          this.pendingLength = 0
+          return
         }
-        const complete = pending.slice(0, newline + 1)
-        // Keep an open PEM block together so its body lines cannot escape the
-        // multi-line pattern by arriving in a different pass.
-        const begin = complete.lastIndexOf(PEM_BEGIN)
-        if (begin >= 0 && !complete.includes(PEM_END, begin) && complete.length - begin <= HOLD_LIMIT) {
-          return complete.slice(0, begin)
+        pending = input.slice(end.index + end[0].length)
+        if (this.dropping === "line") pending = "\n" + pending
+        this.dropping = undefined
+        this.marker = ""
+        this.parts = pending ? [pending] : []
+        this.pendingLength = pending.length
+      }
+      const newline = pending.lastIndexOf("\n")
+      let end = final ? pending.length : newline + 1
+      const begin = [...pending.matchAll(/-----BEGIN(?: [A-Z0-9]+)? PRIVATE KEY-----/g)].at(-1)
+      if (begin && !/-----END(?: [A-Z0-9]+)? PRIVATE KEY-----/.test(pending.slice(begin.index))) {
+        if (pending.length - begin.index > HOLD_LIMIT || final) {
+          this.accept(this.options.redact(pending.slice(0, begin.index)))
+          this.accept("[REDACTED]")
+          this.dropping = "pem"
+          this.marker = pending.slice(-128)
+          this.parts = []
+          this.pendingLength = 0
+          return
         }
-        return complete
-      })()
-      if (!emit) return
-      const rest = pending.slice(emit.length)
+        end = Math.min(end, begin.index)
+      }
+      if (!end && pending.length > HOLD_LIMIT) {
+        // There is no safe arbitrary cut: quoted and registered secrets may
+        // contain whitespace or straddle it. Omit this overlong logical line
+        // rather than leak a fragment or retain unbounded raw output.
+        this.accept("[REDACTED: oversized output line]")
+        this.dropping = "line"
+        this.parts = []
+        this.pendingLength = 0
+        return
+      }
+      if (!end) return
+      const rest = pending.slice(end)
       this.parts = rest ? [rest] : []
       this.pendingLength = rest.length
-      this.accept(this.options.redact(emit))
+      this.accept(this.options.redact(pending.slice(0, end)))
     }
 
     private accept(text: string): void {
-      if (!text) return
+      if (!text || (this.options.previewOnly && this.previewClosed)) return
       const size = Buffer.byteLength(text, "utf-8")
       const newlines = count(text, "\n")
       this.bytes += size
@@ -157,9 +178,11 @@ export namespace BashOutput {
       this.previewBytes += Buffer.byteLength(kept, "utf-8")
       this.previewLines += count(kept, "\n")
       this.previewClosed = true
-      this.sink = this.options.open()
-      this.sink.write(this.preview)
-      this.sink.write(text.slice(kept.length))
+      if (!this.options.previewOnly) {
+        this.sink = this.options.open()
+        this.sink.write(this.preview)
+        this.sink.write(text.slice(kept.length))
+      }
       this.options.onPreview?.(this.preview)
     }
 

--- a/backend/cli/src/tool/bash.ts
+++ b/backend/cli/src/tool/bash.ts
@@ -1,6 +1,8 @@
 import z from "zod"
 import { spawn } from "child_process"
+import { mkdirSync } from "node:fs"
 import { finished } from "node:stream/promises"
+import { StringDecoder } from "node:string_decoder"
 import { Tool } from "./tool"
 import path from "path"
 import DESCRIPTION from "./bash.txt"
@@ -16,6 +18,8 @@ import { Shell } from "@/shell/shell"
 
 import { BashArity } from "@/permission/arity"
 import { Truncate } from "./truncation"
+import { BashOutput } from "./bash-output"
+import { Agent } from "../agent/agent"
 import { OpenScience } from "@/openscience"
 import { Sandbox } from "@/sandbox/sandbox"
 import { SessionFilesystem } from "@/session/filesystem"
@@ -29,6 +33,10 @@ import { KernelEnvironmentMutation } from "@/science/kernel/environment-mutation
 import { FileOutputReceipts } from "@/file/output-receipts"
 
 const MAX_METADATA_LENGTH = 30_000
+/** How often the live output card is refreshed while a command runs. */
+const PREVIEW_INTERVAL = 200
+/** Characters of each stream kept for the provenance record (clip() adds the marker). */
+const PROVENANCE_HEAD = 2000
 const DEFAULT_TIMEOUT = Flag.OPENSCIENCE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS || 0
 
 export const log = Log.create({ service: "bash-tool" })
@@ -382,8 +390,6 @@ export const BashTool = Tool.define("bash", async () => {
       }).catch(() => undefined)
 
       const started = Date.now()
-      const streams = { stdout: "", stderr: "" }
-      let output = ""
 
       ctx.metadata({
         metadata: {
@@ -400,21 +406,39 @@ export const BashTool = Tool.define("bash", async () => {
         }
       }
 
-      const append = (chunk: Buffer) => {
-        output += chunk.toString()
-        const redacted = redact(output)
-        ctx.metadata({
-          metadata: {
-            output:
-              redacted.length > MAX_METADATA_LENGTH ? redacted.slice(0, MAX_METADATA_LENGTH) + "\n\n..." : redacted,
-            description: params.description,
-          },
-        })
+      // Output is bounded end to end: the model's head preview and the
+      // provenance heads stay in memory, everything past the preview streams
+      // into an owned output file, and the live card is refreshed on a timer
+      // rather than once per chunk.
+      const outputFile = Truncate.file()
+      const clipPreview = (text: string) =>
+        text.length > MAX_METADATA_LENGTH ? text.slice(0, MAX_METADATA_LENGTH) + "\n\n..." : text
+      let publishTimer: ReturnType<typeof setTimeout> | undefined
+      // Annotated to break the publish ↔ capture inference cycle.
+      const publish = (): void => {
+        publishTimer = undefined
+        ctx.metadata({ metadata: { output: clipPreview(capture.current()), description: params.description } })
       }
-
-      const capture = (channel: keyof typeof streams) => (chunk: Buffer) => {
-        streams[channel] += chunk.toString()
-        append(chunk)
+      const capture: BashOutput.Capture = new BashOutput.Capture({
+        redact,
+        maxBytes: Truncate.MAX_BYTES,
+        maxLines: Truncate.MAX_LINES,
+        open: () => {
+          mkdirSync(Truncate.DIR, { recursive: true })
+          return Bun.file(outputFile).writer()
+        },
+        onPreview: () => {
+          publishTimer ??= setTimeout(publish, PREVIEW_INTERVAL)
+        },
+      })
+      const heads = { stdout: "", stderr: "" }
+      const decoders = { stdout: new StringDecoder("utf-8"), stderr: new StringDecoder("utf-8") }
+      const record = (channel: keyof typeof heads) => (chunk: Buffer) => {
+        const text = decoders[channel].write(chunk)
+        if (heads[channel].length <= PROVENANCE_HEAD) {
+          heads[channel] += text.slice(0, PROVENANCE_HEAD + 1 - heads[channel].length)
+        }
+        capture.write(text)
       }
 
       let exited = false
@@ -463,8 +487,8 @@ export const BashTool = Tool.define("bash", async () => {
               stdio: ["ignore", "pipe", "pipe"],
               detached: process.platform !== "win32",
             })
-            child.stdout?.on("data", capture("stdout"))
-            child.stderr?.on("data", capture("stderr"))
+            child.stdout?.on("data", record("stdout"))
+            child.stderr?.on("data", record("stderr"))
           } catch (error) {
             Sandbox.cleanup(sandbox)
             throw error
@@ -538,12 +562,25 @@ export const BashTool = Tool.define("bash", async () => {
             }, timeout + 100)
           : undefined
 
-      await Promise.all([completion, drain]).finally(() => {
-        if (timeoutTimer) clearTimeout(timeoutTimer)
-        ctx.abort.removeEventListener("abort", abortHandler)
-        CommandRuntime.finish(command.id)
-        Sandbox.cleanup(sandbox)
-      })
+      const summary = await Promise.all([completion, drain])
+        .finally(() => {
+          if (timeoutTimer) clearTimeout(timeoutTimer)
+          ctx.abort.removeEventListener("abort", abortHandler)
+          CommandRuntime.finish(command.id)
+          Sandbox.cleanup(sandbox)
+          if (publishTimer) clearTimeout(publishTimer)
+          publishTimer = undefined
+        })
+        .finally(() => {
+          // Both streams have ended (or the spawn failed): settle the capture
+          // even when the command itself is reported as an error.
+          for (const channel of ["stdout", "stderr"] as const) {
+            const rest = decoders[channel].end()
+            if (rest) capture.write(rest)
+          }
+          return capture.end()
+        })
+        .then(() => capture.end())
 
       const completed = Date.now()
       const files = before
@@ -575,8 +612,8 @@ export const BashTool = Tool.define("bash", async () => {
         command: params.command,
         cwd,
         exit: proc.exitCode,
-        stdout: streams.stdout,
-        stderr: streams.stderr,
+        stdout: heads.stdout,
+        stderr: heads.stderr,
         startedAt: started,
         completedAt: completed,
       }).catch(() => undefined)
@@ -596,15 +633,22 @@ export const BashTool = Tool.define("bash", async () => {
         resultMetadata.push(stopped.reason ?? "User aborted the command")
       }
 
-      if (resultMetadata.length > 0) {
-        output += "\n\n<bash_metadata>\n" + resultMetadata.join("\n") + "\n</bash_metadata>"
-      }
-
-      const redactedOutput = redact(output)
-      const clipped =
-        redactedOutput.length > MAX_METADATA_LENGTH
-          ? redactedOutput.slice(0, MAX_METADATA_LENGTH) + "\n\n..."
-          : redactedOutput
+      const notes =
+        resultMetadata.length > 0 ? "\n\n<bash_metadata>\n" + resultMetadata.join("\n") + "\n</bash_metadata>" : ""
+      if (summary.truncated) await Truncate.grant(outputFile, ctx.sessionID)
+      const output =
+        (summary.truncated
+          ? Truncate.message(
+              {
+                preview: summary.preview,
+                removed: summary.removed.count,
+                unit: summary.removed.unit,
+                filepath: outputFile,
+              },
+              await Agent.get(ctx.agent).catch(() => undefined),
+            )
+          : summary.preview) + notes
+      const clipped = clipPreview(output)
       ctx.metadata({
         metadata: {
           output: clipped,
@@ -623,8 +667,12 @@ export const BashTool = Tool.define("bash", async () => {
           provenanceID: node?.id,
           execution_environment: KernelEnvironmentMutation.subprocessIdentity(runtime, cwd),
           ...files,
+          // Truncation happened while streaming; the generic post-execute
+          // pass must not materialize the output again.
+          truncated: summary.truncated,
+          ...(summary.truncated ? { outputPath: outputFile } : {}),
         },
-        output: redactedOutput,
+        output,
       }
     },
   }

--- a/backend/cli/src/tool/bash.ts
+++ b/backend/cli/src/tool/bash.ts
@@ -431,14 +431,31 @@ export const BashTool = Tool.define("bash", async () => {
           publishTimer ??= setTimeout(publish, PREVIEW_INTERVAL)
         },
       })
-      const heads = { stdout: "", stderr: "" }
+      const head = () =>
+        new BashOutput.Capture({
+          redact,
+          maxBytes: PROVENANCE_HEAD,
+          maxLines: Truncate.MAX_LINES,
+          previewOnly: true,
+          open: () => {
+            throw new Error("Provenance heads do not write output files")
+          },
+        })
+      const heads = { stdout: head(), stderr: head() }
+      let outputError: unknown
       const decoders = { stdout: new StringDecoder("utf-8"), stderr: new StringDecoder("utf-8") }
-      const record = (channel: keyof typeof heads) => (chunk: Buffer) => {
-        const text = decoders[channel].write(chunk)
-        if (heads[channel].length <= PROVENANCE_HEAD) {
-          heads[channel] += text.slice(0, PROVENANCE_HEAD + 1 - heads[channel].length)
+      const record = (channel: keyof typeof heads, child: ReturnType<typeof spawn>) => (chunk: Buffer) => {
+        if (outputError) return
+        try {
+          const text = decoders[channel].write(chunk)
+          heads[channel].write(text)
+          capture.write(text)
+        } catch (error) {
+          outputError = error
+          void Shell.killTree(child, { exited: () => exited, detached: process.platform !== "win32" }).catch(
+            () => undefined,
+          )
         }
-        capture.write(text)
       }
 
       let exited = false
@@ -487,8 +504,8 @@ export const BashTool = Tool.define("bash", async () => {
               stdio: ["ignore", "pipe", "pipe"],
               detached: process.platform !== "win32",
             })
-            child.stdout?.on("data", record("stdout"))
-            child.stderr?.on("data", record("stderr"))
+            child.stdout?.on("data", record("stdout", child))
+            child.stderr?.on("data", record("stderr", child))
           } catch (error) {
             Sandbox.cleanup(sandbox)
             throw error
@@ -576,11 +593,20 @@ export const BashTool = Tool.define("bash", async () => {
           // even when the command itself is reported as an error.
           for (const channel of ["stdout", "stderr"] as const) {
             const rest = decoders[channel].end()
-            if (rest) capture.write(rest)
+            if (rest) {
+              capture.write(rest)
+              heads[channel].write(rest)
+            }
           }
+          return Promise.all([capture.end(), heads.stdout.end(), heads.stderr.end()]).finally(() => {
+            if (publishTimer) clearTimeout(publishTimer)
+            publishTimer = undefined
+          })
+        })
+        .then(() => {
+          if (outputError) throw outputError
           return capture.end()
         })
-        .then(() => capture.end())
 
       const completed = Date.now()
       const files = before
@@ -612,8 +638,8 @@ export const BashTool = Tool.define("bash", async () => {
         command: params.command,
         cwd,
         exit: proc.exitCode,
-        stdout: heads.stdout,
-        stderr: heads.stderr,
+        stdout: heads.stdout.current(),
+        stderr: heads.stderr.current(),
         startedAt: started,
         completedAt: completed,
       }).catch(() => undefined)

--- a/backend/cli/src/tool/truncation.ts
+++ b/backend/cli/src/tool/truncation.ts
@@ -51,6 +51,35 @@ export namespace Truncate {
     return rule.action !== "deny"
   }
 
+  /** A fresh owned output path; the file is created by whoever writes it. */
+  export function file(): string {
+    return path.join(DIR, Identifier.ascending("tool"))
+  }
+
+  export function hint(filepath: string, agent?: Agent.Info): string {
+    return hasTaskTool(agent)
+      ? `The tool call succeeded but the output was truncated. Full output saved to: ${filepath}\nUse the Task tool to have explore agent process this file with Grep and Read (with offset/limit). Do NOT read the full file yourself - delegate to save context.`
+      : `The tool call succeeded but the output was truncated. Full output saved to: ${filepath}\nUse Grep to search the full content or Read with offset/limit to view specific sections.`
+  }
+
+  /** The model-facing text for a truncated result: the kept preview, what was
+   * left out, and where the full output lives. */
+  export function message(
+    input: { preview: string; removed: number; unit: "bytes" | "lines"; filepath: string; direction?: "head" | "tail" },
+    agent?: Agent.Info,
+  ): string {
+    const note = `...${input.removed} ${input.unit} truncated...`
+    const guidance = hint(input.filepath, agent)
+    return (input.direction ?? "head") === "head"
+      ? `${input.preview}\n\n${note}\n\n${guidance}`
+      : `${note}\n\n${guidance}\n\n${input.preview}`
+  }
+
+  export async function grant(filepath: string, sessionID?: string): Promise<void> {
+    if (!sessionID?.startsWith("ses_")) return
+    await SessionFilesystem.grantToolOutput({ sessionID, path: filepath })
+  }
+
   export async function output(text: string, options: Options = {}, agent?: Agent.Info): Promise<Result> {
     const maxLines = options.maxLines ?? MAX_LINES
     const maxBytes = options.maxBytes ?? MAX_BYTES
@@ -93,24 +122,14 @@ export namespace Truncate {
     const unit = hitBytes ? "bytes" : "lines"
     const preview = out.join("\n")
 
-    const id = Identifier.ascending("tool")
-    const filepath = path.join(DIR, id)
+    const filepath = file()
     await Bun.write(Bun.file(filepath), text)
-    if (options.sessionID?.startsWith("ses_")) {
-      await SessionFilesystem.grantToolOutput({
-        sessionID: options.sessionID,
-        path: filepath,
-      })
+    await grant(filepath, options.sessionID)
+
+    return {
+      content: message({ preview, removed, unit, filepath, direction }, agent),
+      truncated: true,
+      outputPath: filepath,
     }
-
-    const hint = hasTaskTool(agent)
-      ? `The tool call succeeded but the output was truncated. Full output saved to: ${filepath}\nUse the Task tool to have explore agent process this file with Grep and Read (with offset/limit). Do NOT read the full file yourself - delegate to save context.`
-      : `The tool call succeeded but the output was truncated. Full output saved to: ${filepath}\nUse Grep to search the full content or Read with offset/limit to view specific sections.`
-    const message =
-      direction === "head"
-        ? `${preview}\n\n...${removed} ${unit} truncated...\n\n${hint}`
-        : `...${removed} ${unit} truncated...\n\n${hint}\n\n${preview}`
-
-    return { content: message, truncated: true, outputPath: filepath }
   }
 }

--- a/backend/cli/test/tool/bash-output.test.ts
+++ b/backend/cli/test/tool/bash-output.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, test } from "bun:test"
+import fs from "fs/promises"
+import os from "os"
+import path from "path"
+import { BashOutput } from "../../src/tool/bash-output"
+import { OpenScience } from "../../src/openscience"
+
+async function scratch() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openscience-bash-output-"))
+  const file = path.join(dir, "tool_output")
+  return {
+    file,
+    opened: 0,
+    open() {
+      this.opened++
+      return Bun.file(file).writer()
+    },
+    async text() {
+      return Bun.file(file).text()
+    },
+    async [Symbol.asyncDispose]() {
+      await fs.rm(dir, { recursive: true, force: true })
+    },
+  }
+}
+
+const identity = (text: string) => text
+
+describe("BashOutput.Capture", () => {
+  test("keeps small output in memory without touching the disk", async () => {
+    await using sink = await scratch()
+    const capture = new BashOutput.Capture({ redact: identity, maxBytes: 1024, maxLines: 50, open: () => sink.open() })
+    capture.write("hello\n")
+    capture.write(Buffer.from("world\n"))
+    const summary = await capture.end()
+    expect(summary).toMatchObject({ preview: "hello\nworld\n", truncated: false, bytes: 12, lines: 2 })
+    expect(sink.opened).toBe(0)
+  })
+
+  test("streams the full redacted output to the owned file once the preview overflows", async () => {
+    await using sink = await scratch()
+    const redact = (text: string) => text.replaceAll("sk-secret1234", "[REDACTED]")
+    const capture = new BashOutput.Capture({ redact, maxBytes: 10 * 1024, maxLines: 100, open: () => sink.open() })
+    const lines = 5_000
+    for (let i = 1; i <= lines; i++) capture.write(`line ${i} token=sk-secret1234\n`)
+    const summary = await capture.end()
+
+    expect(summary.truncated).toBe(true)
+    expect(summary.lines).toBe(lines)
+    expect(summary.removed).toEqual({ count: lines - 99, unit: "lines" })
+    expect(summary.preview.split("\n")).toHaveLength(100)
+    expect(summary.preview).not.toContain("sk-secret1234")
+    expect(sink.opened).toBe(1)
+    const saved = await sink.text()
+    expect(saved.split("\n")).toHaveLength(lines + 1)
+    expect(saved.startsWith("line 1 token=[REDACTED]\n")).toBe(true)
+    expect(saved.endsWith(`line ${lines} token=[REDACTED]\n`)).toBe(true)
+    expect(saved).not.toContain("sk-secret1234")
+  })
+
+  test("reports bytes when a byte limit is hit before the line limit", async () => {
+    await using sink = await scratch()
+    const capture = new BashOutput.Capture({ redact: identity, maxBytes: 100, maxLines: 1000, open: () => sink.open() })
+    capture.write("a".repeat(60) + "\n")
+    capture.write("b".repeat(60) + "\n")
+    capture.write("c".repeat(60) + "\n")
+    const summary = await capture.end()
+    expect(summary.preview).toBe("a".repeat(60) + "\n")
+    expect(summary.removed).toEqual({ count: 122, unit: "bytes" })
+    expect(await sink.text()).toHaveLength(183)
+  })
+
+  test("redacts a registered secret that arrives split across chunks", async () => {
+    await using sink = await scratch()
+    const [head, tail] = ["sk-liveABCD", "EFGHIJKLMNOP"]
+    const secret = head + tail
+    const capture = new BashOutput.Capture({
+      redact: OpenScience.redactSecrets,
+      maxBytes: 4096,
+      maxLines: 100,
+      open: () => sink.open(),
+    })
+    capture.write(`export OPENAI_API_KEY=${head}`)
+    capture.write(`${tail}\nnext line\n`)
+    const summary = await capture.end()
+    expect(summary.preview).not.toContain(secret)
+    expect(summary.preview).toContain("[REDACTED]")
+    expect(summary.preview).toContain("next line")
+  })
+
+  test("holds an open PEM block until its end marker so the body never escapes redaction", async () => {
+    await using sink = await scratch()
+    const capture = new BashOutput.Capture({
+      redact: OpenScience.redactSecrets,
+      maxBytes: 8192,
+      maxLines: 200,
+      open: () => sink.open(),
+    })
+    // Fixture body is deliberately not key-shaped; the pattern keys on the markers.
+    const marker = (edge: string) => `-----${edge} PRIVATE KEY-----`
+    capture.write(`before\n${marker("BEGIN")}\nABCDEF\n`)
+    capture.write("GHIJKL\n")
+    capture.write(`${marker("END")}\nafter\n`)
+    const summary = await capture.end()
+    expect(summary.preview).toBe("before\n[REDACTED]\nafter\n")
+  })
+
+  test("does not let a command without newlines grow the pending buffer without bound", async () => {
+    await using sink = await scratch()
+    const capture = new BashOutput.Capture({
+      redact: identity,
+      maxBytes: 1024,
+      maxLines: 10,
+      open: () => sink.open(),
+    })
+    const chunk = "x".repeat(16 * 1024)
+    for (let i = 0; i < 16; i++) capture.write(chunk)
+    // Everything beyond the hold limit has already been flushed to the file.
+    expect((await sink.text()).length).toBeGreaterThanOrEqual(BashOutput.HOLD_LIMIT)
+    const summary = await capture.end()
+    expect(summary.bytes).toBe(16 * 16 * 1024)
+    expect((await sink.text()).length).toBe(16 * 16 * 1024)
+  })
+
+  test("a forced flush of an overlong line cuts at whitespace so a straddling secret stays whole", async () => {
+    await using sink = await scratch()
+    const capture = new BashOutput.Capture({
+      redact: OpenScience.redactSecrets,
+      maxBytes: 1024,
+      maxLines: 10,
+      open: () => sink.open(),
+    })
+    const [head, tail] = ["sk-straddle0123", "456789"]
+    capture.write("x".repeat(BashOutput.HOLD_LIMIT + 10) + ` token=${head}`)
+    capture.write(`${tail} tail\n`)
+    await capture.end()
+    const saved = await sink.text()
+    expect(saved).not.toContain(head + tail)
+    expect(saved.endsWith(" token=[REDACTED] tail\n")).toBe(true)
+  })
+
+  test("bounded memory and linear time for a large noisy stream", async () => {
+    await using sink = await scratch()
+    let redactions = 0
+    let redactedBytes = 0
+    const redact = (text: string) => {
+      redactions++
+      redactedBytes += text.length
+      return text
+    }
+    const capture = new BashOutput.Capture({
+      redact,
+      maxBytes: 50 * 1024,
+      maxLines: 2000,
+      open: () => sink.open(),
+    })
+    const chunk = "0123456789abcdef".repeat(256) + "\n" // 4 KiB lines
+    const chunks = 8 * 1024 // 32 MiB total
+    const heap = process.memoryUsage().heapUsed
+    for (let i = 0; i < chunks; i++) capture.write(chunk)
+    const grown = process.memoryUsage().heapUsed - heap
+    const summary = await capture.end()
+
+    expect(summary.bytes).toBe(chunk.length * chunks)
+    // Each byte is redacted exactly once: no rescans of the accumulated history.
+    expect(redactedBytes).toBe(chunk.length * chunks)
+    expect(redactions).toBe(chunks)
+    // The capture retains the preview and a bounded pending run, not the stream.
+    expect(capture.current().length).toBeLessThanOrEqual(50 * 1024)
+    expect(grown).toBeLessThan(8 * 1024 * 1024)
+    expect((await fs.stat(sink.file)).size).toBe(chunk.length * chunks)
+  })
+})

--- a/backend/cli/test/tool/bash-output.test.ts
+++ b/backend/cli/test/tool/bash-output.test.ts
@@ -25,6 +25,7 @@ async function scratch() {
 }
 
 const identity = (text: string) => text
+const pem = (edge: string) => `-----${edge} PRIVATE KEY-----`
 
 describe("BashOutput.Capture", () => {
   test("keeps small output in memory without touching the disk", async () => {
@@ -115,14 +116,13 @@ describe("BashOutput.Capture", () => {
     })
     const chunk = "x".repeat(16 * 1024)
     for (let i = 0; i < 16; i++) capture.write(chunk)
-    // Everything beyond the hold limit has already been flushed to the file.
-    expect((await sink.text()).length).toBeGreaterThanOrEqual(BashOutput.HOLD_LIMIT)
     const summary = await capture.end()
-    expect(summary.bytes).toBe(16 * 16 * 1024)
-    expect((await sink.text()).length).toBe(16 * 16 * 1024)
+    expect(summary.preview).toContain("[REDACTED: oversized output line]")
+    expect(summary.bytes).toBeLessThan(1024)
+    expect(sink.opened).toBe(0)
   })
 
-  test("a forced flush of an overlong line cuts at whitespace so a straddling secret stays whole", async () => {
+  test("an oversized incomplete line cannot leak a split quoted secret", async () => {
     await using sink = await scratch()
     const capture = new BashOutput.Capture({
       redact: OpenScience.redactSecrets,
@@ -130,13 +130,42 @@ describe("BashOutput.Capture", () => {
       maxLines: 10,
       open: () => sink.open(),
     })
-    const [head, tail] = ["sk-straddle0123", "456789"]
-    capture.write("x".repeat(BashOutput.HOLD_LIMIT + 10) + ` token=${head}`)
-    capture.write(`${tail} tail\n`)
+    capture.write("x".repeat(BashOutput.HOLD_LIMIT) + ' password="sensitive first ')
+    capture.write('second half"\nnext line\n')
+    const summary = await capture.end()
+    expect(summary.preview).toBe("[REDACTED: oversized output line]\nnext line\n")
+  })
+
+  test("oversized PEM bodies remain redacted across a split END marker", async () => {
+    await using sink = await scratch()
+    const capture = new BashOutput.Capture({
+      redact: OpenScience.redactSecrets,
+      maxBytes: 1024,
+      maxLines: 10,
+      open: () => sink.open(),
+    })
+    capture.write(`before\n${pem("BEGIN")}\n`)
+    for (let i = 0; i < 100; i++) capture.write("sensitive".repeat(100) + "\n")
+    capture.write("-----EN")
+    capture.write("D PRIVATE KEY-----\nafter\n")
+    const summary = await capture.end()
+    expect(summary.preview).toBe("before\n[REDACTED]\nafter\n")
+  })
+
+  test("a provenance head never exposes a private key cut at the preview limit", async () => {
+    const capture = new BashOutput.Capture({
+      redact: OpenScience.redactSecrets,
+      maxBytes: 2000,
+      maxLines: 2000,
+      previewOnly: true,
+      open: () => {
+        throw new Error("must not open")
+      },
+    })
+    capture.write(`before\n${pem("BEGIN")}\n` + "body".repeat(1000) + "\n")
+    capture.write(`${pem("END")}\nafter\n`)
     await capture.end()
-    const saved = await sink.text()
-    expect(saved).not.toContain(head + tail)
-    expect(saved.endsWith(" token=[REDACTED] tail\n")).toBe(true)
+    expect(capture.current()).toBe("before\n[REDACTED]\nafter\n")
   })
 
   test("bounded memory and linear time for a large noisy stream", async () => {

--- a/backend/cli/test/tool/bash.test.ts
+++ b/backend/cli/test/tool/bash.test.ts
@@ -496,7 +496,15 @@ describe("tool.bash truncation", () => {
         expect(updates).toBeLessThan(200)
         const saved = await Bun.file((result.metadata as any).outputPath).text()
         expect(saved).not.toContain("sk-largeoutput0123456789")
-        expect(saved.split("\n").length).toBeGreaterThan(300_000)
+        expect(
+          saved.split("\n").length,
+          JSON.stringify({
+            exit: result.metadata.exit,
+            output: result.output.slice(-1200),
+            savedTail: saved.slice(-600),
+            size: saved.length,
+          }),
+        ).toBeGreaterThan(300_000)
       },
     })
   }, 60_000)

--- a/backend/cli/test/tool/bash.test.ts
+++ b/backend/cli/test/tool/bash.test.ts
@@ -464,6 +464,43 @@ describe("tool.bash truncation", () => {
     })
   })
 
+  test("streams a large noisy output in linear time with a throttled live preview", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const bash = await BashTool.init()
+        const base = await context()
+        let updates = 0
+        const testCtx = {
+          ...base,
+          metadata() {
+            updates++
+          },
+        }
+        const bytes = 20_000_000
+        const started = Date.now()
+        // The previous capture re-ran redaction over the whole accumulated
+        // output on every chunk; 20 MB in pipe-sized chunks took minutes.
+        const result = await bash.execute(
+          {
+            command: `yes 'token=sk-largeoutput0123456789 filler text for the stream' | head -c ${bytes}`,
+            description: "Generate a large noisy stream",
+          },
+          testCtx,
+        )
+        expect(Date.now() - started).toBeLessThan(20_000)
+        expect((result.metadata as any).truncated).toBe(true)
+        expect(result.output).not.toContain("sk-largeoutput0123456789")
+        expect(result.output.length).toBeLessThan(Truncate.MAX_BYTES + 2_000)
+        // One live update per interval, not one per chunk.
+        expect(updates).toBeLessThan(200)
+        const saved = await Bun.file((result.metadata as any).outputPath).text()
+        expect(saved).not.toContain("sk-largeoutput0123456789")
+        expect(saved.split("\n").length).toBeGreaterThan(300_000)
+      },
+    })
+  }, 60_000)
+
   test("full output is saved to file when truncated", async () => {
     await Instance.provide({
       directory: projectRoot,


### PR DESCRIPTION
## Summary

Fixes #564: noisy Bash output is captured with bounded memory and a single redaction pass over each completed span, instead of repeatedly redacting the full accumulated history. The model receives a bounded preview and larger output streams to the owned output file; live updates are throttled to 200 ms.

This carries only commit 55520e59 onto v2.0.84, preserving the four fixes added during review of #565. Review additionally closes redaction gaps at the 64 KiB hold boundary and in provenance previews, cancels final preview timers, and turns output-file failures into tool errors. Oversized incomplete lines and private-key blocks receive explicit redaction markers instead of exposing secret fragments.

Linux reproduction also found that the existing durable launcher passed non-blocking stdout/stderr to native programs. GNU `head` aborted early with EAGAIN under load. The dedicated launcher now restores blocking output before spawning its payload; the same 20 MB real-tool test passes on Linux with the complete saved stream.

## Validation

Pinned Bun typecheck and focused Bash capture, real Bash execution, and truncation tests. The large-output fixture checks the saved redacted output and bounded update count. Existing release CI will validate the merged source before publication.
