### PR TITLE
fix: preserve partial search and kernel traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ tagged release also ships native binaries for Linux, macOS, and Windows.
 
 ### Fixed
 
+- Session traces remain available when a search or scientific kernel returns a
+  partial result, preserving that outcome instead of failing the entire trace.
 - ACP editor integrations use stable session listing and resumption, and expose
   models and reasoning variants through session configuration with the updated SDK.
   Unsupported MCP-over-ACP connections return a clear error before creating a session.

--- a/backend/cli/src/session/trace.ts
+++ b/backend/cli/src/session/trace.ts
@@ -74,7 +74,7 @@ export namespace SessionTrace {
         modelID: z.string(),
       })
       .optional(),
-    status: z.enum(["pending", "running", "completed", "partial", "error"]),
+    status: Tool.shape.status,
     startedAt: z.number().optional(),
     completedAt: z.number().optional(),
     durationMs: z.number().optional(),
@@ -89,7 +89,7 @@ export namespace SessionTrace {
     tool: z.string(),
     query: z.string().optional(),
     signature: z.string(),
-    status: z.enum(["pending", "running", "completed", "error"]),
+    status: Tool.shape.status,
     dedupeHit: z.boolean(),
     dedupeOf: z
       .object({
@@ -107,7 +107,7 @@ export namespace SessionTrace {
     toolID: z.string(),
     messageID: z.string(),
     language: z.enum(["python", "r"]),
-    status: z.enum(["pending", "running", "completed", "error"]),
+    status: Tool.shape.status,
     startedAt: z.number().optional(),
     completedAt: z.number().optional(),
     durationMs: z.number().optional(),

--- a/backend/cli/test/session/trace.test.ts
+++ b/backend/cli/test/session/trace.test.ts
@@ -12,6 +12,61 @@ import { tmpdir } from "../fixture/fixture"
 import { TokenUsage } from "@synsci/util/token-usage"
 import { TaskAttempt } from "../../src/tool/task-attempt"
 import { ArtifactStore } from "../../src/artifact/store"
+import { SessionRoutes } from "../../src/server/routes/session"
+
+test.each(["research_search", "python", "r"])("trace endpoint preserves partial %s results", async (tool) => {
+  await using tmp = await tmpdir({ git: true })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const session = await Session.create({ title: "Partial research output" })
+      const started = Date.now()
+      const assistant: MessageV2.Assistant = {
+        id: "msg_partial_assistant",
+        sessionID: session.id,
+        role: "assistant",
+        time: { created: started, completed: started + 100 },
+        parentID: "msg_partial_user",
+        modelID: "gpt-5",
+        providerID: "openai",
+        mode: "research",
+        agent: "research",
+        path: { cwd: tmp.path, root: tmp.path },
+        cost: 0,
+        tokens: { input: 10, output: 10, reasoning: 0, cache: { read: 0, write: 0 } },
+        finish: "stop",
+      }
+      await Session.updateMessage(assistant)
+      await Session.updatePart({
+        id: "part_partial_result",
+        sessionID: session.id,
+        messageID: assistant.id,
+        type: "tool",
+        callID: "call_partial_result",
+        tool,
+        state: {
+          status: "completed",
+          input: tool === "research_search" ? { query: "forecast reliability" } : { code: "1 + 1" },
+          output: "Partial output that the trace must not copy",
+          title: "Partial research output",
+          metadata: { outcome: "partial" },
+          time: { start: started + 10, end: started + 90 },
+        },
+      })
+
+      const response = await SessionRoutes().request(`/${session.id}/trace`)
+      expect(response.status).toBe(200)
+      const trace = SessionTrace.Info.parse(await response.json())
+      expect(trace.tools).toMatchObject([{ id: "part_partial_result", status: "partial" }])
+      expect(tool === "research_search" ? trace.searches : trace.kernels).toMatchObject([
+        { toolID: "part_partial_result", status: "partial" },
+      ])
+      expect(trace.summary).toMatchObject({ toolCalls: 1, failureCount: 0 })
+      expect(JSON.stringify(trace)).not.toContain("Partial output that the trace must not copy")
+      await Session.remove(session.id)
+    },
+  })
+})
 
 test("builds one local observable harness trace without reasoning or copied outputs", async () => {
   await using tmp = await tmpdir({ git: true })

--- a/tooling/sdk/js/src/v2/gen/types.gen.ts
+++ b/tooling/sdk/js/src/v2/gen/types.gen.ts
@@ -11001,7 +11001,7 @@ export type SessionTraceResponses = {
       tool: string
       query?: string
       signature: string
-      status: "pending" | "running" | "completed" | "error"
+      status: "pending" | "running" | "completed" | "partial" | "error"
       dedupeHit: boolean
       dedupeOf?: {
         messageID: string
@@ -11016,7 +11016,7 @@ export type SessionTraceResponses = {
       toolID: string
       messageID: string
       language: "python" | "r"
-      status: "pending" | "running" | "completed" | "error"
+      status: "pending" | "running" | "completed" | "partial" | "error"
       startedAt?: number
       completedAt?: number
       durationMs?: number

--- a/tooling/sdk/openapi.json
+++ b/tooling/sdk/openapi.json
@@ -27400,6 +27400,7 @@
                               "pending",
                               "running",
                               "completed",
+                              "partial",
                               "error"
                             ]
                           },
@@ -27469,6 +27470,7 @@
                               "pending",
                               "running",
                               "completed",
+                              "partial",
                               "error"
                             ]
                           },


### PR DESCRIPTION
A research search can return useful partial output while its tool call is transport-complete. The trace builder preserves that partial outcome, but the search and kernel response schemas rejected it, causing the entire session trace endpoint to return HTTP 500.

Search, kernel and child trace entries now share the tool status schema. The generated OpenAPI contract and TypeScript SDK include partial search/kernel results, so the trace remains readable and preserves the actual outcome.

Validation:
- Three route-level regressions reproduced HTTP 500 before the fix and HTTP 200 after it, covering research search, Python and R.
- All 11 trace tests pass, including checks that raw tool output is excluded.
- An isolated loopback HTTP replay of 34 recorded literature-search calls preserved all 14 partial outcomes and returned HTTP 200.
- SDK regenerated; full repository checks and CI are running. Merge only after green.

Small fix, no issue.
