### PR TITLE
Skills: install the bundled archive once per process and survive a lost rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ tagged release also ships native binaries for Linux, macOS, and Windows.
 
 ## Unreleased
 
+### Fixed
+
+- A packaged build no longer fails requests in its first seconds when several
+  project runtimes start together. Every runtime asked to install the bundled
+  skills, and the losers of that race renamed onto a directory the winner had
+  just filled (`ENOTEMPTY`). One extraction is now shared per bundle within a
+  process, and a rename that loses to another process accepts the winner's
+  verified bundle.
+
 ### Changed
 
 - The default Research prompt now follows the shape of OpenCode's harness

--- a/backend/cli/src/skill/bundled.ts
+++ b/backend/cli/src/skill/bundled.ts
@@ -21,22 +21,35 @@ export namespace BundledSkills {
     return import("./bundled.generated").catch(() => undefined)
   }
 
-  export async function materialize(input: {
-    archive: string
-    digest: string
-    files: number
-    skills: number
-    cache?: string
-  }): Promise<string> {
-    if (!/^[a-f0-9]{64}$/.test(input.digest)) throw new Error("Invalid bundled skill digest")
+  type Materialize = { archive: string; digest: string; files: number; skills: number; cache?: string }
+
+  // Every project instance asks for the bundle root as it starts. Sharing one
+  // in-flight extraction per target keeps a burst of instances from racing
+  // each other's rename; other processes are handled at the rename itself.
+  const inflight = new Map<string, Promise<string>>()
+
+  export function materialize(input: Materialize): Promise<string> {
+    if (!/^[a-f0-9]{64}$/.test(input.digest)) return Promise.reject(new Error("Invalid bundled skill digest"))
     const base = input.cache ?? path.join(Global.Path.cache, "bundled-skills")
-    const root = path.join(base, input.digest)
-    const marker = path.join(root, ".openscience-bundle.json")
-    const ready = await Bun.file(marker)
+    const key = path.join(base, input.digest)
+    const pending = inflight.get(key)
+    if (pending) return pending
+    const task = extract(input, base).finally(() => inflight.delete(key))
+    inflight.set(key, task)
+    return task
+  }
+
+  async function verified(marker: string, input: Materialize) {
+    return Bun.file(marker)
       .json()
       .then((value) => value?.digest === input.digest && value?.files === input.files && value?.skills === input.skills)
       .catch(() => false)
-    if (ready) return root
+  }
+
+  async function extract(input: Materialize, base: string): Promise<string> {
+    const root = path.join(base, input.digest)
+    const marker = path.join(root, ".openscience-bundle.json")
+    if (await verified(marker, input)) return root
 
     const tmp = path.join(base, `.${input.digest}.${process.pid}.${Date.now()}`)
     await fs.mkdir(base, { recursive: true })
@@ -61,18 +74,30 @@ export namespace BundledSkills {
       JSON.stringify({ digest: input.digest, files: input.files, skills: input.skills }),
     )
 
-    const raced = await Bun.file(marker)
-      .json()
-      .then((value) => value?.digest === input.digest && value?.files === input.files && value?.skills === input.skills)
-      .catch(() => false)
-    if (raced) {
+    if (await verified(marker, input)) {
       await fs.rm(tmp, { recursive: true, force: true })
       return root
     }
 
     await fs.rm(root, { recursive: true, force: true })
-    await fs.rename(tmp, root)
-    return root
+    // Another process can complete the same rename between the checks above
+    // and this one; a non-empty target then fails with ENOTEMPTY or EEXIST.
+    // Its verified bundle is as good as ours.
+    const renamed = await fs.rename(tmp, root).then(
+      () => true,
+      (error: unknown) => {
+        const code = error && typeof error === "object" && "code" in error ? error.code : undefined
+        if (code !== "ENOTEMPTY" && code !== "EEXIST" && code !== "EPERM") throw error
+        return false
+      },
+    )
+    if (renamed) return root
+    if (await verified(marker, input)) {
+      await fs.rm(tmp, { recursive: true, force: true })
+      return root
+    }
+    await fs.rm(tmp, { recursive: true, force: true })
+    throw new Error("Bundled skill archive could not be installed: another installation left an incomplete bundle")
   }
 
   export async function root(): Promise<string | undefined> {

--- a/backend/cli/test/skill/bundled-runtime.test.ts
+++ b/backend/cli/test/skill/bundled-runtime.test.ts
@@ -44,6 +44,65 @@ test("materializes and verifies the complete bundled skill archive offline", asy
   }
 })
 
+async function fixture() {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openscience-skills-bundle-"))
+  const source = path.join(tmp, "source")
+  const cache = path.join(tmp, "cache")
+  const archive = path.join(tmp, "skills.tar.gz")
+  await fs.mkdir(path.join(source, "research", "example"), { recursive: true })
+  await Bun.write(
+    path.join(source, "research", "example", "SKILL.md"),
+    "---\nname: example\ndescription: offline example\n---\n\n# Example\n",
+  )
+  const digest = await directoryDigest(source)
+  await Bun.Archive.write(
+    archive,
+    { "research/example/SKILL.md": await Bun.file(path.join(source, "research", "example", "SKILL.md")).bytes() },
+    { compress: "gzip" },
+  )
+  return { tmp, cache, archive, digest }
+}
+
+test("a burst of instances shares one extraction instead of racing the rename", async () => {
+  const { tmp, cache, archive, digest } = await fixture()
+  try {
+    const input = { archive, digest, files: 1, skills: 1, cache }
+    const roots = await Promise.all(Array.from({ length: 6 }, () => BundledSkills.materialize(input)))
+    expect(new Set(roots).size).toBe(1)
+    // No abandoned temporary extraction directories remain beside the bundle.
+    expect((await fs.readdir(cache)).filter((name) => name.startsWith("."))).toEqual([])
+    expect(await Bun.file(path.join(roots[0]!, "research", "example", "SKILL.md")).text()).toContain("offline example")
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true })
+  }
+})
+
+test("two processes installing the same bundle both succeed on one root", async () => {
+  const { tmp, cache, archive, digest } = await fixture()
+  try {
+    const script = `
+      import { BundledSkills } from ${JSON.stringify(path.resolve(import.meta.dir, "../../src/skill/bundled.ts"))}
+      const root = await BundledSkills.materialize(${JSON.stringify({ archive, digest, files: 1, skills: 1, cache })})
+      console.log(root)
+    `
+    const runs = Array.from({ length: 3 }, () =>
+      Bun.spawn(["bun", "-e", script], { cwd: path.resolve(import.meta.dir, "../.."), stdout: "pipe", stderr: "pipe" }),
+    )
+    const results = await Promise.all(
+      runs.map(async (run) => ({
+        code: await run.exited,
+        out: (await new Response(run.stdout).text()).trim(),
+        err: await new Response(run.stderr).text(),
+      })),
+    )
+    for (const result of results) expect(result.err.includes("ENOTEMPTY") || result.code !== 0).toBe(false)
+    expect(new Set(results.map((result) => result.out)).size).toBe(1)
+    expect(results[0]!.out).toBe(path.join(cache, digest))
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true })
+  }
+})
+
 test("rejects retired Atlas and graph skills before archive generation", () => {
   for (const name of [
     "atlas",


### PR DESCRIPTION
## What

Root cause of the `packaged-e2e` failure in release rehearsal [34680449430](https://github.com/synthetic-sciences/openscience/actions/runs/34680449430): the server log shows twelve `ENOTEMPTY: directory not empty, rename '…/cache/openscience/bundled-skills/.<digest>.<pid>.<ts>'` errors. `BundledSkills.materialize` is called by every project runtime as it starts; concurrent callers all pass the "is the bundle ready" check, each extract to their own temp dir, and the losers `rename` onto the directory the winner just filled. The failed request surfaces as a 500 to the workspace, which is why "Current history" never rendered in that test. It only happens in packaged builds (dev uses the source `skills/` tree), so local e2e never sees it, and it would hit a fresh install's first seconds the same way.

Fix:
- One in-flight extraction per bundle target within a process; concurrent callers share the promise.
- A rename that fails with `ENOTEMPTY`/`EEXIST`/`EPERM` re-verifies the winner's marker and accepts that bundle; only a still-invalid target throws.

## Evidence

- New tests: a burst of six in-process callers shares one extraction and leaves no temp dirs; three separate `bun` processes installing the same bundle all succeed on one root. Both fail on the previous code (the in-process test deterministically, the multi-process test in 2 of 3 runs) and pass now.
- `./test/skill` 58 pass; backend typecheck clean.

This is the fix Aayam's next rehearsal needs alongside #603; the packaged-e2e job in that run failed on this, not on the archive download.

Made with [Cursor](https://cursor.com)