### PR TITLE
LSP: stand down when pyright cannot be installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ tagged release also ships native binaries for Linux, macOS, and Windows.
 
 ## Unreleased
 
+### Fixed
+
+- When pyright is not installed and cannot be downloaded, Python diagnostics
+  stand down with one warning instead of starting a language server that exits
+  at once and is reported as a crash on every new project.
+
 ## v2.0.90–v2.0.91 — 2026-09-10
 
 v2.0.91 republishes the v2.0.90 source unchanged; two publish dispatches

--- a/backend/cli/src/lsp/server.ts
+++ b/backend/cli/src/lsp/server.ts
@@ -730,6 +730,18 @@ export namespace LSPServer {
             },
           }).exited
         }
+        // An install that could not reach the registry leaves nothing to run.
+        // Say so once and stand down, instead of starting a process that exits
+        // before it owns anything and is reported as a crashed language server.
+        if (!(await Bun.file(js).exists())) {
+          log.warn(
+            "pyright is not installed and could not be downloaded; Python diagnostics are off for this session",
+            {
+              expected: js,
+            },
+          )
+          return
+        }
         binary = BunProc.which()
         args.push(...["run", js])
       }


### PR DESCRIPTION
On a machine without pyright and without registry access, the pyright server definition ran `bun install pyright`, then spawned `bun run <missing entry point>`, which exited before it owned anything and was logged as `Failed to spawn LSP server pyright` on every new project (seen in the desktop sidecar log today). After the install attempt the entry point is checked; if it is still missing, one warning and no spawn. The server is marked unavailable for the session as before.

Made with [Cursor](https://cursor.com)