### PR TITLE
Authority: a gap resyncs only when it named this project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ tagged release also ships native binaries for Linux, macOS, and Windows.
 
 ### Fixed
 
+- Opening a project no longer stops its own kernels, terminals and compute jobs
+  because of an authority change some other project never acknowledged. The
+  durable authority record now names the last revision addressed to each
+  project and the last addressed to all of them, so a watcher that finds a gap
+  it cannot replay resyncs only when something in that gap was for it.
 - A finished turn kept a burst of one tool call inside a folded group with no
   header, so a lone write or command between two thoughts vanished from the
   trace. It renders as its own row again.

--- a/backend/cli/src/project/authority-signal.ts
+++ b/backend/cli/src/project/authority-signal.ts
@@ -56,6 +56,13 @@ export namespace AuthoritySignal {
     // its own process's settled work (already applied through the in-process
     // bus) or another process's, which still earns the conservative resync.
     history: HistoryEvent.array().default([]),
+    // The last revision that touched each project, and the last that reached
+    // every project (an installation-wide grant). A watcher that knows its
+    // project can tell from these alone whether a gap it cannot replay held
+    // anything addressed to it. A stale unsettled entry once made every new
+    // watcher walk a two-hundred-revision gap and stop everything it owned.
+    projects: z.record(z.string(), z.number().int().positive()).default({}),
+    global: z.number().int().nonnegative().default(0),
   })
   type State = z.infer<typeof State>
   const HISTORY = 16
@@ -99,6 +106,7 @@ export namespace AuthoritySignal {
         backlog.push({ revision: previous.revision, event: previous.event })
       }
       const revision = (previous?.revision ?? 0) + 1
+      const everywhere = parsed.kind === "filesystem" && parsed.scope === "installation"
       return {
         version: 1,
         revision,
@@ -108,6 +116,8 @@ export namespace AuthoritySignal {
         event: parsed,
         backlog,
         history: [...(previous?.history ?? []), { revision, event: parsed, origin: process.pid }].slice(-HISTORY),
+        projects: { ...(previous?.projects ?? {}), [parsed.projectID]: revision },
+        global: everywhere ? revision : (previous?.global ?? 0),
       }
     })
   }
@@ -149,11 +159,24 @@ export namespace AuthoritySignal {
     return true
   }
 
+  /** Whether any revision after `since` was addressed to this project, or to
+   * every project. Records written before these fields existed report nothing
+   * and leave the caller to resync. */
+  function addressed(state: State, since: number, projectID: string) {
+    return state.global > since || (state.projects[projectID] ?? 0) > since
+  }
+
   /** Poll a tiny revision record. A skipped revision causes a conservative
    * resync signal because the last event alone cannot describe every affected
    * process, unless the record shows the gap to be this process's own settled
-   * work. The timer is unref'd and disposed with its project instance. */
-  export async function watch(handler: (change: Change) => Promise<boolean | void>, pollMs = 200) {
+   * work, or a watcher that named its project can see nothing in the gap was
+   * addressed to it. The timer is unref'd and disposed with its project
+   * instance. */
+  export async function watch(
+    handler: (change: Change) => Promise<boolean | void>,
+    pollMs = 200,
+    scope?: { projectID: string },
+  ) {
     const initial = await current()
     const firstPending = initial
       ? Math.min(...initial.backlog.map((item) => item.revision), ...(initial.pending ? [initial.revision] : []))
@@ -166,6 +189,7 @@ export namespace AuthoritySignal {
     // no longer names, earns the resync.
     const catchUp = async (state: State, upTo: number) => {
       if (upTo <= revision + 1 || ownSettledGap(state, revision, upTo)) return
+      if (scope && Object.keys(state.projects).length > 0 && !addressed(state, revision, scope.projectID)) return
       await handler({ type: "resync", revision: upTo - 1 })
     }
     const poll = async () => {

--- a/backend/cli/src/project/bootstrap.ts
+++ b/backend/cli/src/project/bootstrap.ts
@@ -120,89 +120,93 @@ const authoritySync = Instance.state(
   async () => {
     const directory = Instance.directory
     const projectID = Instance.project.id
-    return AuthoritySignal.watch(async (change) => {
-      // A runtime never mints an instance: without one there is nothing to stop.
-      if (!Instance.has(directory)) return false
-      return Instance.provide({
-        directory,
-        projectID,
-        fn: async () => {
-          if (change.type === "resync") {
-            const sessions = []
-            for await (const session of Session.list()) sessions.push(session.id)
-            await Promise.all([
-              stopSessions(sessions),
-              LSP.dispose(),
-              MCP.disposeLocal(),
-              invalidateProjectExecutionCaches(),
-            ])
-            await Promise.all([
-              AuthorityProcessLedger.revoke({ projectID }),
-              CredentialProcessLedger.revoke({ kind: "mcp", projectID }),
-              CredentialProcessLedger.revoke({ kind: "provider", projectID }),
-              invalidateProjectTokenCache(projectID),
-            ])
-            return true
-          }
-          const event = change.event
-          if (event.kind === "trust") {
-            if (event.projectID !== projectID) return false
-            if (!event.denied) {
-              await invalidateProjectExecutionCaches()
+    return AuthoritySignal.watch(
+      async (change) => {
+        // A runtime never mints an instance: without one there is nothing to stop.
+        if (!Instance.has(directory)) return false
+        return Instance.provide({
+          directory,
+          projectID,
+          fn: async () => {
+            if (change.type === "resync") {
+              const sessions = []
+              for await (const session of Session.list()) sessions.push(session.id)
+              await Promise.all([
+                stopSessions(sessions),
+                LSP.dispose(),
+                MCP.disposeLocal(),
+                invalidateProjectExecutionCaches(),
+              ])
+              await Promise.all([
+                AuthorityProcessLedger.revoke({ projectID }),
+                CredentialProcessLedger.revoke({ kind: "mcp", projectID }),
+                CredentialProcessLedger.revoke({ kind: "provider", projectID }),
+                invalidateProjectTokenCache(projectID),
+              ])
               return true
             }
-            const jobs = import("../compute/jobs").then((module) => module.ComputeJobs.cancelProject(projectID))
-            const biology = BiologyKernelLifecycle.releaseProject(projectID)
-            await Promise.all([
-              Pty.releaseAll(),
-              KernelRuntime.releaseProject(projectID),
-              CommandRuntime.stopProject(projectID),
-              LSP.dispose(),
-              MCP.disposeLocal(),
-              invalidateProjectExecutionCaches(),
-              biology,
-              jobs,
-            ])
-            await Promise.all([
-              AuthorityProcessLedger.revoke({ projectID }),
-              CredentialProcessLedger.revoke({ kind: "mcp", projectID }),
-              CredentialProcessLedger.revoke({ kind: "provider", projectID }),
-              invalidateProjectTokenCache(projectID),
-            ])
-            return true
-          }
-          if (event.kind === "access") {
-            if (event.projectID !== projectID) return false
-            if (event.narrowing === false) {
-              await Promise.all([invalidateProjectExecutionCaches(), invalidateProjectTokenCache(projectID)])
+            const event = change.event
+            if (event.kind === "trust") {
+              if (event.projectID !== projectID) return false
+              if (!event.denied) {
+                await invalidateProjectExecutionCaches()
+                return true
+              }
+              const jobs = import("../compute/jobs").then((module) => module.ComputeJobs.cancelProject(projectID))
+              const biology = BiologyKernelLifecycle.releaseProject(projectID)
+              await Promise.all([
+                Pty.releaseAll(),
+                KernelRuntime.releaseProject(projectID),
+                CommandRuntime.stopProject(projectID),
+                LSP.dispose(),
+                MCP.disposeLocal(),
+                invalidateProjectExecutionCaches(),
+                biology,
+                jobs,
+              ])
+              await Promise.all([
+                AuthorityProcessLedger.revoke({ projectID }),
+                CredentialProcessLedger.revoke({ kind: "mcp", projectID }),
+                CredentialProcessLedger.revoke({ kind: "provider", projectID }),
+                invalidateProjectTokenCache(projectID),
+              ])
               return true
             }
-            const jobs = import("../compute/jobs").then((module) => module.ComputeJobs.cancelProject(projectID))
-            const biology = BiologyKernelLifecycle.releaseProject(projectID)
-            await Promise.all([
-              Pty.releaseAll(),
-              KernelRuntime.releaseProject(projectID),
-              CommandRuntime.stopProject(projectID),
-              LSP.dispose(),
-              MCP.disposeLocal(),
-              invalidateProjectExecutionCaches(),
-              biology,
-              jobs,
-            ])
-            await Promise.all([
-              AuthorityProcessLedger.revoke({ projectID }),
-              CredentialProcessLedger.revoke({ kind: "mcp", projectID }),
-              CredentialProcessLedger.revoke({ kind: "provider", projectID }),
-              invalidateProjectTokenCache(projectID),
-            ])
+            if (event.kind === "access") {
+              if (event.projectID !== projectID) return false
+              if (event.narrowing === false) {
+                await Promise.all([invalidateProjectExecutionCaches(), invalidateProjectTokenCache(projectID)])
+                return true
+              }
+              const jobs = import("../compute/jobs").then((module) => module.ComputeJobs.cancelProject(projectID))
+              const biology = BiologyKernelLifecycle.releaseProject(projectID)
+              await Promise.all([
+                Pty.releaseAll(),
+                KernelRuntime.releaseProject(projectID),
+                CommandRuntime.stopProject(projectID),
+                LSP.dispose(),
+                MCP.disposeLocal(),
+                invalidateProjectExecutionCaches(),
+                biology,
+                jobs,
+              ])
+              await Promise.all([
+                AuthorityProcessLedger.revoke({ projectID }),
+                CredentialProcessLedger.revoke({ kind: "mcp", projectID }),
+                CredentialProcessLedger.revoke({ kind: "provider", projectID }),
+                invalidateProjectTokenCache(projectID),
+              ])
+              return true
+            }
+            if (event.scope !== "installation" && event.projectID !== projectID) return false
+            await stopFilesystem(event.sessionID, event.scope)
             return true
-          }
-          if (event.scope !== "installation" && event.projectID !== projectID) return false
-          await stopFilesystem(event.sessionID, event.scope)
-          return true
-        },
-      })
-    })
+          },
+        })
+      },
+      200,
+      { projectID },
+    )
   },
   async (watcher) => {
     await watcher[Symbol.asyncDispose]()

--- a/backend/cli/test/project/authority-signal.test.ts
+++ b/backend/cli/test/project/authority-signal.test.ts
@@ -33,6 +33,83 @@ describe("AuthoritySignal.watch", () => {
     }
   })
 
+  test("a fresh watcher behind a stale unsettled entry does not stop its own project over a gap that never named it", async () => {
+    // What CI showed: an entry from an earlier project left pending at revision
+    // 133, two hundred later revisions for other projects, and every new
+    // watcher walking from 132, finding a gap the history could not cover and
+    // stopping everything it owned. Only a revision addressed to this project,
+    // or to every project, may cost it a resync.
+    await using tmp = await tmpdir({ git: true })
+    void tmp
+    const stale = await AuthoritySignal.publish({
+      kind: "filesystem",
+      projectID: "prj_stale",
+      sessionID: "ses_stale",
+      scope: "session",
+    })
+    for (let index = 0; index < 40; index++) {
+      const published = await AuthoritySignal.publish(trust(`prj_other_${index}`))
+      await AuthoritySignal.settle(published.revision)
+    }
+    // Another process's writes are what a gap cannot vouch for.
+    await Storage.update<{ history: Array<{ origin: number }> }>(["authority", "revision"], (draft) => {
+      for (const item of draft.history) item.origin = process.pid + 1
+    })
+    const seen: AuthoritySignal.Change[] = []
+    const watcher = await AuthoritySignal.watch(
+      async (change) => {
+        seen.push(change)
+        return change.type === "event" && change.event.projectID === "prj_mine"
+      },
+      1_000_000,
+      { projectID: "prj_mine" },
+    )
+    try {
+      await watcher.poll()
+      // The stale entry is offered (and declined); nothing in the gap resyncs.
+      expect(seen.map((change) => change.type)).not.toContain("resync")
+      expect(seen[0]).toMatchObject({ type: "event", revision: stale.revision })
+      seen.length = 0
+      const mine = await AuthoritySignal.publish(trust("prj_mine"))
+      await watcher.poll()
+      expect(seen).toEqual([{ type: "event", revision: mine.revision, event: mine.event }])
+    } finally {
+      await watcher[Symbol.asyncDispose]()
+    }
+  })
+
+  test("a fresh watcher behind a stale entry still resyncs when the gap did name its project", async () => {
+    await using tmp = await tmpdir({ git: true })
+    void tmp
+    await AuthoritySignal.publish({
+      kind: "filesystem",
+      projectID: "prj_stale",
+      sessionID: "ses_stale",
+      scope: "session",
+    })
+    for (let index = 0; index < 40; index++) {
+      const published = await AuthoritySignal.publish(trust(index === 20 ? "prj_mine" : `prj_other_${index}`))
+      await AuthoritySignal.settle(published.revision)
+    }
+    await Storage.update<{ history: Array<{ origin: number }> }>(["authority", "revision"], (draft) => {
+      for (const item of draft.history) item.origin = process.pid + 1
+    })
+    const seen: AuthoritySignal.Change[] = []
+    const watcher = await AuthoritySignal.watch(
+      async (change) => {
+        seen.push(change)
+      },
+      1_000_000,
+      { projectID: "prj_mine" },
+    )
+    try {
+      await watcher.poll()
+      expect(seen.some((change) => change.type === "resync")).toBe(true)
+    } finally {
+      await watcher[Symbol.asyncDispose]()
+    }
+  })
+
   test("a gap holding another process's settled work still resyncs conservatively", async () => {
     await using tmp = await tmpdir({ git: true })
     void tmp


### PR DESCRIPTION
The diagnostic added in #582 caught the cross-project compute cancellation on the next Deep CI run: a backlog entry from an earlier project left unsettled at revision 133, two hundred later revisions for other projects, and every new watcher walking from 132 into a gap the 16-entry history could not cover, so it stopped everything it owned. In production the same shape stops a project's own kernels, terminals and jobs when it opens after another project left an unacknowledged change.

The durable record now tracks the last revision addressed to each project and the last installation-wide one. A watcher that names its project (the bootstrap watchers do) resyncs over an unreplayable gap only when a revision in it was for that project or for everyone. Two tests reproduce the CI record shape; the unscoped watcher keeps the conservative behaviour.

Made with [Cursor](https://cursor.com)