### PR TITLE
Fusion: give up on a dead stream in minutes; tell a worker why a path was refused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ tagged release also ships native binaries for Linux, macOS, and Windows.
 
 ### Changed
 
+- A remote model stream that stops producing bytes is given up after ten
+  minutes, and on the Ace gateway after five, instead of thirty. Keepalives and
+  streamed private reasoning still reset the clock, so a thinking model is
+  never cut off; a connection that died without closing no longer holds a
+  worker for most of an hour.
+- The task tool tells the lead that workers read its workspace but write only in
+  their own, and a worker is told the same, so a brief no longer sends a worker
+  to write where it cannot. When a worker stops on a provider error, the lead is
+  told to finish that step itself rather than send the same brief to the same
+  worker again.
+
 - While a turn runs, its header reads as one calm word for what is happening:
   Thinking, or the activity of the tool that is running, beside the elapsed
   clock. Preparing, sending, waiting-for-output and quiet-stream phases no
@@ -21,6 +32,10 @@ tagged release also ships native binaries for Linux, macOS, and Windows.
 
 ### Fixed
 
+- A refused file path now says why and what to do: which folders this session
+  may read or write, and, for a lead's folder, that it is read-only here and
+  files go back as saved artifacts. The bare error name a worker used to see
+  sent it back into minutes of thought and the same denied write.
 - The wallet balance check before an Ace request now waits up to 8 seconds
   instead of 3, so a slow afternoon at the account service no longer turns every
   step into a paused turn and a retry countdown.

--- a/backend/cli/src/config/config.ts
+++ b/backend/cli/src/config/config.ts
@@ -1198,13 +1198,13 @@ export namespace Config {
                 .positive()
                 .max(2_147_483_647)
                 .describe(
-                  "Maximum provider response-body inactivity in milliseconds; resets on every body chunk, including keepalives and streamed private reasoning. Remote endpoints default to 1800000 (30 minutes); local endpoints default to disabled.",
+                  "Maximum provider response-body inactivity in milliseconds; resets on every body chunk, including keepalives and streamed private reasoning. Remote endpoints default to 600000 (10 minutes), the managed Ace gateway to 300000 (5 minutes); local endpoints default to disabled.",
                 ),
               z.literal(false).describe("Disable the provider inactivity watchdog."),
             ])
             .optional()
             .describe(
-              "Maximum provider response-body inactivity in milliseconds. Remote endpoints default to 1800000 (30 minutes); local endpoints (loopback or .local base URLs and bundled local providers) default to disabled. Set false to disable.",
+              "Maximum provider response-body inactivity in milliseconds. Remote endpoints default to 600000 (10 minutes) and the managed Ace gateway to 300000 (5 minutes); local endpoints (loopback or .local base URLs and bundled local providers) default to disabled. Set false to disable.",
             ),
           connectTimeout: z
             .union([z.number().int().positive().max(2_147_483_647), z.literal(false)])

--- a/backend/cli/src/provider/provider.ts
+++ b/backend/cli/src/provider/provider.ts
@@ -66,8 +66,14 @@ export namespace Provider {
   // Raw body activity includes keepalives and private reasoning, so this only
   // expires a remote response that has stopped producing bytes altogether.
   // Local runtimes keep the deadline disabled because slow inference can be
-  // legitimately silent (see defaultIdleTimeout).
-  export const DEFAULT_REMOTE_IDLE_TIMEOUT_MS = 1_800_000
+  // legitimately silent (see defaultIdleTimeout). Ten minutes of byte silence
+  // from a remote endpoint is a dead connection, not a thinking model; the
+  // earlier half-hour turned one hung stream into a 45-minute worker failure.
+  export const DEFAULT_REMOTE_IDLE_TIMEOUT_MS = 600_000
+  // The managed gateway and OpenRouter keep a live stream ticking with
+  // keepalive comments and streamed private reasoning, so five silent minutes
+  // there is a connection that died without closing.
+  export const DEFAULT_MANAGED_IDLE_TIMEOUT_MS = 300_000
   export const DEFAULT_OUTPUT_IDLE_TIMEOUT_MS = false
 
   export type RequestContext = {
@@ -1196,7 +1202,8 @@ export namespace Provider {
   }
 
   export function defaultIdleTimeout(input: { providerID: string; baseURL?: unknown }): number | false {
-    return localEndpoint(input) ? false : DEFAULT_REMOTE_IDLE_TIMEOUT_MS
+    if (localEndpoint(input)) return false
+    return isAtlasProxyBaseURL(input.baseURL) ? DEFAULT_MANAGED_IDLE_TIMEOUT_MS : DEFAULT_REMOTE_IDLE_TIMEOUT_MS
   }
 
   /** Pin a user-owned key to a public endpoint when stale proxy config remains. */

--- a/backend/cli/src/session/filesystem.ts
+++ b/backend/cli/src/session/filesystem.ts
@@ -143,6 +143,7 @@ export namespace SessionFilesystem {
       sessionID: z.string(),
       path: z.string(),
       access: Access,
+      message: z.string().optional(),
     }),
   )
 
@@ -266,6 +267,30 @@ export namespace SessionFilesystem {
     return { root, workspace: grant.path }
   }
 
+  /** The refusal a model reads. A bare class name once sent a worker back into
+   * seven minutes of thought and the same denied write; the message names the
+   * places this session can use and, for a lead's folder, how to hand files
+   * back instead. */
+  function denial(record: State, target: string, access: Access) {
+    const live = record.grants.filter((grant) => !grant.time.revoked && grant.scope !== "once")
+    const usable = [
+      ...new Set(
+        live.filter((grant) => (access === "write" ? grant.access === "write" : true)).map((grant) => grant.path),
+      ),
+    ]
+    const lead = live.find((grant) => grant.source === "handoff" && Filesystem.contains(grant.path, target))
+    const handoff = lead
+      ? ` ${lead.path} belongs to the lead session and is read-only here: write under this session's own workspace and hand files back with artifact(action="save_file", path=...).`
+      : ""
+    const where = usable.length ? ` This session can ${access} under: ${usable.join(", ")}.` : ""
+    return new DeniedError({
+      sessionID: record.sessionID,
+      path: target,
+      access,
+      message: `No ${access} access to ${target} from this session.${handoff}${where}`,
+    })
+  }
+
   function assertPrivate(record: State, target: string, access: Access) {
     const boundary = isolated(record)
     if (!boundary) return
@@ -282,11 +307,7 @@ export namespace SessionFilesystem {
       )
     )
       return
-    throw new DeniedError({
-      sessionID: record.sessionID,
-      path: target,
-      access,
-    })
+    throw denial(record, target, access)
   }
 
   async function read(sessionID: string): Promise<State> {
@@ -734,13 +755,7 @@ export namespace SessionFilesystem {
         return b.path.length - a.path.length
       })
     const grant = matches[0]
-    if (!grant) {
-      throw new DeniedError({
-        sessionID: input.sessionID,
-        path: target,
-        access: input.access,
-      })
-    }
+    if (!grant) throw denial(record, target, input.access)
     if (grant.scope === "once") {
       const consumed = Date.now()
       await Storage.update<State>(key(input.sessionID), (draft) => {

--- a/backend/cli/src/tool/task.ts
+++ b/backend/cli/src/tool/task.ts
@@ -692,7 +692,7 @@ export const TaskTool = Tool.define("task", async (ctx) => {
                   "Do not return a diary of searches, reads, or commands. Your final response is a decision-ready handoff to the lead, not a second user-facing report.",
                   "Use only the Markdown sections that carry substance: Outcome; Findings; Evidence; Changes / outputs; Limitations; Next action.",
                   "Preserve exact paths, identifiers, numeric results, commands, and error strings when they matter. Distinguish observed evidence from inference. If blocked or partial, say exactly what remains.",
-                  'Save important scratch outputs with artifact(action="save_file", path=...) before returning. The lead receives immutable artifact/version handles and can read them without access to your private scratch. A saved file proves an output exists, not that its claims or tests passed.',
+                  'The lead\'s workspace is read-only for you: write under your own workspace. Save important scratch outputs with artifact(action="save_file", path=...) before returning. The lead receives immutable artifact/version handles and can read them without access to your private scratch. A saved file proves an output exists, not that its claims or tests passed.',
                   "Do not wrap the response in XML or JSON and do not restate these instructions.",
                   settings.autonomy === "interactive"
                     ? "If the assignment contains a genuinely consequential ambiguity, return one precise question to the lead instead of guessing."
@@ -790,7 +790,9 @@ export const TaskTool = Tool.define("task", async (ctx) => {
               : taskOutcome.stopReason === "tool_partial"
                 ? ["[One or more child tool operations remain partial or unsettled; treat this as a partial result.]"]
                 : taskOutcome.stopReason === "provider_error"
-                  ? ["[Child stopped on a provider error; its usable partial result follows.]"]
+                  ? [
+                      "[Child stopped on a provider error; its usable partial result follows. The worker's model or connection failed, not the task: finish this step yourself now rather than sending the same brief to the same worker again.]",
+                    ]
                   : taskOutcome.stopReason === "cancelled"
                     ? ["[Child was cancelled; completed actions and usable partial evidence follow.]"]
                     : taskOutcome.stopReason === "empty_handoff"

--- a/backend/cli/src/tool/task.txt
+++ b/backend/cli/src/tool/task.txt
@@ -5,12 +5,13 @@ Profiles:
 
 Use `explore` for evidence and `execute` for implementation or compute.
 
-- Use as many independent workers as useful. Delegation posture is guidance, not a quota; capacity may queue work.
+- Use as many independent workers as useful; posture is guidance, not a quota.
 - Issue independent calls together. Task waits for a decision-ready handoff.
 - Only the lead dispatches workers, asks questions, synthesizes and verifies. Children cannot dispatch children.
-- Avoid sequential work, small edits, ceremonial reviews and duplicate retrieval.
-- Verify setup and imports before dependent work; pass tested executable and authorized paths,
-  not installation promises.
+- Avoid sequential work, small edits and duplicate retrieval.
+- Verify setup and imports before dependent work; pass tested, authorized paths, not installation
+  promises. Workers read your workspace but write only in their own; ask for outputs back as
+  saved artifacts.
 - Continue a `session_id` only for missing work. Include objective, inputs, references, constraints,
   allowed actions, expected output and validation.
-- Preserve decisive handoff evidence; the child's transcript remains in `session_id`. Do not redo its phase.
+- Preserve decisive handoff evidence; the child's transcript remains in `session_id`.

--- a/backend/cli/test/provider/idle-watchdog.test.ts
+++ b/backend/cli/test/provider/idle-watchdog.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, spyOn, test } from "bun:test"
+import { managedApiBase } from "../../src/endpoints"
 import { Config } from "../../src/config/config"
 import { Provider } from "../../src/provider/provider"
 import { SessionProcessor } from "../../src/session/processor"
@@ -129,8 +130,22 @@ describe("provider activity watchdog", () => {
     expect(Provider.resolveIdleTimeout(undefined)).toBe(false)
     expect(Provider.resolveOutputIdleTimeout(undefined)).toBe(false)
     expect(Provider.defaultIdleTimeout({ providerID: "openrouter", baseURL: "https://openrouter.ai/api/v1" })).toBe(
-      1_800_000,
+      600_000,
     )
+    // The test preload points the managed base at loopback, which the local
+    // rule would claim first; a remote managed origin shows the gateway tier.
+    const base = process.env["OPENSCIENCE_API_BASE"]
+    process.env["OPENSCIENCE_API_BASE"] = "https://managed.test"
+    try {
+      expect(
+        Provider.defaultIdleTimeout({
+          providerID: "openrouter",
+          baseURL: `${managedApiBase()}/api/llm/proxy/openrouter/v1`,
+        }),
+      ).toBe(300_000)
+    } finally {
+      process.env["OPENSCIENCE_API_BASE"] = base
+    }
     expect(Provider.defaultIdleTimeout({ providerID: "ollama" })).toBe(false)
     expect(Provider.defaultIdleTimeout({ providerID: "custom", baseURL: "http://127.0.0.1:11434/v1" })).toBe(false)
     expect(Provider.defaultIdleTimeout({ providerID: "custom", baseURL: "http://inference.local/v1" })).toBe(false)
@@ -531,13 +546,13 @@ describe("provider activity watchdog", () => {
       expect(new TextDecoder().decode((await reader.read()).value)).toBe(": response started\n\n")
       const pending = reader.read()
       void pending.catch(() => {})
-      await time.advance(1_800_001)
-      await expect(pending).rejects.toMatchObject({ phase: "stream", timeoutMs: 1_800_000 })
+      await time.advance(600_001)
+      await expect(pending).rejects.toMatchObject({ phase: "stream", timeoutMs: 600_000 })
       expect(timings).toHaveLength(1)
       expect(timings[0]).toMatchObject({
         outcome: "idle_timeout",
         timeoutPhase: "stream",
-        idleTimeoutMs: 1_800_000,
+        idleTimeoutMs: 600_000,
       })
     } finally {
       time.restore()
@@ -571,7 +586,7 @@ describe("provider activity watchdog", () => {
         ": still processing\n\n",
       ]) {
         const pending = reader.read()
-        await time.advance(1_200_000)
+        await time.advance(400_000)
         source.enqueue(encoder.encode(activity))
         expect(new TextDecoder().decode((await pending).value)).toBe(activity)
       }
@@ -579,8 +594,8 @@ describe("provider activity watchdog", () => {
       closed = true
       expect((await reader.read()).done).toBe(true)
       expect(timings).toHaveLength(1)
-      expect(timings[0]).toMatchObject({ outcome: "completed", idleTimeoutMs: 1_800_000 })
-      expect(timings[0].completedAt - timings[0].startedAt).toBeGreaterThan(1_800_000)
+      expect(timings[0]).toMatchObject({ outcome: "completed", idleTimeoutMs: 600_000 })
+      expect(timings[0].completedAt - timings[0].startedAt).toBeGreaterThan(600_000)
     } finally {
       if (!closed) source.close()
       time.restore()

--- a/backend/cli/test/tool/task-handoff.test.ts
+++ b/backend/cli/test/tool/task-handoff.test.ts
@@ -35,9 +35,21 @@ describe("Task tool-output handoff", () => {
           await expect(
             SessionFilesystem.authorize({ sessionID: child.id, path: parentFile, access: "read" }),
           ).resolves.toBeDefined()
-          await expect(
-            SessionFilesystem.authorize({ sessionID: child.id, path: parentFile, access: "write" }),
-          ).rejects.toBeInstanceOf(SessionFilesystem.DeniedError)
+          // The refusal a worker reads names the cause and the way out; a bare
+          // class name once cost a worker seven minutes and the same write again.
+          const refused = await SessionFilesystem.authorize({
+            sessionID: child.id,
+            path: parentFile,
+            access: "write",
+          }).then(
+            () => undefined,
+            (error: unknown) => error,
+          )
+          expect(refused).toBeInstanceOf(SessionFilesystem.DeniedError)
+          expect((refused as Error).message).toContain(`No write access to ${parentFile}`)
+          expect((refused as Error).message).toContain("belongs to the lead session and is read-only here")
+          expect((refused as Error).message).toContain('artifact(action="save_file"')
+          expect((refused as Error).message).toContain(await SessionFilesystem.workspace(child.id))
           await expect(
             SessionFilesystem.authorize({ sessionID: child.id, path: siblingFile, access: "read" }),
           ).rejects.toBeInstanceOf(SessionFilesystem.DeniedError)

--- a/frontend/docs/src/content/openscience/custom-providers.mdx
+++ b/frontend/docs/src/content/openscience/custom-providers.mdx
@@ -99,11 +99,11 @@ Provider options support request deadlines in milliseconds:
 | Option | Default |
 | --- | --- |
 | `connectTimeout` | 300000 (5 minutes): waiting for response headers; disabled by default for local endpoints. |
-| `idleTimeout` | 1800000 (30 minutes) for remote endpoints; reset by every response-body chunk and disabled by default for local endpoints. |
+| `idleTimeout` | 600000 (10 minutes) for remote endpoints and 300000 (5 minutes) for the managed Ace gateway; reset by every response-body chunk and disabled by default for local endpoints. |
 | `outputIdleTimeout` | Disabled; optionally bound the wait for readable output or tool-call activity. |
 | `timeout` | No total-duration limit by default. |
 
-Active remote responses keep running because keepalives and streamed private reasoning reset the body-activity deadline. Set `idleTimeout` to `false` if a remote provider legitimately stays byte-silent for longer than 30 minutes. Use **Stop** to cancel your wait. To opt into a twenty-minute readable-output deadline, merge an override into that provider's options:
+Active remote responses keep running because keepalives and streamed private reasoning reset the body-activity deadline. Set `idleTimeout` to `false` if a remote provider legitimately stays byte-silent for longer than ten minutes. Use **Stop** to cancel your wait. To opt into a twenty-minute readable-output deadline, merge an override into that provider's options:
 
 ```json
 {

--- a/tooling/sdk/js/src/v2/gen/types.gen.ts
+++ b/tooling/sdk/js/src/v2/gen/types.gen.ts
@@ -1851,7 +1851,7 @@ export type ProviderConfig = {
      */
     timeout?: number | false
     /**
-     * Maximum provider response-body inactivity in milliseconds. Remote endpoints default to 1800000 (30 minutes); local endpoints (loopback or .local base URLs and bundled local providers) default to disabled. Set false to disable.
+     * Maximum provider response-body inactivity in milliseconds. Remote endpoints default to 600000 (10 minutes) and the managed Ace gateway to 300000 (5 minutes); local endpoints (loopback or .local base URLs and bundled local providers) default to disabled. Set false to disable.
      */
     idleTimeout?: number | false
     /**

--- a/tooling/sdk/openapi.json
+++ b/tooling/sdk/openapi.json
@@ -58901,10 +58901,10 @@
                 ]
               },
               "idleTimeout": {
-                "description": "Maximum provider response-body inactivity in milliseconds. Remote endpoints default to 1800000 (30 minutes); local endpoints (loopback or .local base URLs and bundled local providers) default to disabled. Set false to disable.",
+                "description": "Maximum provider response-body inactivity in milliseconds. Remote endpoints default to 600000 (10 minutes) and the managed Ace gateway to 300000 (5 minutes); local endpoints (loopback or .local base URLs and bundled local providers) default to disabled. Set false to disable.",
                 "anyOf": [
                   {
-                    "description": "Maximum provider response-body inactivity in milliseconds; resets on every body chunk, including keepalives and streamed private reasoning. Remote endpoints default to 1800000 (30 minutes); local endpoints default to disabled.",
+                    "description": "Maximum provider response-body inactivity in milliseconds; resets on every body chunk, including keepalives and streamed private reasoning. Remote endpoints default to 600000 (10 minutes), the managed Ace gateway to 300000 (5 minutes); local endpoints default to disabled.",
                     "type": "integer",
                     "exclusiveMinimum": 0,
                     "maximum": 2147483647


### PR DESCRIPTION
A Titanic EDA took 72 minutes on 2.0.88 (Ace, lead `openai/gpt-5.6-sol`, Fusion worker `z-ai/glm-5.3`). Reconstructed from the sidecar log and the stored parts:

| When (UTC) | What | Cost |
| --- | --- | --- |
| 12:31–12:36 | Lead reasons 278 s before its first tool call | 4.6 min |
| 12:37–12:46 | Worker reasons 7 min, writes a 39 KB script into the **lead's** workspace → `SessionFilesystemDeniedError` (that literal string was the whole error) | 9 min |
| 12:46–13:21 | Worker re-thinks, starts re-streaming the script; the stream goes byte-silent; client waits its full **30-minute** idle deadline | 35 min |
| 13:21–13:41 | Lead re-delegates; the new worker's first stream hangs 19 min until the socket dies; retry hits the gateway's idempotency 410 (by design) → worker fails with 0 tool calls | 19 min |
| 13:41–13:44 | Lead does the work itself | 3 min |

### Changes
- **Idle deadline**: remote 30 → 10 min; the managed Ace gateway (keepalives + streamed private reasoning keep a live stream ticking) 5 min. A thinking model is never cut off; a dead connection costs minutes, not most of an hour. Config/docs/SDK descriptions updated.
- **Refused paths explain themselves**: `No write access to <path> from this session. <lead workspace> belongs to the lead session and is read-only here: write under this session's own workspace and hand files back with artifact(action="save_file", path=...). This session can write under: <own workspace>.`
- **Task contract**: the lead is told workers write only in their own workspace (ask for artifacts back); the worker is told the lead's workspace is read-only; a worker that stops on a provider error tells the lead to finish the step itself rather than re-send the same brief to the same worker.

Not changed: the idempotency policy (a dispatched managed request is never re-sent automatically) — it is the documented billing-safety rule; with the shorter deadline it now costs five minutes instead of nineteen.

Tests: session + tool + provider suites 1554 pass; handoff test asserts the new message; contract budget respected.
