### PR TITLE
A calm header while a turn runs; a patient balance check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,22 @@ tagged release also ships native binaries for Linux, macOS, and Windows.
 
 ## Unreleased
 
+### Changed
+
+- While a turn runs, its header reads as one calm word for what is happening:
+  Thinking, or the activity of the tool that is running, beside the elapsed
+  clock. Preparing, sending, waiting-for-output and quiet-stream phases no
+  longer take turns on the line; the request detail ("No new output from
+  openai/gpt-5.6-sol for 58s") sits in the tooltip, and only a retry countdown
+  or a conflict wait still speaks for itself.
+- A tool's body renders as a receipt: a loaded skill's SKILL.md and other
+  tool output sit at the meta type level with headings brought down to it.
+
 ### Fixed
 
+- The wallet balance check before an Ace request now waits up to 8 seconds
+  instead of 3, so a slow afternoon at the account service no longer turns every
+  step into a paused turn and a retry countdown.
 - Stopping a turn now cancels the MCP tool call that is still running: OpenScience sends the protocol cancellation to the server instead of abandoning the request, ignores a reply that arrives afterwards, and releases the update lease the call was holding.
 - The shell installer uses CPU flags exposed by Windows POSIX environments and defaults to the baseline archive when they are absent or unreadable, so x86-64 Windows hosts without confirmed AVX2 support avoid an optimized binary that dies with an illegal instruction.
 - The global event stream the workspace subscribes to now buffers a bounded number of events per connection instead of growing the server's memory for as long as a browser tab stays stalled, and a tab that misses events re-hydrates on the next `server.connected` frame exactly as it does after a reconnect.

--- a/backend/cli/src/openscience/index.ts
+++ b/backend/cli/src/openscience/index.ts
@@ -1670,7 +1670,10 @@ export namespace OpenScience {
   // the background, up to this age. A missing, non-positive or older value
   // blocks on the fetch so an empty wallet is noticed promptly.
   const BALANCE_STALE_MAX_MS = 5 * 60_000
-  const BALANCE_FETCH_TIMEOUT_MS = 3_000
+  // The account service has answered in 1–2 s on slow afternoons; a 3 s cap
+  // turned those into a paused turn and a retry countdown before every step.
+  // Match the credential sync's patience instead.
+  const BALANCE_FETCH_TIMEOUT_MS = 8_000
 
   /** Expire the cached balance after a spend or credential change. A positive
    * value is kept past its TTL so the next check serves it while a refresh runs

--- a/frontend/ui/src/components/session-turn-progress.test.ts
+++ b/frontend/ui/src/components/session-turn-progress.test.ts
@@ -3,7 +3,7 @@ import { readdirSync } from "node:fs"
 import { fileURLToPath } from "node:url"
 import type { SessionRequestProgress } from "@synsci/sdk/v2/client"
 import { dict as en } from "../i18n/en"
-import { PROGRESS_HINT_MS, PROGRESS_SLOW_MS, progressStatus } from "./session-turn-progress"
+import { PROGRESS_HINT_MS, PROGRESS_SLOW_MS, headerProgress, progressStatus } from "./session-turn-progress"
 
 const since = 1_000_000
 const base: SessionRequestProgress = {
@@ -133,5 +133,23 @@ describe("request phase status copy", () => {
         for (const name of Object.keys(item.params)) expect(mod.dict[item.key]).toContain(`{{${name}}}`)
       }
     }
+  })
+})
+
+describe("headerProgress", () => {
+  test("only a retry countdown or a conflict wait earn a label of their own", () => {
+    expect(headerProgress(at("preparing"), since + 40_000)).toBeUndefined()
+    expect(headerProgress(at("connecting"), since + 5_000)).toBeUndefined()
+    expect(headerProgress(at("waiting_first_token"), since + 20_000)).toBeUndefined()
+    expect(headerProgress(at("streaming", { lastOutputAt: since }), since + 90_000)).toBeUndefined()
+    expect(headerProgress(undefined, since)).toBeUndefined()
+    expect(headerProgress(at("retry_wait", { retryAfterMs: 8_000 }), since + 1_000)).toEqual({
+      key: "ui.sessionTurn.progress.retryWait",
+      params: { seconds: 7 },
+    })
+    expect(headerProgress(at("conflict_wait"), since + 4_000)).toEqual({
+      key: "ui.sessionTurn.progress.conflictWait",
+      params: { seconds: 4 },
+    })
   })
 })

--- a/frontend/ui/src/components/session-turn-progress.ts
+++ b/frontend/ui/src/components/session-turn-progress.ts
@@ -56,3 +56,12 @@ export function progressStatus(progress: SessionRequestProgress | undefined, now
       return
   }
 }
+
+/** The phases the header names while a turn runs. A retry countdown and a
+ * conflict wait change what the reader might do next; every other phase — the
+ * access check, the connect, a body that has gone quiet — reads as thinking,
+ * with the elapsed clock beside it and the request detail one hover away. */
+export function headerProgress(progress: SessionRequestProgress | undefined, now: number): ProgressStatus | undefined {
+  if (progress?.phase !== "retry_wait" && progress?.phase !== "conflict_wait") return
+  return progressStatus(progress, now)
+}

--- a/frontend/ui/src/components/session-turn-trajectory.test.ts
+++ b/frontend/ui/src/components/session-turn-trajectory.test.ts
@@ -1044,6 +1044,8 @@ describe("execution inspection", () => {
     })
     const host = mount(() => turn.SessionTurn({ sessionID, messageID: user.id, lastUserMessageID: user.id }), store)
     const status = () => host.querySelector('[data-slot="session-turn-status-text"]')?.textContent ?? ""
+    const detail = () =>
+      host.querySelector('[data-slot="session-turn-collapsible-trigger-content"]')?.getAttribute("title") ?? ""
     await ready(() => status().includes("Running commands"))
     setStore("session_progress", {
       [sessionID]: {
@@ -1069,8 +1071,11 @@ describe("execution inspection", () => {
     })
     await settle()
     // The model is still generating arguments; no command is executing yet.
-    expect(status()).toContain("No new output from")
+    // The header reads as thinking; the quiet stream is a hover away.
+    expect(status()).toBe("Thinking")
     expect(status()).not.toContain("Running commands")
+    expect(detail()).toMatch(/No new output from openai\/gpt-5\.6-sol for (59|60)s/)
+    expect(detail()).toContain("The response is still open.")
     setStore("part", first.id, 0, {
       ...command,
       state: {
@@ -1098,8 +1103,18 @@ describe("execution inspection", () => {
         stalls: 0,
       },
     })
-    await ready(() => status().includes("Waiting for output from openai/gpt-5.6-sol"))
+    await ready(() => detail().includes("Waiting for output from openai/gpt-5.6-sol (7s)"))
+    expect(status()).toBe("Thinking")
     expect(status()).not.toContain("Running commands")
+    // A retry countdown is the one request phase worth its own words.
+    setStore("session_progress", sessionID, {
+      ...store.session_progress![sessionID],
+      phase: "retry_wait",
+      since: Date.now(),
+      retryAfterMs: 8_000,
+    })
+    await ready(() => status().includes("Retrying in"))
+    expect(status()).toMatch(/Retrying in [78]s/)
   })
 })
 
@@ -1230,10 +1245,11 @@ describe("timeout recovery", () => {
         since: Date.now(),
       })
       await ready(() =>
-        (host.querySelector('[data-slot="session-turn-status-text"]')?.textContent ?? "").includes(
-          "Waiting for output from openai/gpt-5.6-sol",
-        ),
+        (
+          host.querySelector('[data-slot="session-turn-collapsible-trigger-content"]')?.getAttribute("title") ?? ""
+        ).includes("Waiting for output from openai/gpt-5.6-sol"),
       )
+      expect(host.querySelector('[data-slot="session-turn-status-text"]')?.textContent).toBe("Thinking")
       expect(host.querySelector('[data-slot="session-turn-trace-control"] [data-component="spinner"]')).not.toBeNull()
     },
   )
@@ -1594,7 +1610,7 @@ describe("trace control", () => {
     )
     await ready(() => status(host) !== null)
     expect(host.querySelector('[data-slot="session-turn-collapsible-trigger-content"]')).toBeNull()
-    expect(status(host)?.textContent).toContain("Preparing next step")
+    expect(status(host)?.textContent).toContain("Thinking")
   })
 })
 

--- a/frontend/ui/src/components/session-turn.tsx
+++ b/frontend/ui/src/components/session-turn.tsx
@@ -54,7 +54,7 @@ import { createStore } from "solid-js/store"
 import { createAutoScroll } from "../hooks"
 import { createResizeObserver } from "@solid-primitives/resize-observer"
 import { responseText } from "./session-turn-response"
-import { progressStatus } from "./session-turn-progress"
+import { headerProgress, progressStatus } from "./session-turn-progress"
 import { collapsibleTracePart, elapsedLabel, visibleResearchTrace, type ResearchTraceEntry } from "./research-trace"
 import { buildTraceRows, editedLabel, exploredLabel, thoughtLabel, type TraceRow } from "./trace-rows"
 import { Collapsible } from "./collapsible"
@@ -795,25 +795,21 @@ export function SessionTurn(
     onCleanup(() => clearInterval(timer))
   })
 
-  // Waiting belongs to the current request. Completed tools from earlier
-  // steps must never replace it with a stale execution label.
-  const phase = createMemo(() => {
-    const current = progress()
-    const status = progressStatus(current, store.now)
-    const latest = assistantMessages().at(-1)
-    const running =
-      latest &&
-      (data.store.part[latest.id] ?? emptyParts).some((part) => part.type === "tool" && part.state.status === "running")
-    if (current?.phase === "streaming" && running) return
-    if (current?.phase === "streaming" && !status?.hint && rawStatus()) return
-    return status
+  // The header names what the reader can act on: a retry countdown or a
+  // conflict wait. A request being prepared, sent or quietly streamed reads
+  // as thinking, and the tool that is running reads as its own activity. The
+  // clock beside the label keeps the wait honest; the request detail
+  // ("Waiting for output from …", "No new output for 58s") sits in the tooltip.
+  const phase = createMemo(() => headerProgress(progress(), store.now))
+  const detail = createMemo(() => {
+    const status = progressStatus(progress(), store.now)
+    if (!status) return
+    return [i18n.t(status.key, status.params), status.hint ? i18n.t(status.hint) : ""].filter(Boolean).join(" ")
   })
   const statusText = createMemo(() => {
     const live = phase()
     if (live) return i18n.t(live.key, live.params)
-    const current = rawStatus()
-    if (current) return current
-    return i18n.t("ui.sessionTurn.status.consideringNextSteps")
+    return rawStatus() ?? i18n.t("ui.sessionTurn.status.thinking")
   })
 
   return (
@@ -869,7 +865,7 @@ export function SessionTurn(
                             aria-expanded={expanded()}
                             aria-controls={traceID()}
                             aria-label={i18n.t(expanded() ? "ui.sessionTurn.steps.hide" : "ui.sessionTurn.steps.show")}
-                            title={i18n.t("ui.sessionTurn.totalTime")}
+                            title={(working() && detail()) || i18n.t("ui.sessionTurn.totalTime")}
                             onClick={toggleSteps}
                           >
                             <Show when={working()}>
@@ -907,7 +903,7 @@ export function SessionTurn(
                           </Button>
                         </Show>
                         <Show when={working() && !hasSteps()}>
-                          <div data-slot="session-turn-live-status" aria-live="off" title={statusText()}>
+                          <div data-slot="session-turn-live-status" aria-live="off" title={detail() ?? statusText()}>
                             <Spinner />
                             <span data-slot="session-turn-status-text">{statusText()}</span>
                             <span data-slot="session-turn-duration" aria-live="off">

--- a/frontend/ui/src/i18n/ar.ts
+++ b/frontend/ui/src/i18n/ar.ts
@@ -22,7 +22,6 @@ export const dict = {
   "ui.sessionTurn.status.runningCommands": "تشغيل الأوامر",
   "ui.sessionTurn.status.thinking": "تفكير",
   "ui.sessionTurn.status.gatheringThoughts": "جمع الأفكار",
-  "ui.sessionTurn.status.consideringNextSteps": "النظر في الخطوات التالية",
   "ui.sessionTurn.progress.connecting": "جارٍ الاتصال بـ {{model}}…",
   "ui.sessionTurn.progress.stillConnecting": "لا يزال الاتصال بـ {{model}} جارياً ({{seconds}} ث)",
   "ui.sessionTurn.progress.waitingFirstToken": "في انتظار بدء {{model}} ({{seconds}} ث)",

--- a/frontend/ui/src/i18n/br.ts
+++ b/frontend/ui/src/i18n/br.ts
@@ -22,7 +22,6 @@ export const dict = {
   "ui.sessionTurn.status.runningCommands": "Executando comandos",
   "ui.sessionTurn.status.thinking": "Pensando",
   "ui.sessionTurn.status.gatheringThoughts": "Organizando pensamentos",
-  "ui.sessionTurn.status.consideringNextSteps": "Considerando próximos passos",
   "ui.sessionTurn.progress.connecting": "Conectando a {{model}}…",
   "ui.sessionTurn.progress.stillConnecting": "Ainda conectando a {{model}} ({{seconds}}s)",
   "ui.sessionTurn.progress.waitingFirstToken": "Aguardando {{model}} começar ({{seconds}}s)",

--- a/frontend/ui/src/i18n/da.ts
+++ b/frontend/ui/src/i18n/da.ts
@@ -22,7 +22,6 @@ export const dict = {
   "ui.sessionTurn.status.runningCommands": "Kører kommandoer",
   "ui.sessionTurn.status.thinking": "Tænker",
   "ui.sessionTurn.status.gatheringThoughts": "Samler tanker",
-  "ui.sessionTurn.status.consideringNextSteps": "Overvejer næste skridt",
   "ui.sessionTurn.progress.connecting": "Forbinder til {{model}}…",
   "ui.sessionTurn.progress.stillConnecting": "Forbinder stadig til {{model}} ({{seconds}}s)",
   "ui.sessionTurn.progress.waitingFirstToken": "Venter på at {{model}} starter ({{seconds}}s)",

--- a/frontend/ui/src/i18n/de.ts
+++ b/frontend/ui/src/i18n/de.ts
@@ -26,7 +26,6 @@ export const dict = {
   "ui.sessionTurn.status.runningCommands": "Befehle ausführen",
   "ui.sessionTurn.status.thinking": "Denken",
   "ui.sessionTurn.status.gatheringThoughts": "Gedanken sammeln",
-  "ui.sessionTurn.status.consideringNextSteps": "Nächste Schritte erwägen",
   "ui.sessionTurn.progress.connecting": "Verbindung zu {{model}} wird hergestellt…",
   "ui.sessionTurn.progress.stillConnecting": "Verbindung zu {{model}} wird noch hergestellt ({{seconds}}s)",
   "ui.sessionTurn.progress.waitingFirstToken": "Warten auf den Start von {{model}} ({{seconds}}s)",

--- a/frontend/ui/src/i18n/en.ts
+++ b/frontend/ui/src/i18n/en.ts
@@ -25,7 +25,6 @@ export const dict = {
   "ui.sessionTurn.status.runningCommands": "Running commands",
   "ui.sessionTurn.status.thinking": "Thinking",
   "ui.sessionTurn.status.gatheringThoughts": "Writing response",
-  "ui.sessionTurn.status.consideringNextSteps": "Preparing next step",
   "ui.sessionTurn.progress.connecting": "Sending request to {{model}}…",
   "ui.sessionTurn.progress.stillConnecting": "Waiting for a response from {{model}} ({{seconds}}s)",
   "ui.sessionTurn.progress.waitingFirstToken": "Waiting for output from {{model}} ({{seconds}}s)",

--- a/frontend/ui/src/i18n/es.ts
+++ b/frontend/ui/src/i18n/es.ts
@@ -22,7 +22,6 @@ export const dict = {
   "ui.sessionTurn.status.runningCommands": "Ejecutando comandos",
   "ui.sessionTurn.status.thinking": "Pensando",
   "ui.sessionTurn.status.gatheringThoughts": "Recopilando pensamientos",
-  "ui.sessionTurn.status.consideringNextSteps": "Considerando siguientes pasos",
   "ui.sessionTurn.progress.connecting": "Conectando con {{model}}…",
   "ui.sessionTurn.progress.stillConnecting": "Todavía conectando con {{model}} ({{seconds}}s)",
   "ui.sessionTurn.progress.waitingFirstToken": "Esperando a que {{model}} empiece ({{seconds}}s)",

--- a/frontend/ui/src/i18n/fr.ts
+++ b/frontend/ui/src/i18n/fr.ts
@@ -22,7 +22,6 @@ export const dict = {
   "ui.sessionTurn.status.runningCommands": "Exécution des commandes",
   "ui.sessionTurn.status.thinking": "Réflexion",
   "ui.sessionTurn.status.gatheringThoughts": "Rassemblement des idées",
-  "ui.sessionTurn.status.consideringNextSteps": "Examen des prochaines étapes",
   "ui.sessionTurn.progress.connecting": "Connexion à {{model}}…",
   "ui.sessionTurn.progress.stillConnecting": "Connexion à {{model}} toujours en cours ({{seconds}}s)",
   "ui.sessionTurn.progress.waitingFirstToken": "En attente du démarrage de {{model}} ({{seconds}}s)",

--- a/frontend/ui/src/i18n/ja.ts
+++ b/frontend/ui/src/i18n/ja.ts
@@ -22,7 +22,6 @@ export const dict = {
   "ui.sessionTurn.status.runningCommands": "コマンドを実行中",
   "ui.sessionTurn.status.thinking": "思考中",
   "ui.sessionTurn.status.gatheringThoughts": "考えをまとめています",
-  "ui.sessionTurn.status.consideringNextSteps": "次のステップを検討中",
   "ui.sessionTurn.progress.connecting": "{{model}} に接続中…",
   "ui.sessionTurn.progress.stillConnecting": "{{model}} にまだ接続中（{{seconds}}秒）",
   "ui.sessionTurn.progress.waitingFirstToken": "{{model}} の応答開始を待機中（{{seconds}}秒）",

--- a/frontend/ui/src/i18n/ko.ts
+++ b/frontend/ui/src/i18n/ko.ts
@@ -22,7 +22,6 @@ export const dict = {
   "ui.sessionTurn.status.runningCommands": "명령어 실행 중",
   "ui.sessionTurn.status.thinking": "생각 중",
   "ui.sessionTurn.status.gatheringThoughts": "생각 정리 중",
-  "ui.sessionTurn.status.consideringNextSteps": "다음 단계 고려 중",
   "ui.sessionTurn.progress.connecting": "{{model}}에 연결 중…",
   "ui.sessionTurn.progress.stillConnecting": "{{model}}에 계속 연결 중 ({{seconds}}초)",
   "ui.sessionTurn.progress.waitingFirstToken": "{{model}}의 응답 시작을 기다리는 중 ({{seconds}}초)",

--- a/frontend/ui/src/i18n/no.ts
+++ b/frontend/ui/src/i18n/no.ts
@@ -25,7 +25,6 @@ export const dict = {
   "ui.sessionTurn.status.runningCommands": "Kjører kommandoer",
   "ui.sessionTurn.status.thinking": "Tenker",
   "ui.sessionTurn.status.gatheringThoughts": "Samler tanker",
-  "ui.sessionTurn.status.consideringNextSteps": "Vurderer neste trinn",
   "ui.sessionTurn.progress.connecting": "Kobler til {{model}}…",
   "ui.sessionTurn.progress.stillConnecting": "Kobler fortsatt til {{model}} ({{seconds}}s)",
   "ui.sessionTurn.progress.waitingFirstToken": "Venter på at {{model}} starter ({{seconds}}s)",

--- a/frontend/ui/src/i18n/pl.ts
+++ b/frontend/ui/src/i18n/pl.ts
@@ -22,7 +22,6 @@ export const dict = {
   "ui.sessionTurn.status.runningCommands": "Uruchamianie poleceń",
   "ui.sessionTurn.status.thinking": "Myślenie",
   "ui.sessionTurn.status.gatheringThoughts": "Zbieranie myśli",
-  "ui.sessionTurn.status.consideringNextSteps": "Rozważanie kolejnych kroków",
   "ui.sessionTurn.progress.connecting": "Łączenie z {{model}}…",
   "ui.sessionTurn.progress.stillConnecting": "Nadal trwa łączenie z {{model}} ({{seconds}}s)",
   "ui.sessionTurn.progress.waitingFirstToken": "Oczekiwanie na rozpoczęcie odpowiedzi {{model}} ({{seconds}}s)",

--- a/frontend/ui/src/i18n/ru.ts
+++ b/frontend/ui/src/i18n/ru.ts
@@ -22,7 +22,6 @@ export const dict = {
   "ui.sessionTurn.status.runningCommands": "Выполнение команд",
   "ui.sessionTurn.status.thinking": "Размышление",
   "ui.sessionTurn.status.gatheringThoughts": "Сбор мыслей",
-  "ui.sessionTurn.status.consideringNextSteps": "Рассмотрение следующих шагов",
   "ui.sessionTurn.progress.connecting": "Подключение к {{model}}…",
   "ui.sessionTurn.progress.stillConnecting": "Подключение к {{model}} всё ещё выполняется ({{seconds}}с)",
   "ui.sessionTurn.progress.waitingFirstToken": "Ожидание начала ответа {{model}} ({{seconds}}с)",

--- a/frontend/ui/src/i18n/th.ts
+++ b/frontend/ui/src/i18n/th.ts
@@ -23,7 +23,6 @@ export const dict = {
   "ui.sessionTurn.status.runningCommands": "กำลังเรียกใช้คำสั่ง",
   "ui.sessionTurn.status.thinking": "กำลังคิด",
   "ui.sessionTurn.status.gatheringThoughts": "รวบรวมความคิด",
-  "ui.sessionTurn.status.consideringNextSteps": "พิจารณาขั้นตอนถัดไป",
   "ui.sessionTurn.progress.connecting": "กำลังเชื่อมต่อกับ {{model}}…",
   "ui.sessionTurn.progress.stillConnecting": "ยังคงเชื่อมต่อกับ {{model}} ({{seconds}} วินาที)",
   "ui.sessionTurn.progress.waitingFirstToken": "กำลังรอให้ {{model}} เริ่มตอบ ({{seconds}} วินาที)",

--- a/frontend/ui/src/i18n/zh.ts
+++ b/frontend/ui/src/i18n/zh.ts
@@ -26,7 +26,6 @@ export const dict = {
   "ui.sessionTurn.status.runningCommands": "正在运行命令",
   "ui.sessionTurn.status.thinking": "思考中",
   "ui.sessionTurn.status.gatheringThoughts": "正在整理思路",
-  "ui.sessionTurn.status.consideringNextSteps": "正在考虑下一步",
   "ui.sessionTurn.progress.connecting": "正在连接 {{model}}…",
   "ui.sessionTurn.progress.stillConnecting": "仍在连接 {{model}}（{{seconds}}秒）",
   "ui.sessionTurn.progress.waitingFirstToken": "等待 {{model}} 开始响应（{{seconds}}秒）",

--- a/frontend/ui/src/i18n/zht.ts
+++ b/frontend/ui/src/i18n/zht.ts
@@ -26,7 +26,6 @@ export const dict = {
   "ui.sessionTurn.status.runningCommands": "正在執行命令",
   "ui.sessionTurn.status.thinking": "思考中",
   "ui.sessionTurn.status.gatheringThoughts": "正在整理思緒",
-  "ui.sessionTurn.status.consideringNextSteps": "正在考慮下一步",
   "ui.sessionTurn.progress.connecting": "正在連線至 {{model}}…",
   "ui.sessionTurn.progress.stillConnecting": "仍在連線至 {{model}}（{{seconds}}秒）",
   "ui.sessionTurn.progress.waitingFirstToken": "等待 {{model}} 開始回應（{{seconds}}秒）",

--- a/frontend/workspace/src/components/chat-surface.css
+++ b/frontend/workspace/src/components/chat-surface.css
@@ -460,6 +460,26 @@
   line-height: var(--chat-meta-line-height);
 }
 
+/* A tool's body is a receipt, not a document: a loaded skill's SKILL.md or a
+   command's notes render at the meta level with their headings brought down
+   to it, so nothing inside a folded row ever outweighs the answer. */
+.session-scroller [data-component="tool-output"] [data-component="markdown"] {
+  font-size: var(--chat-meta-font-size);
+  line-height: var(--chat-meta-line-height);
+}
+
+.session-scroller [data-component="tool-output"] [data-component="markdown"] :is(h1, h2, h3, h4, h5, h6) {
+  margin: 8px 0 2px;
+  font-size: var(--chat-meta-font-size);
+  line-height: var(--chat-meta-line-height);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-secondary);
+}
+
+.session-scroller [data-component="tool-output"] [data-component="markdown"] :is(p, ul, ol, pre) {
+  margin: 2px 0;
+}
+
 /* Every trajectory row is one 32px line: a live call, the placeholder a
    write shows before its diff exists, a folded reasoning clock. Rows then
    swap state without moving anything below them. */


### PR DESCRIPTION
Follow-up from testing 2.0.88 on Ace with `openai/gpt-5.6-sol`.

### What was seen
- The turn header cycled `Preparing request for … (12s)` → `Retrying in 8s` → `Waiting for output …` → `No new output from openai/gpt-5.6-sol for 58s`.
- A 4½-minute turn with nothing on screen: the lead reasoned for 278 s before its first tool call (OpenAI streams the summary only at the end of a reasoning block), while the Ace account service was slow enough that the 3 s balance cap failed and paused the turn into a retry loop.

### Changes
- **Calm header.** While a turn runs the label is `Thinking` or the running tool's activity (`Running commands`, `Reading files`, `Writing response`), beside the elapsed clock. The request-phase detail moves to the tooltip. A retry countdown and a conflict wait keep their own words. `Preparing next step` is gone from every locale.
- **Balance check** waits 8 s instead of 3 s (matching the credential sync).
- **Tool bodies** (a loaded skill's SKILL.md, notes in command output) render at the meta level with headings brought down.

Not changed: reasoning summaries already flow on the Ace route (verified against stored parts and a live request), so no provider option was touched.

Tests: ui 295, workspace 990, backend provider/openscience suites, format, typecheck.
