### PR TITLE
fix: stabilize process registration and scientific canary startup

### DIFF
--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -620,6 +620,7 @@ jobs:
           mkdir -p "$HOME" "$XDG_DATA_HOME" "$XDG_CACHE_HOME" "$XDG_CONFIG_HOME" "$XDG_STATE_HOME" "$OPENSCIENCE_DATA_DIR" "$project"
           cd "$project"
           openscience --print-logs debug capability-canary "$CANARY_CAPABILITY" --target local --timeout 900 \
+            2> >(tee "$RUNNER_TEMP/scientific-capability-canary.log" >&2) \
             | tee "$RUNNER_TEMP/scientific-capability-canary.json"
           CANARY_RESULT="$RUNNER_TEMP/scientific-capability-canary.json" \
           EXPECTED_CAPABILITY="$CANARY_CAPABILITY" \
@@ -659,6 +660,7 @@ jobs:
           retention-days: 30
           path: |
             ${{ runner.temp }}/scientific-capability-canary.json
+            ${{ runner.temp }}/scientific-capability-canary.log
             ${{ runner.temp }}/openscience-capability/data/scientific-capability-evidence.json
             ${{ runner.temp }}/openscience-capability/data/log
             ${{ runner.temp }}/openscience-capability/data/compute/projects

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ tagged release also ships native binaries for Linux, macOS, and Windows.
 
 ### Fixed
 
+- Short provider and Modal SDK probes can finish immediately after durable process
+  registration without being mistaken for failed launches. Failed scientific setup
+  records its failed state and logs the exact archive-attestation rejection.
+- Scientific canaries stay isolated from credential sync and unrelated environment
+  installation when logging flags appear before their command.
 - Packaged startup shares one bundled-skill extraction per process and coordinates
   installation across processes. Failed extraction leaves no staging files, and a
   repaired cache becomes available without restarting the app.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@ tagged release also ships native binaries for Linux, macOS, and Windows.
   registration without being mistaken for failed launches. Failed scientific setup
   records its failed state and logs the exact archive-attestation rejection.
 - Scientific canaries stay isolated from credential sync and unrelated environment
-  installation when logging flags appear before their command.
+  installation when logging flags appear before their command. A failed canary
+  preserves completed results and its error in the JSON report.
 - Packaged startup shares one bundled-skill extraction per process and coordinates
   installation across processes. Failed extraction leaves no staging files, and a
   repaired cache becomes available without restarting the app.

--- a/backend/cli/src/cli/cmd/debug/capability-canary.ts
+++ b/backend/cli/src/cli/cmd/debug/capability-canary.ts
@@ -63,20 +63,32 @@ export const CapabilityCanaryCommand = cmd({
       const agent = await Agent.get("research")
       if (!agent) throw new Error("The research agent is unavailable")
       const tool = await createScientificCapabilityCanaryTool({ agent })
-      const results = []
+      const results: Awaited<ReturnType<typeof runScientificCapabilityCanary>>[] = []
+      const report = (failure?: { failed_capability: string; error: string }) =>
+        new Promise<void>((resolve, reject) => {
+          process.stdout.write(
+            JSON.stringify({ schema_version: 1, target, results, ...failure }, null, 2) + EOL,
+            (error) => (error ? reject(error) : resolve()),
+          )
+        })
       for (const id of selected) {
-        const ctx = await createScientificCapabilityCanaryContext(agent)
-        results.push(
-          await runScientificCapabilityCanary({
-            tool,
-            ctx,
-            id,
-            target,
-            timeoutSeconds: Number(args.timeout),
-          }),
-        )
+        try {
+          const ctx = await createScientificCapabilityCanaryContext(agent)
+          results.push(
+            await runScientificCapabilityCanary({
+              tool,
+              ctx,
+              id,
+              target,
+              timeoutSeconds: Number(args.timeout),
+            }),
+          )
+        } catch (error) {
+          await report({ failed_capability: id, error: error instanceof Error ? error.message : String(error) })
+          throw error
+        }
       }
-      process.stdout.write(JSON.stringify({ schema_version: 1, target, results }, null, 2) + EOL)
+      await report()
     })
   },
 })

--- a/backend/cli/src/credentials/process-ledger.ts
+++ b/backend/cli/src/credentials/process-ledger.ts
@@ -540,15 +540,6 @@ export namespace CredentialProcessLedger {
         if (windowsJob) WindowsJob.terminate(windowsJob)
         throw error
       })
-      if (windowsJob && input.windowsRelease) {
-        try {
-          WindowsJob.release(input.windowsRelease, input.pid)
-        } catch (error) {
-          await teardownGroup(next)
-          await write(entries.filter((entry) => entry.id !== input.id))
-          throw error
-        }
-      }
       if (process.platform === "darwin" && input.windowsRelease) {
         try {
           await fs.writeFile(input.windowsRelease, String(input.pid), { encoding: "utf8", flag: "wx", mode: 0o600 })
@@ -576,17 +567,6 @@ export namespace CredentialProcessLedger {
         const position = entries.findIndex((entry) => entry.id === input.id)
         if (position >= 0) entries[position] = next
         await write(entries)
-        try {
-          await fs.writeFile(`${input.windowsRelease}${DARWIN_RESPONSIBILITY_ACTIVATION_SUFFIX}`, String(input.pid), {
-            encoding: "utf8",
-            flag: "wx",
-            mode: 0o600,
-          })
-        } catch (error) {
-          await teardownGroup(next)
-          await write(entries.filter((entry) => entry.id !== input.id))
-          throw error
-        }
       }
       if (darwinResponsibility && !DarwinResponsibility.uniquelyOwns(darwinResponsibility, input.pid)) {
         await teardownGroup(next)
@@ -605,6 +585,22 @@ export namespace CredentialProcessLedger {
         if (next.detached || windowsJob) await teardownGroup(next)
         await write(entries.filter((entry) => entry.id !== input.id))
         return false
+      }
+      // Verify ownership while the workload is still gated. After activation,
+      // a short successful probe may exit before another identity check runs.
+      try {
+        if (windowsJob && input.windowsRelease) WindowsJob.release(input.windowsRelease, input.pid)
+        if (darwinResponsibility) {
+          await fs.writeFile(`${input.windowsRelease}${DARWIN_RESPONSIBILITY_ACTIVATION_SUFFIX}`, String(input.pid), {
+            encoding: "utf8",
+            flag: "wx",
+            mode: 0o600,
+          })
+        }
+      } catch (error) {
+        await teardownGroup(next)
+        await write(entries.filter((entry) => entry.id !== input.id))
+        throw error
       }
       return true
     })

--- a/backend/cli/src/index.ts
+++ b/backend/cli/src/index.ts
@@ -104,10 +104,6 @@ process.on("uncaughtException", (e) => {
   })
 })
 
-function isScientificCapabilityCanary(command: string | undefined, argv: string[]): boolean {
-  return command === "debug" && argv[1] === "capability-canary"
-}
-
 // Yargs handles --help/--version before middleware. Run the exact, fail-safe
 // retirement migration here so the first post-upgrade invocation cleans old
 // agent instructions even when it exits through those built-in paths. Internal
@@ -136,7 +132,7 @@ const cli = yargs(hideBin(process.argv))
   })
   .middleware(async (opts) => {
     const initialize = async () => {
-      const capabilityCanary = isScientificCapabilityCanary(command, process.argv.slice(2))
+      const capabilityCanary = command === "debug" && opts._[1] === "capability-canary"
       await Log.init({
         print: process.argv.includes("--print-logs"),
         dev: Installation.isLocal(),

--- a/backend/cli/src/science/kernel/environment-manager.ts
+++ b/backend/cli/src/science/kernel/environment-manager.ts
@@ -1011,7 +1011,10 @@ async function lockedFileSha256(file: string) {
 }
 
 async function verifyOwnership(prefix: string, ownership: Ownership, options: { allowCondaMetadata?: boolean } = {}) {
-  const reject = (_reason: string, _relative?: string) => false
+  const reject = (reason: string, relative?: string) => {
+    log.warn("managed environment archive attestation failed", { reason, relative })
+    return false
+  }
   const root = await fs.realpath(prefix).catch(() => undefined)
   if (!root) return reject("missing root")
   const base = `${root}${path.sep}`
@@ -1572,8 +1575,14 @@ export namespace ManagedEnvironments {
     }
     await ensureMicromamba()
     await using lease = await FileLease.acquire(path.join(root(), `task-${parsed}.lock`), 45 * 60 * 1000)
-    await ensureTaskEnvironment(parsed, input, selected)
-    await state({ status: "ready", phase: "ready", error: undefined })
+    try {
+      await ensureTaskEnvironment(parsed, input, selected)
+      await state({ status: "ready", phase: "ready", error: undefined })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      await state({ status: "failed", phase: `failed:task:${parsed}`, error: message }).catch(() => undefined)
+      throw error
+    }
   }
 
   export async function inspect(

--- a/backend/cli/test/cli/capability-canary-startup.test.ts
+++ b/backend/cli/test/cli/capability-canary-startup.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "bun:test"
+import path from "node:path"
+import { tmpdir } from "../fixture/fixture"
+
+const entry = path.resolve(import.meta.dir, "../../src/index.ts")
+
+for (const argv of [
+  ["--print-logs", "debug", "capability-canary", "missing-startup-canary"],
+  ["--log-level", "INFO", "debug", "--print-logs", "capability-canary", "missing-startup-canary"],
+  ["debug", "capability-canary", "missing-startup-canary", "--print-logs"],
+]) {
+  test(`canary flags do not start unrelated environments: ${argv.join(" ")}`, async () => {
+    await using tmp = await tmpdir()
+    const data = path.join(tmp.path, "data")
+    const blocker = path.join(data, "conda")
+    // A mistaken background bootstrap fails immediately instead of downloading
+    // packages. The unknown canary itself never requests environment setup.
+    await Bun.write(blocker, "no unrelated environment setup")
+    const env = Object.fromEntries(
+      Object.entries(process.env).filter(([name, value]) =>
+        value === undefined ? false : ["PATH", "HOME", "USER", "LOGNAME", "SHELL", "TMPDIR", "LANG"].includes(name),
+      ),
+    )
+    const proc = Bun.spawn([process.execPath, "--no-env-file", entry, ...argv], {
+      cwd: tmp.path,
+      env: {
+        ...env,
+        OPENSCIENCE_TEST_HOME: tmp.path,
+        OPENSCIENCE_TEST_MANAGED_ENVIRONMENTS: "1",
+        OPENSCIENCE_CONFIG_DIR: path.join(tmp.path, "config"),
+        OPENSCIENCE_DATA_DIR: data,
+        XDG_CACHE_HOME: path.join(tmp.path, "cache"),
+        XDG_CONFIG_HOME: path.join(tmp.path, "xdg-config"),
+        XDG_DATA_HOME: path.join(tmp.path, "share"),
+        XDG_STATE_HOME: path.join(tmp.path, "state"),
+        OPENSCIENCE_DISABLE_DEFAULT_PLUGINS: "true",
+        OPENSCIENCE_DISABLE_PROJECT_CONFIG: "true",
+        OPENSCIENCE_DISABLE_LSP_DOWNLOAD: "true",
+        OPENSCIENCE_DISABLE_SHARE: "true",
+        OPENSCIENCE_EXPERIMENTAL_DISABLE_FILEWATCHER: "true",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    const timer = setTimeout(() => proc.kill(), 10_000)
+    const [exit, stdout, stderr] = await Promise.all([
+      proc.exited,
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ]).finally(() => clearTimeout(timer))
+    expect(exit).toBe(1)
+    expect(stdout + stderr).toContain("Unknown scientific capability: missing-startup-canary")
+    expect(stderr).not.toContain("starter environment setup failed")
+    expect(await Bun.file(blocker).text()).toBe("no unrelated environment setup")
+  })
+}

--- a/backend/cli/test/cli/capability-canary-startup.test.ts
+++ b/backend/cli/test/cli/capability-canary-startup.test.ts
@@ -50,6 +50,13 @@ for (const argv of [
     ]).finally(() => clearTimeout(timer))
     expect(exit).toBe(1)
     expect(stdout + stderr).toContain("Unknown scientific capability: missing-startup-canary")
+    expect(JSON.parse(stdout)).toMatchObject({
+      schema_version: 1,
+      target: "local",
+      results: [],
+      failed_capability: "missing-startup-canary",
+      error: expect.stringContaining("Unknown scientific capability: missing-startup-canary"),
+    })
     expect(stderr).not.toContain("starter environment setup failed")
     expect(await Bun.file(blocker).text()).toBe("no unrelated environment setup")
   })

--- a/backend/cli/test/credentials/process-ledger.test.ts
+++ b/backend/cli/test/credentials/process-ledger.test.ts
@@ -1,12 +1,64 @@
-import { expect, test } from "bun:test"
+import { expect, spyOn, test } from "bun:test"
 import { spawn } from "node:child_process"
 import fs from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
 import { CredentialProcessLedger } from "../../src/credentials/process-ledger"
 import { WindowsJobLauncher } from "../../src/process/windows-job-launcher"
+import { DARWIN_RESPONSIBILITY_ACTIVATION_SUFFIX } from "../../src/process/darwin-responsibility-launcher"
 
 const linuxTest = process.platform === "linux" ? test : test.skip
+
+test.skipIf(process.platform !== "darwin" && process.platform !== "win32")(
+  "gated commands can finish immediately after durable registration",
+  async () => {
+    for (let attempt = 0; attempt < 8; attempt++) {
+      const wrapped = WindowsJobLauncher.wrap({
+        file: process.platform === "darwin" ? "/usr/bin/true" : process.execPath,
+        args: process.platform === "darwin" ? [] : ["-e", ""],
+      })
+      const id = `provider-fast-${crypto.randomUUID()}`
+      const child = spawn(wrapped.file, wrapped.args, { detached: process.platform !== "win32", stdio: "ignore" })
+      const completion = new Promise<number | null>((resolve, reject) => {
+        child.once("close", resolve)
+        child.once("error", reject)
+      })
+      void completion.catch(() => undefined)
+      const write = fs.writeFile
+      // Let the real child finish as soon as its activation file is written.
+      // This controls scheduling without replacing process or filesystem work.
+      const activation =
+        process.platform === "darwin"
+          ? spyOn(fs, "writeFile").mockImplementation(async (...args) => {
+              await write(...args)
+              if (args[0] === `${wrapped.release}${DARWIN_RESPONSIBILITY_ACTIVATION_SUFFIX}`) await completion
+            })
+          : undefined
+      try {
+        expect(
+          await CredentialProcessLedger.register({
+            id,
+            kind: "provider",
+            pid: child.pid!,
+            detached: process.platform !== "win32",
+            windowsRelease: wrapped.release,
+          }),
+        ).toBe(true)
+        expect(await completion).toBe(0)
+        expect(await CredentialProcessLedger.complete(id)).toBe(true)
+      } finally {
+        activation?.mockRestore()
+        await CredentialProcessLedger.revoke({ id })
+        if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL")
+        await completion.catch(() => undefined)
+        if (wrapped.release) {
+          await fs.rm(wrapped.release, { force: true })
+          await fs.rm(`${wrapped.release}${DARWIN_RESPONSIBILITY_ACTIVATION_SUFFIX}`, { force: true })
+        }
+      }
+    }
+  },
+)
 
 async function waitText(file: string, attempt = 0): Promise<string> {
   const value = await fs.readFile(file, "utf8").catch(() => undefined)

--- a/backend/cli/test/fixture/managed-environment.ts
+++ b/backend/cli/test/fixture/managed-environment.ts
@@ -6,6 +6,9 @@ import {
 } from "../../src/science/capability/pack"
 import fs from "node:fs/promises"
 import path from "node:path"
+import { Log } from "../../src/util/log"
+
+await Log.init({ print: false, dev: true })
 
 const support = {
   micromambaSha256: process.env.OPENSCIENCE_TEST_MICROMAMBA_SHA256,
@@ -185,3 +188,5 @@ if (process.argv[2] === "runtime") {
 } else {
   throw new Error("Expected a managed environment fixture mode")
 }
+
+await Log.flush()

--- a/backend/cli/test/science/kernel/environment-manager.test.ts
+++ b/backend/cli/test/science/kernel/environment-manager.test.ts
@@ -395,6 +395,12 @@ test.skipIf(!capabilityPlatform())("rejects an unowned .pth planted before the f
     const result = await invoke("task", current.env)
     expect(result.exit).not.toBe(0)
     expect(result.stderr).toContain("failed Conda-only archive attestation before Python startup")
+    const state = await Bun.file(path.join(current.conda, "state.json")).json()
+    expect(state).toMatchObject({ status: "failed", phase: `failed:task:${CORE_SCIENCE_RUNTIME.pack_id}` })
+    expect(state.error).toContain("failed Conda-only archive attestation")
+    const diagnostic = await Bun.file(path.join(current.data, "log", "dev.log")).text()
+    expect(diagnostic).toContain("reason=unowned file")
+    expect(diagnostic).toContain("relative=lib/python3.12/site-packages/inject.pth")
     expect(await Bun.file(current.pythonLog).exists()).toBe(false)
     expect(await Bun.file(current.startupMarker).exists()).toBe(false)
   } finally {


### PR DESCRIPTION
A short Modal SDK probe could exit after its activation gate opened but before the final ownership check, causing successful remote work to fail artifact delivery. Keep the workload gated until durable process ownership is fully verified; normal immediate completion is then accepted, with existing revocation and descendant cleanup preserved.

Logging flags before `debug capability-canary` also bypassed the CLI’s canary isolation because detection used raw argv positions. Use parsed commands so canaries do not start unrelated environment installation or credential sync. Failed task setup now records a failed state and logs its precise archive-attestation rejection; CI retains stderr as an artifact. Failed canaries also flush their completed results and error into a valid JSON report before exiting unsuccessfully.

Validation:
- Native immediate-exit regression reproduces the old handoff failure; 67 ownership/provider/Modal tests pass, with 13 platform-specific skips.
- Real CLI flag regressions: two failures before, all three pass after; 15 canary tests pass overall.
- 18 environment-manager tests pass, including failed-state recording and rejecting unowned startup code before Python runs.
- Two local Biopython lifecycles and eight fresh Conda installations at different prefix lengths pass. The earlier macOS CI attestation failure did not retain its exact rejected file, so these checks do not establish its precise cause; diagnostics now preserve that evidence.
- All seven package typechecks and formatting pass. A fresh compiled Biopython lifecycle passes with a ready doctor, semantic artifact validation, and no unrelated starter errors.

No archive-verification checks or release gates were weakened. The failed candidate is not being promoted.
