### PR TITLE
fix(science): recover interrupted runtime archive downloads

### DIFF
--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -619,7 +619,7 @@ jobs:
           project="$RUNNER_TEMP/openscience-capability/project"
           mkdir -p "$HOME" "$XDG_DATA_HOME" "$XDG_CACHE_HOME" "$XDG_CONFIG_HOME" "$XDG_STATE_HOME" "$OPENSCIENCE_DATA_DIR" "$project"
           cd "$project"
-          openscience debug capability-canary "$CANARY_CAPABILITY" --target local --timeout 900 \
+          openscience --print-logs debug capability-canary "$CANARY_CAPABILITY" --target local --timeout 900 \
             | tee "$RUNNER_TEMP/scientific-capability-canary.json"
           CANARY_RESULT="$RUNNER_TEMP/scientific-capability-canary.json" \
           EXPECTED_CAPABILITY="$CANARY_CAPABILITY" \
@@ -660,6 +660,9 @@ jobs:
           path: |
             ${{ runner.temp }}/scientific-capability-canary.json
             ${{ runner.temp }}/openscience-capability/data/scientific-capability-evidence.json
+            ${{ runner.temp }}/openscience-capability/data/log
+            ${{ runner.temp }}/openscience-capability/data/compute/projects
+            ${{ runner.temp }}/openscience-capability/data/conda/state.json
 
   promote-test:
     needs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ tagged release also ships native binaries for Linux, macOS, and Windows.
 
 ### Fixed
 
+- Scientific environment setup retries interrupted archive downloads and temporary
+  upstream failures within its existing timeout, while retaining checksum verification.
 - Local Jupyter notebooks, R Markdown, and Quarto files open as rendered documents
   with separate cells, saved outputs, and explicit Python/R execution in the session's
   local kernel. Source editing remains available; opening a file never runs its code.

--- a/backend/cli/src/science/kernel/download.ts
+++ b/backend/cli/src/science/kernel/download.ts
@@ -1,0 +1,42 @@
+import { Log } from "@/util/log"
+
+const log = Log.create({ service: "science.environment.download" })
+
+export async function download(url: string, timeout: number): Promise<ArrayBuffer> {
+  const source = new URL(url)
+  const label = `${source.origin}${source.pathname}`
+  const deadline = Date.now() + timeout
+  for (let attempt = 1; ; attempt++) {
+    const delay = 250 * 2 ** (attempt - 1)
+    const result = await fetch(url, {
+      redirect: "follow",
+      signal: AbortSignal.timeout(Math.max(1, deadline - Date.now())),
+    })
+      .then(async (response) => {
+        if (response.ok) return { ok: true as const, bytes: await response.arrayBuffer() }
+        await response.body?.cancel().catch(() => undefined)
+        const after = response.headers.get("retry-after")
+        const seconds = after === null ? Number.NaN : Number(after)
+        const wait = after === null ? 0 : Number.isFinite(seconds) ? seconds * 1_000 : Date.parse(after) - Date.now()
+        return {
+          ok: false as const,
+          error: new Error(`HTTP ${response.status}`),
+          retry: response.status === 408 || response.status === 429 || response.status >= 500,
+          delay: Number.isFinite(wait) ? Math.max(delay, wait) : delay,
+        }
+      })
+      .catch((error: unknown) => ({
+        ok: false as const,
+        error: error instanceof Error ? error : new Error(String(error)),
+        retry: true,
+        delay,
+      }))
+    if (result.ok) return result.bytes
+    const reason = result.error.message.replaceAll(url, label)
+    if (!result.retry || attempt === 3 || Date.now() + result.delay >= deadline) {
+      throw new Error(`Download ${label} failed after ${attempt} attempt${attempt === 1 ? "" : "s"}: ${reason}`)
+    }
+    log.warn("retrying archive download", { source: label, attempt, error: reason })
+    await Bun.sleep(result.delay)
+  }
+}

--- a/backend/cli/src/science/kernel/environment-manager.ts
+++ b/backend/cli/src/science/kernel/environment-manager.ts
@@ -13,6 +13,7 @@ import { constants } from "node:fs"
 import fs from "node:fs/promises"
 import path from "node:path"
 import z from "zod"
+import { download } from "./download"
 import type { KernelStartOptions } from "./types"
 
 const log = Log.create({ service: "science.environment" })
@@ -369,9 +370,7 @@ async function ensureCondaArchives(digest: string, selected: CoreScienceCondaPla
         if ((await lockedFileSha256(cached)) === artifact.digest) {
           await fs.copyFile(cached, temporary)
         } else {
-          const response = await fetch(artifact.url, { redirect: "follow", signal: AbortSignal.timeout(120_000) })
-          if (!response.ok) throw new Error(`Locked Conda archive download failed with HTTP ${response.status}`)
-          await Bun.write(temporary, await response.arrayBuffer(), { mode: 0o600 })
+          await Bun.write(temporary, await download(artifact.url, 120_000), { mode: 0o600 })
         }
         if ((await lockedFileSha256(temporary)) !== artifact.digest) {
           throw new Error(`Locked Conda archive ${artifact.name} failed its sha256 checksum`)
@@ -474,12 +473,11 @@ async function installMicromamba() {
   let preservePrevious = false
   try {
     await fs.mkdir(extracted, { recursive: true })
-    const response = await fetch(`https://micro.mamba.pm/api/micromamba/${selectedPlatform}/${MICROMAMBA_VERSION}`, {
-      redirect: "follow",
-      signal: AbortSignal.timeout(60_000),
-    })
-    if (!response.ok) throw new Error(`Micromamba download failed with HTTP ${response.status}`)
-    await Bun.write(archive, await response.arrayBuffer(), { mode: 0o600 })
+    await Bun.write(
+      archive,
+      await download(`https://micro.mamba.pm/api/micromamba/${selectedPlatform}/${MICROMAMBA_VERSION}`, 60_000),
+      { mode: 0o600 },
+    )
     if ((await sha256(archive)) !== locked.archive) {
       throw new Error(`Micromamba ${MICROMAMBA_VERSION} archive failed its ${selectedPlatform} checksum`)
     }

--- a/backend/cli/test/science/kernel/download.test.ts
+++ b/backend/cli/test/science/kernel/download.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test"
+import net from "node:net"
+import { download } from "../../../src/science/kernel/download"
+
+describe("managed environment downloads", () => {
+  test("recovers from a temporary upstream failure", async () => {
+    let requests = 0
+    using server = Bun.serve({
+      port: 0,
+      fetch() {
+        requests++
+        return requests === 1 ? new Response("unavailable", { status: 503 }) : new Response("locked archive")
+      },
+    })
+    expect(new TextDecoder().decode(await download(server.url.href, 5_000))).toBe("locked archive")
+    expect(requests).toBe(2)
+  })
+
+  test("restarts a truncated response without returning partial archive bytes", async () => {
+    let requests = 0
+    const server = net.createServer((socket) => {
+      socket.once("data", () => {
+        requests++
+        socket.end(
+          "HTTP/1.1 200 OK\r\nContent-Length: 14\r\nConnection: close\r\n\r\n" +
+            (requests === 1 ? "cut" : "locked archive"),
+        )
+      })
+    })
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve))
+    try {
+      const address = server.address()
+      if (!address || typeof address === "string") throw new Error("Missing fixture address")
+      expect(new TextDecoder().decode(await download(`http://127.0.0.1:${address.port}/archive`, 5_000))).toBe(
+        "locked archive",
+      )
+      expect(requests).toBe(2)
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())))
+    }
+  })
+
+  test("does not retry permanent HTTP failures", async () => {
+    let requests = 0
+    using server = Bun.serve({
+      port: 0,
+      fetch() {
+        requests++
+        return new Response("missing", { status: 404 })
+      },
+    })
+    await expect(download(server.url.href, 5_000)).rejects.toThrow("HTTP 404")
+    expect(requests).toBe(1)
+  })
+
+  test("bounds attempts and identifies the failed archive without its query", async () => {
+    let requests = 0
+    using server = Bun.serve({
+      port: 0,
+      fetch() {
+        requests++
+        return new Response("unavailable", { status: 502 })
+      },
+    })
+    const error = await download(new URL("/archive?token=fixture-secret", server.url).href, 5_000).catch(
+      (error: unknown) => error,
+    )
+    expect(error).toBeInstanceOf(Error)
+    expect((error as Error).message).toContain("/archive")
+    expect((error as Error).message).toContain("3 attempts")
+    expect((error as Error).message).toContain("HTTP 502")
+    expect((error as Error).message).not.toContain("fixture-secret")
+    expect(requests).toBe(3)
+  })
+
+  test("keeps retries inside the original timeout budget", async () => {
+    let requests = 0
+    using server = Bun.serve({
+      port: 0,
+      fetch() {
+        requests++
+        return new Response("busy", { status: 503 })
+      },
+    })
+    const started = performance.now()
+    await expect(download(server.url.href, 100)).rejects.toThrow("HTTP 503")
+    expect(performance.now() - started).toBeLessThan(500)
+    expect(requests).toBe(1)
+  })
+
+  test("does not retry earlier than the upstream Retry-After deadline", async () => {
+    let requests = 0
+    using server = Bun.serve({
+      port: 0,
+      fetch() {
+        requests++
+        return new Response("rate limited", { status: 429, headers: { "Retry-After": "60" } })
+      },
+    })
+    await expect(download(server.url.href, 1_000)).rejects.toThrow("HTTP 429")
+    expect(requests).toBe(1)
+  })
+})


### PR DESCRIPTION
Scientific environment setup could abort on a dropped archive connection or temporary upstream error. Release rehearsal [34680449430](https://github.com/synthetic-sciences/openscience/actions/runs/34680449430/job/103519732070) exposed a socket failure during setup; its empty result artifact also lacked the detailed app log.

Retry complete Micromamba and locked Conda archive downloads up to three times within their existing timeout. Permanent HTTP errors still fail immediately, Retry-After is respected, and checksum verification still runs before any archive is installed. Exhausted downloads identify the archive and attempt count without exposing URL queries. The rehearsal now prints and retains application logs, setup state, and compute evidence on failure.

Validation: reproduced the same socket error with a real truncated HTTP response; the previous single-fetch behavior failed three regression cases. All 46 targeted download, environment, and canary tests passed (283 assertions), all seven workspace typechecks passed, and formatting passed. The original candidate passed all five real Modal canaries with verified artifacts and closed paid resources; this source change will receive a fresh fully gated release rehearsal before publication.
