### PR TITLE
Fix inference latency, optional search inputs and result links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,16 @@ tagged release also ships native binaries for Linux, macOS, and Windows.
   durable authority record now names the last revision addressed to each
   project and the last addressed to all of them, so a watcher that finds a gap
   it cannot replay resyncs only when something in that gap was for it.
+- Inference and Ace credential requests use fresh connections, avoiding Bun's
+  reuse of unresponsive pooled sockets that could delay a simple reply for
+  minutes before the gateway received it. Streaming, cancellation and the
+  managed request's billing-safe idempotency policy are unchanged.
+- OpenAI tools through OpenRouter explicitly preserve optional inputs. Searches
+  no longer have to invent date bounds when none were requested; required
+  fields and supplied filters still pass the same runtime validation.
+- Local `sandbox:` result links and images open through the Files viewer,
+  including generated plots and CSVs, instead of losing their destination
+  during Markdown sanitization. File access remains checked by the backend.
 - A finished turn kept a burst of one tool call inside a folded group with no
   header, so a lone write or command between two thoughts vanished from the
   trace. It renders as its own row again.

--- a/backend/cli/src/openscience/index.ts
+++ b/backend/cli/src/openscience/index.ts
@@ -15,6 +15,7 @@ import { DataRootBarrier } from "@/global/data-root-barrier"
 import { ToolOutputPath } from "@/tool/tool-output-path"
 import { Lock } from "@/util/lock"
 import { Log } from "@/util/log"
+import { fetchWithFreshConnection } from "@/util/fetch"
 import { managedApiBase } from "@/endpoints"
 import {
   BYOK_LLM_BASE_URL_KEYS,
@@ -375,7 +376,7 @@ async function atomicWrite(filepath: string, content: string, mode = 0o600): Pro
 function atlasFetch(input: string, init: RequestInit = {}, timeoutMs = ATLAS_FETCH_TIMEOUT_MS): Promise<Response> {
   const timeout = AbortSignal.timeout(timeoutMs)
   const signal = init.signal ? AbortSignal.any([init.signal, timeout]) : timeout
-  return fetch(input, { ...init, signal })
+  return fetchWithFreshConnection(input, { ...init, signal })
 }
 
 async function readWorkspaceScope(key: string): Promise<WorkspaceScope | null | undefined> {
@@ -789,7 +790,9 @@ export namespace OpenScience {
     headers: Record<string, string>,
     signal: AbortSignal,
   ): Promise<number | undefined> {
-    const response = await fetch(`${apiBase()}/api/cli/sync/version`, { headers, signal }).catch(() => undefined)
+    const response = await fetchWithFreshConnection(`${apiBase()}/api/cli/sync/version`, { headers, signal }).catch(
+      () => undefined,
+    )
     if (!response) return
     if (!response.ok) {
       await response.body?.cancel().catch(() => undefined)
@@ -858,7 +861,10 @@ export namespace OpenScience {
           return (synced = { state: "ready", organization_id: session.organization_id, synced_at: Date.now() })
         const result = await Promise.race([
           (async () => {
-            const response = await fetch(`${apiBase()}/api/cli/sync`, { headers, signal: controller.signal })
+            const response = await fetchWithFreshConnection(`${apiBase()}/api/cli/sync`, {
+              headers,
+              signal: controller.signal,
+            })
             if (!response.ok) return { response }
             return { response, body: await response.json() }
           })(),

--- a/backend/cli/src/provider/provider.ts
+++ b/backend/cli/src/provider/provider.ts
@@ -54,6 +54,7 @@ import { createVercel } from "@ai-sdk/vercel"
 import { createGitLab } from "@gitlab/gitlab-ai-provider"
 import { ProviderTransform } from "./transform"
 import { LocalProvider } from "./local"
+import { fetchWithFreshConnection } from "../util/fetch"
 
 export namespace Provider {
   const log = Log.create({ service: "provider" })
@@ -1038,6 +1039,23 @@ export namespace Provider {
     const normalized = { ...body }
     delete normalized.tool_choice
     return normalized
+  }
+
+  export function normalizeOpenRouterRequestBody(value: Record<string, unknown>) {
+    if (typeof value.model !== "string" || !value.model.startsWith("openai/") || !Array.isArray(value.tools))
+      return value
+    return {
+      ...value,
+      tools: value.tools.map((tool: unknown) => {
+        if (typeof tool !== "object" || tool === null || !("type" in tool) || tool.type !== "function") return tool
+        if (!("function" in tool) || typeof tool.function !== "object" || tool.function === null) return tool
+        if ("strict" in tool.function) return tool
+        // OpenRouter forwards these tools to Responses, whose default strict
+        // mode makes optional fields required. Preserve our actual schema;
+        // runtime validation still enforces every required field and constraint.
+        return { ...tool, function: { ...tool.function, strict: false } }
+      }),
+    }
   }
 
   export function normalizeAstraRequestBody(value: Record<string, unknown>) {
@@ -2953,8 +2971,16 @@ export namespace Provider {
       options["fetch"] = async (input: any, init?: BunFetchRequestInit) => {
         // Preserve custom fetch if it exists, then add an activity watchdog.
         // A configured `timeout` is still an opt-in total wall-clock cap.
-        const fetchFn = customFetch ?? fetch
+        const fetchFn = customFetch ?? fetchWithFreshConnection
         const opts = { ...(init ?? {}) }
+
+        if (
+          model.api.npm === "@openrouter/ai-sdk-provider" &&
+          typeof opts.body === "string" &&
+          opts.method === "POST"
+        ) {
+          opts.body = JSON.stringify(normalizeOpenRouterRequestBody(JSON.parse(opts.body)))
+        }
 
         if (model.api.npm === "@ai-sdk/deepseek" && opts.body && opts.method === "POST") {
           const body = normalizeDeepSeekRequestBody(JSON.parse(opts.body as string))

--- a/backend/cli/src/util/fetch.ts
+++ b/backend/cli/src/util/fetch.ts
@@ -1,0 +1,10 @@
+/** Bun 1.3.14 can reuse a half-open pooled socket without checking that the
+ * peer still answers. Keep inference and its credential requests off that
+ * pool: a fresh connection avoids minute-long waits before gateway dispatch.
+ * Connection: close is necessary on the pinned runtime; keepalive: false
+ * alone does not reliably disable reuse. This does not retry a request. */
+export function fetchWithFreshConnection(input: string | URL | Request, init?: BunFetchRequestInit): Promise<Response> {
+  const headers = new Headers(init?.headers ?? (input instanceof Request ? input.headers : undefined))
+  headers.set("Connection", "close")
+  return fetch(input, { ...init, headers, keepalive: false })
+}

--- a/backend/cli/test/provider/fresh-connection.test.ts
+++ b/backend/cli/test/provider/fresh-connection.test.ts
@@ -1,0 +1,111 @@
+import { expect, test } from "bun:test"
+import type { Socket } from "bun"
+import { fetchWithFreshConnection } from "../../src/util/fetch"
+import { Provider } from "../../src/provider/provider"
+
+test("inference does not reuse an unresponsive pooled socket or resend its body", async () => {
+  type State = { requests: number; buffer: string }
+  const sockets = new Set<Socket<State>>()
+  const requests: string[] = []
+  const server = Bun.listen<State>({
+    hostname: "127.0.0.1",
+    port: 0,
+    socket: {
+      open(socket) {
+        socket.data = { requests: 0, buffer: "" }
+        sockets.add(socket)
+      },
+      data(socket, data) {
+        socket.data.buffer += data.toString()
+        const end = socket.data.buffer.indexOf("\r\n\r\n")
+        if (end < 0) return
+        const length = Number(/content-length: (\d+)/i.exec(socket.data.buffer)?.[1] ?? 0)
+        if (socket.data.buffer.length < end + 4 + length) return
+        requests.push(socket.data.buffer)
+        socket.data.buffer = ""
+        // A middlebox silently forgets the established connection. Its next
+        // request receives neither a response nor a TCP close/reset.
+        if (++socket.data.requests > 1) return
+        socket.write("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: keep-alive\r\n\r\nok")
+      },
+      close(socket) {
+        sockets.delete(socket)
+      },
+    },
+  })
+  const url = `http://127.0.0.1:${server.port}`
+  try {
+    expect(await (await fetch(url)).text()).toBe("ok")
+    await Bun.sleep(10)
+    const headers = new Headers({ authorization: "test-only", "Idempotency-Key": "logical-request" })
+    for (const body of ["first", "second"]) {
+      const response = await Provider.fetchWithIdleWatchdog(
+        fetchWithFreshConnection,
+        url,
+        {
+          method: "POST",
+          headers,
+          body,
+        },
+        { providerID: "fixture", modelID: "fixture", connectTimeout: 500, idleTimeout: 500 },
+      )
+      expect(await response.text()).toBe("ok")
+      await Bun.sleep(10)
+    }
+    expect(headers.has("connection")).toBe(false)
+    expect(requests).toHaveLength(3)
+    for (const [index, body] of ["first", "second"].entries()) {
+      expect(requests[index + 1]).toContain("Connection: close")
+      expect(requests[index + 1]).toContain("Idempotency-Key: logical-request")
+      expect(requests[index + 1]).toEndWith(body)
+    }
+  } finally {
+    for (const socket of sockets) socket.end()
+    server.stop(true)
+  }
+})
+
+test("fresh streaming connections keep activity, Request headers and cancellation intact", async () => {
+  let calls = 0
+  const server = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    fetch(request) {
+      calls++
+      expect(request.headers.get("x-test")).toBe("preserved")
+      return new Response(
+        new ReadableStream({
+          async start(controller) {
+            for (let i = 0; i < 5; i++) {
+              controller.enqueue(new TextEncoder().encode(": keepalive\n\n"))
+              await Bun.sleep(15)
+            }
+            controller.close()
+          },
+        }),
+      )
+    },
+  })
+  try {
+    const input = new Request(server.url, { headers: { "x-test": "preserved" } })
+    const signal = new AbortController()
+    const response = await Provider.fetchWithIdleWatchdog(
+      fetchWithFreshConnection,
+      input,
+      { signal: signal.signal },
+      {
+        providerID: "fixture",
+        modelID: "fixture",
+        connectTimeout: 500,
+        idleTimeout: 50,
+      },
+    )
+    expect((await response.text()).match(/keepalive/g)).toHaveLength(5)
+    signal.abort()
+    await expect(fetchWithFreshConnection(input, { signal: signal.signal })).rejects.toThrow()
+    expect(calls).toBe(1)
+    expect(input.headers.has("connection")).toBe(false)
+  } finally {
+    server.stop(true)
+  }
+})

--- a/backend/cli/test/provider/openrouter-tool-schema.test.ts
+++ b/backend/cli/test/provider/openrouter-tool-schema.test.ts
@@ -1,0 +1,72 @@
+import { expect, test } from "bun:test"
+import z from "zod"
+import type { JSONSchema7 } from "@ai-sdk/provider"
+import { Provider } from "../../src/provider/provider"
+import { ResearchSearchParameters } from "../../src/tool/research-search"
+import { tmpdir } from "../fixture/fixture"
+import { Instance } from "../../src/project/instance"
+
+test("the actual OpenRouter SDK sends optional tool inputs without implicit strict mode", async () => {
+  const requests: Record<string, unknown>[] = []
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    async fetch(request) {
+      requests.push(await request.json())
+      return Response.json({
+        id: "fixture",
+        model: "openai/gpt-5.6-sol",
+        created: 1,
+        choices: [{ index: 0, finish_reason: "stop", message: { role: "assistant", content: "done" } }],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      })
+    },
+  })
+  await using tmp = await tmpdir({
+    config: {
+      provider: {
+        router: {
+          npm: "@openrouter/ai-sdk-provider",
+          options: { apiKey: "test-only", baseURL: `${server.url.origin}/v1` },
+          models: { "openai/gpt-5.6-sol": { name: "fixture", limit: { context: 10000, output: 1000 } } },
+        },
+      },
+    },
+  })
+  try {
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const language = await Provider.getLanguage(await Provider.getModel("router", "openai/gpt-5.6-sol"))
+        const schema = z.toJSONSchema(ResearchSearchParameters, { io: "input" })
+        await language.doGenerate({
+          prompt: [{ role: "user", content: [{ type: "text", text: "Find the original paper without date filters" }] }],
+          tools: [{ type: "function", name: "research_search", inputSchema: schema as JSONSchema7 }],
+        })
+        expect(requests).toHaveLength(1)
+        expect(requests[0].tools).toEqual([
+          { type: "function", function: { name: "research_search", parameters: schema, strict: false } },
+        ])
+        expect(ResearchSearchParameters.parse({ query: "Benjamini Hochberg" }).published_after).toBeUndefined()
+        expect(ResearchSearchParameters.safeParse({ query: "paper", published_after: "" }).success).toBe(false)
+        expect(ResearchSearchParameters.safeParse({ published_after: "2026-01-01" }).success).toBe(false)
+      },
+    })
+  } finally {
+    server.stop(true)
+  }
+})
+
+test("strict adaptation preserves explicit policy, other models and provider tools", () => {
+  const tools = [
+    true,
+    { type: "web_search" },
+    { type: "function", function: { name: "custom", strict: true } },
+    { type: "function", function: { name: "custom", strict: false } },
+  ]
+  expect(Provider.normalizeOpenRouterRequestBody({ model: "openai/gpt-5.6-sol", tools }).tools).toEqual(tools)
+  for (const model of ["anthropic/claude-sonnet-5", "deepseek/deepseek-v4", "custom"]) {
+    const input = { model, tools: [{ type: "function", function: { name: "custom" } }] }
+    expect(Provider.normalizeOpenRouterRequestBody(input)).toBe(input)
+  }
+})

--- a/frontend/docs/src/content/openscience/troubleshooting.mdx
+++ b/frontend/docs/src/content/openscience/troubleshooting.mdx
@@ -50,7 +50,13 @@ A pending reservation can reduce available funds before the final charge appears
 
 ## A response is slow or times out
 
-Check whether the app is connecting, waiting for output, receiving output, or running a tool. A wait before the first response can include connection and service processing time.
+The running header shows **Thinking** or the active tool, with elapsed time.
+Hover over it for connection and provider details. A wait before the first
+response can include connection and service processing time.
+
+Inference and Ace credential requests use fresh connections to avoid stale
+connection reuse in the bundled runtime. This prevents one source of long
+connection waits; it does not shorten a model's reasoning or an upstream queue.
 
 Start with a short request and verify the selected model. For a self-hosted model, check server load, memory, context size, and whether it can complete a request directly.
 
@@ -72,6 +78,10 @@ If a `--bare` request works but research tasks fail, verify tool calling and red
 ## Files are missing or the wrong copy opens
 
 Confirm that you opened the intended project. In Files, check **Project files** and **Session scratch** separately. Read the location shown in the preview.
+
+Local result links using `file:` or `sandbox:` open in Files. These prefixes do
+not grant access to a folder: the server still checks the current session's
+file permissions.
 
 For protected folders on macOS, grant the folder access the operating system requests to the app or terminal you are using, then reopen the folder. A project path must exist and be accessible on the machine running OpenScience.
 

--- a/frontend/ui/src/components/markdown.test.ts
+++ b/frontend/ui/src/components/markdown.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect } from "bun:test"
 import katex from "katex"
 import morphdom from "morphdom"
+import { parseMarkdown } from "../context/marked"
 import {
   openFileLink,
   resolveFileLinks,
@@ -11,6 +12,42 @@ import {
 } from "./markdown"
 
 const tex = "\\delta\\omega/\\omega < 10^{-6}"
+
+test("sandbox result URLs survive parsing and sanitization and open exactly once in Files", async () => {
+  const path = "/Users/me/.openscience/workspaces/session/mean sem.png"
+  const root = document.createElement("div")
+  root.innerHTML = sanitize(
+    await parseMarkdown(`[View plot](sandbox:${encodeURI(path)})\n\n![plot](sandbox:${encodeURI(path)})`),
+  )
+  expect(root.querySelector("a")?.getAttribute("href")).toBe(path)
+  expect(root.querySelector("img")?.getAttribute("src")).toBe(path)
+  const opened: string[] = []
+  resolveFileLinks(root, (href) => (href === path ? path : undefined))
+  root.addEventListener("click", (event) => openFileLink(root, event, (file) => opened.push(file)))
+  root.querySelector("a")!.click()
+  expect(opened).toEqual([path])
+  expect(root.querySelector("a")?.hasAttribute("target")).toBe(false)
+})
+
+test("local URL normalization covers native HTML without allowing remote or executable schemes", () => {
+  const root = document.createElement("div")
+  root.innerHTML = sanitize(
+    '<a href="sandbox:/tmp/a%22%3E%3Cimg%3E.csv">result</a><a href="file:///C:/data/plot.png">windows</a>',
+  )
+  expect(root.querySelectorAll("a")[0].getAttribute("href")).toBe('/tmp/a"><img>.csv')
+  expect(root.querySelectorAll("a")[1].getAttribute("href")).toBe("/C:/data/plot.png")
+  expect(root.querySelector("img")).toBeNull()
+  for (const url of [
+    "sandbox://remote.test/a.csv",
+    "sandbox:javascript:alert(1)",
+    "sandbox:/%2Fevil.test/a",
+    "sandbox:/tmp/a%00.csv",
+    "javascript:alert(1)",
+  ]) {
+    root.innerHTML = sanitize(`<a href="${url}">unsafe</a>`)
+    expect(root.querySelector("a")?.hasAttribute("href")).toBe(false)
+  }
+})
 
 describe("sanitize (KaTeX MathML annotation)", () => {
   test("keeps the <annotation> wrapper so raw TeX doesn't leak as visible text", () => {

--- a/frontend/ui/src/components/markdown.tsx
+++ b/frontend/ui/src/components/markdown.tsx
@@ -3,6 +3,7 @@ import { useI18n } from "../context/i18n"
 import DOMPurify from "dompurify"
 import morphdom from "morphdom"
 import { checksum } from "@synsci/util/encode"
+import { localFilePath } from "@synsci/util/path"
 import {
   ComponentProps,
   ParentProps,
@@ -25,6 +26,17 @@ const max = 200
 const cache = new Map<string, Entry>()
 
 if (typeof window !== "undefined" && DOMPurify.isSupported) {
+  // Also cover images, raw HTML and native Markdown parsers. Normalize only
+  // validated local URLs before URI sanitization; never allow arbitrary schemes.
+  DOMPurify.addHook("uponSanitizeAttribute", (node, attribute) => {
+    if (!(
+      (node.nodeName === "A" && attribute.attrName === "href") ||
+      (node.nodeName === "IMG" && attribute.attrName === "src")
+    ))
+      return
+    const path = localFilePath(attribute.attrValue)
+    if (path) attribute.attrValue = path
+  })
   DOMPurify.addHook("afterSanitizeAttributes", (node: Element) => {
     if (!(node instanceof HTMLAnchorElement)) return
     const target = node.getAttribute("target")

--- a/frontend/ui/src/context/marked.tsx
+++ b/frontend/ui/src/context/marked.tsx
@@ -2,6 +2,7 @@ import type { BundledLanguage } from "shiki"
 import { createSimpleContext } from "./helper"
 import type { ThemeRegistrationResolved } from "@pierre/diffs"
 import { backslashMath, guardedDollarMath } from "./marked-math"
+import { localFilePath } from "@synsci/util/path"
 
 // Heavy render deps (katex ~150KB gzip, shiki grammar registry, the marked
 // extensions) are loaded on FIRST USE, not at module load — so first paint (the
@@ -432,18 +433,6 @@ const codeBlockEntities = {
 /** Decode exactly one HTML-entity layer from Marked's escaped code. A single
  * replacement pass keeps input such as `&amp;lt;` literal instead of turning it
  * into `<` through a second, unsafe decode. */
-function localFilePath(href: string): string | undefined {
-  if (!/^file:/i.test(href)) return
-  try {
-    const url = new URL(href)
-    if (url.hostname && url.hostname !== "localhost") return
-    const pathname = decodeURIComponent(url.pathname)
-    return /^\/[A-Za-z]:\//.test(pathname) ? pathname.slice(1) : pathname
-  } catch {
-    return
-  }
-}
-
 export function decodeCodeBlockEntities(input: string) {
   return input.replace(
     /&(lt|gt|amp|quot|#39);/g,
@@ -485,7 +474,7 @@ const loadJsParser = retryable(async () => {
       renderer: {
         link({ href, title, text }) {
           const titleAttr = title ? ` title="${title}"` : ""
-          // Models link local results as file:// URLs. The sanitizer drops that
+          // Models link local results as file: or sandbox: URLs. The sanitizer drops that
           // scheme outright, so hand the plain path on instead; the file-link
           // resolver decides whether it opens in the Files tab.
           const local = localFilePath(href)

--- a/frontend/workspace/src/utils/markdown-assets.test.ts
+++ b/frontend/workspace/src/utils/markdown-assets.test.ts
@@ -12,6 +12,21 @@ import {
 const raw = (path: string) => `http://127.0.0.1:4096/file/raw?path=${encodeURIComponent(path)}&project=prj_1`
 
 describe("markdown asset resolution", () => {
+  test("resolves sandbox result URLs without granting unrelated workspace reads", () => {
+    const path = "/Users/me/.openscience/scratch/plot.png"
+    expect(chatFilePath(`sandbox:${path}`, "/work/project")).toBe(path)
+    expect(workspaceAssetPath(`sandbox:${path}`, "/work/project")).toBeUndefined()
+    expect(localAssetPath("sandbox:/C:/research/plot%20one.png")).toBe("C:/research/plot one.png")
+    expect(localAssetPath("/C:/research/plot%20one.png")).toBe("C:/research/plot one.png")
+    for (const value of [
+      "sandbox://remote.test/a.csv",
+      "sandbox:relative.csv",
+      "sandbox:/%2Fevil.test/a",
+      "sandbox:/tmp/a%00.csv",
+    ]) {
+      expect(chatFilePath(value, "/work/project")).toBeUndefined()
+    }
+  })
   test("exact completed receipts preserve filesystem bytes without broadening raw Markdown links", () => {
     for (const path of [
       "/research/note.md",

--- a/frontend/workspace/src/utils/markdown-assets.ts
+++ b/frontend/workspace/src/utils/markdown-assets.ts
@@ -3,6 +3,8 @@
 // both project-relative and absolute filesystem paths through the authenticated
 // backend while leaving genuine web, email, and embedded URLs untouched.
 
+import { localFilePath } from "@synsci/util/path"
+
 const external = /^(?:https?:|mailto:|tel:|data:|blob:|\/\/|#)/i
 const scheme = /^[a-z][a-z0-9+.-]*:/i
 const windows = /^[A-Za-z]:[\\/]/
@@ -61,18 +63,6 @@ export function resolvePath(base: string, reference: string): string {
   return rooted ? `/${resolved}` : resolved
 }
 
-function localFileUrl(value: string): string | undefined {
-  if (!/^file:/i.test(value)) return
-  try {
-    const url = new URL(value)
-    if (url.hostname && url.hostname !== "localhost") return
-    const pathname = decode(url.pathname)
-    return /^\/[A-Za-z]:\//.test(pathname) ? pathname.slice(1) : pathname
-  } catch {
-    return
-  }
-}
-
 /**
  * Turn a Markdown reference into a filesystem path, or return undefined when
  * the reference belongs to the browser (http(s), mailto, data, blob, etc.).
@@ -81,10 +71,11 @@ function localFileUrl(value: string): string | undefined {
 export function localAssetPath(src: string, base = ""): string | undefined {
   const value = src.trim()
   if (!value || external.test(value)) return
-  const file = localFileUrl(value)
-  if (/^file:/i.test(value)) return file ? resolvePath("", file) : undefined
+  const file = localFilePath(value)
+  if (/^(?:file|sandbox):/i.test(value))
+    return file ? resolvePath("", file.replace(/^\/([A-Za-z]:\/)/, "$1")) : undefined
   if (scheme.test(value) && !windows.test(value)) return
-  const target = decode(value.replace(/[?#].*$/, ""))
+  const target = decode(value.replace(/[?#].*$/, "")).replace(/^\/([A-Za-z]:\/)/, "$1")
   if (!target) return
   return resolvePath(base, target)
 }

--- a/tooling/util/src/path.ts
+++ b/tooling/util/src/path.ts
@@ -1,3 +1,19 @@
+/** Local URLs emitted by models. Keep a leading slash (including /C:/ on
+ * Windows) so sanitizers never mistake the result for an executable scheme.
+ * Resolving the path does not authorize reading it. */
+export function localFilePath(value: string): string | undefined {
+  if (!/^(?:file|sandbox):/i.test(value)) return
+  try {
+    const url = new URL(value)
+    if (url.hostname && url.hostname !== "localhost") return
+    const path = decodeURIComponent(url.pathname)
+    if (!path.startsWith("/") || path.startsWith("//") || /[\x00-\x1f\\]/.test(path)) return
+    return path
+  } catch {
+    return
+  }
+}
+
 export function getFilename(path: string | undefined) {
   if (!path) return ""
   const trimmed = path.replace(/[\/\\]+$/, "")


### PR DESCRIPTION
Simple Ace requests could wait over a minute before reaching the gateway, optional search inputs became effectively mandatory through OpenRouter, and generated `sandbox:` result links lost their destinations during sanitization.

This change uses fresh native connections for inference and Ace credential requests, explicitly disables implicit strict function schemas on OpenRouter's OpenAI route, and normalizes local file URLs before sanitization and Files resolution. Custom fetch implementations, explicit strict policies, runtime tool validation, stream deadlines, cancellation, filesystem authorization and managed idempotency are preserved. Fusion behavior is unchanged.

Validation:
- Reproduced half-open socket reuse on pinned Bun 1.3.14. Real loopback regression verifies fresh connections, preserved headers/body, streaming keepalives and cancellation without resubmission.
- Live Ace comparison: omitted strict filled optional date fields; explicit false omitted them. Actual SDK regression verifies the transmitted schema and runtime validation.
- 552 backend tests passed (one intentionally skipped live-catalog test), typecheck passed, workspace built; Markdown parsing/sanitization/click and workspace file-link tests passed.
- Patched harness, Sol Medium, delegation off: simple answers completed in 7.4s, 5.3s and 3.9s. Original-paper lookup completed in 20.7s using one successful unfiltered search with five sources. CSV/plot completed in 54.8s with verified numbers and artifacts; SEM follow-up in 28.2s. Stop preserved output and the next arithmetic reply completed in 3.7s. A fresh untitled session after idle replied in 5.2s and generated its title. All 28 recorded provider operations completed; response headers arrived in 2.68–3.88s. Clicked the model-generated sandbox plot link in the patched browser: opened in Files.

Updates the changelog and troubleshooting documentation. No manual version bump.
