### PR TITLE
Composer: Independence chip, question card form, Send again after a stopped turn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ tagged release also ships native binaries for Linux, macOS, and Windows.
 
 ## Unreleased
 
+### Added
+
+- Independence sits beside the model and effort chips in the composer, with a
+  one-click menu (Interactive, Balanced, Independent) and one-line descriptions
+  that match what each level does. It stays visible with delegation off, since
+  it governs the lead's own questions.
+- A turn that stopped because the provider stopped answering, or because the
+  request timed out, offers "Send again": the same message goes out as a new
+  request through the composer. Turns with attachments are put back for the
+  user to re-attach and send.
+
+### Changed
+
+- Question cards are one form on the card's own surface: the question at the
+  prose level, choices as rows with a radio mark, the model's "(Recommended)"
+  suffix shown as a quiet tag, the free-text choice as one more row, and a real
+  Dismiss button. A single question reads "Question · <its header>".
+- The managed Ace gateway's idle deadline is ten minutes, the same as other
+  remote endpoints. The gateway sends no keepalives while an upstream model
+  thinks (healthy requests have gone 133 s from response headers to the first
+  body byte), so five minutes could cut off deep reasoning.
+
 ### Fixed
 
 - When pyright is not installed and cannot be downloaded, Python diagnostics

--- a/backend/cli/src/config/config.ts
+++ b/backend/cli/src/config/config.ts
@@ -1198,13 +1198,13 @@ export namespace Config {
                 .positive()
                 .max(2_147_483_647)
                 .describe(
-                  "Maximum provider response-body inactivity in milliseconds; resets on every body chunk, including keepalives and streamed private reasoning. Remote endpoints default to 600000 (10 minutes), the managed Ace gateway to 300000 (5 minutes); local endpoints default to disabled.",
+                  "Maximum provider response-body inactivity in milliseconds; resets on every body chunk, including keepalives and streamed private reasoning. Remote endpoints, including the managed Ace gateway, default to 600000 (10 minutes); local endpoints default to disabled.",
                 ),
               z.literal(false).describe("Disable the provider inactivity watchdog."),
             ])
             .optional()
             .describe(
-              "Maximum provider response-body inactivity in milliseconds. Remote endpoints default to 600000 (10 minutes) and the managed Ace gateway to 300000 (5 minutes); local endpoints (loopback or .local base URLs and bundled local providers) default to disabled. Set false to disable.",
+              "Maximum provider response-body inactivity in milliseconds. Remote endpoints, including the managed Ace gateway, default to 600000 (10 minutes); local endpoints (loopback or .local base URLs and bundled local providers) default to disabled. Set false to disable.",
             ),
           connectTimeout: z
             .union([z.number().int().positive().max(2_147_483_647), z.literal(false)])

--- a/backend/cli/src/provider/provider.ts
+++ b/backend/cli/src/provider/provider.ts
@@ -71,10 +71,13 @@ export namespace Provider {
   // from a remote endpoint is a dead connection, not a thinking model; the
   // earlier half-hour turned one hung stream into a 45-minute worker failure.
   export const DEFAULT_REMOTE_IDLE_TIMEOUT_MS = 600_000
-  // The managed gateway and OpenRouter keep a live stream ticking with
-  // keepalive comments and streamed private reasoning, so five silent minutes
-  // there is a connection that died without closing.
-  export const DEFAULT_MANAGED_IDLE_TIMEOUT_MS = 300_000
+  // The managed gateway does not send keepalives while an upstream model
+  // thinks: healthy requests have gone 133 s from response headers to the
+  // first body byte. A dead connection and a long think are indistinguishable
+  // at the byte level, so this deadline trades the two: ten minutes bounds a
+  // hang without cutting off deep reasoning. (Gateway keepalives would let it
+  // drop to a couple of minutes.)
+  export const DEFAULT_MANAGED_IDLE_TIMEOUT_MS = 600_000
   export const DEFAULT_OUTPUT_IDLE_TIMEOUT_MS = false
 
   export type RequestContext = {

--- a/backend/cli/test/provider/idle-watchdog.test.ts
+++ b/backend/cli/test/provider/idle-watchdog.test.ts
@@ -142,7 +142,7 @@ describe("provider activity watchdog", () => {
           providerID: "openrouter",
           baseURL: `${managedApiBase()}/api/llm/proxy/openrouter/v1`,
         }),
-      ).toBe(300_000)
+      ).toBe(600_000)
     } finally {
       process.env["OPENSCIENCE_API_BASE"] = base
     }

--- a/frontend/docs/src/content/openscience/custom-providers.mdx
+++ b/frontend/docs/src/content/openscience/custom-providers.mdx
@@ -99,7 +99,7 @@ Provider options support request deadlines in milliseconds:
 | Option | Default |
 | --- | --- |
 | `connectTimeout` | 300000 (5 minutes): waiting for response headers; disabled by default for local endpoints. |
-| `idleTimeout` | 600000 (10 minutes) for remote endpoints and 300000 (5 minutes) for the managed Ace gateway; reset by every response-body chunk and disabled by default for local endpoints. |
+| `idleTimeout` | 600000 (10 minutes) for remote endpoints, including the managed Ace gateway; reset by every response-body chunk and disabled by default for local endpoints. |
 | `outputIdleTimeout` | Disabled; optionally bound the wait for readable output or tool-call activity. |
 | `timeout` | No total-duration limit by default. |
 

--- a/frontend/ui/src/components/message-part.css
+++ b/frontend/ui/src/components/message-part.css
@@ -1724,13 +1724,16 @@
   }
 }
 
+/* A question is a short form on the card's own surface: the question at the
+   prose level, choices as rows with a radio mark, the free-text choice as one
+   more row, and one real button to dismiss. Three type levels, no boxes in
+   boxes, and the same 4px rhythm as the rest of the trace. */
 [data-component="question-prompt"] {
   display: flex;
   flex-direction: column;
-  padding: 12px;
-  background-color: var(--surface-inset-base);
-  border-radius: 0 0 var(--radius-xs) var(--radius-xs);
-  gap: 12px;
+  gap: 10px;
+  padding: 10px 12px 12px;
+  border-top: 1px solid var(--border-weaker-base);
 
   [data-slot="question-tabs"] {
     display: flex;
@@ -1738,12 +1741,15 @@
     flex-wrap: wrap;
 
     [data-slot="question-tab"] {
-      padding: 4px 12px;
-      font-size: var(--font-size-medium);
-      border-radius: var(--radius-xs);
-      background-color: var(--surface-base);
-      color: var(--text-base);
-      border: none;
+      height: 24px;
+      padding: 0 10px;
+      font: inherit;
+      font-size: var(--font-size-small);
+      line-height: 18px;
+      border-radius: var(--radius-sm);
+      background-color: transparent;
+      color: var(--text-weak);
+      border: 0;
       cursor: pointer;
       transition:
         color 0.15s,
@@ -1753,12 +1759,18 @@
         background-color: var(--surface-base-hover);
       }
 
+      &[data-answered="true"] {
+        color: var(--text-strong);
+      }
+
       &[data-active="true"] {
+        color: var(--text-strong);
         background-color: var(--surface-raised-base);
       }
 
-      &[data-answered="true"] {
-        color: var(--text-strong);
+      &:focus-visible {
+        outline: 2px solid var(--border-selected);
+        outline-offset: -2px;
       }
     }
   }
@@ -1770,8 +1782,8 @@
 
     [data-slot="question-text"] {
       font-size: var(--font-size-base);
-      color: var(--text-base);
-      line-height: 1.5;
+      line-height: 21px;
+      color: var(--text-strong);
     }
 
     /* Credential requests: one hairline row that sends the user to the
@@ -1781,11 +1793,12 @@
       align-items: center;
       justify-content: space-between;
       gap: 12px;
-      padding: 8px 12px;
+      padding: 6px 10px;
       border: 1px solid var(--border-weaker-base);
-      border-radius: var(--radius-xs);
+      border-radius: var(--radius-sm);
       color: var(--text-weak);
       font-size: var(--font-size-small);
+      line-height: 18px;
 
       button {
         flex: 0 0 auto;
@@ -1807,76 +1820,107 @@
   [data-slot="question-options"] {
     display: flex;
     flex-direction: column;
-    gap: 4px;
+    gap: 2px;
+    margin: 0 -8px;
 
     [data-slot="question-option"] {
       display: flex;
-      flex-direction: column;
       align-items: flex-start;
-      gap: 2px;
-      padding: 8px 12px;
-      background-color: var(--surface-base);
-      border: 1px solid var(--border-weaker-base);
-      border-radius: var(--radius-xs);
-      cursor: pointer;
-      text-align: left;
+      gap: 10px;
       width: 100%;
-      transition:
-        background-color 0.15s,
-        border-color 0.15s;
-      position: relative;
+      padding: 6px 8px;
+      border: 0;
+      border-radius: var(--radius-sm);
+      background-color: transparent;
+      color: var(--text-strong);
+      font: inherit;
+      text-align: left;
+      cursor: pointer;
+      transition: background-color 0.15s;
 
       &:hover {
         background-color: var(--surface-base-hover);
-        border-color: var(--border-default);
       }
 
-      &[data-picked="true"] {
-        [data-component="icon"] {
-          position: absolute;
-          right: 12px;
-          top: 50%;
-          transform: translateY(-50%);
-          color: var(--text-strong);
-        }
+      &:focus-visible {
+        outline: 2px solid var(--border-selected);
+        outline-offset: -2px;
+      }
+
+      [data-slot="option-mark"] {
+        flex: 0 0 auto;
+        box-sizing: border-box;
+        width: 14px;
+        height: 14px;
+        margin-top: 3px;
+        border: 1.5px solid var(--border-default);
+        border-radius: 50%;
+        transition:
+          border-color 0.15s,
+          border-width 0.15s;
+      }
+
+      &[data-picked="true"] [data-slot="option-mark"] {
+        border-width: 4.5px;
+        border-color: var(--text-strong);
+      }
+
+      &[data-custom="true"] [data-slot="option-mark"] {
+        border-style: dashed;
+      }
+
+      [data-slot="option-copy"] {
+        display: flex;
+        flex-direction: column;
+        gap: 1px;
+        min-width: 0;
       }
 
       [data-slot="option-label"] {
-        font-size: var(--font-size-base);
-        color: var(--text-base);
-        font-weight: var(--font-weight-medium);
+        font-size: var(--font-size-medium);
+        line-height: 20px;
+        color: var(--text-strong);
+      }
+
+      [data-slot="option-tag"] {
+        margin-left: 8px;
+        font-size: var(--font-size-small);
+        line-height: 18px;
+        color: var(--text-weak);
       }
 
       [data-slot="option-description"] {
         font-size: var(--font-size-small);
+        line-height: 18px;
         color: var(--text-weak);
       }
+    }
+
+    &[data-multiple="true"] [data-slot="option-mark"] {
+      border-radius: var(--radius-xs);
     }
 
     [data-slot="custom-input-form"] {
       display: flex;
       gap: 8px;
-      padding: 8px 0;
-      align-items: stretch;
+      align-items: center;
+      padding: 4px 8px 2px 32px;
 
       [data-slot="custom-input"] {
         flex: 1;
-        padding: 8px 12px;
-        font-size: var(--font-size-base);
+        height: 28px;
+        padding: 0 10px;
+        font: inherit;
+        font-size: var(--font-size-medium);
+        line-height: 20px;
         border: 1px solid var(--border-default);
-        border-radius: var(--radius-xs);
+        border-radius: var(--radius-sm);
         background-color: var(--surface-base);
-        color: var(--text-base);
+        color: var(--text-strong);
         outline: none;
 
-        /* This field frames itself — the border and radius above ARE the frame
-           — so it takes the lit frame, not the halo the app-wide rule hands
-           fields whose border box is just the glyphs (atlas.css). That rule is
-           !important, so out-specifying it is not enough; matching its weight
-           is the only way the treatment declared here reaches the screen at
-           all. Outline included: text inputs match :focus-visible on mouse
-           focus too, and without this the halo's offset ring survives on top
-           of the frame, at a different radius. */
+        /* This field frames itself, so it takes the lit frame rather than the
+           app-wide halo, which is declared !important and must be matched. */
         &:focus {
           border-color: var(--focus-lit-ring);
           outline: none !important;
@@ -1887,17 +1931,13 @@
           color: var(--text-weak);
         }
       }
-
-      [data-component="button"] {
-        height: auto;
-      }
     }
   }
 
   [data-slot="question-review"] {
     display: flex;
     flex-direction: column;
-    gap: 12px;
+    gap: 10px;
 
     [data-slot="review-title"] {
       display: none;
@@ -1906,8 +1946,9 @@
     [data-slot="review-item"] {
       display: flex;
       flex-direction: column;
-      gap: 2px;
+      gap: 1px;
       font-size: var(--font-size-medium);
+      line-height: 20px;
 
       [data-slot="review-label"] {
         color: var(--text-weak);
@@ -1926,8 +1967,8 @@
   [data-slot="question-actions"] {
     display: flex;
     align-items: center;
-    gap: 8px;
     justify-content: flex-end;
+    gap: 8px;
   }
 }
 

--- a/frontend/ui/src/components/message-part.tsx
+++ b/frontend/ui/src/components/message-part.tsx
@@ -2069,11 +2069,17 @@ ToolRegistry.register({
     const answers = createMemo(() => (props.metadata.answers ?? []) as QuestionAnswer[])
     const completed = createMemo(() => answers().length > 0)
 
+    // One question reads as "Question · <its header>"; several read as
+    // "Questions · 3 questions". Answered, the count of answers follows.
+    const title = createMemo(() =>
+      questions().length === 1 ? i18n.t("ui.tool.question") : i18n.t("ui.tool.questions"),
+    )
     const subtitle = createMemo(() => {
       const count = questions().length
       if (count === 0) return ""
       if (completed()) return i18n.t("ui.question.subtitle.answered", { count })
-      return `${count} ${i18n.t(count > 1 ? "ui.common.question.other" : "ui.common.question.one")}`
+      if (count === 1) return questions()[0]?.header ?? ""
+      return `${count} ${i18n.t("ui.common.question.other")}`
     })
 
     return (
@@ -2082,7 +2088,7 @@ ToolRegistry.register({
         defaultOpen={completed()}
         icon="bubble-5"
         trigger={{
-          title: i18n.t("ui.tool.questions"),
+          title: title(),
           subtitle: subtitle(),
         }}
       >
@@ -2405,35 +2411,59 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
               </button>
             </div>
           </Show>
-          <div data-slot="question-options">
+          <div
+            data-slot="question-options"
+            role={multi() ? "group" : "radiogroup"}
+            data-multiple={multi() ? "true" : undefined}
+          >
             <For each={options()}>
               {(opt, i) => {
                 const picked = () => store.answers[store.tab]?.includes(opt.label) ?? false
+                // The model marks its recommendation in the label itself; show
+                // it as a quiet tag and keep the full label as the answer.
+                const recommended = () => /\s*\(recommended\)\s*$/i.test(opt.label)
+                const shown = () => opt.label.replace(/\s*\(recommended\)\s*$/i, "")
                 return (
-                  <button data-slot="question-option" data-picked={picked()} onClick={() => selectOption(i())}>
-                    <span data-slot="option-label">{opt.label}</span>
-                    <Show when={opt.description}>
-                      <span data-slot="option-description">{opt.description}</span>
-                    </Show>
-                    <Show when={picked()}>
-                      <Icon name="check-small" size="normal" />
-                    </Show>
+                  <button
+                    type="button"
+                    data-slot="question-option"
+                    data-picked={picked()}
+                    role={multi() ? "checkbox" : "radio"}
+                    aria-checked={picked()}
+                    onClick={() => selectOption(i())}
+                  >
+                    <span data-slot="option-mark" aria-hidden="true" />
+                    <span data-slot="option-copy">
+                      <span data-slot="option-label">
+                        {shown()}
+                        <Show when={recommended()}>
+                          <span data-slot="option-tag">{i18n.t("ui.question.recommended")}</span>
+                        </Show>
+                      </span>
+                      <Show when={opt.description}>
+                        <span data-slot="option-description">{opt.description}</span>
+                      </Show>
+                    </span>
                   </button>
                 )
               }}
             </For>
             <button
+              type="button"
               data-slot="question-option"
+              data-custom="true"
               data-picked={customPicked()}
+              role={multi() ? "checkbox" : "radio"}
+              aria-checked={customPicked()}
               onClick={() => selectOption(options().length)}
             >
-              <span data-slot="option-label">{i18n.t("ui.messagePart.option.typeOwnAnswer")}</span>
-              <Show when={!store.editing && input()}>
-                <span data-slot="option-description">{input()}</span>
-              </Show>
-              <Show when={customPicked()}>
-                <Icon name="check-small" size="normal" />
-              </Show>
+              <span data-slot="option-mark" aria-hidden="true" />
+              <span data-slot="option-copy">
+                <span data-slot="option-label">{i18n.t("ui.messagePart.option.typeOwnAnswer")}</span>
+                <Show when={!store.editing && input()}>
+                  <span data-slot="option-description">{input()}</span>
+                </Show>
+              </span>
             </button>
             <Show when={store.editing}>
               <form data-slot="custom-input-form" onSubmit={handleCustomSubmit}>
@@ -2482,7 +2512,7 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
       </Show>
 
       <div data-slot="question-actions">
-        <Button variant="ghost" size="small" onClick={reject}>
+        <Button variant="secondary" size="small" onClick={reject}>
           {i18n.t("ui.common.dismiss")}
         </Button>
         <Show when={!single()}>

--- a/frontend/ui/src/components/session-turn-trajectory.test.ts
+++ b/frontend/ui/src/components/session-turn-trajectory.test.ts
@@ -94,6 +94,7 @@ type Callbacks = {
   openFile?: (path: string) => void
   loadComputeJob?: Parameters<typeof data.DataProvider>[0]["onLoadComputeJob"]
   resolveFileReceipts?: Parameters<typeof data.DataProvider>[0]["onResolveFileReceipts"]
+  resendTurn?: Parameters<typeof data.DataProvider>[0]["onResendTurn"]
 }
 const mount = (view: () => JSX.Element, store: Store, callbacks: Callbacks = {}) => {
   const host = document.createElement("div")
@@ -109,6 +110,7 @@ const mount = (view: () => JSX.Element, store: Store, callbacks: Callbacks = {})
           onOpenFile: callbacks.openFile,
           onLoadComputeJob: callbacks.loadComputeJob,
           onResolveFileReceipts: callbacks.resolveFileReceipts,
+          onResendTurn: callbacks.resendTurn,
           get children() {
             return dialog.DialogProvider({
               get children() {
@@ -1205,6 +1207,49 @@ describe("timeout recovery", () => {
       },
     },
   }
+
+  test("offers to send the message again after a terminal timeout, through the host", async () => {
+    const message = assistant()
+    const sent: Array<{ sessionID: string; messageID: string }> = []
+    const [store] = reactive.createStore<Store>({
+      ...empty(),
+      message: { [sessionID]: [user, { ...message, error: timeout, time: { created: 2, completed: 3 } }] },
+      part: { [user.id]: [], [message.id]: [] },
+    })
+    const host = mount(() => turn.SessionTurn({ sessionID, messageID: user.id }), store, {
+      resendTurn: (input) => sent.push(input),
+    })
+    await ready(() => host.querySelector('[data-slot="session-turn-stop"] button') !== null)
+    const button = host.querySelector<HTMLButtonElement>('[data-slot="session-turn-stop"] button')!
+    expect(button.textContent).toBe("Send again")
+    button.click()
+    expect(sent).toEqual([{ sessionID, messageID: user.id }])
+  })
+
+  test("a stop the user asked for offers no resend", async () => {
+    const message = assistant()
+    const [store] = reactive.createStore<Store>({
+      ...empty(),
+      message: {
+        [sessionID]: [
+          user,
+          {
+            ...message,
+            error: { name: "MessageAbortedError", data: { message: "The operation was aborted." } },
+            time: { created: 2, completed: 3 },
+          },
+        ],
+      },
+      part: { [user.id]: [], [message.id]: [] },
+    })
+    const host = mount(() => turn.SessionTurn({ sessionID, messageID: user.id }), store, {
+      resendTurn: () => undefined,
+    })
+    await ready(() => host.querySelector('[data-component="session-turn"]') !== null)
+    await settle()
+    expect(host.querySelector('[data-slot="session-turn-stop"]')).toBeNull()
+    expect(host.querySelector('[data-slot="session-turn-stop-note"]')).toBeNull()
+  })
 
   test.each(["busy", "retry"] as const)(
     "keeps partial output and stops live indicators after a terminal timeout despite stale %s state",

--- a/frontend/ui/src/components/session-turn.css
+++ b/frontend/ui/src/components/session-turn.css
@@ -552,8 +552,16 @@
       margin-top: 2px;
     }
 
-    > [data-slot="session-turn-stop-note"] {
-      margin: 8px 0 0;
+    > [data-slot="session-turn-stop"] {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 8px;
+      margin-top: 8px;
+    }
+
+    > [data-slot="session-turn-stop"] [data-slot="session-turn-stop-note"] {
+      margin: 0;
       color: var(--text-weaker);
       font-size: var(--font-size-medium);
       line-height: 20px;
@@ -857,6 +865,11 @@
 
     [data-slot="session-state-message"] {
       overflow-wrap: anywhere;
+    }
+
+    [data-slot="session-state-actions"] {
+      display: flex;
+      justify-content: flex-end;
     }
   }
 

--- a/frontend/ui/src/components/session-turn.tsx
+++ b/frontend/ui/src/components/session-turn.tsx
@@ -311,8 +311,16 @@ function AssistantTrace(props: {
 /** A fault or a pause the reader must act on. A plain stop is not one: it
  * reads on the header line ("Stopped after 2m 3s") and, when a provider or a
  * credential change ended the turn, as one quiet line under the trace. */
-function SessionErrorNotice(props: { error: unknown }) {
+function SessionErrorNotice(props: { error: unknown; sessionID: string; messageID: string }) {
+  const data = useData()
+  const i18n = useI18n()
   const display = () => sessionErrorDisplay(props.error)
+  // A provider that stopped answering, a wait the runtime gave up on, or a
+  // plain failure: one click sends the same message as a new request. Stops
+  // the user asked for, and pauses that resume on their own, do not need it.
+  const resend = () =>
+    !!data.resendTurn &&
+    (display().state === "error" || display().reason === "timeout" || display().reason === "provider")
   return (
     <Card
       variant={display().state === "paused" ? "warning" : "error"}
@@ -335,6 +343,17 @@ function SessionErrorNotice(props: { error: unknown }) {
           </div>
         </Show>
       </div>
+      <Show when={resend()}>
+        <div data-slot="session-state-actions">
+          <Button
+            variant="secondary"
+            size="small"
+            onClick={() => data.resendTurn?.({ sessionID: props.sessionID, messageID: props.messageID })}
+          >
+            {i18n.t("ui.sessionTurn.sendAgain")}
+          </Button>
+        </div>
+      </Show>
     </Card>
   )
 }
@@ -641,6 +660,14 @@ export function SessionTurn(
     const display = sessionErrorDisplay(value)
     if (display.state !== "stopped" || display.reason === "user") return undefined
     return display.message
+  })
+  // A provider that stopped answering or a wait the runtime gave up on: the
+  // same message can go again as a new request in one click.
+  const resendable = createMemo(() => {
+    const value = error()
+    if (!value || !data.resendTurn) return false
+    const reason = sessionErrorDisplay(value).reason
+    return reason === "timeout" || reason === "provider"
   })
 
   const response = createMemo(() =>
@@ -963,12 +990,29 @@ export function SessionTurn(
                           {(value) => (
                             <Switch>
                               <Match when={stopped() && stopNote()}>
-                                <p data-slot="session-turn-stop-note" role="status">
-                                  {stopNote()}
-                                </p>
+                                <div data-slot="session-turn-stop">
+                                  <p data-slot="session-turn-stop-note" role="status">
+                                    {stopNote()}
+                                  </p>
+                                  <Show when={resendable()}>
+                                    <Button
+                                      variant="secondary"
+                                      size="small"
+                                      onClick={() =>
+                                        data.resendTurn?.({ sessionID: props.sessionID, messageID: props.messageID })
+                                      }
+                                    >
+                                      {i18n.t("ui.sessionTurn.sendAgain")}
+                                    </Button>
+                                  </Show>
+                                </div>
                               </Match>
                               <Match when={!stopped()}>
-                                <SessionErrorNotice error={value()} />
+                                <SessionErrorNotice
+                                  error={value()}
+                                  sessionID={props.sessionID}
+                                  messageID={props.messageID}
+                                />
                               </Match>
                             </Switch>
                           )}

--- a/frontend/ui/src/context/data.tsx
+++ b/frontend/ui/src/context/data.tsx
@@ -90,6 +90,8 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
     onResolveFileReceipts?: (sessionID: string, paths: readonly string[]) => Promise<string[]>
     /** Open the host's credential settings; question cards that ask for a login offer it. */
     onOpenCredentials?: () => void
+    /** Send a turn's user message again as a new request, after a provider stopped answering. */
+    onResendTurn?: (input: { sessionID: string; messageID: string }) => void
   }) => {
     return {
       get store() {
@@ -108,6 +110,7 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
       loadComputeJob: props.onLoadComputeJob,
       resolveFileReceipts: props.onResolveFileReceipts,
       openCredentials: props.onOpenCredentials,
+      resendTurn: props.onResendTurn,
     }
   },
 })

--- a/frontend/ui/src/i18n/ar.ts
+++ b/frontend/ui/src/i18n/ar.ts
@@ -1,4 +1,5 @@
 export const dict = {
+  "ui.sessionTurn.sendAgain": "إعادة الإرسال",
   "ui.sessionTurn.steps.show": "إظهار سجل التنفيذ",
   "ui.sessionTurn.steps.hide": "إخفاء سجل التنفيذ",
   "ui.lineComment.label.prefix": "تعليق على ",
@@ -60,6 +61,7 @@ export const dict = {
   "ui.tool.patch": "تصحيح",
   "ui.tool.todos": "المهام",
   "ui.tool.todos.read": "قراءة المهام",
+  "ui.tool.question": "سؤال",
   "ui.tool.questions": "أسئلة",
   "ui.tool.agent": "وكيل {{type}}",
   "ui.tool.websearch": "بحث الويب",
@@ -134,6 +136,7 @@ export const dict = {
   "ui.question.subtitle.answered": "{{count}} أجيب",
   "ui.question.answer.none": "(لا توجد إجابة)",
   "ui.question.review.notAnswered": "(لم يتم الرد)",
+  "ui.question.recommended": "موصى به",
   "ui.question.multiHint": "(حدد كل ما ينطبق)",
   "ui.question.custom.placeholder": "اكتب إجابتك...",
 }

--- a/frontend/ui/src/i18n/br.ts
+++ b/frontend/ui/src/i18n/br.ts
@@ -1,4 +1,5 @@
 export const dict = {
+  "ui.sessionTurn.sendAgain": "Enviar novamente",
   "ui.sessionTurn.steps.show": "Mostrar rastreamento de execução",
   "ui.sessionTurn.steps.hide": "Ocultar rastreamento de execução",
   "ui.lineComment.label.prefix": "Comentar em ",
@@ -61,6 +62,7 @@ export const dict = {
   "ui.tool.patch": "Patch",
   "ui.tool.todos": "Tarefas",
   "ui.tool.todos.read": "Ler tarefas",
+  "ui.tool.question": "Pergunta",
   "ui.tool.questions": "Perguntas",
   "ui.tool.agent": "Agente {{type}}",
   "ui.tool.websearch": "Busca na Web",
@@ -135,6 +137,7 @@ export const dict = {
   "ui.question.subtitle.answered": "{{count}} respondidas",
   "ui.question.answer.none": "(sem resposta)",
   "ui.question.review.notAnswered": "(não respondida)",
+  "ui.question.recommended": "Recomendado",
   "ui.question.multiHint": "(selecione todas que se aplicam)",
   "ui.question.custom.placeholder": "Digite sua resposta...",
 }

--- a/frontend/ui/src/i18n/da.ts
+++ b/frontend/ui/src/i18n/da.ts
@@ -1,4 +1,5 @@
 export const dict = {
+  "ui.sessionTurn.sendAgain": "Send igen",
   "ui.sessionTurn.steps.show": "Vis udførelsesspor",
   "ui.sessionTurn.steps.hide": "Skjul udførelsesspor",
   "ui.lineComment.label.prefix": "Kommenter på ",
@@ -60,6 +61,7 @@ export const dict = {
   "ui.tool.patch": "Patch",
   "ui.tool.todos": "To-dos",
   "ui.tool.todos.read": "Læs to-dos",
+  "ui.tool.question": "Spørgsmål",
   "ui.tool.questions": "Spørgsmål",
   "ui.tool.agent": "{{type}} Agent",
   "ui.tool.websearch": "Websøgning",
@@ -134,6 +136,7 @@ export const dict = {
   "ui.question.subtitle.answered": "{{count}} besvaret",
   "ui.question.answer.none": "(intet svar)",
   "ui.question.review.notAnswered": "(ikke besvaret)",
+  "ui.question.recommended": "Anbefalet",
   "ui.question.multiHint": "(vælg alle der gælder)",
   "ui.question.custom.placeholder": "Skriv dit svar...",
 }

--- a/frontend/ui/src/i18n/de.ts
+++ b/frontend/ui/src/i18n/de.ts
@@ -3,6 +3,7 @@ import { dict as en } from "./en"
 type Keys = keyof typeof en
 
 export const dict = {
+  "ui.sessionTurn.sendAgain": "Erneut senden",
   "ui.sessionTurn.steps.show": "Ausführungsprotokoll anzeigen",
   "ui.sessionTurn.steps.hide": "Ausführungsprotokoll ausblenden",
   "ui.lineComment.label.prefix": "Kommentar zu ",
@@ -64,6 +65,7 @@ export const dict = {
   "ui.tool.patch": "Patch",
   "ui.tool.todos": "Aufgaben",
   "ui.tool.todos.read": "Aufgaben lesen",
+  "ui.tool.question": "Frage",
   "ui.tool.questions": "Fragen",
   "ui.tool.agent": "{{type}} Agent",
   "ui.tool.websearch": "Websuche",
@@ -137,6 +139,7 @@ export const dict = {
   "ui.question.subtitle.answered": "{{count}} beantwortet",
   "ui.question.answer.none": "(keine Antwort)",
   "ui.question.review.notAnswered": "(nicht beantwortet)",
+  "ui.question.recommended": "Empfohlen",
   "ui.question.multiHint": "(alle zutreffenden auswählen)",
   "ui.question.custom.placeholder": "Geben Sie Ihre Antwort ein...",
 } satisfies Partial<Record<Keys, string>>

--- a/frontend/ui/src/i18n/en.ts
+++ b/frontend/ui/src/i18n/en.ts
@@ -1,4 +1,5 @@
 export const dict = {
+  "ui.sessionTurn.sendAgain": "Send again",
   "ui.sessionTurn.steps.show": "Show reasoning and activity",
   "ui.sessionTurn.steps.hide": "Hide reasoning and activity",
   "ui.sessionTurn.workedFor": "Worked for {{duration}}",
@@ -69,6 +70,7 @@ export const dict = {
   "ui.tool.patch": "Edited",
   "ui.tool.todos": "To-dos",
   "ui.tool.todos.read": "Read to-dos",
+  "ui.tool.question": "Question",
   "ui.tool.questions": "Questions",
   "ui.tool.agent": "{{type}} agent",
   "ui.tool.websearch": "Searched the web",
@@ -161,6 +163,7 @@ export const dict = {
   "ui.question.subtitle.answered": "{{count}} answered",
   "ui.question.answer.none": "(no answer)",
   "ui.question.review.notAnswered": "(not answered)",
+  "ui.question.recommended": "Recommended",
   "ui.question.multiHint": "(select all that apply)",
   "ui.question.custom.placeholder": "Type your answer...",
 }

--- a/frontend/ui/src/i18n/es.ts
+++ b/frontend/ui/src/i18n/es.ts
@@ -1,4 +1,5 @@
 export const dict = {
+  "ui.sessionTurn.sendAgain": "Enviar de nuevo",
   "ui.sessionTurn.steps.show": "Mostrar traza de ejecución",
   "ui.sessionTurn.steps.hide": "Ocultar traza de ejecución",
   "ui.lineComment.label.prefix": "Comentar en ",
@@ -60,6 +61,7 @@ export const dict = {
   "ui.tool.patch": "Parche",
   "ui.tool.todos": "Tareas",
   "ui.tool.todos.read": "Leer tareas",
+  "ui.tool.question": "Pregunta",
   "ui.tool.questions": "Preguntas",
   "ui.tool.agent": "Agente {{type}}",
   "ui.tool.websearch": "Búsqueda web",
@@ -134,6 +136,7 @@ export const dict = {
   "ui.question.subtitle.answered": "{{count}} respondidas",
   "ui.question.answer.none": "(sin respuesta)",
   "ui.question.review.notAnswered": "(no respondida)",
+  "ui.question.recommended": "Recomendado",
   "ui.question.multiHint": "(selecciona todas las que correspondan)",
   "ui.question.custom.placeholder": "Escribe tu respuesta...",
 }

--- a/frontend/ui/src/i18n/fr.ts
+++ b/frontend/ui/src/i18n/fr.ts
@@ -1,4 +1,5 @@
 export const dict = {
+  "ui.sessionTurn.sendAgain": "Renvoyer",
   "ui.sessionTurn.steps.show": "Afficher la trace d’exécution",
   "ui.sessionTurn.steps.hide": "Masquer la trace d’exécution",
   "ui.lineComment.label.prefix": "Commenter sur ",
@@ -62,6 +63,7 @@ export const dict = {
   "ui.tool.patch": "Patch",
   "ui.tool.todos": "Tâches",
   "ui.tool.todos.read": "Lire les tâches",
+  "ui.tool.question": "Question",
   "ui.tool.questions": "Questions",
   "ui.tool.agent": "Agent {{type}}",
   "ui.tool.websearch": "Recherche web",
@@ -136,6 +138,7 @@ export const dict = {
   "ui.question.subtitle.answered": "{{count}} répondu(s)",
   "ui.question.answer.none": "(pas de réponse)",
   "ui.question.review.notAnswered": "(non répondu)",
+  "ui.question.recommended": "Recommandé",
   "ui.question.multiHint": "(sélectionnez tout ce qui s'applique)",
   "ui.question.custom.placeholder": "Tapez votre réponse...",
 }

--- a/frontend/ui/src/i18n/ja.ts
+++ b/frontend/ui/src/i18n/ja.ts
@@ -1,4 +1,5 @@
 export const dict = {
+  "ui.sessionTurn.sendAgain": "再送信",
   "ui.sessionTurn.steps.show": "実行トレースを表示",
   "ui.sessionTurn.steps.hide": "実行トレースを非表示",
   "ui.lineComment.label.prefix": "",
@@ -60,6 +61,7 @@ export const dict = {
   "ui.tool.patch": "Patch",
   "ui.tool.todos": "Todo",
   "ui.tool.todos.read": "Todo読み込み",
+  "ui.tool.question": "質問",
   "ui.tool.questions": "質問",
   "ui.tool.agent": "{{type}}エージェント",
   "ui.tool.websearch": "Web検索",
@@ -134,6 +136,7 @@ export const dict = {
   "ui.question.subtitle.answered": "{{count}}件回答済み",
   "ui.question.answer.none": "(回答なし)",
   "ui.question.review.notAnswered": "(未回答)",
+  "ui.question.recommended": "推奨",
   "ui.question.multiHint": "(該当するものをすべて選択)",
   "ui.question.custom.placeholder": "回答を入力...",
 }

--- a/frontend/ui/src/i18n/ko.ts
+++ b/frontend/ui/src/i18n/ko.ts
@@ -1,4 +1,5 @@
 export const dict = {
+  "ui.sessionTurn.sendAgain": "다시 보내기",
   "ui.sessionTurn.steps.show": "실행 추적 표시",
   "ui.sessionTurn.steps.hide": "실행 추적 숨기기",
   "ui.lineComment.label.prefix": "",
@@ -60,6 +61,7 @@ export const dict = {
   "ui.tool.patch": "패치",
   "ui.tool.todos": "할 일",
   "ui.tool.todos.read": "할 일 읽기",
+  "ui.tool.question": "질문",
   "ui.tool.questions": "질문",
   "ui.tool.agent": "{{type}} 에이전트",
   "ui.tool.websearch": "웹 검색",
@@ -134,6 +136,7 @@ export const dict = {
   "ui.question.subtitle.answered": "{{count}}개 답변됨",
   "ui.question.answer.none": "(답변 없음)",
   "ui.question.review.notAnswered": "(답변되지 않음)",
+  "ui.question.recommended": "권장",
   "ui.question.multiHint": "(해당하는 항목 모두 선택)",
   "ui.question.custom.placeholder": "답변 입력...",
 }

--- a/frontend/ui/src/i18n/no.ts
+++ b/frontend/ui/src/i18n/no.ts
@@ -2,6 +2,7 @@ import { dict as en } from "./en"
 type Keys = keyof typeof en
 
 export const dict = {
+  "ui.sessionTurn.sendAgain": "Send igjen",
   "ui.sessionTurn.steps.show": "Vis utføringsspor",
   "ui.sessionTurn.steps.hide": "Skjul utføringsspor",
   "ui.lineComment.label.prefix": "Kommenter på ",
@@ -63,6 +64,7 @@ export const dict = {
   "ui.tool.patch": "Patch",
   "ui.tool.todos": "Gjøremål",
   "ui.tool.todos.read": "Les gjøremål",
+  "ui.tool.question": "Spørsmål",
   "ui.tool.questions": "Spørsmål",
   "ui.tool.agent": "{{type}}-agent",
   "ui.tool.websearch": "Websøk",
@@ -139,6 +141,7 @@ export const dict = {
   "ui.question.subtitle.answered": "{{count}} besvart",
   "ui.question.answer.none": "(ingen svar)",
   "ui.question.review.notAnswered": "(ikke besvart)",
+  "ui.question.recommended": "Anbefalt",
   "ui.question.multiHint": "(velg alle som gjelder)",
   "ui.question.custom.placeholder": "Skriv svaret ditt...",
 } satisfies Partial<Record<Keys, string>>

--- a/frontend/ui/src/i18n/pl.ts
+++ b/frontend/ui/src/i18n/pl.ts
@@ -1,4 +1,5 @@
 export const dict = {
+  "ui.sessionTurn.sendAgain": "Wyślij ponownie",
   "ui.sessionTurn.steps.show": "Pokaż ślad wykonania",
   "ui.sessionTurn.steps.hide": "Ukryj ślad wykonania",
   "ui.lineComment.label.prefix": "Komentarz do ",
@@ -60,6 +61,7 @@ export const dict = {
   "ui.tool.patch": "Patch",
   "ui.tool.todos": "Zadania",
   "ui.tool.todos.read": "Czytaj zadania",
+  "ui.tool.question": "Pytanie",
   "ui.tool.questions": "Pytania",
   "ui.tool.agent": "Agent {{type}}",
   "ui.tool.websearch": "Wyszukiwanie w sieci",
@@ -134,6 +136,7 @@ export const dict = {
   "ui.question.subtitle.answered": "{{count}} odpowiedzi",
   "ui.question.answer.none": "(brak odpowiedzi)",
   "ui.question.review.notAnswered": "(bez odpowiedzi)",
+  "ui.question.recommended": "Zalecane",
   "ui.question.multiHint": "(zaznacz wszystkie pasujące)",
   "ui.question.custom.placeholder": "Wpisz swoją odpowiedź...",
 }

--- a/frontend/ui/src/i18n/ru.ts
+++ b/frontend/ui/src/i18n/ru.ts
@@ -1,4 +1,5 @@
 export const dict = {
+  "ui.sessionTurn.sendAgain": "Отправить снова",
   "ui.sessionTurn.steps.show": "Показать трассировку выполнения",
   "ui.sessionTurn.steps.hide": "Скрыть трассировку выполнения",
   "ui.lineComment.label.prefix": "Комментарий к ",
@@ -60,6 +61,7 @@ export const dict = {
   "ui.tool.patch": "Патч",
   "ui.tool.todos": "Задачи",
   "ui.tool.todos.read": "Читать задачи",
+  "ui.tool.question": "Вопрос",
   "ui.tool.questions": "Вопросы",
   "ui.tool.agent": "Агент {{type}}",
   "ui.tool.websearch": "Веб-поиск",
@@ -134,6 +136,7 @@ export const dict = {
   "ui.question.subtitle.answered": "{{count}} отвечено",
   "ui.question.answer.none": "(нет ответа)",
   "ui.question.review.notAnswered": "(не отвечено)",
+  "ui.question.recommended": "Рекомендуется",
   "ui.question.multiHint": "(выберите все подходящие)",
   "ui.question.custom.placeholder": "Введите ваш ответ...",
 }

--- a/frontend/ui/src/i18n/th.ts
+++ b/frontend/ui/src/i18n/th.ts
@@ -1,4 +1,5 @@
 export const dict = {
+  "ui.sessionTurn.sendAgain": "ส่งอีกครั้ง",
   "ui.sessionTurn.steps.show": "แสดงร่องรอยการทำงาน",
   "ui.sessionTurn.steps.hide": "ซ่อนร่องรอยการทำงาน",
   "ui.lineComment.label.prefix": "แสดงความคิดเห็นบน ",
@@ -61,6 +62,7 @@ export const dict = {
   "ui.tool.patch": "แพตช์",
   "ui.tool.todos": "รายการงาน",
   "ui.tool.todos.read": "อ่านรายการงาน",
+  "ui.tool.question": "คำถาม",
   "ui.tool.questions": "คำถาม",
   "ui.tool.agent": "เอเจนต์ {{type}}",
   "ui.tool.websearch": "ค้นหาเว็บ",
@@ -135,6 +137,7 @@ export const dict = {
   "ui.question.subtitle.answered": "{{count}} ตอบแล้ว",
   "ui.question.answer.none": "(ไม่มีคำตอบ)",
   "ui.question.review.notAnswered": "(ไม่ได้ตอบ)",
+  "ui.question.recommended": "แนะนำ",
   "ui.question.multiHint": "(เลือกทั้งหมดที่ใช้)",
   "ui.question.custom.placeholder": "พิมพ์คำตอบของคุณ...",
 }

--- a/frontend/ui/src/i18n/zh.ts
+++ b/frontend/ui/src/i18n/zh.ts
@@ -3,6 +3,7 @@ import { dict as en } from "./en"
 type Keys = keyof typeof en
 
 export const dict = {
+  "ui.sessionTurn.sendAgain": "重新发送",
   "ui.sessionTurn.steps.show": "显示执行轨迹",
   "ui.sessionTurn.steps.hide": "隐藏执行轨迹",
   "ui.lineComment.label.prefix": "评论 ",
@@ -64,6 +65,7 @@ export const dict = {
   "ui.tool.patch": "补丁",
   "ui.tool.todos": "待办",
   "ui.tool.todos.read": "读取待办",
+  "ui.tool.question": "个问题",
   "ui.tool.questions": "问题",
   "ui.tool.agent": "{{type}} 智能体",
   "ui.tool.websearch": "网络搜索",
@@ -137,6 +139,7 @@ export const dict = {
   "ui.question.subtitle.answered": "{{count}} 已回答",
   "ui.question.answer.none": "(无答案)",
   "ui.question.review.notAnswered": "(未回答)",
+  "ui.question.recommended": "推荐",
   "ui.question.multiHint": "(可多选)",
   "ui.question.custom.placeholder": "输入你的答案...",
 } satisfies Partial<Record<Keys, string>>

--- a/frontend/ui/src/i18n/zht.ts
+++ b/frontend/ui/src/i18n/zht.ts
@@ -3,6 +3,7 @@ import { dict as en } from "./en"
 type Keys = keyof typeof en
 
 export const dict = {
+  "ui.sessionTurn.sendAgain": "重新傳送",
   "ui.sessionTurn.steps.show": "顯示執行軌跡",
   "ui.sessionTurn.steps.hide": "隱藏執行軌跡",
   "ui.lineComment.label.prefix": "評論 ",
@@ -64,6 +65,7 @@ export const dict = {
   "ui.tool.patch": "修補",
   "ui.tool.todos": "待辦",
   "ui.tool.todos.read": "讀取待辦",
+  "ui.tool.question": "個問題",
   "ui.tool.questions": "問題",
   "ui.tool.agent": "{{type}} 代理程式",
   "ui.tool.websearch": "網路搜尋",
@@ -137,6 +139,7 @@ export const dict = {
   "ui.question.subtitle.answered": "{{count}} 已回答",
   "ui.question.answer.none": "(無答案)",
   "ui.question.review.notAnswered": "(未回答)",
+  "ui.question.recommended": "推薦",
   "ui.question.multiHint": "(可多選)",
   "ui.question.custom.placeholder": "輸入你的答案...",
 } satisfies Partial<Record<Keys, string>>

--- a/frontend/workspace/src/atlas/store/ui.ts
+++ b/frontend/workspace/src/atlas/store/ui.ts
@@ -549,13 +549,12 @@ export function createContextState(options: { storage?: ContextStorage } = {}) {
       update({ ...current(), artifactPaneTab: tab })
     },
     prefill: () => transient().prefill,
-    setPrefill(prefill: string | undefined) {
-      updateTransient({ ...transient(), prefill })
+    /** One write for text and send flag: the composer's prefill effect runs on
+     * the first, so two writes would send with the stale flag. */
+    setPrefill(prefill: string | undefined, send = false) {
+      updateTransient({ ...transient(), prefill, send })
     },
     prefillSend: () => transient().send,
-    setPrefillSend(send: boolean) {
-      updateTransient({ ...transient(), send })
-    },
   }
 }
 
@@ -610,5 +609,4 @@ export const uiStore = {
   prefill: state.prefill,
   setPrefill: state.setPrefill,
   prefillSend: state.prefillSend,
-  setPrefillSend: state.setPrefillSend,
 }

--- a/frontend/workspace/src/components/independence-chip.tsx
+++ b/frontend/workspace/src/components/independence-chip.tsx
@@ -25,7 +25,6 @@ export const IndependenceChip: Component<{
         <Kobalte.Trigger
           ref={trigger}
           type="button"
-          data-model-effort-chip
           data-independence-chip
           aria-label={`Independence: ${current().label}. Independence options`}
         >

--- a/frontend/workspace/src/components/independence-chip.tsx
+++ b/frontend/workspace/src/components/independence-chip.tsx
@@ -1,0 +1,82 @@
+import { Popover as Kobalte } from "@kobalte/core/popover"
+import { Icon } from "@synsci/ui/icon"
+import { createSignal, For, Show, type Component } from "solid-js"
+import { DELEGATION_AUTONOMY, type DelegationAutonomy } from "./prompt-capabilities"
+import { ModelPopoverSurface, focusModelRadio } from "./model-settings-popover"
+
+/** How independently OpenScience decides: whether it takes the recommended
+ * option itself or asks. This governs the lead's own questions, not only
+ * delegated work, so it sits beside the model and effort chips where it can be
+ * seen and changed in one click. */
+export const IndependenceChip: Component<{
+  value: DelegationAutonomy
+  onSelect: (value: DelegationAutonomy) => void
+}> = (props) => {
+  const [open, setOpen] = createSignal(false)
+  let trigger: HTMLButtonElement | undefined
+  const current = () => DELEGATION_AUTONOMY.find((option) => option.value === props.value) ?? DELEGATION_AUTONOMY[1]!
+  const close = () => {
+    setOpen(false)
+    queueMicrotask(() => trigger?.focus({ preventScroll: true }))
+  }
+  return (
+    <div data-model-control-group="label" data-independence-control>
+      <Kobalte open={open()} onOpenChange={setOpen} placement="top-end" gutter={12}>
+        <Kobalte.Trigger
+          ref={trigger}
+          type="button"
+          data-model-effort-chip
+          data-independence-chip
+          aria-label={`Independence: ${current().label}. Independence options`}
+        >
+          <strong>{current().label}</strong>
+          <Icon name="chevron-down" size="small" aria-hidden="true" />
+        </Kobalte.Trigger>
+        <ModelPopoverSurface
+          kind="effort"
+          view="effort"
+          title="Independence"
+          close={close}
+          initialFocus='[data-independence-option][aria-checked="true"]'
+        >
+          <div data-model-effort-panel data-independence-menu>
+            <section class="model-settings-option-section" aria-label="Independence">
+              <div
+                role="radiogroup"
+                aria-label="How independently should OpenScience decide?"
+                class="flex flex-col"
+                onKeyDown={focusModelRadio}
+              >
+                <For each={DELEGATION_AUTONOMY}>
+                  {(option) => (
+                    <button
+                      type="button"
+                      role="radio"
+                      data-independence-option
+                      data-model-option-id={option.value}
+                      aria-checked={props.value === option.value}
+                      tabindex={props.value === option.value ? 0 : -1}
+                      class="model-settings-row flex w-full min-w-0 items-center justify-between text-left transition-colors"
+                      onClick={() => {
+                        props.onSelect(option.value)
+                        close()
+                      }}
+                    >
+                      <span class="model-settings-setting">
+                        <span data-model-menu-label>{option.label}</span>
+                        <small>{option.description}</small>
+                      </span>
+                      <Show when={props.value === option.value}>
+                        <Icon name="check" size="small" class="model-settings-check" aria-hidden="true" />
+                      </Show>
+                    </button>
+                  )}
+                </For>
+              </div>
+            </section>
+          </div>
+        </ModelPopoverSurface>
+      </Kobalte>
+    </div>
+  )
+}

--- a/frontend/workspace/src/components/model-settings-popover.css
+++ b/frontend/workspace/src/components/model-settings-popover.css
@@ -6,6 +6,7 @@
   [data-model-control-group],
   [data-model-settings-trigger],
   [data-model-effort-chip],
+  [data-independence-chip],
   [data-model-settings-popover]
 ) {
   --model-control-surface: var(--color-surface-solid);
@@ -78,7 +79,8 @@
   outline-offset: -2px;
 }
 
-[data-model-effort-chip] {
+[data-model-effort-chip],
+[data-independence-chip] {
   position: relative;
   min-height: 34px;
   display: inline-flex;
@@ -109,7 +111,8 @@
   content: "";
 }
 
-[data-model-effort-chip] strong {
+[data-model-effort-chip] strong,
+[data-independence-chip] strong {
   display: block;
   overflow: hidden;
   max-width: 116px;
@@ -136,18 +139,23 @@
 
 [data-model-effort-chip]:hover,
 [data-model-effort-chip]:focus-visible,
-[data-model-effort-chip][aria-expanded="true"] {
+[data-model-effort-chip][aria-expanded="true"],
+[data-independence-chip]:hover,
+[data-independence-chip]:focus-visible,
+[data-independence-chip][aria-expanded="true"] {
   background: var(--model-control-hover);
   color: var(--model-control-text);
 }
 
-[data-model-effort-chip]:focus-visible {
+[data-model-effort-chip]:focus-visible,
+[data-independence-chip]:focus-visible {
   outline: 2px solid var(--color-focus);
   outline-offset: -2px;
 }
 
 [data-component="button"][data-variant="ghost"][data-model-settings-trigger-style="label"]:active:not(:disabled),
-[data-model-effort-chip]:active:not(:disabled) {
+[data-model-effort-chip]:active:not(:disabled),
+[data-independence-chip]:active:not(:disabled) {
   transform: scale(0.98);
 }
 
@@ -160,7 +168,8 @@
     min-height: 44px;
   }
 
-  [data-model-effort-chip] {
+  [data-model-effort-chip],
+  [data-independence-chip] {
     min-height: 44px;
   }
 }
@@ -826,9 +835,6 @@
 
 /* The Independence chip stands alone in its own group: no left divider, and
    its three descriptions may wrap, since each is a full sentence. */
-[data-independence-control] [data-model-effort-chip]::before {
-  display: none;
-}
 
 [data-independence-menu] .model-settings-setting small {
   white-space: normal;

--- a/frontend/workspace/src/components/model-settings-popover.css
+++ b/frontend/workspace/src/components/model-settings-popover.css
@@ -823,3 +823,14 @@
     min-height: 44px;
   }
 }
+
+/* The Independence chip stands alone in its own group: no left divider, and
+   its three descriptions may wrap, since each is a full sentence. */
+[data-independence-control] [data-model-effort-chip]::before {
+  display: none;
+}
+
+[data-independence-menu] .model-settings-setting small {
+  white-space: normal;
+  line-height: 16px;
+}

--- a/frontend/workspace/src/components/model-settings-popover.tsx
+++ b/frontend/workspace/src/components/model-settings-popover.tsx
@@ -198,7 +198,7 @@ type ModelPopoverSurfaceProps = {
   children: JSX.Element
 }
 
-const ModelPopoverSurface: Component<ModelPopoverSurfaceProps> = (props) => {
+export const ModelPopoverSurface: Component<ModelPopoverSurfaceProps> = (props) => {
   let content: HTMLElement | undefined
 
   return (

--- a/frontend/workspace/src/components/prompt-capabilities.ts
+++ b/frontend/workspace/src/components/prompt-capabilities.ts
@@ -48,17 +48,17 @@ export const DELEGATION_AUTONOMY: Array<{
   {
     value: "interactive",
     label: "Interactive",
-    description: "Plan together and ask at consequential choices, with one recommended option",
+    description: "Asks every question, with one recommended option",
   },
   {
     value: "balanced",
     label: "Balanced",
-    description: "Decide routine reversible details and ask only when the outcome could materially change",
+    description: "Takes the recommended plan; asks before consequential decisions",
   },
   {
     value: "autonomous",
     label: "Independent",
-    description: "Take the recommended path, record assumptions, and ask only when blocked or missing authority",
+    description: "Takes the recommended option; asks only when input or authority is missing",
   },
 ]
 

--- a/frontend/workspace/src/components/prompt-input.tsx
+++ b/frontend/workspace/src/components/prompt-input.tsx
@@ -54,7 +54,9 @@ import { showToast } from "@synsci/ui/toast"
 import { uiStore } from "@/atlas/store/ui"
 import { confirmDialog } from "@/atlas/dialogs"
 import { projectHref, projectPathname } from "@/utils/project-route"
+import { createMediaQuery } from "@solid-primitives/media"
 import { ModelSettingsPopover } from "./model-settings-popover"
+import { IndependenceChip } from "./independence-chip"
 import {
   loadedSkillNamesThisTurn,
   recordRecentSkill,
@@ -262,6 +264,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       })
   }
   const delegation = createMemo(() => delegationSettings(capabilities()))
+  const narrow = createMediaQuery("(max-width: 719px)")
   // The pair Fusion will run: the selected model leads; the configured worker
   // model executes. Without a worker model the worker is the lead itself,
   // which keeps a persistent context but saves nothing on price.
@@ -2502,7 +2505,6 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     editorRef.textContent = text
     prompt.set([{ type: "text", content: text, start: 0, end: text.length }], text.length)
     uiStore.setPrefill(undefined)
-    uiStore.setPrefillSend(false)
     requestAnimationFrame(() => {
       editorRef.focus()
       setCursorPosition(editorRef, text.length)
@@ -2911,13 +2913,15 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                         disabled={!capabilities()}
                         onSelect={(value) => saveDelegation({ level: value as DelegationLevel })}
                       />
+                      {/* Independence governs the lead's own questions, not only
+                          delegated work, so it stays visible with delegation off. */}
+                      <ResearchSlider
+                        label="Independence"
+                        value={delegation().autonomy}
+                        options={DELEGATION_AUTONOMY}
+                        onSelect={(value) => saveDelegation({ autonomy: value as DelegationAutonomy })}
+                      />
                       <Show when={delegation().level !== "off"}>
-                        <ResearchSlider
-                          label="Independence"
-                          value={delegation().autonomy}
-                          options={DELEGATION_AUTONOMY}
-                          onSelect={(value) => saveDelegation({ autonomy: value as DelegationAutonomy })}
-                        />
                         <ResearchSlider
                           label="Workers"
                           value={delegation().strategy}
@@ -3047,6 +3051,12 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
             aria-label="Model, effort, and send"
           >
             <ModelSettingsPopover />
+            <Show when={capabilities() && !narrow()}>
+              <IndependenceChip
+                value={delegation().autonomy}
+                onSelect={(value) => saveDelegation({ autonomy: value })}
+              />
+            </Show>
             <Tooltip
               placement="top"
               inactive={!prompt.dirty() && !working()}

--- a/frontend/workspace/src/pages/directory-layout.tsx
+++ b/frontend/workspace/src/pages/directory-layout.tsx
@@ -277,6 +277,30 @@ export default function Layout(props: ParentProps) {
                       ),
                   })
                 const file = (href: string) => chatFilePath(href, directory(), globalThis.location?.origin)
+                // The turn's own words go back through the composer, which owns
+                // model, effort and delegation choices, so the resend is an
+                // ordinary new request. Attachments do not travel: those turns
+                // are put back for the user to re-attach and send.
+                const resendTurn = (input: { sessionID: string; messageID: string }) => {
+                  const parts = sync.data.part[input.messageID] ?? []
+                  const text = parts
+                    .filter((part) => part.type === "text" && !part.synthetic)
+                    .map((part) => (part.type === "text" ? part.text : ""))
+                    .join("\n")
+                    .trim()
+                  if (!text) {
+                    showToast({
+                      title: "Nothing to send again",
+                      description: "This turn has no message text to resend.",
+                    })
+                    return
+                  }
+                  const attachments = parts.some((part) => part.type === "file")
+                  uiStore.setPrefill(text, !attachments)
+                  if (attachments) {
+                    showToast({ title: "Message restored", description: "Re-attach the files, then send." })
+                  }
+                }
 
                 return (
                   <DataProvider
@@ -292,6 +316,7 @@ export default function Layout(props: ParentProps) {
                     onResolveFileReceipts={receipts.files}
                     onSaveArtifact={saveArtifact}
                     onOpenCredentials={() => dialog.show(() => <DialogSettings initial="credentials" />)}
+                    onResendTurn={resendTurn}
                   >
                     <MarkdownImages
                       resolve={image}

--- a/tooling/sdk/js/src/v2/gen/types.gen.ts
+++ b/tooling/sdk/js/src/v2/gen/types.gen.ts
@@ -1851,7 +1851,7 @@ export type ProviderConfig = {
      */
     timeout?: number | false
     /**
-     * Maximum provider response-body inactivity in milliseconds. Remote endpoints default to 600000 (10 minutes) and the managed Ace gateway to 300000 (5 minutes); local endpoints (loopback or .local base URLs and bundled local providers) default to disabled. Set false to disable.
+     * Maximum provider response-body inactivity in milliseconds. Remote endpoints, including the managed Ace gateway, default to 600000 (10 minutes); local endpoints (loopback or .local base URLs and bundled local providers) default to disabled. Set false to disable.
      */
     idleTimeout?: number | false
     /**

--- a/tooling/sdk/openapi.json
+++ b/tooling/sdk/openapi.json
@@ -58901,10 +58901,10 @@
                 ]
               },
               "idleTimeout": {
-                "description": "Maximum provider response-body inactivity in milliseconds. Remote endpoints default to 600000 (10 minutes) and the managed Ace gateway to 300000 (5 minutes); local endpoints (loopback or .local base URLs and bundled local providers) default to disabled. Set false to disable.",
+                "description": "Maximum provider response-body inactivity in milliseconds. Remote endpoints, including the managed Ace gateway, default to 600000 (10 minutes); local endpoints (loopback or .local base URLs and bundled local providers) default to disabled. Set false to disable.",
                 "anyOf": [
                   {
-                    "description": "Maximum provider response-body inactivity in milliseconds; resets on every body chunk, including keepalives and streamed private reasoning. Remote endpoints default to 600000 (10 minutes), the managed Ace gateway to 300000 (5 minutes); local endpoints default to disabled.",
+                    "description": "Maximum provider response-body inactivity in milliseconds; resets on every body chunk, including keepalives and streamed private reasoning. Remote endpoints, including the managed Ace gateway, default to 600000 (10 minutes); local endpoints default to disabled.",
                     "type": "integer",
                     "exclusiveMinimum": 0,
                     "maximum": 2147483647


### PR DESCRIPTION
## What

Three things the owner flagged from the desktop app, plus the evidence-based deadline correction they led to.

**Independence is discoverable.** A chip beside the model and effort chips (\`Balanced ▾\`) opens a one-click menu: Interactive, Balanced, Independent, each with a one-line description that matches the runtime rule in \`tool/question.ts\` (Interactive asks everything; Balanced takes the recommended plan and asks before consequential decisions; Independent takes the recommended option and asks only when input or authority is missing). The slider in Tools stays visible with delegation off, since independence governs the lead's own questions, not only delegated work.

**Question cards are one form.** Question at the prose level, choices as rows with a radio mark (checkbox mark for multi-select), the model's \`(Recommended)\` suffix rendered as a quiet tag while the full label stays the answer, the free-text choice as one more row, and a real Dismiss button. A single question is titled \`Question · <its header>\`. Three type levels, no boxes in boxes.

**Send again.** A turn that stopped because the provider stopped answering or the request timed out offers a button that routes the same text through the composer as a new request (new idempotency key, so the documented billing rule is untouched). Turns with attachments are put back for the user to re-attach. A stop the user asked for offers nothing.

**Managed idle deadline: 10 minutes.** The pasted trajectory hit the 5-minute deadline (\`activeBodyMs=457\`, then 300 s of silence). The sidecar log also shows healthy gpt-5.6-sol requests with \`firstBodyChunkMs=133596\` and \`70149\`: the gateway sends no keepalives while a model thinks, so byte silence cannot distinguish a hang from deep reasoning. Ten minutes bounds a hang without cutting legitimate thinking; gateway keepalives would let this drop to a couple of minutes.

## Evidence

- \`bun run check\` green: backend 4356, ui 300, workspace 991, sdk 29, docs 6.
- e2e: interactive-requests, prompt, classic-chat, model-picker, model-tier, mobile-compose (17 passed); full suite running.
- knip: no new findings (unused exports 96 → 94).
- Verified in a fake-model lab: question card, Independence menu, and Send again producing a new turn.

Made with [Cursor](https://cursor.com)