### PR TITLE
fix: recover startup catalogs and preserve early slash commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,6 @@ tagged release also ships native binaries for Linux, macOS, and Windows.
 
 ## Unreleased
 
-### Fixed
-
-- A packaged build no longer fails requests in its first seconds when several
-  project runtimes start together. Every runtime asked to install the bundled
-  skills, and the losers of that race renamed onto a directory the winner had
-  just filled (`ENOTEMPTY`). One extraction is now shared per bundle within a
-  process, and a rename that loses to another process accepts the winner's
-  verified bundle.
-
 ### Changed
 
 - The default Research prompt now follows the shape of OpenCode's harness
@@ -31,6 +22,11 @@ tagged release also ships native binaries for Linux, macOS, and Windows.
 
 ### Fixed
 
+- Packaged startup shares one bundled-skill extraction per process and coordinates
+  installation across processes. Failed extraction leaves no staging files, and a
+  repaired cache becomes available without restarting the app.
+- Custom slash commands sent immediately after opening a session wait for their
+  catalog instead of being submitted as ordinary chat text.
 - Scientific environment setup retries interrupted archive downloads and temporary
   upstream failures within its existing timeout, while retaining checksum verification.
 - Local Jupyter notebooks, R Markdown, and Quarto files open as rendered documents

--- a/backend/cli/src/skill/bundled.ts
+++ b/backend/cli/src/skill/bundled.ts
@@ -3,6 +3,7 @@ import path from "node:path"
 import { Global } from "@/global"
 import { Installation } from "@/installation"
 import { Filesystem } from "@/util/filesystem"
+import { FileLease } from "@/util/file-lease"
 import { Log } from "@/util/log"
 import { directoryDigest } from "./bundle-format"
 
@@ -23,9 +24,7 @@ export namespace BundledSkills {
 
   type Materialize = { archive: string; digest: string; files: number; skills: number; cache?: string }
 
-  // Every project instance asks for the bundle root as it starts. Sharing one
-  // in-flight extraction per target keeps a burst of instances from racing
-  // each other's rename; other processes are handled at the rename itself.
+  // Project instances share one extraction; the lease also coordinates processes.
   const inflight = new Map<string, Promise<string>>()
 
   export function materialize(input: Materialize): Promise<string> {
@@ -51,53 +50,44 @@ export namespace BundledSkills {
     const marker = path.join(root, ".openscience-bundle.json")
     if (await verified(marker, input)) return root
 
-    const tmp = path.join(base, `.${input.digest}.${process.pid}.${Date.now()}`)
-    await fs.mkdir(base, { recursive: true })
-    await fs.rm(tmp, { recursive: true, force: true })
-    const bytes = await Bun.file(input.archive).bytes()
-    const count = await new Bun.Archive(bytes).extract(tmp)
-    if (count < input.files) {
-      await fs.rm(tmp, { recursive: true, force: true })
-      throw new Error(`Bundled skill archive is incomplete: expected ${input.files} files, extracted ${count}`)
-    }
-    const digest = await directoryDigest(tmp)
-    if (digest !== input.digest) {
-      await fs.rm(tmp, { recursive: true, force: true })
-      throw new Error(`Bundled skill archive failed verification: expected ${input.digest}, got ${digest}`)
-    }
+    // Multiple project instances and processes share this content-addressed cache.
+    await using lease = await FileLease.acquire(path.join(base, `${input.digest}.lock`), 60_000)
+    if (await verified(marker, input)) return root
+    const tmp = await fs.mkdtemp(path.join(base, `.${input.digest}.`))
+    try {
+      const bytes = await Bun.file(input.archive).bytes()
+      const count = await new Bun.Archive(bytes).extract(tmp)
+      if (count < input.files) {
+        throw new Error(`Bundled skill archive is incomplete: expected ${input.files} files, extracted ${count}`)
+      }
+      const digest = await directoryDigest(tmp)
+      if (digest !== input.digest) {
+        throw new Error(`Bundled skill archive failed verification: expected ${input.digest}, got ${digest}`)
+      }
 
-    for await (const script of new Bun.Glob("**/*.{py,sh,js,ts}").scan({ cwd: tmp, absolute: true, onlyFiles: true })) {
-      await fs.chmod(script, 0o755).catch(() => {})
-    }
-    await Bun.write(
-      path.join(tmp, ".openscience-bundle.json"),
-      JSON.stringify({ digest: input.digest, files: input.files, skills: input.skills }),
-    )
+      for await (const script of new Bun.Glob("**/*.{py,sh,js,ts}").scan({
+        cwd: tmp,
+        absolute: true,
+        onlyFiles: true,
+      })) {
+        await fs.chmod(script, 0o755).catch(() => {})
+      }
+      await Bun.write(
+        path.join(tmp, ".openscience-bundle.json"),
+        JSON.stringify({ digest: input.digest, files: input.files, skills: input.skills }),
+      )
 
-    if (await verified(marker, input)) {
-      await fs.rm(tmp, { recursive: true, force: true })
+      // An older app may still publish the same bundle without taking the lease.
+      if (await verified(marker, input)) return root
+      await fs.rm(root, { recursive: true, force: true })
+      await fs.rename(tmp, root).catch(async (error) => {
+        if (await verified(marker, input)) return
+        throw error
+      })
       return root
-    }
-
-    await fs.rm(root, { recursive: true, force: true })
-    // Another process can complete the same rename between the checks above
-    // and this one; a non-empty target then fails with ENOTEMPTY or EEXIST.
-    // Its verified bundle is as good as ours.
-    const renamed = await fs.rename(tmp, root).then(
-      () => true,
-      (error: unknown) => {
-        const code = error && typeof error === "object" && "code" in error ? error.code : undefined
-        if (code !== "ENOTEMPTY" && code !== "EEXIST" && code !== "EPERM") throw error
-        return false
-      },
-    )
-    if (renamed) return root
-    if (await verified(marker, input)) {
+    } finally {
       await fs.rm(tmp, { recursive: true, force: true })
-      return root
     }
-    await fs.rm(tmp, { recursive: true, force: true })
-    throw new Error("Bundled skill archive could not be installed: another installation left an incomplete bundle")
   }
 
   export async function root(): Promise<string | undefined> {

--- a/backend/cli/src/skill/skill.ts
+++ b/backend/cli/src/skill/skill.ts
@@ -371,7 +371,12 @@ export namespace Skill {
     // Default skills are an immutable release asset. Source builds scan the
     // repository tree; compiled releases materialize their embedded archive to
     // a versioned cache directory. Neither path needs Atlas or a network.
-    for (const skill of await defaults()) add(skill)
+    for (const skill of await defaults().catch((error) => {
+      defaults.reset()
+      State.clear(Instance.directory, compute)
+      throw error
+    }))
+      add(skill)
 
     // === User Skills: authored locally via openscience/web, private by default ===
     for (const name of RETIRED_PRODUCT_SKILL_NAMES) {

--- a/backend/cli/test/skill/bundled-runtime.test.ts
+++ b/backend/cli/test/skill/bundled-runtime.test.ts
@@ -2,8 +2,90 @@ import { expect, test } from "bun:test"
 import fs from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
-import { assertNoRetiredProductSkills, directoryDigest } from "../../src/skill/bundle-format"
+import { assertNoRetiredProductSkills, bundleDigest, directoryDigest } from "../../src/skill/bundle-format"
 import { BundledSkills } from "../../src/skill/bundled"
+
+async function raceFixture() {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openscience-skills-race-"))
+  const entries = [
+    {
+      path: "research/example/SKILL.md",
+      bytes: new TextEncoder().encode("---\nname: example\ndescription: test\n---\n"),
+    },
+    ...Array.from({ length: 64 }, (_, index) => ({
+      path: `research/example/references/${index}.txt`,
+      bytes: new TextEncoder().encode(`reference ${index}\n`.repeat(100)),
+    })),
+  ]
+  const archive = path.join(tmp, "skills.tar.gz")
+  await Bun.Archive.write(archive, Object.fromEntries(entries.map((entry) => [entry.path, entry.bytes])), {
+    compress: "gzip",
+  })
+  return {
+    tmp,
+    input: { archive, digest: bundleDigest(entries), files: entries.length, skills: 1, cache: path.join(tmp, "cache") },
+    async [Symbol.asyncDispose]() {
+      await fs.rm(tmp, { recursive: true, force: true })
+    },
+  }
+}
+
+test("concurrent initializers share one complete bundle without deleting each other's staging files", async () => {
+  await using bundle = await raceFixture()
+  const results = await Promise.allSettled(Array.from({ length: 32 }, () => BundledSkills.materialize(bundle.input)))
+  expect(results.filter((result) => result.status === "rejected")).toEqual([])
+  const roots = results.flatMap((result) => (result.status === "fulfilled" ? [result.value] : []))
+  expect(new Set(roots).size).toBe(1)
+  expect(await directoryDigest(roots[0])).toBe(bundle.input.digest)
+  expect(await fs.readdir(bundle.input.cache)).toEqual([bundle.input.digest])
+})
+
+test("separate processes can initialize the same bundled skill cache", async () => {
+  await using bundle = await raceFixture()
+  const start = path.join(bundle.tmp, "start")
+  const module = new URL("../../src/skill/bundled.ts", import.meta.url).href
+  const workers = Array.from({ length: 4 }, (_, index) => {
+    const ready = path.join(bundle.tmp, `ready-${index}`)
+    const script = `
+      import { BundledSkills } from ${JSON.stringify(module)};
+      await Bun.write(${JSON.stringify(ready)}, "ready");
+      const deadline = Date.now() + 10_000;
+      while (!(await Bun.file(${JSON.stringify(start)}).exists())) {
+        if (Date.now() > deadline) throw new Error("Fixture start timed out");
+        await Bun.sleep(5);
+      }
+      console.log(await BundledSkills.materialize(${JSON.stringify(bundle.input)}));
+    `
+    const child = Bun.spawn([process.execPath, "-e", script], { stdout: "pipe", stderr: "pipe" })
+    return {
+      ready,
+      result: Promise.all([child.exited, new Response(child.stdout).text(), new Response(child.stderr).text()]),
+    }
+  })
+  const deadline = Date.now() + 10_000
+  while (!(await Promise.all(workers.map((worker) => Bun.file(worker.ready).exists()))).every(Boolean)) {
+    if (Date.now() > deadline) break
+    await Bun.sleep(5)
+  }
+  await Bun.write(start, "start")
+  const results = await Promise.all(workers.map((worker) => worker.result))
+  expect(results.filter(([code]) => code !== 0)).toEqual([])
+  expect(new Set(results.map(([, stdout]) => stdout.trim())).size).toBe(1)
+  expect(await directoryDigest(path.join(bundle.input.cache, bundle.input.digest))).toBe(bundle.input.digest)
+  expect(await fs.readdir(bundle.input.cache)).toEqual([bundle.input.digest])
+})
+
+test("failed extraction is cleaned up and an incomplete cache can be repaired", async () => {
+  await using bundle = await raceFixture()
+  const broken = path.join(bundle.tmp, "broken.tar.gz")
+  await Bun.write(broken, "invalid archive")
+  await expect(BundledSkills.materialize({ ...bundle.input, archive: broken })).rejects.toThrow()
+  expect(await fs.readdir(bundle.input.cache)).toEqual([])
+  await Bun.write(path.join(bundle.input.cache, bundle.input.digest, "incomplete.txt"), "interrupted extraction")
+  const root = await BundledSkills.materialize(bundle.input)
+  expect(await directoryDigest(root)).toBe(bundle.input.digest)
+  expect(await Bun.file(path.join(root, "incomplete.txt")).exists()).toBe(false)
+})
 
 test("materializes and verifies the complete bundled skill archive offline", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openscience-skills-bundle-"))

--- a/frontend/workspace/e2e/model-tier.spec.ts
+++ b/frontend/workspace/e2e/model-tier.spec.ts
@@ -6,6 +6,35 @@ test.skip(
   "requires the deterministic model supplied by test:e2e:local (or the E2E CI harness)",
 )
 
+test("a custom slash command waits for a delayed command catalog", async ({ page, openSession }) => {
+  const gate = Promise.withResolvers<void>()
+  await page.route("**/command", async (route) => {
+    if (route.request().method() === "GET") await gate.promise
+    await route.continue()
+  })
+  try {
+    await openSession("delayed command catalog")
+    const command = page.waitForRequest((request) => {
+      const pathname = new URL(request.url()).pathname
+      return request.method() === "POST" && /\/session\/[^/]+\/command$/.test(pathname)
+    })
+    const completion = page.waitForResponse((response) => {
+      const pathname = new URL(response.url()).pathname
+      return response.request().method() === "POST" && /\/session\/[^/]+\/command$/.test(pathname)
+    })
+    const prompt = page.locator(promptSelector)
+    await prompt.fill("/e2e-tier-override ")
+    await page.getByRole("button", { name: "Send", exact: true }).click()
+    await expect(prompt).toHaveText("")
+    gate.resolve()
+    expect((await command).postDataJSON()).toMatchObject({ command: "e2e-tier-override", arguments: "" })
+    expect((await completion).ok()).toBe(true)
+  } finally {
+    gate.resolve()
+    await page.unroute("**/command")
+  }
+})
+
 test("model speed toggles through model options and reaches the prompt request", async ({ page, sdk, gotoSession }) => {
   await gotoSession()
 

--- a/frontend/workspace/src/components/prompt-input.tsx
+++ b/frontend/workspace/src/components/prompt-input.tsx
@@ -2111,7 +2111,25 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     if (text.startsWith("/")) {
       const [cmdName, ...args] = text.split(" ")
       const commandName = cmdName.slice(1)
-      const customCommand = sync.data.command.find((c) => c.name === commandName)
+      // Catalogs load after first paint; an early slash command must not become
+      // ordinary prompt text just because that background request is pending.
+      const commands =
+        sessionDirectory === projectDirectory && sync.data.command.some((command) => command.name === commandName)
+          ? sync.data.command
+          : await client.command
+              .list()
+              .then((response) => response.data)
+              .catch((error) => {
+                const failure = requestFailure(error, "Load commands")
+                showToast({ title: failure.title, description: failure.description })
+                return undefined
+              })
+      if (!commands) {
+        setSubmitting(false)
+        restoreInputAfterFailure()
+        return
+      }
+      const customCommand = commands.find((command) => command.name === commandName)
       if (customCommand) {
         const request = {
           sessionID: session.id,


### PR DESCRIPTION
A repaired bundled-skill cache could keep returning HTTP 500 until the server restarted because both the default catalog and project state retained a rejected initialization promise. An early custom slash command could also beat the deferred catalog request and be sent as ordinary chat text.

This builds on #604: retain shared in-process extraction, coordinate separate processes with the existing file lease, use unique staging directories with unconditional cleanup, and evict failed catalog initialization. Custom command submission loads the target catalog when necessary and restores the draft if that request fails.

Validation:
- 61 skill tests pass, including concurrent subprocess initialization and interrupted extraction cleanup; one unrelated optional RDKit case skips.
- 36 prompt tests and all seven package typechecks pass.
- Real compiled server: obstruct cache, observe HTTP 500, repair path, then recover all 313 skills without restarting.
- Full compiled browser suite: 98/98 pass in 1.8 minutes, first attempt, no retries. Includes real Python/R notebook execution, permissions, tools, traces, and the deliberately delayed command-catalog regression.

No package versions or release gates changed.
