### PR TITLE
Trace: state-accurate tool labels, cached code highlights while streaming, managed header wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ tagged release also ships native binaries for Linux, macOS, and Windows.
 
 ## Unreleased
 
+### Changed
+
+- Tool rows follow the recorded execution state. A call the model has not
+  finished writing reads as the plain tool noun with a "Preparing" mark, not as
+  "Reading" or "Finding relevant skills"; only a running call claims an
+  activity. A call cancelled before it started is "Cancelled", not a failed
+  lookup.
+- Streaming Markdown no longer re-highlights every finished code block on each
+  update. Highlights are cached per block, and a block still being written is
+  rendered as plain code once it passes 2 KB until its fence closes. A response
+  with two finished scripts and a third streaming cost 63 ms per update before
+  and 2.6 ms after, which is the difference between a frozen and a responsive
+  workspace while a long script streams.
+- The managed Ace gateway's header wait is ten minutes, matching its body
+  deadline. The gateway sends its response headers only once the upstream body
+  begins (one request reported upstream headers at 3.1 s while the client saw
+  them at 133 s), so a long silent think lands in the header wait.
+
 ## v2.0.92 — 2026-09-11
 
 ### Added

--- a/backend/cli/src/config/config.ts
+++ b/backend/cli/src/config/config.ts
@@ -1210,7 +1210,7 @@ export namespace Config {
             .union([z.number().int().positive().max(2_147_483_647), z.literal(false)])
             .optional()
             .describe(
-              "Maximum wait for provider response headers in milliseconds, including connection setup and upstream admission. Defaults to 300000 (5 minutes), and to disabled for local endpoints (loopback or .local base URLs and the ollama, lmstudio, llamacpp, vllm and jan providers), which send headers only after prompt processing. Set false to disable.",
+              "Maximum wait for provider response headers in milliseconds, including connection setup and upstream admission. Defaults to 300000 (5 minutes), to 600000 (10 minutes) for the managed Ace gateway, which sends headers only once the upstream body begins, and to disabled for local endpoints (loopback or .local base URLs and the ollama, lmstudio, llamacpp, vllm and jan providers), which send headers only after prompt processing. Set false to disable.",
             ),
           outputIdleTimeout: z
             .union([z.number().int().positive().max(2_147_483_647), z.literal(false)])

--- a/backend/cli/src/provider/provider.ts
+++ b/backend/cli/src/provider/provider.ts
@@ -78,6 +78,12 @@ export namespace Provider {
   // hang without cutting off deep reasoning. (Gateway keepalives would let it
   // drop to a couple of minutes.)
   export const DEFAULT_MANAGED_IDLE_TIMEOUT_MS = 600_000
+  // The managed gateway also holds its response headers until the upstream
+  // body begins: one healthy request reported upstream headers at 3.1 s in
+  // its Server-Timing while the client saw them at 133 s, with the first body
+  // byte 420 ms later. A silent think therefore lands in the header wait, so
+  // that wait needs the same allowance as the body deadline.
+  export const DEFAULT_MANAGED_CONNECT_TIMEOUT_MS = 600_000
   export const DEFAULT_OUTPUT_IDLE_TIMEOUT_MS = false
 
   export type RequestContext = {
@@ -1219,7 +1225,8 @@ export namespace Provider {
   }
 
   export function defaultConnectTimeout(input: { providerID: string; baseURL?: unknown }): number | false {
-    return localEndpoint(input) ? false : DEFAULT_CONNECT_TIMEOUT_MS
+    if (localEndpoint(input)) return false
+    return isAtlasProxyBaseURL(input.baseURL) ? DEFAULT_MANAGED_CONNECT_TIMEOUT_MS : DEFAULT_CONNECT_TIMEOUT_MS
   }
 
   export function defaultIdleTimeout(input: { providerID: string; baseURL?: unknown }): number | false {

--- a/backend/cli/test/provider/idle-watchdog.test.ts
+++ b/backend/cli/test/provider/idle-watchdog.test.ts
@@ -143,6 +143,17 @@ describe("provider activity watchdog", () => {
           baseURL: `${managedApiBase()}/api/llm/proxy/openrouter/v1`,
         }),
       ).toBe(600_000)
+      // The gateway holds headers until the upstream body starts, so a silent
+      // think lands in the header wait; it gets the same allowance.
+      expect(
+        Provider.defaultConnectTimeout({
+          providerID: "openrouter",
+          baseURL: `${managedApiBase()}/api/llm/proxy/openrouter/v1`,
+        }),
+      ).toBe(600_000)
+      expect(
+        Provider.defaultConnectTimeout({ providerID: "openrouter", baseURL: "https://openrouter.ai/api/v1" }),
+      ).toBe(300_000)
     } finally {
       process.env["OPENSCIENCE_API_BASE"] = base
     }

--- a/frontend/docs/src/content/openscience/custom-providers.mdx
+++ b/frontend/docs/src/content/openscience/custom-providers.mdx
@@ -98,7 +98,7 @@ Provider options support request deadlines in milliseconds:
 
 | Option | Default |
 | --- | --- |
-| `connectTimeout` | 300000 (5 minutes): waiting for response headers; disabled by default for local endpoints. |
+| `connectTimeout` | 300000 (5 minutes) waiting for response headers; 600000 (10 minutes) for the managed Ace gateway, which sends headers only once the upstream body begins; disabled by default for local endpoints. |
 | `idleTimeout` | 600000 (10 minutes) for remote endpoints, including the managed Ace gateway; reset by every response-body chunk and disabled by default for local endpoints. |
 | `outputIdleTimeout` | Disabled; optionally bound the wait for readable output or tool-call activity. |
 | `timeout` | No total-duration limit by default. |

--- a/frontend/ui/src/components/basic-tool.css
+++ b/frontend/ui/src/components/basic-tool.css
@@ -48,7 +48,8 @@
     font-weight: var(--font-weight-regular);
   }
 
-  &[data-outcome="cancelled"] [data-slot="basic-tool-tool-failure-label"] {
+  &[data-outcome="cancelled"] [data-slot="basic-tool-tool-failure-label"],
+  &[data-outcome="pending"] [data-slot="basic-tool-tool-failure-label"] {
     color: var(--text-weak);
   }
 

--- a/frontend/ui/src/components/basic-tool.tsx
+++ b/frontend/ui/src/components/basic-tool.tsx
@@ -164,7 +164,7 @@ export function BasicTool(props: BasicToolProps) {
                         >
                           {trigger().title}
                         </span>
-                        <Show when={props.status && failed()}>
+                        <Show when={props.status && (failed() || outcome() === "pending")}>
                           <span data-slot="basic-tool-tool-failure-label" title={detail()}>
                             {i18n.t(glyphLabel[outcome()])}
                           </span>

--- a/frontend/ui/src/components/message-part.tsx
+++ b/frontend/ui/src/components/message-part.tsx
@@ -200,11 +200,12 @@ export type ToolInfo = {
   subtitle?: string
 }
 
-/** A row reads as what happened: "Ran", "Read", "Searched". While the call is
- * still in flight it reads as what is happening. */
+/** A row reads as what happened: "Ran", "Read", "Searched". While the call
+ * executes it reads as what is happening. A pending call is still being
+ * written by the model, so it keeps the noun: nothing is being read or run
+ * yet, and the row's state glyph says "Preparing". */
 function toolVerb(i18n: ReturnType<typeof useI18n>, tool: string, status: string | undefined, done: UiI18nKey) {
-  const live = status === "running" || status === "pending"
-  const key = live ? runningLabel(tool) : undefined
+  const key = status === "running" ? runningLabel(tool) : undefined
   return i18n.t(key ?? done)
 }
 
@@ -1061,7 +1062,13 @@ ToolRegistry.register({
   name: "skill",
   render(props) {
     const activity = () =>
-      skillActivity({ metadata: props.metadata, input: props.input, title: props.title, status: props.status })
+      skillActivity({
+        metadata: props.metadata,
+        input: props.input,
+        title: props.title,
+        status: props.status,
+        error: props.error,
+      })
     return (
       <BasicTool {...props} icon="mcp" trigger={{ title: activity().title, subtitle: activity().subtitle }}>
         <Show when={loadedSkillName(props)}>

--- a/frontend/ui/src/components/research-search-tool.tsx
+++ b/frontend/ui/src/components/research-search-tool.tsx
@@ -79,7 +79,8 @@ export function ResearchSearchTool(props: ToolProps) {
   const title = () => {
     if (toolOutcome(props.status, props.error) === "cancelled") return "Research search cancelled"
     if (failed()) return "Research search unavailable"
-    if (props.status !== "completed") return "Searching sources"
+    if (props.status === "running") return "Searching sources"
+    if (props.status !== "completed") return "Research search"
     const count = result().results?.length
     if (count === undefined) return "Research search"
     return count === 0 ? "No results returned" : `Found ${count} ${count === 1 ? "source" : "sources"}`

--- a/frontend/ui/src/components/session-turn-trajectory.test.ts
+++ b/frontend/ui/src/components/session-turn-trajectory.test.ts
@@ -560,6 +560,37 @@ describe("research search receipts", () => {
     expect(JSON.stringify(failed)).toBe(original)
   })
 
+  test("a skill call the model has not finished writing reads as preparing, and one that never started as cancelled", () => {
+    const pending: ToolPart = {
+      ...read("prt_pending_skill", "", 1_000),
+      tool: "skill",
+      state: { status: "pending", input: {}, raw: "" },
+    }
+    const host = mount(() => parts.Part({ part: pending, message: assistant(2_000) }), empty())
+    expect(host.querySelector('[data-slot="basic-tool-tool-title"]')?.textContent).toBe("Skill")
+    expect(host.querySelector('[data-slot="basic-tool-tool-failure-label"]')?.textContent).toBe("Preparing")
+    expect(host.textContent).not.toContain("Finding relevant skills")
+    expect(host.querySelector('[data-component="tool-trigger"]')?.getAttribute("data-outcome")).toBe("pending")
+
+    const aborted: ToolPart = {
+      ...pending,
+      id: "prt_aborted_skill",
+      state: {
+        status: "error",
+        input: {},
+        raw: "",
+        metadata: { cancelled: true, started: false },
+        error: "Tool execution aborted. The skill call had not started; no action was taken.",
+        time: { start: 1_000, end: 1_001 },
+      },
+    }
+    const stopped = mount(() => parts.Part({ part: aborted, message: assistant(2_000) }), empty())
+    expect(stopped.querySelector('[data-slot="basic-tool-tool-title"]')?.textContent).toBe("Skill")
+    expect(stopped.querySelector('[data-slot="basic-tool-tool-failure-label"]')?.textContent).toBe("Cancelled")
+    expect(stopped.textContent).not.toContain("Skill lookup failed")
+    expect(stopped.querySelector('[data-component="tool-trigger"]')?.getAttribute("data-outcome")).toBe("cancelled")
+  })
+
   test("labels cancellation without implying a search-provider outage", () => {
     const part: ToolPart = {
       ...read("prt_cancelled_search", "", 1_000),

--- a/frontend/ui/src/components/tool-display.test.ts
+++ b/frontend/ui/src/components/tool-display.test.ts
@@ -135,6 +135,32 @@ describe("skillName", () => {
     expect(skillName({})).toBeUndefined()
     expect(skillActivity({ status: "running" })).toEqual({ title: "Finding relevant skills" })
   })
+  test("a pending call the model has not finished writing claims no activity", () => {
+    expect(skillActivity({ status: "pending", input: {} })).toEqual({ title: "Skill" })
+    expect(skillActivity({ status: "pending", input: { name: "matplotlib" } })).toEqual({
+      title: "Skill",
+      subtitle: "matplotlib",
+    })
+    expect(skillActivity({ status: "pending", input: { query: "plots" } })).toEqual({ title: "Skill" })
+  })
+  test("a cancelled call that never started is not a failed lookup", () => {
+    expect(
+      skillActivity({
+        status: "error",
+        input: {},
+        metadata: { cancelled: true, started: false },
+        error: "Tool execution aborted. The skill call had not started; no action was taken.",
+      }),
+    ).toEqual({ title: "Skill" })
+    expect(
+      skillActivity({
+        status: "error",
+        input: { name: "matplotlib" },
+        metadata: { cancelled: true, started: true },
+        error: "The operation was aborted",
+      }),
+    ).toEqual({ title: "Skill", subtitle: "matplotlib" })
+  })
   test("distinguishes a requested load, recorded load and discovered candidates", () => {
     expect(skillActivity({ input: { name: "scientific-schematics" }, status: "running" })).toEqual({
       title: "Loading scientific-schematics",

--- a/frontend/ui/src/components/tool-display.ts
+++ b/frontend/ui/src/components/tool-display.ts
@@ -647,17 +647,29 @@ export function loadedSkillName(source: {
   return name || title
 }
 
+/**
+ * The label follows the recorded execution state. A pending part is a call
+ * the model has not finished writing: nothing is being searched or loaded, so
+ * it reads as the plain noun and the row's state glyph says "Preparing". Only
+ * a running call claims an activity; a cancelled call that never started is
+ * not a failed lookup.
+ */
 export function skillActivity(source: {
   metadata?: Record<string, unknown>
   input?: Record<string, unknown>
   title?: string
   status?: string
+  error?: string
 }): { title: string; subtitle?: string } {
+  const requested = typeof source.input?.name === "string" && source.input.name ? source.input.name : undefined
+  if (source.status === "pending") return { title: "Skill", ...(requested ? { subtitle: requested } : {}) }
   if (source.status === "error" || source.metadata?.ok === false) {
-    const name = source.input?.name
-    return typeof name === "string" && name
-      ? { title: "Skill load failed", subtitle: name }
-      : { title: "Skill lookup failed" }
+    const cancelled =
+      source.metadata?.cancelled === true ||
+      source.metadata?.started === false ||
+      toolOutcome("error", source.error) === "cancelled"
+    if (cancelled) return { title: "Skill", ...(requested ? { subtitle: requested } : {}) }
+    return requested ? { title: "Skill load failed", subtitle: requested } : { title: "Skill lookup failed" }
   }
   // Models may send discovery fields with an exact load. The completed result
   // identifies what actually happened, rather than the optional input fields.

--- a/frontend/ui/src/context/marked-loading.test.ts
+++ b/frontend/ui/src/context/marked-loading.test.ts
@@ -3,7 +3,10 @@ import { readFile } from "node:fs/promises"
 import {
   decodeCodeBlockEntities,
   highlightSnippet,
+  LIVE_HIGHLIGHT_LIMIT,
+  openFence,
   parseMarkdown,
+  plainStreamingFence,
   registerOpenScienceDiffTheme,
   retryable,
 } from "./marked"
@@ -63,5 +66,43 @@ describe("markdown runtime loading", () => {
     expect(decodeCodeBlockEntities("&lt;tag&gt; &amp; &quot;text&quot; &#39;value&#39;")).toBe(`<tag> & "text" 'value'`)
     expect(decodeCodeBlockEntities("&amp;lt;script&amp;gt;")).toBe("&lt;script&gt;")
     expect(decodeCodeBlockEntities("&amp;quot; &amp;#39; &amp;amp;")).toBe("&quot; &#39; &amp;")
+  })
+})
+
+describe("streaming code fences", () => {
+  const script = Array.from({ length: 120 }, (_, i) => `def step_${i}(model):\n    return model.train(step=${i})`).join(
+    "\n",
+  )
+
+  test("finds the fence a response is still inside and the code written so far", () => {
+    const open = openFence("Intro\n\n```python\nprint(1)\nprint(2)")
+    expect(open?.code).toBe("print(1)\nprint(2)")
+    expect("Intro\n\n```python\nprint(1)\nprint(2)".slice(open!.info.start, open!.info.end)).toBe("python")
+    expect(openFence("```python\nprint(1)\n```\nDone")).toBeUndefined()
+    // A closing fence must match the character and be at least as long.
+    expect(openFence("````python\n```\ninner\n")?.code).toBe("```\ninner\n")
+    expect(openFence("~~~py\ncode\n```\n")?.code).toBe("code\n```\n")
+    // A backtick fence whose info string contains a backtick is not a fence.
+    expect(openFence("``` `x`\ntext")).toBeUndefined()
+    expect(openFence("plain prose only")).toBeUndefined()
+  })
+
+  test("keeps a long, still-open block plain until its fence closes, and leaves everything else alone", () => {
+    expect(script.length).toBeGreaterThan(LIVE_HIGHLIGHT_LIMIT)
+    const streaming = `Here is the script:\n\n\`\`\`python title="train.py"\n${script}`
+    expect(plainStreamingFence(streaming)).toBe(`Here is the script:\n\n\`\`\`text\n${script}`)
+    const closed = `${streaming}\n\`\`\`\n`
+    expect(plainStreamingFence(closed)).toBe(closed)
+    const short = "```python\nprint(1)"
+    expect(plainStreamingFence(short)).toBe(short)
+  })
+
+  test("renders the streaming block as plain code and highlights it once the fence closes", async () => {
+    const streaming = `\`\`\`python\n${script}`
+    const live = await parseMarkdown(streaming)
+    expect(live).toContain(script.split("\n")[0])
+    expect(live).not.toContain("var(--syntax-keyword)")
+    const done = await parseMarkdown(`${streaming}\n\`\`\`\n`)
+    expect(done).toContain("var(--syntax-keyword)")
   })
 })

--- a/frontend/ui/src/context/marked.tsx
+++ b/frontend/ui/src/context/marked.tsx
@@ -390,6 +390,92 @@ const loadDiffs = retryable(() =>
   }),
 )
 
+type Highlighter = Awaited<ReturnType<DiffsModule["getSharedHighlighter"]>>
+
+/**
+ * A streaming response is reparsed about thirty times a second, and every
+ * parse used to re-highlight every code block. Highlighting is the expensive
+ * step (a 30 KB Python block costs ~25 ms), so finished blocks are served from
+ * this bounded cache and only the block still being written pays each tick.
+ */
+const highlighted = new Map<string, string>()
+const HIGHLIGHT_CACHE_MAX = 128
+
+async function highlightBlock(highlighter: Highlighter, code: string, lang: string): Promise<string> {
+  const key = `${lang}\u0000${code}`
+  const hit = highlighted.get(key)
+  if (hit !== undefined) {
+    highlighted.delete(key)
+    highlighted.set(key, hit)
+    return hit
+  }
+  if (!highlighter.getLoadedLanguages().includes(lang)) {
+    await highlighter.loadLanguage(lang as BundledLanguage)
+  }
+  const html = highlighter.codeToHtml(code, { lang, theme: "OpenScience", tabindex: false })
+  highlighted.set(key, html)
+  if (highlighted.size > HIGHLIGHT_CACHE_MAX) {
+    const oldest = highlighted.keys().next().value
+    if (oldest !== undefined) highlighted.delete(oldest)
+  }
+  return html
+}
+
+/**
+ * The unterminated fenced block a streaming response currently ends inside:
+ * where its info string sits and the code written so far. Follows the
+ * CommonMark fence rules (three or more backticks or tildes, up to three
+ * spaces of indent, closed only by the same character at the same or greater
+ * length, and a backtick fence's info string may not contain a backtick).
+ */
+export function openFence(markdown: string): { info: { start: number; end: number }; code: string } | undefined {
+  let open: { char: string; length: number; infoStart: number; infoEnd: number; codeStart: number } | undefined
+  let offset = 0
+  for (const line of markdown.split("\n")) {
+    const match = /^ {0,3}(`{3,}|~{3,})(.*)$/.exec(line)
+    if (match) {
+      const fence = match[1]
+      const char = fence[0]
+      if (!open) {
+        if (!(char === "`" && match[2].includes("`"))) {
+          const infoStart = offset + line.indexOf(fence) + fence.length
+          open = {
+            char,
+            length: fence.length,
+            infoStart,
+            infoEnd: offset + line.length,
+            codeStart: offset + line.length + 1,
+          }
+        }
+      } else if (char === open.char && fence.length >= open.length && match[2].trim() === "") {
+        open = undefined
+      }
+    }
+    offset += line.length + 1
+  }
+  if (!open) return
+  return {
+    info: { start: open.infoStart, end: open.infoEnd },
+    code: markdown.slice(Math.min(open.codeStart, markdown.length)),
+  }
+}
+
+/** Above this size, the block still being streamed is rendered as plain text
+ * until its fence closes; grammar highlighting then lands once. Plain-text
+ * tokenization of a 30 KB block costs ~2 ms against ~25 ms for Python. */
+export const LIVE_HIGHLIGHT_LIMIT = 2_000
+
+/**
+ * Rewrite the info string of a long, still-open fenced block to `text`, so the
+ * thirty-per-second reparse of a streaming response does not re-tokenize a
+ * growing script with a full grammar on every tick.
+ */
+export function plainStreamingFence(markdown: string): string {
+  const fence = openFence(markdown)
+  if (!fence || fence.code.length <= LIVE_HIGHLIGHT_LIMIT) return markdown
+  return `${markdown.slice(0, fence.info.start)}text${markdown.slice(fence.info.end)}`
+}
+
 async function highlightCodeBlocks(html: string): Promise<string> {
   const codeBlockRegex = /<pre><code(?:\s+class="language-([^"]*)")?>([\s\S]*?)<\/code><\/pre>/g
   const matches = [...html.matchAll(codeBlockRegex)]
@@ -402,21 +488,9 @@ async function highlightCodeBlocks(html: string): Promise<string> {
   for (const match of matches) {
     const [fullMatch, lang, escapedCode] = match
     const code = decodeCodeBlockEntities(escapedCode)
-
-    let language = lang || "text"
-    if (!(language in bundledLanguages)) {
-      language = "text"
-    }
-    if (!highlighter.getLoadedLanguages().includes(language)) {
-      await highlighter.loadLanguage(language as BundledLanguage)
-    }
-
-    const highlighted = highlighter.codeToHtml(code, {
-      lang: language,
-      theme: "OpenScience",
-      tabindex: false,
-    })
-    result = result.replace(fullMatch, () => highlighted)
+    const language = lang && lang in bundledLanguages ? lang : "text"
+    const block = await highlightBlock(highlighter, code, language)
+    result = result.replace(fullMatch, () => block)
   }
 
   return result
@@ -492,19 +566,14 @@ const loadJsParser = retryable(async () => {
       async highlight(code, lang) {
         const diffs = await loadDiffs()
         const highlighter = await diffs.getSharedHighlighter({ themes: ["OpenScience"], langs: [] })
-        if (!(lang in bundledLanguages)) {
-          lang = "text"
-        }
-        if (!highlighter.getLoadedLanguages().includes(lang)) {
-          await highlighter.loadLanguage(lang as BundledLanguage)
-        }
-        return highlighter.codeToHtml(code, { lang: lang || "text", theme: "OpenScience", tabindex: false })
+        return highlightBlock(highlighter, code, lang && lang in bundledLanguages ? lang : "text")
       },
     }),
   )
 })
 
-export async function parseMarkdown(markdown: string, nativeParser?: NativeMarkdownParser): Promise<string> {
+export async function parseMarkdown(input: string, nativeParser?: NativeMarkdownParser): Promise<string> {
+  const markdown = plainStreamingFence(input)
   // Native parsers may consume TeX backslashes as Markdown escapes. Parse math
   // from the original source; never substitute equations into arbitrary HTML.
   if (nativeParser && !/\$|\\[([]/.test(markdown)) return highlightCodeBlocks(await nativeParser(markdown))

--- a/tooling/sdk/js/src/v2/gen/types.gen.ts
+++ b/tooling/sdk/js/src/v2/gen/types.gen.ts
@@ -1855,7 +1855,7 @@ export type ProviderConfig = {
      */
     idleTimeout?: number | false
     /**
-     * Maximum wait for provider response headers in milliseconds, including connection setup and upstream admission. Defaults to 300000 (5 minutes), and to disabled for local endpoints (loopback or .local base URLs and the ollama, lmstudio, llamacpp, vllm and jan providers), which send headers only after prompt processing. Set false to disable.
+     * Maximum wait for provider response headers in milliseconds, including connection setup and upstream admission. Defaults to 300000 (5 minutes), to 600000 (10 minutes) for the managed Ace gateway, which sends headers only once the upstream body begins, and to disabled for local endpoints (loopback or .local base URLs and the ollama, lmstudio, llamacpp, vllm and jan providers), which send headers only after prompt processing. Set false to disable.
      */
     connectTimeout?: number | false
     /**

--- a/tooling/sdk/openapi.json
+++ b/tooling/sdk/openapi.json
@@ -58917,7 +58917,7 @@
                 ]
               },
               "connectTimeout": {
-                "description": "Maximum wait for provider response headers in milliseconds, including connection setup and upstream admission. Defaults to 300000 (5 minutes), and to disabled for local endpoints (loopback or .local base URLs and the ollama, lmstudio, llamacpp, vllm and jan providers), which send headers only after prompt processing. Set false to disable.",
+                "description": "Maximum wait for provider response headers in milliseconds, including connection setup and upstream admission. Defaults to 300000 (5 minutes), to 600000 (10 minutes) for the managed Ace gateway, which sends headers only once the upstream body begins, and to disabled for local endpoints (loopback or .local base URLs and the ollama, lmstudio, llamacpp, vllm and jan providers), which send headers only after prompt processing. Set false to disable.",
                 "anyOf": [
                   {
                     "type": "integer",


### PR DESCRIPTION
## What

Items 1 and 3 of the OpenCode smoothness audit, plus the one client-side finding from item 2 that the evidence supports.

**Labels follow recorded state.** A `pending` part is a call the model has not finished writing. It now reads as the tool noun ("Skill", "Read") with a "Preparing" mark; only `running` claims an activity ("Finding relevant skills", "Reading"). A call cancelled with `started: false` reads "Skill · Cancelled", not "Skill lookup failed". Same rule applied to the generic verb labels and research search. Unit and rendering tests cover both wrong labels from the incident.

**Streaming Markdown stops re-highlighting finished code.** Measured cause of the "super slow while a script streams" complaint: the typewriter reparses ~30×/s and every parse re-ran shiki on every code block (a 30 KB Python block costs ~25 ms). Finished blocks now come from a bounded per-block cache; a block still being written renders as plain code past 2 KB until its fence closes (plain tokenization is ~14× cheaper), then highlights once. Benchmark, two finished 60-function scripts plus a third streaming: **63 ms → 2.6 ms per update** (1.9 s → 77 ms of main-thread work per second).

For scale, the audit's other candidate (full-part snapshots on every delta) measures at 0.08 ms to serialize and 0.02 ms to parse a 38 KB part, so ~5 ms/s server-side and ~1 ms/s client-side at 60 deltas/s. Bandwidth, not CPU; loopback in the desktop app. Left alone for now.

**Managed header wait: 10 min.** The `Server-Timing` we already log shows the gateway had upstream headers at 3.1 s on a request whose headers reached the client at 133 s, with the first body byte 420 ms later. The gateway holds headers until the upstream body begins, so a silent think lands in the *header* wait, which was still 5 min after #594 raised the body deadline. Both are now 10 min on the managed route; other remote routes unchanged.

## Evidence

- `bun run check` green: backend 4356, ui 306, workspace 991, sdk 29, docs 6.
- SDK regenerated for the `connectTimeout` description.
- No product behaviour change to skills, prompts, retries, or Fusion.

Made with [Cursor](https://cursor.com)